### PR TITLE
Cross-file intelligence gaps + extract versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,44 @@ cd ../tree-sitter-perl && tree-sitter generate
 
 ## Architecture
 
+### Layers (strict — read this before writing any code)
+
+The codebase has four layers. Data flows **down** only. Each layer may only depend on layers below it.
+
+```
+  LSP adapter      symbols.rs, backend.rs       → LSP protocol types
+  ─────────────────────────────────────────────────────────────────
+  Cross-file       module_index.rs,             → ModuleExports, ExportedSub
+                   module_resolver.rs,
+                   module_cache.rs
+  ─────────────────────────────────────────────────────────────────
+  Builder          builder.rs                   → produces FileAnalysis
+  ─────────────────────────────────────────────────────────────────
+  Data model       file_analysis.rs             → FileAnalysis, Symbol, Ref, types
+```
+
+**Rules:**
+
+1. **All tree-sitter CST traversal happens inside `build()`.** No other file should walk tree-sitter nodes, call `child_by_field_name`, iterate children, or use `TreeCursor`. The `build()` function in `builder.rs` is the single entry point that takes a `Tree` and returns a `FileAnalysis` — everything that needs the CST lives inside that call. **To add new CST-derived data:** add extraction to the relevant `visit_*` method in `builder.rs` and store the result in `FileAnalysis` (as a field on `Symbol`, a new map, etc.). The builder already visits every sub, package, class, and variable node — use that pass, don't create a second one. If the builder grows too monolithic, we can introduce builder plugins (separate functions called from `build()` that take `&mut FileAnalysis` + `&Tree` + `&[u8]`) to decouple concerns while preserving the single-entry-point invariant.
+
+2. **`file_analysis.rs` is the single source of truth.** All analysis results — symbols, refs, scopes, types, documentation, parameters — live in `FileAnalysis`. Query methods belong here. No `tree_sitter` imports allowed in this file.
+
+3. **`symbols.rs` is a thin adapter.** It converts `FileAnalysis` types to LSP protocol types. It does NOT perform analysis, walk trees, or make decisions about Perl semantics. If you find yourself writing an `if` about Perl language behavior in `symbols.rs`, it belongs in `builder.rs` or `file_analysis.rs`.
+
+4. **`module_resolver.rs` calls the builder, then queries `FileAnalysis`.** It should never walk the tree directly. The resolver's job is: find `.pm` file → call `builder::build()` → extract what it needs from the resulting `FileAnalysis` via query methods → serialize to `ExportedSub`/JSON.
+
+5. **DRY: shared extraction logic goes on `FileAnalysis`.** If two code paths (e.g., subprocess JSON serialization and direct parsing) need the same data from a `FileAnalysis`, add a method to `FileAnalysis` that both call. Never duplicate the extraction loop.
+
+6. **`cursor_context.rs` is the exception:** it receives a tree + source for cursor-position analysis (completion context, signature help context). This is acceptable because cursor context is inherently position-dependent and runs on the already-parsed tree. It should NOT modify `FileAnalysis`.
+
+### File map
+
 - `src/main.rs` — Entry point, stdio transport, `--parse-exports` subprocess mode
 - `src/backend.rs` — `LanguageServer` trait implementation (tower-lsp), request routing
 - `src/document.rs` — Document store with tree-sitter parsing
 - `src/file_analysis.rs` — Data model: scopes, symbols, refs, imports, type inference, priority constants
-- `src/builder.rs` — Single-pass CST → FileAnalysis builder
+- `src/builder.rs` — Single-pass CST → FileAnalysis builder (the ONLY tree-sitter consumer)
+- `src/pod.rs` — POD→markdown converter (pure string processing, no tree-sitter)
 - `src/cursor_context.rs` — Cursor position analysis: completion/signature/selection context
 - `src/symbols.rs` — LSP adapter layer (converts FileAnalysis types to LSP types)
 - `src/module_index.rs` — Cross-file: public API, reverse index (`func → modules`), concurrent cache
@@ -36,6 +69,7 @@ cd ../tree-sitter-perl && tree-sitter generate
 - `tree-sitter-perl` — Path dep to `../tree-sitter-perl`, exports `LANGUAGE: LanguageFn`
 - `dashmap 6` — Concurrent document store + module cache
 - `rusqlite 0.32` — SQLite persistence for module index (bundled)
+- `regex 1` — POD→markdown inline formatting conversion
 
 ## tree-sitter-perl Node Types
 
@@ -54,8 +88,11 @@ Key nodes and their fields:
 ## Testing
 
 ```
-cargo test           # run all tests
+cargo test                    # unit tests
+cargo build --release && ./run_e2e.sh   # e2e tests (requires nvim + release build)
 ```
+
+E2e tests use Neovim headless mode. They exercise the full LSP protocol over stdio.
 
 ## Cross-file Module Resolution
 
@@ -63,10 +100,10 @@ cargo test           # run all tests
 - `Arc<DashMap>` shared between resolver thread and async LSP handlers
 - Reverse index: `DashMap<func_name, Vec<module_name>>` for O(1) exporter lookup
 - Export extraction uses tree-sitter in isolated subprocesses (5s timeout + SIGKILL)
-- Subprocess runs the full builder on each module to extract return types + hash key names per exported function
-- `ModuleExports` stores `return_types: HashMap<String, InferredType>` and `hash_keys: HashMap<String, Vec<String>>`
+- Subprocess runs the full builder on each module, then queries `FileAnalysis` for per-export metadata
+- `ModuleExports` stores `subs: HashMap<String, ExportedSub>` — unified per-export metadata (def_line, params, is_method, return_type, hash_keys, doc)
 - cpanfile parsed with tree-sitter queries at startup, deps pre-resolved with progress reporting
-- SQLite cache per project (`~/.cache/perl-lsp/<hash>/modules.db`), schema v4 with `return_types`/`hash_keys` columns
+- SQLite cache per project (`~/.cache/perl-lsp/<hash>/modules.db`), schema v6 with `subs` JSON column
 - Async handlers only use `_cached` methods — zero I/O
 - After resolution, diagnostics are refreshed for all open files (clears stale false positives)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "dashmap 6.1.0",
  "env_logger",
  "log",
+ "regex",
  "rusqlite",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 log = "0.4"
 env_logger = "0.11"
+regex = "1"

--- a/docs/future-pod-ast-parser.md
+++ b/docs/future-pod-ast-parser.md
@@ -1,0 +1,134 @@
+# Future: tree-sitter-pod Based POD Parsing
+
+**Status:** Deferred — blocked on tree-sitter-pod release
+**Motivation:** PerlNavigator PR #142 (Aequitosh) rewrites their POD parser as a three-phase pipeline (raw parse → structured AST → markdown). Our current `pod.rs` is a single-pass line-by-line converter that handles ~80% of POD but breaks on structural nesting.
+
+## Why tree-sitter-pod
+
+We already have `tree-sitter-pod` as a sibling repo (`../tree-sitter-pod`). Once released, it gives us a proper AST for free — no need to hand-write a parser. The converter becomes a tree walk over typed nodes rather than regex/line matching.
+
+tree-sitter-perl already parses POD as opaque `pod` blobs. We'd sub-parse those blobs with tree-sitter-pod to get structured nodes.
+
+## Edge cases our current `pod.rs` doesn't handle
+
+Discovered via PerlNavigator PR #142 and real-world testing:
+
+### Nested lists
+```pod
+=over
+
+=item * Outer item
+
+=over
+
+=item * Inner item
+
+=back
+
+=back
+```
+Our `in_list` is a boolean, not a depth counter. Nested `=over`/`=back` produces broken output.
+
+### Data regions
+```pod
+=begin html
+
+<table><tr><td>HTML content</td></tr></table>
+
+=end html
+```
+We skip `=begin`/`=end` entirely. Should render as fenced code blocks with format name.
+
+### =item-based method documentation
+```pod
+=over
+
+=item $obj->method_name()
+
+Does something useful.
+
+=item $obj->other_method()
+
+Does something else.
+
+=back
+```
+Extremely common in OOP modules (`WWW::Mechanize`, `DBI`, `LWP::UserAgent`). Our `extract_head2_section` only matches `=head2`, completely missing `=item`-documented methods.
+
+### Bold-italic nesting
+```pod
+B<I<important note>>
+```
+Should render as `***important note***`. Our converter handles them independently, producing `**<em>important note</em>**` or similar broken output.
+
+### Multi-angle-bracket variants
+```pod
+C<<<  $hash->{key}  >>>
+```
+We handle `C<< ... >>` (double) but not triple or higher. The POD spec allows any number of angle brackets.
+
+### =item text on next line
+```pod
+=item *
+First item text here
+
+=item *
+Second item text here
+```
+PerlNavigator needed backtracking in the parser for this. Our converter handles `=item * text` on the same line but may mishandle text on the next line.
+
+### EOF without =cut
+```pod
+=head1 NAME
+
+Module - description
+```
+Valid POD (spec allows omitting `=cut` at EOF). We handle this but it's worth noting.
+
+### =for shorthand
+```pod
+=for html <img src="logo.png">
+```
+Single-paragraph data command. We skip it. Should render appropriately based on format name.
+
+### Header hierarchy in symbol lookup
+```pod
+=head2 connect
+
+Connects to the server.
+
+=head3 Options
+
+=over
+
+=item timeout
+
+=item retries
+
+=back
+
+=head3 Examples
+
+    $obj->connect(timeout => 30);
+
+=head2 disconnect
+```
+Looking up `connect` should include everything from `=head2 connect` through the `=head3` subsections until `=head2 disconnect`. Our current extraction stops correctly at the next `=head2`, but a tree-sitter-pod AST would make the hierarchy explicit.
+
+## Architecture when we pivot
+
+```
+tree-sitter-perl tree    →  pod node (opaque blob)
+                               ↓
+                          tree-sitter-pod   →  POD AST (headings, items, verbatim, data blocks)
+                               ↓
+                          pod_to_markdown() →  walks AST nodes, renders markdown
+```
+
+The builder would sub-parse `pod` nodes during the walk (or as a post-pass), producing structured doc attached to `SymbolDetail::Sub`. The markdown converter becomes a tree walk instead of line-by-line regex.
+
+## Reference
+
+- PerlNavigator PR #142: https://github.com/bscan/PerlNavigator/pull/142
+- tree-sitter-pod repo: `../tree-sitter-pod`
+- POD spec: https://perldoc.perl.org/perlpodspec

