### PR TITLE
Add CI: rust tests + headless nvim e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,12 @@ jobs:
       - name: Clone tree-sitter-perl
         run: git clone https://github.com/tree-sitter-perl/tree-sitter-perl.git ../tree-sitter-perl
 
-      - name: Generate parser (if needed)
-        working-directory: ../tree-sitter-perl
-        run: |
-          if [ ! -f src/parser.c ]; then
-            npm ci
-            npx tree-sitter generate
-          fi
-
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Generate parser
+        run: cargo install tree-sitter-cli && cd ../tree-sitter-perl && tree-sitter generate
 
       - name: Build
         run: cargo build
@@ -46,17 +41,12 @@ jobs:
       - name: Clone tree-sitter-perl
         run: git clone https://github.com/tree-sitter-perl/tree-sitter-perl.git ../tree-sitter-perl
 
-      - name: Generate parser (if needed)
-        working-directory: ../tree-sitter-perl
-        run: |
-          if [ ! -f src/parser.c ]; then
-            npm ci
-            npx tree-sitter generate
-          fi
-
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Generate parser
+        run: cargo install tree-sitter-cli && cd ../tree-sitter-perl && tree-sitter generate
 
       - name: Build release binary
         run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust-tests:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone tree-sitter-perl
+        run: git clone https://github.com/tree-sitter-perl/tree-sitter-perl.git ../tree-sitter-perl
+
+      - name: Generate parser (if needed)
+        working-directory: ../tree-sitter-perl
+        run: |
+          if [ ! -f src/parser.c ]; then
+            npm ci
+            npx tree-sitter generate
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build
+
+      - name: Test
+        run: cargo test
+
+  e2e-tests:
+    name: E2E tests (headless nvim)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone tree-sitter-perl
+        run: git clone https://github.com/tree-sitter-perl/tree-sitter-perl.git ../tree-sitter-perl
+
+      - name: Generate parser (if needed)
+        working-directory: ../tree-sitter-perl
+        run: |
+          if [ ! -f src/parser.c ]; then
+            npm ci
+            npx tree-sitter generate
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.11.0
+
+      - name: Run e2e tests
+        run: nvim --headless --clean -u test_nvim_init.lua -l test_e2e.lua


### PR DESCRIPTION
## Summary
- Two GitHub Actions jobs: `rust-tests` (cargo test) and `e2e-tests` (headless nvim)
- Both clone tree-sitter-perl as sibling and generate parser if needed
- E2E uses nvim 0.11 headless with the existing test_nvim_init.lua + test_e2e.lua

## Test plan
- [ ] Verify rust-tests job passes
- [ ] Verify e2e-tests job passes
- [ ] Check that caching works on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)