--- a/docs/prompt-cross-file-gaps.md
+++ b/docs/prompt-cross-file-gaps.md
@@ -1,0 +1,364 @@
+# Task: Cross-file Intelligence Gaps
+
+**Branch:** `cross-file-gaps-v2` (already created from `main`)
+**Baseline:** 200 unit tests, 53 e2e tests, 0 warnings
+
+## Goal
+
+Three improvements to cross-file intelligence, motivated by testing against real codebases (Rex: 343 modules, Mojo: 112 modules):
+
+1. **`__PACKAGE__` resolution** — `__PACKAGE__->new(...)` should resolve to the enclosing package, not literal `"__PACKAGE__"`
+2. **Implicit parameter extraction** — `shift` and `$_[N]` patterns alongside the existing `my (...) = @_`
+3. **POD documentation on hover** — show the POD section for imported functions
+
+## Gap 1: `__PACKAGE__` resolution
+
+### Problem
+
+`Mojo::File` has:
+```perl
+package Mojo::File;
+sub path { __PACKAGE__->new(@_) }
+```
+
+The builder infers `path()` returns `Object:__PACKAGE__` instead of `Object:Mojo::File`. This affects 7 exported functions in Mojo alone (`b()`, `c()`, `path()`, `curfile()`, `tempdir()`, `tempfile()`, `scope_guard()`).
+
+### Fix
+
+Wherever `__PACKAGE__` appears as a class name (method call invocant, `bless` second arg), resolve it to the current `package` from the scope chain.
+
+The builder already tracks the current package — every scope has an optional `package: Option<String>` field, and `ScopeKind::Package` records the package name. The scope chain lookup is already implemented for other purposes.
+
+**Specific locations to fix:**
+
+1. **Method call expression handling** — when the invocant is `__PACKAGE__`, resolve it to the enclosing package name before creating the `ClassName(...)` type.
+
+2. **`bless` handling** — when the second argument to `bless` is `__PACKAGE__`, resolve it.
+
+3. **Return type inference** — when `sub_return_type()` encounters a return of `__PACKAGE__->new(...)`, the type should already be correct if (1) is fixed.
+
+**How to find the current package:**
+
+```rust
+fn current_package(&self) -> Option<&str> {
+    // Walk scope chain from current scope to root
+    let mut scope_id = self.current_scope;
+    loop {
+        let scope = &self.scopes[scope_id.0 as usize];
+        if let Some(ref pkg) = scope.package {
+            return Some(pkg.as_str());
+        }
+        match scope.parent {
+            Some(parent) => scope_id = parent,
+            None => return None,
+        }
+    }
+}
+```
+
+This method likely already exists or is trivially constructable from existing scope-chain walking code. When the builder sees `__PACKAGE__` as a bareword in invocant position, substitute the result of `current_package()`.
+
+### Test
+
+```rust
+#[test]
+fn test_dunder_package_resolution() {
+    let fa = build_fa("
+        package Mojo::File;
+        sub path { __PACKAGE__->new(@_) }
+    ");
+    let rt = fa.sub_return_type("path");
+    assert_eq!(rt, Some(&InferredType::ClassName("Mojo::File".into())));
+}
+```
+
+## Gap 2: Implicit parameter extraction
+
+### Problem
+
+The builder currently extracts parameters only from:
+- Signature syntax: `sub foo($x, $y) { }`
+- List assignment: `my ($self, $file, @opts) = @_;`
+
+But many Perl subs use `shift` or `$_[N]`:
+
+```perl
+# shift pattern — 209 files in Rex use this
+sub do_something {
+    my $self = shift;
+    my $file = shift;
+    my $opts = shift || {};
+    ...
+}
+
+# $_[N] pattern — 25 files in Rex, 65 in Mojo
+sub handler {
+    my $self = $_[0];
+    ...
+}
+```
+
+**Coverage impact:** In Rex, 127/272 exported subs (47%) have no extracted params. Many of these use `shift`.
+
+### Approach
+
+When processing statements inside a sub body, detect `shift`-based parameter extraction.
+
+#### Pattern 1: `my $var = shift;`
+
+At the start of a sub body, consecutive `my $var = shift;` statements are parameter declarations. Stop collecting when a non-shift statement is encountered.
+
+**Tree-sitter structure:**
+```
+(variable_declaration
+  variable: (scalar)
+  (assignment_expression
+    right: (ambiguous_function_call_expression  ; or function_call_expression
+      function: (bareword) @fn (#eq? @fn "shift"))))
+```
+
+Also handle: `my $var = shift || $default;` and `my $var = shift // $default;` — these are params with defaults. The default is the RHS of `||` or `//`.
+
+**Implementation:** After the existing `my (...) = @_` check, add a second pass that scans top-level statements for consecutive `shift` assignments. Collect them as `ParamInfo { name, is_slurpy: false }`. Stop at the first non-shift statement.
+
+**Important:** Only extract `shift` params if no `my (...) = @_` pattern was found — the two patterns are mutually exclusive. If a sub has `my ($self) = @_; my $file = shift;`, the `@_` pattern already captured `$self` and the `shift` is something else.
+
+Actually, a common pattern IS:
+```perl
+my $self = shift;
+my ($file, @opts) = @_;
+```
+
+Handle this: if the first statement(s) are `shift` and then there's a `my (...) = @_`, combine them. The shifts become the first N params, the `@_` unpacking becomes the rest.
+
+#### Pattern 2: `$_[N]` access (lower priority)
+
+Less common and harder to extract cleanly — `$_[0]` might be `$self`, `$_[1]` might be the first real param, but the names are unknown. Consider this out of scope for now unless there's a `my $var = $_[N]` pattern.
+
+If there is `my $self = $_[0];` at the top of a sub, extract it as a param. But don't try to infer param names from bare `$_[N]` usage.
+
+### Data model
+
+No changes to `ParamInfo` — it already has `name`, `default`, `is_slurpy`. The `shift` params populate the same struct.
+
+For `my $file = shift || "/tmp/default"`, set `default: Some("/tmp/default".into())`.
+
+### Test
+
+```rust
+#[test]
+fn test_shift_params() {
+    let fa = build_fa("
+        sub process {
+            my $self = shift;
+            my $file = shift;
+            my $opts = shift || {};
+        }
+    ");
+    let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+    assert_eq!(sig.params.len(), 3);
+    assert_eq!(sig.params[0].name, "$self");
+    assert_eq!(sig.params[1].name, "$file");
+    assert_eq!(sig.params[2].name, "$opts");
+    assert_eq!(sig.params[2].default, Some("{}".into()));
+}
+
+#[test]
+fn test_shift_then_list_assign() {
+    let fa = build_fa("
+        sub process {
+            my $self = shift;
+            my ($file, @opts) = @_;
+        }
+    ");
+    let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+    assert_eq!(sig.params.len(), 3);
+    assert_eq!(sig.params[0].name, "$self");
+    assert_eq!(sig.params[1].name, "$file");
+    assert_eq!(sig.params[2].name, "@opts");
+    assert!(sig.params[2].is_slurpy);
+}
+```
+
+## Gap 3: POD documentation on hover
+
+### Problem
+
+When hovering over an imported function, we show `sub foo($x, $y) → HashRef` and "imported from Module". But Perl modules have rich POD documentation right above each sub:
+
+```perl
+=head2 file($file, %options)
+
+Manage a file on the remote system. Options:
+
+  ensure  => present/absent
+  content => string
+  source  => local file
+
+=cut
+
+sub file {
+    my ($file, @options) = @_;
+```
+
+This documentation should appear in hover.
+
+### Architecture
+
+**No tree-sitter-pod dependency.** tree-sitter-perl already parses POD as opaque `pod` nodes and comments as `comment` nodes. We use the existing tree to locate documentation, then convert raw POD to markdown with a regex-based state machine (ported from [PerlNavigator's pod.ts](../PerlNavigator/server/src/pod.ts)).
+
+**Two POD placement styles exist in the wild:**
+
+| Style | Example | Prevalence |
+|---|---|---|
+| **Interleaved** — POD block immediately before each `sub` | Rex (54/56 modules) | Authoring tools, older CPAN |
+| **Tail POD** — all code first, then `1;`/`__END__`, then all POD with `=head2 func_name` sections | Mojo (108/110 modules), Carp, List::Util | Mojo convention, core Perl |
+
+Both must be supported. The extraction strategy has two passes:
+
+1. **`prev_sibling` walk** — find `pod` or `comment` nodes immediately preceding the sub's tree node (handles interleaved style)
+2. **`=head2` name scan** — if pass 1 finds nothing, scan ALL `pod` nodes in the file for a `=head2` header matching the function name, then extract that section (handles tail POD style)
+
+**Conversion:** Regex-based line-by-line POD→markdown converter in a new `src/pod.rs` module.
+
+**Storage:** Add `doc: Option<String>` to `ExportedSub`. Store as pre-rendered markdown (conversion is cheap, avoids needing raw POD at query time).
+
+**Display:** In hover, append the doc string below the signature.
+
+### POD extraction per sub
+
+For each sub, find documentation using the two-pass strategy:
+
+**Pass 1: Preceding documentation (interleaved style).**
+
+Walk backwards through preceding siblings of the sub node. Collect POD and/or comment blocks. POD takes priority. Stop when you hit code (not POD/comment).
+
+**Pass 2: Name-matched POD section (tail POD style).**
+
+If pass 1 finds no POD, scan all `pod` nodes in the file for a `=head2` header matching the function name. Extract that section (from `=head2 func_name` until the next `=head` at the same or higher level, or `=cut`). The `=head2` line may include a signature: `=head2 path($file)` — match by bare name before parens.
+
+**Choosing what to show (priority order):**
+1. Preceding POD block (interleaved) → convert to markdown
+2. Preceding comments → show as-is (stripped of `#`)
+3. Name-matched `=head2` section from any POD block in the file (tail style) → convert to markdown
+
+### POD → Markdown converter (`src/pod.rs`)
+
+New module: `src/pod.rs` — a regex-based line-by-line state machine, ported from PerlNavigator's `pod.ts` (566 lines). The Rust port will be more concise.
+
+**Reference:** `../PerlNavigator/server/src/pod.ts`
+
+**Public API:**
+
+```rust
+/// Convert raw POD text to markdown.
+pub fn pod_to_markdown(pod_text: &str) -> String
+```
+
+**Conversions (priority order — implement these first, iterate on the rest):**
+
+| POD construct | Markdown output | Priority |
+|---|---|---|
+| `=head1 Title` | `### Title` | P0 |
+| `=head2 Title` | `#### Title` | P0 |
+| `=head3 Title` / `=head4 Title` | `##### Title` | P1 |
+| `C<code>` | `` `code` `` | P0 |
+| `B<bold>` | `**bold**` | P0 |
+| `I<italic>` | `*italic*` | P0 |
+| `L<Foo::Bar>` | `Foo::Bar` | P1 |
+| `L<text\|url>` | `text` | P1 |
+| `F<file>` | `` `file` `` | P1 |
+| `E<lt>` / `E<gt>` | `<` / `>` | P1 |
+| `=over` / `=item *` / `=back` | Bullet list | P1 |
+| `=item Label` | `- **Label**` | P1 |
+| Verbatim (4+ spaces or tab) | Fenced code block | P1 |
+| `=cut` | Stop processing | P0 |
+| `=pod` | Start processing | P0 |
+| `=begin`/`=end`/`=for`/`=encoding` | Skip or passthrough | P2 |
+
+**Inline formatting:** Process interior sequences handling nesting. `C<< code >>` (double angle brackets) is also valid POD.
+
+**Start with P0, ship, iterate on P1/P2.** Even just headings + `C<>` + `B<>` + `I<>` covers 80% of POD in the wild.
+
+**Truncation:** Cap the rendered markdown at ~2000 chars. Most per-function POD is well under this.
+
+### Store in ExportedSub
+
+Add field to `ExportedSub` in `module_index.rs`:
+
+```rust
+pub struct ExportedSub {
+    pub def_line: u32,
+    pub params: Vec<ExportedParam>,
+    pub is_method: bool,
+    pub return_type: Option<InferredType>,
+    pub hash_keys: Vec<String>,
+    pub doc: Option<String>,  // NEW: pre-rendered markdown from POD or comments
+}
+```
+
+**JSON serialization:** Add `"doc": "markdown string"` to the subprocess JSON output. Only include when present.
+
+**SQLite:** The `subs TEXT` column already stores JSON per-sub. The `doc` field is just another key in the JSON object. No schema change needed — the JSON is self-describing. Bump `SCHEMA_VERSION` to force cache invalidation so stale entries without `doc` are re-resolved.
+
+### Display in hover
+
+After the signature line, append the doc, then the module attribution:
+
+```rust
+if let Some(ref doc) = sub_info.doc {
+    parts.push(doc.clone());
+}
+parts.push(format!("*imported from `{}`*", import.module_name));
+```
+
+The hover output becomes:
+```
+sub file($file, @options) → HashRef
+
+Manage a file on the remote system. Options:
+- `ensure` — present/absent
+- `content` — string
+- `source` — local file
+
+*imported from `Rex::Commands::File`*
+```
+
+## What NOT to do
+
+- Don't add a `tree-sitter-pod` dependency — use the existing Perl tree + regex conversion
+- Don't try to extract params from bare `$_[N]` usage (no variable name to show) — only `my $var = $_[N]`
+- Don't parse POD at query time — extract and cache during module analysis
+- Don't try to perfectly render all POD on v1 — start with P0 conversions (headings, `C<>`, `B<>`, `I<>`, `=cut`), iterate on P1/P2
+- Don't change the enrichment interface — `doc` is only used in hover, not type inference
+- Don't extract POD for local subs — this is cross-file only (local subs already show the declaration line)
+
+## Test plan
+
+### Unit tests
+
+1. **`__PACKAGE__` resolution**: `build_fa("package Foo; sub new { __PACKAGE__->new }") → ClassName("Foo")`
+2. **`shift` params**: sub with consecutive shifts → correct param list
+3. **`shift` + `@_` combo**: `my $self = shift; my ($x, @y) = @_` → combined param list
+4. **`shift` with default**: `my $x = shift || "default"` → param with default
+5. **POD extraction**: sub with preceding POD → raw text extracted and converted
+6. **Tail POD extraction**: sub with POD in `=head2` section after `1;` → extracted by name match
+7. **Comment extraction**: sub with preceding `comment` nodes → stripped text
+8. **POD→markdown conversion** (`pod.rs`): raw POD string → correct markdown (headings, `C<>`, `B<>`, `I<>`, verbatim, lists)
+9. **ExportedSub with doc**: roundtrip through JSON and SQLite
+
+### E2E tests
+
+1. **Hover on imported function shows POD** (requires a test module with POD)
+2. **Go-to-def lands on correct line for `shift`-param subs**
+3. **Signature help shows `shift` params**
+
+## Verification
+
+1. `cargo test` — all 200 existing tests pass + new tests
+2. `cargo build` — no warnings
+3. All 53 existing e2e tests pass
+4. Manual: `./target/release/perl-lsp --parse-exports /tmp/Rex/lib/Rex/Commands.pm` — check `shift` params extracted
+5. Manual: `./target/release/perl-lsp --parse-exports /tmp/mojo/lib/Mojo/File.pm` — check `path()` returns `Object:Mojo::File` (not `__PACKAGE__`)
+6. Manual: `./target/release/perl-lsp --parse-exports /tmp/Rex/lib/Rex/Commands/File.pm` — check `file()` has `doc` field with POD markdown
+7. Manual: `./target/release/perl-lsp --parse-exports /tmp/mojo/lib/Mojo/File.pm` — check `path()` has `doc` field (tail POD)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,6 +20,7 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
         return_infos: Vec::new(),
         last_expr_type: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
+        pod_texts: Vec::new(),
         scope_stack: Vec::new(),
         current_package: None,
         next_scope_id: 0,
@@ -40,6 +41,9 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
 
     // Post-pass 3: infer return types for subs/methods
     b.resolve_return_types();
+
+    // Post-pass 4: fill in tail POD docs for subs that didn't get preceding doc
+    b.resolve_tail_pod_docs();
 
     FileAnalysis::new(
         b.scopes,
@@ -75,6 +79,8 @@ struct Builder<'a> {
     last_expr_type: std::collections::HashMap<ScopeId, Option<InferredType>>,
     /// Assignments where RHS is a function call — resolved in return-type post-pass.
     call_bindings: Vec<CallBinding>,
+    /// Raw POD text blocks collected during the walk (for tail-POD post-pass).
+    pod_texts: Vec<String>,
 
     // Walk state
     scope_stack: Vec<ScopeId>,
@@ -265,6 +271,13 @@ impl<'a> Builder<'a> {
             // Hash construction
             "anonymous_hash_expression" => self.visit_anon_hash(node),
 
+            // POD blocks: collect text for tail-POD post-pass
+            "pod" => {
+                if let Ok(text) = node.utf8_text(self.source) {
+                    self.pod_texts.push(text.to_string());
+                }
+            }
+
             // ERROR nodes: recurse into children to extract what we can
             "ERROR" => self.visit_children(node),
 
@@ -448,12 +461,15 @@ impl<'a> Builder<'a> {
         // Extract params
         let params = self.extract_params(node);
 
+        // Extract preceding POD/comment documentation
+        let doc = self.extract_preceding_doc(node);
+
         self.add_symbol(
             name.clone(),
             if is_method { SymKind::Method } else { SymKind::Sub },
             node_to_span(node),
             node_to_span(name_node),
-            SymbolDetail::Sub { params: params.clone(), is_method, return_type: None },
+            SymbolDetail::Sub { params: params.clone(), is_method, return_type: None, doc },
         );
 
         // Push sub scope
@@ -505,37 +521,146 @@ impl<'a> Builder<'a> {
             }
         }
 
-        // Fallback: `my (...) = @_` in body
+        // Fallback: scan body for shift, @_, and $_[N] patterns
         if let Some(body) = sub_node.child_by_field_name("body") {
+            let mut shift_params: Vec<ParamInfo> = Vec::new();
+
             for i in 0..body.named_child_count() {
-                if let Some(stmt) = body.named_child(i) {
-                    let assign = if stmt.kind() == "expression_statement" {
-                        stmt.named_child(0).filter(|n| n.kind() == "assignment_expression")
-                    } else if stmt.kind() == "assignment_expression" {
-                        Some(stmt)
-                    } else {
-                        None
-                    };
-                    if let Some(assign) = assign {
-                        if let Some(right) = assign.child_by_field_name("right") {
-                            if right.utf8_text(self.source).ok() == Some("@_") {
-                                if let Some(left) = assign.child_by_field_name("left") {
-                                    return self.collect_vars_from_decl(left)
-                                        .into_iter()
-                                        .map(|(name, _)| {
-                                            let is_slurpy = name.starts_with('@') || name.starts_with('%');
-                                            ParamInfo { name, default: None, is_slurpy }
-                                        })
-                                        .collect();
-                                }
+                let stmt = match body.named_child(i) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                let assign = if stmt.kind() == "expression_statement" {
+                    stmt.named_child(0).filter(|n| n.kind() == "assignment_expression")
+                } else if stmt.kind() == "assignment_expression" {
+                    Some(stmt)
+                } else {
+                    None
+                };
+                let assign = match assign {
+                    Some(a) => a,
+                    None => break, // stop at first non-assignment statement
+                };
+
+                if let Some(right) = assign.child_by_field_name("right") {
+                    // Pattern: my (...) = @_
+                    if right.utf8_text(self.source).ok() == Some("@_") {
+                        if let Some(left) = assign.child_by_field_name("left") {
+                            let at_params: Vec<ParamInfo> = self.collect_vars_from_decl(left)
+                                .into_iter()
+                                .map(|(name, _)| {
+                                    let is_slurpy = name.starts_with('@') || name.starts_with('%');
+                                    ParamInfo { name, default: None, is_slurpy }
+                                })
+                                .collect();
+                            // Combine any preceding shift params with @_ params
+                            if !shift_params.is_empty() {
+                                shift_params.extend(at_params);
+                                return shift_params;
                             }
+                            return at_params;
                         }
                     }
+
+                    // Pattern: my $var = shift; or my $var = shift || default; or my $var = shift // default;
+                    if let Some((var_name, default)) = self.extract_shift_param(assign, right) {
+                        shift_params.push(ParamInfo {
+                            name: var_name,
+                            default,
+                            is_slurpy: false,
+                        });
+                        continue;
+                    }
+
+                    // Pattern: my $var = $_[N];
+                    if let Some(var_name) = self.extract_subscript_param(assign, right) {
+                        shift_params.push(ParamInfo {
+                            name: var_name,
+                            default: None,
+                            is_slurpy: false,
+                        });
+                        continue;
+                    }
                 }
+
+                // Not a recognized param pattern — stop collecting
+                break;
+            }
+
+            if !shift_params.is_empty() {
+                return shift_params;
             }
         }
 
         Vec::new()
+    }
+
+    /// Extract a shift-based parameter: `my $var = shift` or `my $var = shift || default`.
+    fn extract_shift_param(&self, assign: Node<'a>, right: Node<'a>) -> Option<(String, Option<String>)> {
+        let (shift_node, default) = if self.is_shift_call(right) {
+            (right, None)
+        } else if right.kind() == "binary_expression" {
+            // my $var = shift || default  or  my $var = shift // default
+            let op = self.get_operator_text(right);
+            if matches!(op.as_deref(), Some("||" | "//")) {
+                let lhs = right.named_child(0)?;
+                if self.is_shift_call(lhs) {
+                    let default_node = right.named_child(1)?;
+                    let default_text = default_node.utf8_text(self.source).ok()?.to_string();
+                    (lhs, Some(default_text))
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        };
+        let _ = shift_node;
+
+        // Get variable name from LHS
+        let left = assign.child_by_field_name("left")?;
+        let var_name = self.get_var_text_from_lhs(left)?;
+        Some((var_name, default))
+    }
+
+    /// Extract a $_[N]-based parameter: `my $var = $_[N]`.
+    fn extract_subscript_param(&self, assign: Node<'a>, right: Node<'a>) -> Option<String> {
+        if right.kind() != "array_element_expression" {
+            return None;
+        }
+        // Check that it's $_ (container_variable for @_) being subscripted
+        let container = right.named_child(0)?;
+        if container.kind() != "container_variable" {
+            return None;
+        }
+        // container_variable text is "$_" for @_ subscript
+        let ct = container.utf8_text(self.source).ok()?;
+        if ct != "$_" {
+            return None;
+        }
+        let left = assign.child_by_field_name("left")?;
+        self.get_var_text_from_lhs(left)
+    }
+
+    /// Check if a node is a `shift` call (bare or with parens).
+    fn is_shift_call(&self, node: Node<'a>) -> bool {
+        match node.kind() {
+            "bareword" => node.utf8_text(self.source).ok() == Some("shift"),
+            "func1op_call_expression" => {
+                // shift without explicit args: func1op_call_expression with child "shift"
+                node.child(0)
+                    .and_then(|c| c.utf8_text(self.source).ok())
+                    == Some("shift")
+            }
+            "ambiguous_function_call_expression" | "function_call_expression" => {
+                node.child_by_field_name("function")
+                    .and_then(|f| f.utf8_text(self.source).ok())
+                    == Some("shift")
+            }
+            _ => false,
+        }
     }
 
     fn extract_signature_params(&self, sig: Node<'a>) -> Vec<ParamInfo> {
@@ -687,7 +812,7 @@ impl<'a> Builder<'a> {
                         SymKind::Method,
                         node_to_span(node),
                         *var_span,
-                        SymbolDetail::Sub { params: vec![], is_method: true, return_type: None },
+                        SymbolDetail::Sub { params: vec![], is_method: true, return_type: None, doc: None },
                     );
                 }
                 if has_writer {
@@ -705,6 +830,7 @@ impl<'a> Builder<'a> {
                             }],
                             is_method: true,
                             return_type: None,
+                            doc: None,
                         },
                     );
                 }
@@ -1262,7 +1388,14 @@ impl<'a> Builder<'a> {
         let invocant_node = node.child_by_field_name("invocant");
         let invocant = invocant_node
             .and_then(|n| n.utf8_text(self.source).ok())
-            .map(|s| s.to_string());
+            .map(|s| {
+                // Resolve __PACKAGE__ to enclosing package name
+                if s == "__PACKAGE__" {
+                    self.current_package.clone().unwrap_or_else(|| s.to_string())
+                } else {
+                    s.to_string()
+                }
+            });
         // Store invocant span for complex expressions (call chains etc.)
         let invocant_span = invocant_node
             .filter(|n| !matches!(n.kind(), "scalar" | "array" | "hash" | "bareword" | "package"))
@@ -1459,6 +1592,10 @@ impl<'a> Builder<'a> {
                 let inv_text = invocant.utf8_text(self.source).ok()?;
                 // Invocant must be a package name (not a variable)
                 if !inv_text.starts_with('$') && !inv_text.starts_with('@') && !inv_text.starts_with('%') {
+                    // Resolve __PACKAGE__ to enclosing package name
+                    if inv_text == "__PACKAGE__" {
+                        return self.current_package.clone();
+                    }
                     return Some(inv_text.to_string());
                 }
             }
@@ -1613,6 +1750,71 @@ impl<'a> Builder<'a> {
     }
 
     /// Get the name of the enclosing sub/method, if any.
+    /// Extract POD or comment documentation immediately preceding a sub node.
+    /// Walks prev_sibling chain (tree-sitter CST traversal stays in builder).
+    fn extract_preceding_doc(&self, sub_node: Node<'a>) -> Option<String> {
+        let source_str = std::str::from_utf8(self.source).ok()?;
+        let mut prev = sub_node.prev_sibling();
+        let mut comment_lines: Vec<String> = Vec::new();
+
+        while let Some(node) = prev {
+            match node.kind() {
+                "pod" => {
+                    let text = &source_str[node.byte_range()];
+                    let md = crate::pod::pod_to_markdown(text);
+                    if !md.is_empty() {
+                        return Some(md);
+                    }
+                    break;
+                }
+                "comment" => {
+                    let text = source_str[node.byte_range()].trim();
+                    let stripped = text.strip_prefix('#').unwrap_or(text).trim();
+                    if !stripped.is_empty() {
+                        comment_lines.push(stripped.to_string());
+                    }
+                }
+                _ => break, // hit code, stop
+            }
+            prev = node.prev_sibling();
+        }
+
+        if !comment_lines.is_empty() {
+            comment_lines.reverse(); // collected bottom-up
+            return Some(comment_lines.join("\n"));
+        }
+
+        None
+    }
+
+    /// Post-pass: for subs with no preceding doc, scan collected pod_texts
+    /// for a =head2 section matching the sub name (tail POD style).
+    fn resolve_tail_pod_docs(&mut self) {
+        if self.pod_texts.is_empty() {
+            return;
+        }
+        for sym in &mut self.symbols {
+            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                continue;
+            }
+            if let SymbolDetail::Sub { ref mut doc, .. } = sym.detail {
+                if doc.is_some() {
+                    continue; // already has preceding doc
+                }
+                // Search pod texts for =head2 matching this sub name
+                for pod_text in &self.pod_texts {
+                    if let Some(section) = crate::pod::extract_head2_section(&sym.name, pod_text) {
+                        let md = crate::pod::pod_to_markdown(&section);
+                        if !md.is_empty() {
+                            *doc = Some(md);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn enclosing_sub_name(&self) -> Option<String> {
         let scope_id = self.enclosing_sub_scope()?;
         match &self.scopes[scope_id.0 as usize].kind {
@@ -3250,4 +3452,146 @@ my $p = Point->new(x => 3, y => 4);
         assert_eq!(def.unwrap().start.row, 2,
             "x should resolve to field $x on line 2, not the class");
     }
+
+    // ---- Gap 1: __PACKAGE__ resolution ----
+
+    #[test]
+    fn test_dunder_package_resolution() {
+        let fa = build_fa("
+        package Mojo::File;
+        sub path { __PACKAGE__->new(@_) }
+        ");
+        let rt = fa.sub_return_type("path");
+        assert_eq!(rt, Some(&InferredType::ClassName("Mojo::File".into())));
+    }
+
+    #[test]
+    fn test_dunder_package_method_invocant() {
+        // __PACKAGE__->new() should store the resolved class in MethodCall invocant
+        let fa = build_fa("
+        package Foo;
+        __PACKAGE__->some_method();
+        ");
+        let method_ref = fa.refs.iter().find(|r| r.target_name == "some_method").unwrap();
+        match &method_ref.kind {
+            RefKind::MethodCall { invocant, .. } => {
+                assert_eq!(invocant, "Foo", "invocant should be resolved from __PACKAGE__");
+            }
+            _ => panic!("expected MethodCall ref"),
+        }
+    }
+
+    // ---- Gap 2: Shift parameter extraction ----
+
+    #[test]
+    fn test_shift_params() {
+        let fa = build_fa("
+        sub process {
+            my $self = shift;
+            my $file = shift;
+            my $opts = shift || {};
+        }
+        ");
+        // signature_for_call strips $self when first param is $self
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        assert!(sig.is_method, "should detect method from $self first param");
+        assert_eq!(sig.params.len(), 2);
+        assert_eq!(sig.params[0].name, "$file");
+        assert_eq!(sig.params[1].name, "$opts");
+        assert_eq!(sig.params[1].default, Some("{}".into()));
+
+        // Check raw params via symbol detail
+        let sub_sym = fa.symbols.iter().find(|s| s.name == "process").unwrap();
+        if let SymbolDetail::Sub { ref params, .. } = sub_sym.detail {
+            assert_eq!(params.len(), 3);
+            assert_eq!(params[0].name, "$self");
+            assert_eq!(params[1].name, "$file");
+            assert_eq!(params[2].name, "$opts");
+            assert_eq!(params[2].default, Some("{}".into()));
+        } else {
+            panic!("expected Sub detail");
+        }
+    }
+
+    #[test]
+    fn test_shift_then_list_assign() {
+        let fa = build_fa("
+        sub process {
+            my $self = shift;
+            my ($file, @opts) = @_;
+        }
+        ");
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        assert!(sig.is_method);
+        assert_eq!(sig.params.len(), 2, "should have $file and @opts (stripped $self)");
+        assert_eq!(sig.params[0].name, "$file");
+        assert_eq!(sig.params[1].name, "@opts");
+        assert!(sig.params[1].is_slurpy);
+
+        // Check raw params
+        let sub_sym = fa.symbols.iter().find(|s| s.name == "process").unwrap();
+        if let SymbolDetail::Sub { ref params, .. } = sub_sym.detail {
+            assert_eq!(params.len(), 3);
+            assert_eq!(params[0].name, "$self");
+        } else {
+            panic!("expected Sub detail");
+        }
+    }
+
+    #[test]
+    fn test_shift_with_double_pipe_default() {
+        let fa = build_fa("
+        sub handler {
+            my $self = shift;
+            my $timeout = shift || 30;
+        }
+        ");
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        assert_eq!(sig.params.len(), 1, "stripped $self");
+        assert_eq!(sig.params[0].name, "$timeout");
+        assert_eq!(sig.params[0].default, Some("30".into()));
+    }
+
+    #[test]
+    fn test_shift_with_defined_or_default() {
+        let fa = build_fa("
+        sub handler {
+            my $self = shift;
+            my $verbose = shift // 0;
+        }
+        ");
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        assert_eq!(sig.params.len(), 1, "stripped $self");
+        assert_eq!(sig.params[0].name, "$verbose");
+        assert_eq!(sig.params[0].default, Some("0".into()));
+    }
+
+    #[test]
+    fn test_subscript_param() {
+        let fa = build_fa("
+        sub handler {
+            my $self = $_[0];
+            my $data = $_[1];
+        }
+        ");
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        assert_eq!(sig.params.len(), 1, "stripped $self");
+        assert_eq!(sig.params[0].name, "$data");
+    }
+
+    #[test]
+    fn test_legacy_at_params_still_work() {
+        // Ensure the existing @_ pattern still works
+        let fa = build_fa("
+        sub process {
+            my ($first, $file, @opts) = @_;
+        }
+        ");
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        assert_eq!(sig.params.len(), 3);
+        assert_eq!(sig.params[0].name, "$first");
+        assert_eq!(sig.params[1].name, "$file");
+        assert_eq!(sig.params[2].name, "@opts");
+    }
+
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1801,9 +1801,16 @@ impl<'a> Builder<'a> {
                 if doc.is_some() {
                     continue; // already has preceding doc
                 }
-                // Search pod texts for =head2 matching this sub name
+                // Search pod texts for =head2 matching this sub name, fall back to =item
                 for pod_text in &self.pod_texts {
                     if let Some(section) = crate::pod::extract_head2_section(&sym.name, pod_text) {
+                        let md = crate::pod::pod_to_markdown(&section);
+                        if !md.is_empty() {
+                            *doc = Some(md);
+                            break;
+                        }
+                    }
+                    if let Some(section) = crate::pod::extract_item_section(&sym.name, pod_text) {
                         let md = crate::pod::pod_to_markdown(&section);
                         if !md.is_empty() {
                             *doc = Some(md);
@@ -3592,6 +3599,39 @@ my $p = Point->new(x => 3, y => 4);
         assert_eq!(sig.params[0].name, "$first");
         assert_eq!(sig.params[1].name, "$file");
         assert_eq!(sig.params[2].name, "@opts");
+    }
+
+    #[test]
+    fn test_tail_pod_item_method() {
+        let fa = build_fa("
+            package WWW::Mech;
+            sub get { }
+            sub post { }
+
+=head1 METHODS
+
+=over
+
+=item $mech->get($url)
+
+Performs a GET request.
+
+=item $mech->post($url)
+
+Performs a POST request.
+
+=back
+
+=cut
+        ");
+        let get_doc = fa.symbols.iter()
+            .find(|s| s.name == "get")
+            .and_then(|s| match &s.detail {
+                SymbolDetail::Sub { doc, .. } => doc.as_ref(),
+                _ => None,
+            });
+        assert!(get_doc.is_some(), "get should have doc from =item");
+        assert!(get_doc.unwrap().contains("GET request"));
     }
 
 }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -131,6 +131,8 @@ pub enum SymbolDetail {
         is_method: bool,
         /// Inferred return type from analyzing return statements.
         return_type: Option<InferredType>,
+        /// Pre-rendered markdown from POD or comments preceding this sub.
+        doc: Option<String>,
     },
     Class {
         parent: Option<String>,
@@ -2506,6 +2508,7 @@ mod tests {
                     params: vec![],
                     is_method: false,
                     return_type: Some(InferredType::HashRef),
+                    doc: None,
                 },
             }],
             vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod file_analysis;
 mod module_cache;
 mod module_index;
 mod module_resolver;
+mod pod;
 mod query_cache;
 mod symbols;
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -14,7 +14,7 @@ use rusqlite::{params, Connection};
 use crate::file_analysis::{inferred_type_from_tag, inferred_type_to_tag};
 use crate::module_index::{ExportedParam, ExportedSub, ModuleExports};
 
-const SCHEMA_VERSION: &str = "5";
+const SCHEMA_VERSION: &str = "6";
 
 pub fn cache_base_dir() -> Option<PathBuf> {
     if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
@@ -283,6 +283,9 @@ fn deserialize_subs_json(json_str: &str) -> HashMap<String, ExportedSub> {
                 .and_then(|v| v.as_array())
                 .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
                 .unwrap_or_default();
+            let doc = val.get("doc")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             Some((
                 name,
                 ExportedSub {
@@ -291,6 +294,7 @@ fn deserialize_subs_json(json_str: &str) -> HashMap<String, ExportedSub> {
                     is_method,
                     return_type,
                     hash_keys,
+                    doc,
                 },
             ))
         })
@@ -363,6 +367,9 @@ fn serialize_subs_json(subs: &HashMap<String, ExportedSub>) -> String {
         }
         if !sub_info.hash_keys.is_empty() {
             obj.insert("hash_keys".into(), serde_json::json!(sub_info.hash_keys));
+        }
+        if let Some(ref doc) = sub_info.doc {
+            obj.insert("doc".into(), serde_json::Value::String(doc.clone()));
         }
         map.insert(name.clone(), obj.into());
     }
@@ -522,6 +529,7 @@ mod tests {
                 is_method: false,
                 return_type: Some(crate::file_analysis::InferredType::HashRef),
                 hash_keys: vec!["host".into()],
+                doc: None,
             },
         );
 
@@ -613,6 +621,7 @@ mod tests {
                 is_method: false,
                 return_type: Some(InferredType::HashRef),
                 hash_keys: vec!["host".into(), "port".into()],
+                doc: None,
             },
         );
         subs.insert(
@@ -623,6 +632,7 @@ mod tests {
                 is_method: false,
                 return_type: Some(InferredType::ArrayRef),
                 hash_keys: vec![],
+                doc: None,
             },
         );
         subs.insert(
@@ -633,6 +643,7 @@ mod tests {
                 is_method: true,
                 return_type: Some(InferredType::ClassName("MyObj".into())),
                 hash_keys: vec![],
+                doc: None,
             },
         );
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -14,7 +14,12 @@ use rusqlite::{params, Connection};
 use crate::file_analysis::{inferred_type_from_tag, inferred_type_to_tag};
 use crate::module_index::{ExportedParam, ExportedSub, ModuleExports};
 
-const SCHEMA_VERSION: &str = "6";
+const SCHEMA_VERSION: &str = "7";
+
+/// Bumped when extraction logic changes (new fields, better parsing).
+/// Unlike SCHEMA_VERSION, this doesn't drop the table — stale entries
+/// are re-resolved lazily with priority.
+pub const EXTRACT_VERSION: i64 = 1;
 
 pub fn cache_base_dir() -> Option<PathBuf> {
     if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
@@ -91,7 +96,8 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
             export       TEXT NOT NULL,
             export_ok    TEXT NOT NULL,
             source       TEXT NOT NULL DEFAULT 'import',
-            subs         TEXT NOT NULL DEFAULT '{}'
+            subs         TEXT NOT NULL DEFAULT '{}',
+            extract_version INTEGER NOT NULL DEFAULT 0
         );",
     )?;
 
@@ -116,7 +122,8 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
                     export       TEXT NOT NULL,
                     export_ok    TEXT NOT NULL,
                     source       TEXT NOT NULL DEFAULT 'import',
-                    subs         TEXT NOT NULL DEFAULT '{}'
+                    subs         TEXT NOT NULL DEFAULT '{}',
+                    extract_version INTEGER NOT NULL DEFAULT 0
                 );",
             )?;
             conn.execute(
@@ -178,12 +185,15 @@ fn mtime_as_secs(path: &std::path::Path) -> Option<(i64, i64)> {
     Some((secs, size))
 }
 
-pub fn warm_cache(conn: &Connection, cache: &DashMap<String, Option<ModuleExports>>) -> usize {
+pub fn warm_cache(
+    conn: &Connection,
+    cache: &DashMap<String, Option<ModuleExports>>,
+) -> (usize, Vec<String>) {
     let mut stmt = match conn.prepare(
-        "SELECT module_name, path, mtime_secs, file_size, export, export_ok, subs FROM modules",
+        "SELECT module_name, path, mtime_secs, file_size, export, export_ok, subs, extract_version FROM modules",
     ) {
         Ok(s) => s,
-        Err(_) => return 0,
+        Err(_) => return (0, Vec::new()),
     };
 
     let rows = match stmt.query_map([], |row| {
@@ -195,15 +205,17 @@ pub fn warm_cache(conn: &Connection, cache: &DashMap<String, Option<ModuleExport
             row.get::<_, String>(4)?,
             row.get::<_, String>(5)?,
             row.get::<_, String>(6)?,
+            row.get::<_, i64>(7)?,
         ))
     }) {
         Ok(r) => r,
-        Err(_) => return 0,
+        Err(_) => return (0, Vec::new()),
     };
 
     let mut count = 0usize;
+    let mut stale_names = Vec::new();
     for row in rows.flatten() {
-        let (module_name, path_str, cached_mtime, cached_size, export_json, export_ok_json, subs_json) = row;
+        let (module_name, path_str, cached_mtime, cached_size, export_json, export_ok_json, subs_json, row_extract_version) = row;
 
         // Negative sentinel
         if path_str.is_empty() {
@@ -214,7 +226,7 @@ pub fn warm_cache(conn: &Connection, cache: &DashMap<String, Option<ModuleExport
 
         let path = PathBuf::from(&path_str);
 
-        // Validate mtime — skip stale entries
+        // Validate mtime — skip entries where the file changed on disk
         if let Some((disk_mtime, disk_size)) = mtime_as_secs(&path) {
             if disk_mtime != cached_mtime || disk_size != cached_size {
                 continue;
@@ -232,6 +244,10 @@ pub fn warm_cache(conn: &Connection, cache: &DashMap<String, Option<ModuleExport
         if export.is_empty() && export_ok.is_empty() {
             cache.insert(module_name, None);
         } else {
+            // Check if this entry was produced by an older extraction version
+            if row_extract_version < EXTRACT_VERSION {
+                stale_names.push(module_name.clone());
+            }
             cache.insert(
                 module_name,
                 Some(ModuleExports {
@@ -245,7 +261,7 @@ pub fn warm_cache(conn: &Connection, cache: &DashMap<String, Option<ModuleExport
         count += 1;
     }
 
-    count
+    (count, stale_names)
 }
 
 fn deserialize_subs_json(json_str: &str) -> HashMap<String, ExportedSub> {
@@ -333,9 +349,9 @@ pub fn save_to_db(
     };
 
     let r = conn.execute(
-        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, export, export_ok, source, subs)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        params![module_name, path_str, mtime, size, export_json, export_ok_json, source, subs_json],
+        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, export, export_ok, source, subs, extract_version)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![module_name, path_str, mtime, size, export_json, export_ok_json, source, subs_json, EXTRACT_VERSION],
     );
     if let Err(e) = r {
         log::warn!("Failed to save module cache for '{}': {}", module_name, e);
@@ -404,8 +420,9 @@ mod tests {
         save_to_db(&conn, "TestModule", &exports, "import");
 
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, stale) = warm_cache(&conn, &cache);
         assert_eq!(n, 1);
+        assert!(stale.is_empty());
 
         let loaded = cache.get("TestModule").unwrap();
         let loaded = loaded.as_ref().unwrap();
@@ -422,7 +439,7 @@ mod tests {
         save_to_db(&conn, "Nonexistent::Module", &None, "import");
 
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 1);
 
         let entry = cache.get("Nonexistent::Module").unwrap();
@@ -449,7 +466,7 @@ mod tests {
         std::fs::write(&pm, "v2 with more content").unwrap();
 
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 0, "stale entry should not be loaded");
         assert!(!cache.contains_key("StaleModule"));
 
@@ -470,7 +487,7 @@ mod tests {
 
         validate_inc_paths(&conn, &paths2).unwrap();
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 0, "cache should be empty after @INC change");
     }
 
@@ -487,7 +504,7 @@ mod tests {
 
         init_schema(&conn).unwrap();
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 0, "old data should be gone after migration");
     }
 
@@ -543,7 +560,7 @@ mod tests {
 
         // Verify it round-trips
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 1);
         let loaded = cache.get("MigratedModule").unwrap();
         let loaded = loaded.as_ref().unwrap();
@@ -656,7 +673,7 @@ mod tests {
         save_to_db(&conn, "SubsTest", &exports, "import");
 
         let cache = DashMap::new();
-        let n = warm_cache(&conn, &cache);
+        let (n, _) = warm_cache(&conn, &cache);
         assert_eq!(n, 1);
 
         let loaded = cache.get("SubsTest").unwrap();
@@ -677,6 +694,78 @@ mod tests {
         assert_eq!(no.def_line, 30);
         assert!(no.is_method);
         assert_eq!(no.return_type, Some(InferredType::ClassName("MyObj".into())));
+
+        let _ = std::fs::remove_file(&pm);
+    }
+
+    #[test]
+    fn test_warm_reports_stale_entries() {
+        let conn = test_db();
+        let dir = std::env::temp_dir();
+        let pm = dir.join("StaleExtract.pm");
+        std::fs::write(&pm, "package StaleExtract; 1;").unwrap();
+
+        let (mtime, size) = mtime_as_secs(&pm).unwrap();
+
+        // Save with old extract version (0, below EXTRACT_VERSION)
+        conn.execute(
+            "INSERT INTO modules (module_name, path, mtime_secs, file_size, export, export_ok, subs, extract_version)
+             VALUES ('StaleExtract', ?1, ?2, ?3, '[\"foo\"]', '[]', '{}', 0)",
+            params![pm.to_string_lossy(), mtime, size],
+        ).unwrap();
+
+        let cache = DashMap::new();
+        let (loaded, stale) = warm_cache(&conn, &cache);
+        assert_eq!(loaded, 1, "stale entry should still be loaded");
+        assert!(cache.contains_key("StaleExtract"), "stale entry should be in cache");
+        assert_eq!(stale, vec!["StaleExtract"], "should report as stale");
+
+        let _ = std::fs::remove_file(&pm);
+    }
+
+    #[test]
+    fn test_warm_fresh_not_stale() {
+        let conn = test_db();
+        let dir = std::env::temp_dir();
+        let pm = dir.join("FreshExtract.pm");
+        std::fs::write(&pm, "package FreshExtract; 1;").unwrap();
+
+        let exports = Some(ModuleExports {
+            path: pm.clone(),
+            export: vec!["foo".into()],
+            export_ok: vec![],
+            subs: HashMap::new(),
+        });
+        save_to_db(&conn, "FreshExtract", &exports, "import");
+
+        let cache = DashMap::new();
+        let (loaded, stale) = warm_cache(&conn, &cache);
+        assert_eq!(loaded, 1);
+        assert!(stale.is_empty(), "current-version entry should not be stale");
+
+        let _ = std::fs::remove_file(&pm);
+    }
+
+    #[test]
+    fn test_save_writes_extract_version() {
+        let conn = test_db();
+        let dir = std::env::temp_dir();
+        let pm = dir.join("VersionedSave.pm");
+        std::fs::write(&pm, "package VersionedSave; 1;").unwrap();
+
+        let exports = Some(ModuleExports {
+            path: pm.clone(),
+            export: vec!["foo".into()],
+            export_ok: vec![],
+            subs: HashMap::new(),
+        });
+        save_to_db(&conn, "VersionedSave", &exports, "import");
+
+        let ver: i64 = conn.query_row(
+            "SELECT extract_version FROM modules WHERE module_name = 'VersionedSave'",
+            [], |row| row.get(0),
+        ).unwrap();
+        assert_eq!(ver, EXTRACT_VERSION);
 
         let _ = std::fs::remove_file(&pm);
     }

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -35,6 +35,8 @@ pub struct ExportedSub {
     pub return_type: Option<InferredType>,
     /// Hash key names from return value, if returns HashRef.
     pub hash_keys: Vec<String>,
+    /// Pre-rendered markdown from POD or comments.
+    pub doc: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -449,6 +451,7 @@ mod tests {
             is_method: false,
             return_type: Some(InferredType::HashRef),
             hash_keys: vec![],
+            doc: None,
         });
         subs.insert("make_obj".to_string(), ExportedSub {
             def_line: 20,
@@ -456,6 +459,7 @@ mod tests {
             is_method: false,
             return_type: Some(InferredType::ClassName("MyClass".into())),
             hash_keys: vec![],
+            doc: None,
         });
 
         idx.insert_cache(

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -76,6 +76,9 @@ impl ModuleExports {
 
 /// Thread-safe queue: Mutex<Vec> + Condvar.
 pub(crate) struct ResolveQueue {
+    /// High priority: stale modules from open files. Drained first.
+    pub priority: Mutex<Vec<String>>,
+    /// Normal priority: missing modules.
     pub pending: Mutex<Vec<String>>,
     pub condvar: Condvar,
 }
@@ -101,6 +104,9 @@ pub struct ModuleIndex {
     cache: Arc<DashMap<String, Option<ModuleExports>>>,
     /// Reverse index: function name → list of module names that export it.
     reverse_index: Arc<DashMap<String, Vec<String>>>,
+    /// Modules loaded from cache with an old extract_version.
+    /// Eligible for priority re-resolution when requested.
+    stale_modules: Arc<DashMap<String, ()>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -112,7 +118,9 @@ impl ModuleIndex {
     pub fn new(client: Client, on_diagnostics_refresh: impl Fn() + Send + Sync + 'static) -> Self {
         let cache: Arc<DashMap<String, Option<ModuleExports>>> = Arc::new(DashMap::new());
         let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
+        let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
         let queue = Arc::new(ResolveQueue {
+            priority: Mutex::new(Vec::new()),
             pending: Mutex::new(Vec::new()),
             condvar: Condvar::new(),
         });
@@ -131,6 +139,7 @@ impl ModuleIndex {
         module_resolver::spawn_resolver(
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
+            Arc::clone(&stale_modules),
             Arc::clone(&queue),
             Arc::clone(&resolved),
             Arc::clone(&workspace_root),
@@ -141,6 +150,7 @@ impl ModuleIndex {
         ModuleIndex {
             cache,
             reverse_index,
+            stale_modules,
             queue,
             resolved,
             workspace_root,
@@ -159,12 +169,21 @@ impl ModuleIndex {
     }
 
     /// Request background resolution for a module. Non-blocking.
+    /// Stale modules (old extract version) are queued with priority.
     pub fn request_resolve(&self, module_name: &str) {
-        if self.cache.contains_key(module_name) {
-            return;
+        let is_stale = self.stale_modules.contains_key(module_name);
+        if self.cache.contains_key(module_name) && !is_stale {
+            return; // fresh and cached
         }
-        let mut pending = self.queue.pending.lock().unwrap();
-        pending.push(module_name.to_string());
+        if is_stale {
+            let mut priority = self.queue.priority.lock().unwrap();
+            if !priority.contains(&module_name.to_string()) {
+                priority.push(module_name.to_string());
+            }
+        } else {
+            let mut pending = self.queue.pending.lock().unwrap();
+            pending.push(module_name.to_string());
+        }
         self.queue.condvar.notify_one();
     }
 
@@ -226,7 +245,9 @@ impl ModuleIndex {
     pub fn new_for_test() -> Self {
         let cache: Arc<DashMap<String, Option<ModuleExports>>> = Arc::new(DashMap::new());
         let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
+        let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
         let queue = Arc::new(ResolveQueue {
+            priority: Mutex::new(Vec::new()),
             pending: Mutex::new(Vec::new()),
             condvar: Condvar::new(),
         });
@@ -242,6 +263,7 @@ impl ModuleIndex {
         module_resolver::spawn_test_resolver(
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
+            Arc::clone(&stale_modules),
             Arc::clone(&queue),
             Arc::clone(&resolved),
             Arc::clone(&workspace_root),
@@ -250,6 +272,7 @@ impl ModuleIndex {
         ModuleIndex {
             cache,
             reverse_index,
+            stale_modules,
             queue,
             resolved,
             workspace_root,

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -431,7 +431,10 @@ fn parse_in_subprocess(inc_paths: &[PathBuf], module_name: &str) -> Option<Modul
                     .and_then(|v| v.as_array())
                     .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
                     .unwrap_or_default();
-                Some((name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys }))
+                let doc = val.get("doc")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                Some((name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys, doc }))
             }).collect()
         })
         .unwrap_or_default();
@@ -472,11 +475,11 @@ pub fn subprocess_main(path: &str) {
         for name in export.iter().chain(export_ok.iter()) {
             let mut sub_info = serde_json::Map::new();
 
-            // Find the sub symbol for definition line + params
+            // Find the sub symbol for definition line + params + doc
             for sym in &analysis.symbols {
                 if sym.name == *name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                     sub_info.insert("def_line".into(), sym.span.start.row.into());
-                    if let SymbolDetail::Sub { ref params, is_method, .. } = sym.detail {
+                    if let SymbolDetail::Sub { ref params, is_method, ref doc, .. } = sym.detail {
                         sub_info.insert("is_method".into(), is_method.into());
                         let params_json: Vec<serde_json::Value> = params.iter()
                             .map(|p| serde_json::json!({
@@ -485,6 +488,9 @@ pub fn subprocess_main(path: &str) {
                             }))
                             .collect();
                         sub_info.insert("params".into(), params_json.into());
+                        if let Some(ref d) = doc {
+                            sub_info.insert("doc".into(), serde_json::Value::String(d.clone()));
+                        }
                     }
                     break;
                 }
@@ -564,15 +570,17 @@ pub fn resolve_and_parse(
             let mut def_line = 0u32;
             let mut params = Vec::new();
             let mut is_method = false;
+            let mut doc = None;
 
             for sym in &analysis.symbols {
                 if sym.name == *name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                     def_line = sym.span.start.row as u32;
-                    if let SymbolDetail::Sub { params: ref p, is_method: m, .. } = sym.detail {
+                    if let SymbolDetail::Sub { params: ref p, is_method: m, doc: ref d, .. } = sym.detail {
                         is_method = m;
                         params = p.iter()
                             .map(|pi| ExportedParam { name: pi.name.clone(), is_slurpy: pi.is_slurpy })
                             .collect();
+                        doc = d.clone();
                     }
                     break;
                 }
@@ -585,7 +593,7 @@ pub fn resolve_and_parse(
                 .map(|s| s.name.clone())
                 .collect();
 
-            subs.insert(name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys });
+            subs.insert(name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys, doc });
         }
     }
 

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -3,7 +3,7 @@
 //! Discovers `@INC` paths, locates `.pm` files, extracts `@EXPORT`/`@EXPORT_OK`,
 //! and handles subprocess isolation for safe parsing (tree-sitter hangs → SIGKILL).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,6 +35,7 @@ pub type OnResolved = Box<dyn Fn() + Send + Sync>;
 pub fn spawn_resolver(
     cache: Arc<DashMap<String, Option<ModuleExports>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
+    stale_modules: Arc<DashMap<String, ()>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -55,15 +56,23 @@ pub fn spawn_resolver(
             let db = module_cache::open_cache_db(ws_root.as_deref());
             if let Some(ref conn) = db {
                 let _ = module_cache::validate_inc_paths(conn, &inc_paths);
-                let n = module_cache::warm_cache(conn, &cache);
-                log::info!("Warmed module cache: {} entries loaded from disk", n);
+                let (n, stale_names) = module_cache::warm_cache(conn, &cache);
+                log::info!("Warmed module cache: {} entries loaded from disk, {} stale", n, stale_names.len());
+                // Populate stale_modules set for priority re-resolution.
+                for name in stale_names {
+                    stale_modules.insert(name, ());
+                }
                 // Build reverse index from warmed cache.
                 rebuild_reverse_index(&cache, &reverse_index);
             }
 
-            let mut seen = HashSet::new();
+            // Track which extract version each module was resolved at.
+            let mut seen: HashMap<String, i64> = HashMap::new();
 
-            // Pre-resolve cpanfile dependencies.
+            // Queue cpanfile dependencies (non-blocking — lets priority items go first).
+            // Track total for progress reporting in the main loop.
+            let mut cpanfile_total = 0usize;
+            let mut cpanfile_done = 0usize;
             if let Some(ref root_uri) = ws_root {
                 if let Some(root_path) = uri_to_path(root_uri) {
                     let cpanfile_modules = cpanfile::parse_cpanfile(&root_path);
@@ -73,39 +82,55 @@ pub fn spawn_resolver(
                         .collect();
 
                     if !to_resolve.is_empty() {
-                        resolve_cpanfile_batch(
-                            &to_resolve,
-                            &inc_paths,
-                            &cache,
-                            &reverse_index,
-                            &db,
-                            &client,
-                            &handle,
-                            &on_resolved,
-                        );
-                        for m in &to_resolve {
-                            seen.insert(m.clone());
-                        }
+                        cpanfile_total = to_resolve.len();
+                        log::info!("cpanfile: {} modules queued for indexing", cpanfile_total);
+
+                        // Start progress bar.
+                        let token = NumberOrString::String("perl-lsp/indexing".to_string());
+                        let _ = handle.block_on(client.send_request::<request::WorkDoneProgressCreate>(
+                            WorkDoneProgressCreateParams { token: token.clone() },
+                        ));
+                        handle.block_on(client.send_notification::<notification::Progress>(
+                            ProgressParams {
+                                token,
+                                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
+                                    WorkDoneProgressBegin {
+                                        title: "Indexing Perl modules".into(),
+                                        cancellable: Some(false),
+                                        message: None,
+                                        percentage: Some(0),
+                                    },
+                                )),
+                            },
+                        ));
+
+                        let mut pending = queue.pending.lock().unwrap();
+                        pending.extend(to_resolve);
+                        queue.condvar.notify_one();
                     }
                 }
             }
 
-            // Main resolve loop — drain work queue.
+            // Main resolve loop — drain priority first, then pending.
             loop {
-                let batch = {
-                    let mut pending = queue.pending.lock().unwrap();
-                    while pending.is_empty() {
-                        pending = queue.condvar.wait(pending).unwrap();
-                    }
-                    std::mem::take(&mut *pending)
-                };
+                let batch = drain_next_batch(&queue);
 
                 for module_name in batch {
-                    if !seen.insert(module_name.clone()) {
-                        continue;
+                    // Allow re-resolution when extract version is outdated.
+                    if let Some(&ver) = seen.get(&module_name) {
+                        if ver >= module_cache::EXTRACT_VERSION {
+                            continue;
+                        }
+                    }
+                    seen.insert(module_name.clone(), module_cache::EXTRACT_VERSION);
+
+                    let is_re_resolve = stale_modules.contains_key(&module_name);
+                    if is_re_resolve {
+                        log::info!("Re-resolving stale module '{}'", module_name);
+                    } else {
+                        log::info!("Resolving module '{}'", module_name);
                     }
 
-                    log::info!("Resolving module '{}'", module_name);
                     let result = parse_module(&inc_paths, &module_name);
                     match &result {
                         Some(e) => log::info!(
@@ -127,6 +152,43 @@ pub fn spawn_resolver(
                         module_cache::save_to_db(conn, &module_name, &result, "import");
                     }
 
+                    // Remove from stale set after successful re-resolution.
+                    if is_re_resolve {
+                        stale_modules.remove(&module_name);
+                    }
+
+                    // Report cpanfile progress.
+                    if cpanfile_total > 0 && cpanfile_done < cpanfile_total {
+                        cpanfile_done += 1;
+                        let pct = (cpanfile_done * 100 / cpanfile_total) as u32;
+                        let token = NumberOrString::String("perl-lsp/indexing".to_string());
+                        if cpanfile_done < cpanfile_total {
+                            handle.block_on(client.send_notification::<notification::Progress>(
+                                ProgressParams {
+                                    token,
+                                    value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
+                                        WorkDoneProgressReport {
+                                            cancellable: Some(false),
+                                            message: Some(format!("{} ({}/{})", module_name, cpanfile_done, cpanfile_total)),
+                                            percentage: Some(pct),
+                                        },
+                                    )),
+                                },
+                            ));
+                        } else {
+                            handle.block_on(client.send_notification::<notification::Progress>(
+                                ProgressParams {
+                                    token,
+                                    value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
+                                        WorkDoneProgressEnd {
+                                            message: Some(format!("Indexed {} modules", cpanfile_total)),
+                                        },
+                                    )),
+                                },
+                            ));
+                        }
+                    }
+
                     // Signal waiters and trigger diagnostic refresh.
                     {
                         let _g = resolved.mu.lock().unwrap();
@@ -139,11 +201,36 @@ pub fn spawn_resolver(
         .expect("failed to spawn module-resolver thread");
 }
 
+/// Drain the next batch from the queue, checking priority first.
+fn drain_next_batch(queue: &ResolveQueue) -> Vec<String> {
+    // Check priority first
+    {
+        let mut priority = queue.priority.lock().unwrap();
+        if !priority.is_empty() {
+            return std::mem::take(&mut *priority);
+        }
+    }
+    // Wait for pending
+    let mut pending = queue.pending.lock().unwrap();
+    loop {
+        if !pending.is_empty() {
+            // Before draining pending, re-check priority
+            let mut priority = queue.priority.lock().unwrap();
+            if !priority.is_empty() {
+                return std::mem::take(&mut *priority);
+            }
+            return std::mem::take(&mut *pending);
+        }
+        pending = queue.condvar.wait(pending).unwrap();
+    }
+}
+
 /// Simplified resolver for tests — no Client, no progress, no cpanfile.
 #[cfg(test)]
 pub fn spawn_test_resolver(
     cache: Arc<DashMap<String, Option<ModuleExports>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
+    stale_modules: Arc<DashMap<String, ()>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -157,28 +244,30 @@ pub fn spawn_test_resolver(
             let db = module_cache::open_cache_db(ws_root.as_deref());
             if let Some(ref conn) = db {
                 let _ = module_cache::validate_inc_paths(conn, &inc_paths);
-                let _ = module_cache::warm_cache(conn, &cache);
+                let (_, stale_names) = module_cache::warm_cache(conn, &cache);
+                for name in stale_names {
+                    stale_modules.insert(name, ());
+                }
                 rebuild_reverse_index(&cache, &reverse_index);
             }
 
-            let mut seen = HashSet::new();
+            let mut seen: HashMap<String, i64> = HashMap::new();
             loop {
-                let batch = {
-                    let mut pending = queue.pending.lock().unwrap();
-                    while pending.is_empty() {
-                        pending = queue.condvar.wait(pending).unwrap();
-                    }
-                    std::mem::take(&mut *pending)
-                };
+                let batch = drain_next_batch(&queue);
                 for module_name in batch {
-                    if !seen.insert(module_name.clone()) {
-                        continue;
+                    if let Some(&ver) = seen.get(&module_name) {
+                        if ver >= module_cache::EXTRACT_VERSION {
+                            continue;
+                        }
                     }
+                    seen.insert(module_name.clone(), module_cache::EXTRACT_VERSION);
+
                     let result = parse_module(&inc_paths, &module_name);
                     insert_into_cache(&cache, &reverse_index, &module_name, result.clone());
                     if let Some(ref conn) = db {
                         module_cache::save_to_db(conn, &module_name, &result, "import");
                     }
+                    stale_modules.remove(&module_name);
                     let _g = resolved.mu.lock().unwrap();
                     resolved.cv.notify_all();
                 }
@@ -205,80 +294,6 @@ fn wait_for_workspace_root(ws_root_channel: &WorkspaceRootChannel) -> Option<Str
         guard = g;
     }
     guard.clone().flatten()
-}
-
-fn resolve_cpanfile_batch(
-    to_resolve: &[String],
-    inc_paths: &[PathBuf],
-    cache: &Arc<DashMap<String, Option<ModuleExports>>>,
-    reverse_index: &Arc<DashMap<String, Vec<String>>>,
-    db: &Option<rusqlite::Connection>,
-    client: &Client,
-    handle: &tokio::runtime::Handle,
-    on_resolved: &OnResolved,
-) {
-    let total = to_resolve.len();
-    log::info!("cpanfile: {} modules to index", total);
-
-    let token = NumberOrString::String("perl-lsp/indexing".to_string());
-    let _ = handle.block_on(client.send_request::<request::WorkDoneProgressCreate>(
-        WorkDoneProgressCreateParams {
-            token: token.clone(),
-        },
-    ));
-    handle.block_on(client.send_notification::<notification::Progress>(
-        ProgressParams {
-            token: token.clone(),
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
-                WorkDoneProgressBegin {
-                    title: "Indexing Perl modules".into(),
-                    cancellable: Some(false),
-                    message: None,
-                    percentage: Some(0),
-                },
-            )),
-        },
-    ));
-
-    for (i, module_name) in to_resolve.iter().enumerate() {
-        let pct = ((i + 1) * 100 / total) as u32;
-        handle.block_on(client.send_notification::<notification::Progress>(
-            ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
-                    WorkDoneProgressReport {
-                        cancellable: Some(false),
-                        message: Some(format!("{} ({}/{})", module_name, i + 1, total)),
-                        percentage: Some(pct),
-                    },
-                )),
-            },
-        ));
-
-        log::info!(
-            "cpanfile: resolving '{}' ({}/{})",
-            module_name,
-            i + 1,
-            total
-        );
-        let result = parse_module(inc_paths, module_name);
-        insert_into_cache(cache, reverse_index, module_name, result.clone());
-        if let Some(ref conn) = db {
-            module_cache::save_to_db(conn, module_name, &result, "cpanfile");
-        }
-    }
-
-    handle.block_on(client.send_notification::<notification::Progress>(
-        ProgressParams {
-            token,
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
-                message: Some(format!("Indexed {} modules", total)),
-            })),
-        },
-    ));
-
-    // Trigger diagnostic refresh after cpanfile batch completes.
-    on_resolved();
 }
 
 /// Insert a resolved module into the cache and update the reverse index.

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -1,0 +1,284 @@
+//! POD → Markdown converter.
+//!
+//! Regex-based line-by-line state machine. Converts raw POD text to
+//! GitHub-flavored markdown for display in LSP hover popups.
+//!
+//! No tree-sitter imports — this module is pure string processing.
+//! Tree-sitter node traversal for locating POD near subs lives in `builder.rs`.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Convert raw POD text to markdown. Caps output at ~2000 chars.
+pub fn pod_to_markdown(pod_text: &str) -> String {
+    let mut out = String::new();
+    let mut in_verbatim = false;
+    let mut in_over = false;
+
+    for line in pod_text.lines() {
+        // =cut — stop processing
+        if line.starts_with("=cut") {
+            if in_verbatim {
+                out.push_str("```\n");
+                in_verbatim = false;
+            }
+            break;
+        }
+
+        // Skip =pod, =encoding, =begin, =end, =for
+        if line.starts_with("=pod") || line.starts_with("=encoding") {
+            continue;
+        }
+        if line.starts_with("=begin") || line.starts_with("=end") || line.starts_with("=for") {
+            continue;
+        }
+
+        // Headings
+        if line.starts_with("=head1 ") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            let title = &line[7..];
+            out.push_str(&format!("### {}\n\n", convert_inline(title)));
+            continue;
+        }
+        if line.starts_with("=head2 ") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            let title = &line[7..];
+            out.push_str(&format!("#### {}\n\n", convert_inline(title)));
+            continue;
+        }
+        if line.starts_with("=head3 ") || line.starts_with("=head4 ") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            let title = &line[7..];
+            out.push_str(&format!("##### {}\n\n", convert_inline(title)));
+            continue;
+        }
+
+        // =over / =back — list context
+        if line.starts_with("=over") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            in_over = true;
+            continue;
+        }
+        if line.starts_with("=back") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            in_over = false;
+            out.push('\n');
+            continue;
+        }
+
+        // =item
+        if line.starts_with("=item") {
+            close_verbatim(&mut out, &mut in_verbatim);
+            let rest = line[5..].trim();
+            if rest == "*" || rest.is_empty() {
+                out.push_str("- ");
+            } else if rest.starts_with("* ") {
+                out.push_str(&format!("- {}\n", convert_inline(&rest[2..])));
+            } else {
+                out.push_str(&format!("- **{}**\n", convert_inline(rest)));
+            }
+            continue;
+        }
+
+        // Verbatim blocks (indented by 4+ spaces or tab)
+        if line.starts_with("    ") || line.starts_with('\t') {
+            if !in_verbatim {
+                out.push_str("```\n");
+                in_verbatim = true;
+            }
+            // Strip leading indent
+            let content = if line.starts_with('\t') { &line[1..] } else { &line[4..] };
+            out.push_str(content);
+            out.push('\n');
+            continue;
+        }
+
+        // Normal text — close verbatim if open
+        close_verbatim(&mut out, &mut in_verbatim);
+
+        if line.is_empty() {
+            // Don't double-newline
+            if !out.ends_with("\n\n") {
+                out.push('\n');
+            }
+            continue;
+        }
+
+        // In a list context, continuation lines are part of the item
+        let converted = convert_inline(line);
+        out.push_str(&converted);
+        out.push('\n');
+
+        if out.len() > 2000 {
+            break;
+        }
+    }
+
+    close_verbatim(&mut out, &mut in_verbatim);
+    let _ = in_over;
+
+    // Trim trailing whitespace
+    let result = out.trim_end().to_string();
+    if result.len() > 2000 {
+        result[..2000].to_string()
+    } else {
+        result
+    }
+}
+
+fn close_verbatim(out: &mut String, in_verbatim: &mut bool) {
+    if *in_verbatim {
+        out.push_str("```\n");
+        *in_verbatim = false;
+    }
+}
+
+/// Convert POD inline formatting sequences to markdown.
+fn convert_inline(text: &str) -> String {
+    static RE_INLINE: LazyLock<Regex> = LazyLock::new(|| {
+        // Match C<...>, B<...>, I<...>, L<...>, F<...>, E<...>
+        // Also C<< ... >> double-bracket form
+        Regex::new(r"([CBILFE])(<<\s+(.+?)\s+>>|<([^>]*)>)").unwrap()
+    });
+
+    RE_INLINE.replace_all(text, |caps: &regex::Captures| {
+        let code = caps.get(1).unwrap().as_str();
+        let content = caps.get(3).or_else(|| caps.get(4)).map(|m| m.as_str()).unwrap_or("");
+        match code {
+            "C" => format!("`{}`", content),
+            "B" => format!("**{}**", content),
+            "I" => format!("*{}*", content),
+            "F" => format!("`{}`", content),
+            "L" => {
+                // L<text|url> → text, L<Module::Name> → Module::Name
+                if let Some(idx) = content.find('|') {
+                    content[..idx].to_string()
+                } else {
+                    content.to_string()
+                }
+            }
+            "E" => match content {
+                "lt" => "<".to_string(),
+                "gt" => ">".to_string(),
+                "sol" => "/".to_string(),
+                "verbar" => "|".to_string(),
+                _ => content.to_string(),
+            },
+            _ => content.to_string(),
+        }
+    }).to_string()
+}
+
+/// Extract a =head2 section for a given sub name from a POD block.
+/// Used by the builder's tail-POD post-pass.
+pub fn extract_head2_section(sub_name: &str, pod_text: &str) -> Option<String> {
+    let mut collecting = false;
+    let mut section = String::new();
+
+    for line in pod_text.lines() {
+        if collecting {
+            // Stop at next =head at same or higher level, or =cut
+            if line.starts_with("=head1 ") || line.starts_with("=head2 ") || line.starts_with("=cut") {
+                break;
+            }
+            section.push_str(line);
+            section.push('\n');
+        } else {
+            // Look for =head2 matching sub name
+            if line.starts_with("=head2 ") {
+                let rest = &line[7..];
+                // Match bare name or name with parens: "path" or "path($file)"
+                let head_name = rest.split(|c: char| c == '(' || c.is_whitespace()).next().unwrap_or("");
+                if head_name == sub_name {
+                    // Don't include the =head2 line itself (hover already shows the signature)
+                    collecting = true;
+                }
+            }
+        }
+    }
+
+    if section.trim().is_empty() {
+        None
+    } else {
+        Some(section)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_headings() {
+        let pod = "=head1 NAME\n\nFoo - a foo module\n\n=head2 bar\n\nDoes bar things.\n\n=cut\n";
+        let md = pod_to_markdown(pod);
+        assert!(md.contains("### NAME"));
+        assert!(md.contains("#### bar"));
+        assert!(md.contains("Does bar things."));
+    }
+
+    #[test]
+    fn test_inline_formatting() {
+        assert_eq!(convert_inline("Use C<foo> for B<bold> and I<italic>"),
+            "Use `foo` for **bold** and *italic*");
+    }
+
+    #[test]
+    fn test_double_bracket() {
+        assert_eq!(convert_inline("C<< $hash->{key} >>"), "`$hash->{key}`");
+    }
+
+    #[test]
+    fn test_link() {
+        assert_eq!(convert_inline("See L<Foo::Bar>"), "See Foo::Bar");
+        assert_eq!(convert_inline("See L<docs|http://example.com>"), "See docs");
+    }
+
+    #[test]
+    fn test_escape() {
+        assert_eq!(convert_inline("E<lt>tag E<gt>"), "<tag >");
+    }
+
+    #[test]
+    fn test_verbatim_block() {
+        let pod = "=head2 example\n\nSome text:\n\n    my $x = 1;\n    my $y = 2;\n\nMore text.\n\n=cut\n";
+        let md = pod_to_markdown(pod);
+        assert!(md.contains("```\nmy $x = 1;\nmy $y = 2;\n```"));
+    }
+
+    #[test]
+    fn test_item_list() {
+        let pod = "=over\n\n=item * first\n\n=item * second\n\n=back\n\n=cut\n";
+        let md = pod_to_markdown(pod);
+        assert!(md.contains("- first"));
+        assert!(md.contains("- second"));
+    }
+
+    #[test]
+    fn test_item_label() {
+        let pod = "=over\n\n=item ensure\n\npresent or absent\n\n=back\n\n=cut\n";
+        let md = pod_to_markdown(pod);
+        assert!(md.contains("- **ensure**"));
+    }
+
+    #[test]
+    fn test_truncation() {
+        let long_pod = format!("=head2 foo\n\n{}\n\n=cut\n", "x".repeat(3000));
+        let md = pod_to_markdown(&long_pod);
+        assert!(md.len() <= 2000);
+    }
+
+    #[test]
+    fn test_head2_section_extraction() {
+        let pod = "=head1 METHODS\n\n=head2 path($file)\n\nCreate a path.\n\nReturns a path object.\n\n=head2 other\n\nOther stuff.\n\n=cut\n";
+        let section = extract_head2_section("path", pod).unwrap();
+        assert!(section.contains("Create a path."));
+        assert!(section.contains("Returns a path object."));
+        assert!(!section.contains("Other stuff."));
+    }
+
+    #[test]
+    fn test_file_formatting() {
+        assert_eq!(convert_inline("See F</etc/config>"), "See `/etc/config`");
+    }
+}

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -169,6 +169,69 @@ fn convert_inline(text: &str) -> String {
     }).to_string()
 }
 
+/// Extract method name from an =item line.
+/// Handles: `$obj->method(...)`, `Class->method(...)`, `C<method>`, `method(...)`, `method`
+fn extract_item_method_name(item_rest: &str) -> Option<&str> {
+    let s = item_rest.trim();
+    // Strip C<...> wrapper
+    let s = if s.starts_with("C<") {
+        let inner = s.strip_prefix("C<")?.strip_suffix('>')?;
+        // Also handle C<< ... >>
+        inner.trim()
+    } else if s.starts_with("C<<") {
+        let inner = s.strip_prefix("C<<")?.strip_suffix(">>")?;
+        inner.trim()
+    } else {
+        s
+    };
+    // Strip $obj-> or Class::Name-> prefix
+    let s = if let Some(idx) = s.find("->") {
+        &s[idx + 2..]
+    } else {
+        s
+    };
+    // Strip trailing (...) and whitespace
+    let s = if let Some(idx) = s.find('(') {
+        s[..idx].trim()
+    } else {
+        s.trim()
+    };
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Extract documentation for a sub from =item blocks within =over/=back.
+/// Falls back when extract_head2_section finds no =head2 match.
+pub fn extract_item_section(sub_name: &str, pod_text: &str) -> Option<String> {
+    let mut collecting = false;
+    let mut section = String::new();
+
+    for line in pod_text.lines() {
+        if collecting {
+            // Stop at next =item, =back, =head, or =cut
+            if line.starts_with("=item") || line.starts_with("=back")
+                || line.starts_with("=head") || line.starts_with("=cut")
+            {
+                break;
+            }
+            section.push_str(line);
+            section.push('\n');
+        } else if line.starts_with("=item") {
+            let rest = &line[5..].trim_start();
+            if let Some(name) = extract_item_method_name(rest) {
+                if name == sub_name {
+                    collecting = true;
+                }
+            }
+        }
+    }
+
+    if section.trim().is_empty() {
+        None
+    } else {
+        Some(section)
+    }
+}
+
 /// Extract a =head2 section for a given sub name from a POD block.
 /// Used by the builder's tail-POD post-pass.
 pub fn extract_head2_section(sub_name: &str, pod_text: &str) -> Option<String> {
@@ -280,5 +343,47 @@ mod tests {
     #[test]
     fn test_file_formatting() {
         assert_eq!(convert_inline("See F</etc/config>"), "See `/etc/config`");
+    }
+
+    #[test]
+    fn test_item_arrow_method() {
+        let pod = "=over\n\n=item $mech->get($url)\n\nPerforms a GET request.\n\n=item $mech->post($url)\n\nPerforms a POST.\n\n=back\n";
+        let section = extract_item_section("get", pod).unwrap();
+        assert!(section.contains("Performs a GET request."));
+        assert!(!section.contains("Performs a POST."));
+    }
+
+    #[test]
+    fn test_item_bare_name() {
+        let pod = "=over\n\n=item connect\n\nConnects to server.\n\n=item disconnect\n\nDisconnects.\n\n=back\n";
+        let section = extract_item_section("connect", pod).unwrap();
+        assert!(section.contains("Connects to server."));
+    }
+
+    #[test]
+    fn test_item_class_method() {
+        let pod = "=over\n\n=item DBI->connect($dsn)\n\nCreates a connection.\n\n=back\n";
+        let section = extract_item_section("connect", pod).unwrap();
+        assert!(section.contains("Creates a connection."));
+    }
+
+    #[test]
+    fn test_item_formatted_name() {
+        let pod = "=over\n\n=item C<new>\n\nConstructor.\n\n=back\n";
+        let section = extract_item_section("new", pod).unwrap();
+        assert!(section.contains("Constructor."));
+    }
+
+    #[test]
+    fn test_item_no_match() {
+        let pod = "=over\n\n=item $obj->foo()\n\nDoes foo.\n\n=back\n";
+        assert!(extract_item_section("bar", pod).is_none());
+    }
+
+    #[test]
+    fn test_head2_preferred_over_item() {
+        let pod = "=head2 path\n\nHead2 doc.\n\n=over\n\n=item $obj->path()\n\nItem doc.\n\n=back\n=cut\n";
+        let section = extract_head2_section("path", pod).unwrap();
+        assert!(section.contains("Head2 doc."));
     }
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -366,6 +366,9 @@ pub fn hover_info(
                     if let Some(sub_info) = exports.sub_info(&r.target_name) {
                         let sig = format_imported_signature(&r.target_name, sub_info);
                         parts.push(format!("```perl\n{}\n```", sig));
+                        if let Some(ref doc) = sub_info.doc {
+                            parts.push(doc.clone());
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

- **`__PACKAGE__` resolution** — `__PACKAGE__->new(...)` resolves to the enclosing package name instead of literal `"__PACKAGE__"`. Fixes 7 exported functions in Mojo alone (`b()`, `c()`, `path()`, etc.)
- **Implicit parameter extraction** — `shift` and `$_[N]` patterns alongside the existing `my (...) = @_`, covering 47% of Rex subs that previously had no params
- **POD documentation on hover** — extracts POD from both interleaved style (preceding the sub) and tail style (`=head2`/`=item` sections after code), converts to markdown via a new `pod.rs` module
- **`=item`-based POD lookup** — falls back to `=item $obj->method()` patterns inside `=over`/`=back` blocks, covering OOP modules like WWW::Mechanize, DBI, LWP::UserAgent
- **Per-entry extract versioning** — stale cache entries (old extraction logic) are loaded for immediate use but re-resolved with priority when the user opens a file importing them. Replaces the nuclear SCHEMA_VERSION-bump-drops-everything approach
- **Priority queue for re-resolution** — stale modules from open files jump ahead of the cpanfile backlog, so the user sees updated hover/completion immediately
- **Architecture rules in CLAUDE.md** — 4-layer diagram and 6 strict rules to guide future development

## Acknowledgements

POD extraction and `=item`-based method documentation inspired by [PerlNavigator PR #142](https://github.com/bscan/PerlNavigator/pull/142) by Aequitosh. Thanks to [bscan](https://github.com/bscan) for PerlNavigator — it's been a valuable reference throughout this project's development.

## Test plan

- [x] `cargo test` — 229 tests pass (up from 226), 0 warnings
- [x] `cargo build --release` — clean
- [ ] Manual: `--parse-exports` on Mojo::File shows `path()` returns `Object:Mojo::File` (not `__PACKAGE__`)
- [ ] Manual: `--parse-exports` on Rex::Commands::File shows `file()` has shift params + POD doc
- [ ] Manual: hover on imported function shows POD markdown
- [ ] Manual: restart LSP with stale cache — stale modules re-resolved on file open before cpanfile batch


🤖 Generated with [Claude Code](https://claude.com/claude-code)