### PR TITLE
feat: inheritance chain resolution + cross-file OO intelligence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ E2e tests use Neovim headless mode. They exercise the full LSP protocol over std
 - Reverse index: `DashMap<func_name, Vec<module_name>>` for O(1) exporter lookup
 - Export extraction uses tree-sitter in isolated subprocesses (5s timeout + SIGKILL)
 - Subprocess runs the full builder on each module, then queries `FileAnalysis` for per-export metadata
-- `ModuleExports` stores `subs: HashMap<String, ExportedSub>` — unified per-export metadata (def_line, params, is_method, return_type, hash_keys, doc)
+- `ModuleExports` stores `subs: HashMap<String, ExportedSub>` — unified per-export metadata (def_line, params, is_method, return_type, hash_keys, doc) — and `parents: Vec<String>` for inheritance chain
 - cpanfile parsed with tree-sitter queries at startup, deps pre-resolved with progress reporting
-- SQLite cache per project (`~/.cache/perl-lsp/<hash>/modules.db`), schema v6 with `subs` JSON column
+- SQLite cache per project (`~/.cache/perl-lsp/<hash>/modules.db`), schema v8 with `subs` JSON + `parents` JSON columns
 - Async handlers only use `_cached` methods — zero I/O
 - After resolution, diagnostics are refreshed for all open files (clears stale false positives)
 
@@ -118,6 +118,17 @@ Post-build enrichment propagates imported return types and hash keys into the lo
 - Backend wiring: `Arc<ModuleIndex>` on `Backend`, refresh callback uses `OnceLock<Arc<ModuleIndex>>` for deferred init (resolver thread has no tokio context, spawns async work via captured `Handle`)
 - `enrich_analysis()` called from `publish_diagnostics()` and from the refresh callback (which re-enriches all open documents when a module resolves)
 - `InferredType` serialized as simple string tags (`"HashRef"`, `"Object:Foo"`, etc.) for JSON IPC and SQLite TEXT storage — no serde derives
+- `EXTRACT_VERSION` tracks extraction logic version; stale entries loaded from cache but re-resolved with priority
+
+### Inheritance chain resolution
+
+- `FileAnalysis.package_parents: HashMap<String, Vec<String>>` — unified parent map from all inheritance sources
+- Sources: `use parent`, `use base`, `@ISA = (...)`, `class :isa(Parent)` — all feed `package_parents` during builder walk
+- `resolve_method_in_ancestors()` does DFS parent walk (matching Perl's default MRO), depth limit 20
+- `MethodResolution` enum: `Local { class, sym_id }` for same-file, `CrossFile { class }` for module index lookup
+- `complete_methods_for_class` walks ancestors, deduplicates by name (child methods shadow parent)
+- Cross-file: `ModuleExports.parents` stored in SQLite `parents` TEXT column (JSON array) and subprocess JSON output
+- `ModuleIndex.parents_cached(module_name)` returns parent list for cross-file inheritance walking
 
 ## LSP Capabilities
 

--- a/docs/prompt-inheritance.md
+++ b/docs/prompt-inheritance.md
@@ -1,0 +1,496 @@
+# Task: Inheritance Chain Resolution
+
+**Branch:** create `inheritance` from `main`
+**Baseline:** 229 tests, 0 warnings
+
+## Goal
+
+When a user types `$obj->` and `$obj` is typed as `Child`, show methods from `Child` AND all its ancestors. Same for go-to-def, hover, and return type resolution through method chains.
+
+Currently `complete_methods_for_class`, `find_method_in_class`, and `find_method_return_type` all search only the immediate class. This task adds parent chain walking — unified across all inheritance declaration styles.
+
+## Inheritance sources (all must feed the same model)
+
+| Source | Example | Prevalence |
+|---|---|---|
+| `use parent` | `use parent 'DBI::db'` | Modern standard |
+| `use parent -norequire` | `use parent -norequire, 'Local::Base'` | Same, skip require |
+| `use base` | `use base qw(Exporter LWP::UserAgent)` | Older, still common |
+| `@ISA` assignment | `our @ISA = ('Foo', 'Bar')` | Legacy |
+| `class :isa()` | `class Point3D :isa(Point)` | Perl 5.38 corinna |
+
+All produce the same output: a list of parent class names for the current package.
+
+## Data model
+
+### FileAnalysis: unified package parents
+
+```rust
+/// Parent classes for each package in this file.
+/// Populated by the builder from use parent/base, @ISA, and class :isa.
+pub package_parents: HashMap<String, Vec<String>>,
+```
+
+This is on `FileAnalysis`, not `SymbolDetail`. A package can be declared with `package` (no `SymbolDetail::Class`) and still have parents via `use parent`. The `SymbolDetail::Class { parent, .. }` field continues to exist for Perl 5.38 class-specific data (fields, roles), but the canonical inheritance source becomes `package_parents`.
+
+The builder populates `package_parents` from ALL sources. For `class :isa(Foo)`, it writes to BOTH `SymbolDetail::Class { parent }` (for field/role data) and `package_parents` (for method resolution).
+
+### ModuleExports: cross-file parents
+
+```rust
+pub struct ModuleExports {
+    pub path: PathBuf,
+    pub export: Vec<String>,
+    pub export_ok: Vec<String>,
+    pub subs: HashMap<String, ExportedSub>,
+    pub parents: Vec<String>,  // NEW
+}
+```
+
+The subprocess extraction emits parents in JSON. The resolver stores them. Method resolution can walk the chain across module boundaries.
+
+### ModuleIndex: parent lookup
+
+```rust
+/// Return cached parent classes for a module.
+pub fn parents_cached(&self, module_name: &str) -> Vec<String> {
+    self.cache.get(module_name)
+        .and_then(|entry| entry.as_ref())
+        .map(|e| e.parents.clone())
+        .unwrap_or_default()
+}
+```
+
+## Builder extraction
+
+All inheritance detection happens during the CST walk in `builder.rs`. The builder already tracks `current_package`. When it encounters an inheritance declaration, it appends to a `package_parents: HashMap<String, Vec<String>>` on the builder state, which transfers to `FileAnalysis` at the end.
+
+### `use parent` / `use base`
+
+When visiting a `use_statement` where the module is `parent` or `base`:
+- Extract the class names from the arguments (string literals, `qw()` lists)
+- Skip `-norequire` flag arguments (starts with `-`)
+- Append to `package_parents[current_package]`
+
+### `@ISA` assignment
+
+When visiting an assignment where the LHS is `@ISA`:
+- Extract class names from the RHS (string literals in a list, `qw()`)
+- Replace (not append) `package_parents[current_package]` since `@ISA =` is a full replacement
+
+### `class :isa(Parent)`
+
+Already extracted into `SymbolDetail::Class { parent }`. Add a parallel write to `package_parents`.
+
+## Method resolution with inheritance
+
+### Core: `resolve_method_in_ancestors`
+
+A new method on `FileAnalysis` that walks the parent chain:
+
+```rust
+/// Walk the inheritance chain to find a method.
+/// Returns the class it was found in + the method's SymbolId (for local)
+/// or class name (for cross-file lookup).
+pub fn resolve_method_in_ancestors(
+    &self,
+    class_name: &str,
+    method_name: &str,
+    module_index: Option<&ModuleIndex>,
+) -> Option<MethodResolution>
+
+pub enum MethodResolution {
+    /// Found in a local class within this file.
+    Local { class: String, sym_id: SymbolId },
+    /// Found in a cross-file module (use ModuleIndex to get details).
+    CrossFile { class: String },
+}
+```
+
+**Algorithm (DFS, matches Perl's default MRO):**
+
+1. Check `class_name` directly (current behavior)
+2. Look up `self.package_parents[class_name]` for local parents
+3. For each parent:
+   a. If parent is a local package → recurse with `resolve_method_in_ancestors`
+   b. If parent is a cross-file module → check `module_index.get_exports_cached(parent).subs[method_name]`
+   c. If found, return it. If not, get the parent's parents via `module_index.parents_cached(parent)` and recurse
+4. Stop at depth 20 (safety limit for circular inheritance)
+
+### Wire into existing call sites
+
+There are 5 methods in `file_analysis.rs` that currently search only the immediate class. Each needs the parent chain walk:
+
+| Method | Currently does | Change |
+|---|---|---|
+| `complete_methods_for_class` | Collects methods from one class | Collect from class + all ancestors, dedup by name (child wins) |
+| `find_method_in_class` | Finds method def span in one class | Walk ancestors, return first match |
+| `find_method_return_type` | Finds return type in one class | Walk ancestors, return first match |
+| `method_detail` | Formats "Class → Type" | Show actual defining class if inherited |
+| `symbol_in_class` | Checks scope chain for one class | Also match if class is an ancestor of the target |
+
+**Important:** These methods currently don't take a `ModuleIndex` parameter. They'll need an `Option<&ModuleIndex>` parameter (or access it through an enrichment pass). The local-only path (no ModuleIndex) still works for single-file analysis and tests.
+
+### Completion detail for inherited methods
+
+When a method is inherited, the completion detail should indicate the source:
+
+```
+$obj->connect()    DBI::db (from DBI)
+$obj->prepare()    DBI::db
+$obj->new()        DBI::db (from Class::Accessor)
+```
+
+Local methods show the class name. Inherited methods show "ClassName (from AncestorName)".
+
+## Cross-file storage
+
+### Subprocess output
+
+`subprocess_main` and `resolve_and_parse` already extract module metadata. Add parent extraction:
+
+```json
+{
+  "export": ["connect"],
+  "export_ok": ["..."],
+  "subs": { ... },
+  "parents": ["DBI", "Exporter"]
+}
+```
+
+The subprocess runs the full builder on the module file. Read `package_parents` from the resulting `FileAnalysis` — use the primary package's parents (the package matching the module name).
+
+### SQLite
+
+Add a `parents TEXT NOT NULL DEFAULT '[]'` column to the modules table. This is a real schema change → bump `SCHEMA_VERSION` to `"8"`.
+
+JSON array of class name strings: `["DBI", "Exporter"]`.
+
+### ModuleExports
+
+Add `parents: Vec<String>` to `ModuleExports`. Serialize/deserialize as JSON array.
+
+### EXTRACT_VERSION
+
+Also bump `EXTRACT_VERSION` to `2`. Existing cached modules without parent info get lazily re-resolved (the extract versioning system from the previous PR handles this).
+
+## What about multiple packages per file?
+
+A single `.pm` file can define multiple packages. `package_parents` is a HashMap keyed by package name, so it handles this naturally. For cross-file storage, `ModuleExports.parents` stores the parents of the *primary* package (the one matching the module name). Methods from secondary packages in the same file aren't exported anyway, so this is sufficient.
+
+## What NOT to do
+
+- Don't implement C3 MRO — DFS is correct for single inheritance (vast majority) and reasonable for multiple. C3 can be added later if needed.
+- Don't try to resolve parents at query time via `require` — only use what's in the builder output and the module cache
+- Don't walk inheritance for non-method lookups (variables, hash keys) — only methods are inherited in Perl
+- Don't add Moo/Moose `extends`/`with` in this PR — the data model supports it but extraction is a separate task
+- Don't change `SymbolDetail::Class` structure — it keeps its field/role data. `package_parents` is the unified inheritance source
+- Don't add circular inheritance detection beyond the depth limit — it's not worth the complexity
+
+## Tests
+
+### Unit tests (builder — extraction)
+
+```rust
+#[test]
+fn test_use_parent_single() {
+    let fa = build_fa("
+        package Child;
+        use parent 'Parent';
+        sub child_method { }
+    ");
+    assert_eq!(fa.package_parents.get("Child").unwrap(), &vec!["Parent".to_string()]);
+}
+
+#[test]
+fn test_use_parent_multiple() {
+    let fa = build_fa("
+        package Multi;
+        use parent qw(Foo Bar);
+    ");
+    assert_eq!(fa.package_parents.get("Multi").unwrap(), &vec!["Foo".to_string(), "Bar".to_string()]);
+}
+
+#[test]
+fn test_use_parent_norequire() {
+    let fa = build_fa("
+        package Local;
+        use parent -norequire, 'My::Base';
+    ");
+    assert_eq!(fa.package_parents.get("Local").unwrap(), &vec!["My::Base".to_string()]);
+}
+
+#[test]
+fn test_use_base() {
+    let fa = build_fa("
+        package Old;
+        use base 'Legacy::Base';
+    ");
+    assert_eq!(fa.package_parents.get("Old").unwrap(), &vec!["Legacy::Base".to_string()]);
+}
+
+#[test]
+fn test_isa_assignment() {
+    let fa = build_fa("
+        package Direct;
+        our @ISA = ('Alpha', 'Beta');
+    ");
+    assert_eq!(fa.package_parents.get("Direct").unwrap(), &vec!["Alpha".to_string(), "Beta".to_string()]);
+}
+
+#[test]
+fn test_class_isa_populates_package_parents() {
+    let fa = build_fa("
+        class Child :isa(Parent) { }
+    ");
+    assert_eq!(fa.package_parents.get("Child").unwrap(), &vec!["Parent".to_string()]);
+}
+```
+
+### Unit tests (method resolution — local inheritance)
+
+```rust
+#[test]
+fn test_inherited_method_completion() {
+    let fa = build_fa("
+        package Animal;
+        sub speak { }
+        sub eat { }
+
+        package Dog;
+        use parent 'Animal';
+        sub fetch { }
+    ");
+    let methods = fa.complete_methods_for_class("Dog");
+    let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+    assert!(names.contains(&"fetch"), "own method");
+    assert!(names.contains(&"speak"), "inherited from Animal");
+    assert!(names.contains(&"eat"), "inherited from Animal");
+}
+
+#[test]
+fn test_child_method_overrides_parent() {
+    let fa = build_fa("
+        package Base;
+        sub greet { }
+
+        package Override;
+        use parent 'Base';
+        sub greet { }  // override
+    ");
+    let methods = fa.complete_methods_for_class("Override");
+    let greet_count = methods.iter().filter(|c| c.label == "greet").count();
+    assert_eq!(greet_count, 1, "child override should shadow parent");
+}
+
+#[test]
+fn test_find_method_in_parent() {
+    let fa = build_fa("
+        package Base;
+        sub base_method { }
+
+        package Child;
+        use parent 'Base';
+    ");
+    let span = fa.find_method_in_class("Child", "base_method");
+    assert!(span.is_some(), "should find inherited method");
+}
+
+#[test]
+fn test_inherited_return_type() {
+    let fa = build_fa("
+        package Factory;
+        sub create { Factory->new(@_) }
+
+        package SpecialFactory;
+        use parent 'Factory';
+    ");
+    let rt = fa.find_method_return_type("SpecialFactory", "create");
+    assert!(rt.is_some(), "should find return type from parent");
+}
+
+#[test]
+fn test_multi_level_inheritance() {
+    let fa = build_fa("
+        package A;
+        sub from_a { }
+
+        package B;
+        use parent 'A';
+        sub from_b { }
+
+        package C;
+        use parent 'B';
+        sub from_c { }
+    ");
+    let methods = fa.complete_methods_for_class("C");
+    let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+    assert!(names.contains(&"from_a"));
+    assert!(names.contains(&"from_b"));
+    assert!(names.contains(&"from_c"));
+}
+
+#[test]
+fn test_class_isa_inherits_methods() {
+    let fa = build_fa("
+        class Parent {
+            method greet() { }
+        }
+        class Child :isa(Parent) {
+            method wave() { }
+        }
+    ");
+    let methods = fa.complete_methods_for_class("Child");
+    let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+    assert!(names.contains(&"wave"), "own method");
+    assert!(names.contains(&"greet"), "inherited from Parent");
+}
+```
+
+### Cross-file tests (using `insert_cache`)
+
+`ModuleIndex::new_for_test()` + `insert_cache()` lets us build an arbitrary module graph in memory — no filesystem, no subprocess, no resolver thread. This is how existing cross-file tests work (see `test_find_exporters`, `test_get_return_type_cached`).
+
+```rust
+#[test]
+fn test_cross_file_inherited_method_completion() {
+    let idx = ModuleIndex::new_for_test();
+    idx.set_workspace_root(None);
+
+    // Grandparent: DBI has `connect`
+    idx.insert_cache("DBI", Some(ModuleExports {
+        path: PathBuf::from("/fake/DBI.pm"),
+        export: vec![],
+        export_ok: vec![],
+        subs: {
+            let mut s = HashMap::new();
+            s.insert("connect".into(), ExportedSub {
+                def_line: 10, params: vec![], is_method: true,
+                return_type: None, hash_keys: vec![], doc: None,
+            });
+            s
+        },
+        parents: vec![],
+    }));
+
+    // Parent: DBI::db inherits from DBI, has `prepare`
+    idx.insert_cache("DBI::db", Some(ModuleExports {
+        path: PathBuf::from("/fake/DBI/db.pm"),
+        export: vec![],
+        export_ok: vec![],
+        subs: {
+            let mut s = HashMap::new();
+            s.insert("prepare".into(), ExportedSub {
+                def_line: 5, params: vec![], is_method: true,
+                return_type: None, hash_keys: vec![], doc: None,
+            });
+            s
+        },
+        parents: vec!["DBI".into()],
+    }));
+
+    // Local code inherits from DBI::db
+    let fa = build_fa("
+        package MyDB;
+        use parent 'DBI::db';
+        sub custom_query { }
+    ");
+
+    let methods = fa.complete_methods_for_class("MyDB", Some(&idx));
+    let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+    assert!(names.contains(&"custom_query"), "own method");
+    assert!(names.contains(&"prepare"), "from DBI::db");
+    assert!(names.contains(&"connect"), "from DBI (grandparent)");
+}
+
+#[test]
+fn test_cross_file_method_override() {
+    let idx = ModuleIndex::new_for_test();
+    idx.set_workspace_root(None);
+
+    // Parent has `process`
+    idx.insert_cache("Base::Worker", Some(ModuleExports {
+        path: PathBuf::from("/fake/Base/Worker.pm"),
+        export: vec![],
+        export_ok: vec![],
+        subs: {
+            let mut s = HashMap::new();
+            s.insert("process".into(), ExportedSub {
+                def_line: 1, params: vec![], is_method: true,
+                return_type: None, hash_keys: vec![], doc: None,
+            });
+            s
+        },
+        parents: vec![],
+    }));
+
+    // Local child overrides `process`
+    let fa = build_fa("
+        package MyWorker;
+        use parent 'Base::Worker';
+        sub process { }
+    ");
+
+    let methods = fa.complete_methods_for_class("MyWorker", Some(&idx));
+    let process_count = methods.iter().filter(|c| c.label == "process").count();
+    assert_eq!(process_count, 1, "local override should shadow parent");
+}
+
+#[test]
+fn test_cross_file_return_type_through_inheritance() {
+    let idx = ModuleIndex::new_for_test();
+    idx.set_workspace_root(None);
+
+    idx.insert_cache("Fetcher", Some(ModuleExports {
+        path: PathBuf::from("/fake/Fetcher.pm"),
+        export: vec![],
+        export_ok: vec![],
+        subs: {
+            let mut s = HashMap::new();
+            s.insert("fetch".into(), ExportedSub {
+                def_line: 1, params: vec![], is_method: true,
+                return_type: Some(InferredType::HashRef),
+                hash_keys: vec!["status".into(), "body".into()],
+                doc: None,
+            });
+            s
+        },
+        parents: vec![],
+    }));
+
+    let fa = build_fa("
+        package MyFetcher;
+        use parent 'Fetcher';
+    ");
+
+    let rt = fa.find_method_return_type("MyFetcher", "fetch", Some(&idx));
+    assert_eq!(rt, Some(InferredType::HashRef));
+}
+
+#[test]
+fn test_parents_cached() {
+    let idx = ModuleIndex::new_for_test();
+    idx.set_workspace_root(None);
+
+    idx.insert_cache("Child::Mod", Some(ModuleExports {
+        path: PathBuf::from("/fake/Child/Mod.pm"),
+        export: vec![],
+        export_ok: vec![],
+        subs: HashMap::new(),
+        parents: vec!["Parent::Mod".into(), "Mixin::Role".into()],
+    }));
+
+    let parents = idx.parents_cached("Child::Mod");
+    assert_eq!(parents, vec!["Parent::Mod", "Mixin::Role"]);
+    assert!(idx.parents_cached("Unknown::Mod").is_empty());
+}
+```
+
+## Verification
+
+1. `cargo test` — all 229 existing tests pass + new tests
+2. `cargo build` — no warnings
+3. Manual: `./target/release/perl-lsp --parse-exports /path/to/DBI/db.pm` — check `parents` field in output
+4. Manual: open a file with `use parent 'Foo'`, type `$self->` inside a method — verify parent's methods appear in completion
+5. Manual: go-to-def on an inherited method call — should jump to the parent's definition
+6. Manual: hover on inherited method — should show the defining class

--- a/lua/test/lsp.lua
+++ b/lua/test/lsp.lua
@@ -31,6 +31,17 @@ function M.def_line(buf, line, col)
   return nil
 end
 
+--- Get definition result as { uri, line } or nil.
+function M.def_location(buf, line, col)
+  local result = M.request(buf, "textDocument/definition", M.pos_params(buf, line, col))
+  if not result then return nil end
+  local loc = vim.islist(result) and result[1] or result
+  if loc and loc.range then
+    return { uri = loc.uri or loc.targetUri, line = loc.range.start.line }
+  end
+  return nil
+end
+
 --- Get completion labels as a plain list of strings.
 function M.completion_labels(buf, line, col)
   local result = M.request(buf, "textDocument/completion", M.pos_params(buf, line, col))

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export PERL5LIB="${PERL5LIB:-$PWD/test_files/lib}"
 
 failed=0
-for test in test_e2e.lua test_e2e_types.lua test_e2e_cross_file.lua; do
+for test in test_e2e.lua test_e2e_types.lua test_e2e_cross_file.lua test_e2e_inheritance.lua; do
   echo "── $test ──"
   if ! nvim --headless --clean -u test_nvim_init.lua -l "$test"; then
     failed=1

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -204,6 +204,12 @@ impl LanguageServer for Backend {
             for imp in &doc.analysis.imports {
                 self.module_index.request_resolve(&imp.module_name);
             }
+            // Enqueue parent classes for resolution (inheritance chain).
+            for parents in doc.analysis.package_parents.values() {
+                for parent in parents {
+                    self.module_index.request_resolve(parent);
+                }
+            }
             self.documents.insert(uri.clone(), doc);
         }
         self.publish_diagnostics(&uri).await;
@@ -217,6 +223,12 @@ impl LanguageServer for Backend {
                 // Resolve any new imports that appeared during editing.
                 for imp in &doc.analysis.imports {
                     self.module_index.request_resolve(&imp.module_name);
+                }
+                // Resolve parent classes for inheritance.
+                for parents in doc.analysis.package_parents.values() {
+                    for parent in parents {
+                        self.module_index.request_resolve(parent);
+                    }
                 }
             }
         }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -48,7 +48,7 @@ impl Backend {
                 for mut entry in docs.iter_mut() {
                     let uri = entry.key().clone();
                     let (imported_returns, imported_keys) = build_imported_return_types(&entry.analysis, module_index);
-                    entry.analysis.enrich_imported_types_with_keys(imported_returns, imported_keys);
+                    entry.analysis.enrich_imported_types_with_keys(imported_returns, imported_keys, Some(module_index));
                     let diagnostics = symbols::collect_diagnostics(&entry.analysis, module_index);
                     client.publish_diagnostics(uri, diagnostics, None).await;
                 }
@@ -68,7 +68,7 @@ impl Backend {
     fn enrich_analysis(&self, uri: &Url) {
         if let Some(mut doc) = self.documents.get_mut(uri) {
             let (imported_returns, imported_keys) = build_imported_return_types(&doc.analysis, &self.module_index);
-            doc.analysis.enrich_imported_types_with_keys(imported_returns, imported_keys);
+            doc.analysis.enrich_imported_types_with_keys(imported_returns, imported_keys, Some(&self.module_index));
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -935,14 +935,16 @@ impl<'a> Builder<'a> {
 
                 // Extract parent classes from `use parent` / `use base`
                 if module_name == "parent" || module_name == "base" {
-                    if let Some(ref pkg) = self.current_package {
+                    if let Some(pkg) = self.current_package.clone() {
                         let (parents, _) = self.extract_use_import_list(node);
                         let parents: Vec<String> = parents.into_iter()
                             .filter(|s| !s.starts_with('-')) // skip -norequire etc.
                             .collect();
                         if !parents.is_empty() {
+                            // Emit PackageRef for each parent class (for goto-def on parent names)
+                            self.emit_parent_class_refs(node, &parents);
                             self.package_parents
-                                .entry(pkg.clone())
+                                .entry(pkg)
                                 .or_default()
                                 .extend(parents);
                         }
@@ -951,6 +953,10 @@ impl<'a> Builder<'a> {
 
                 // Extract imported symbols from qw(...) or list
                 let (imported_symbols, qw_close_paren) = self.extract_use_import_list(node);
+                // Emit FunctionCall refs for imported symbol names (for goto-def on import args)
+                if module_name != "parent" && module_name != "base" {
+                    self.emit_import_symbol_refs(node, &imported_symbols);
+                }
                 self.imports.push(Import {
                     module_name: module_name.to_string(),
                     imported_symbols,
@@ -960,6 +966,179 @@ impl<'a> Builder<'a> {
             }
         }
         // Don't recurse — use statements don't contain interesting sub-nodes
+    }
+
+    /// Emit PackageRef refs for parent class names in `use parent`/`use base` statements.
+    /// Walks the use statement's children to find string literals or qw words matching parent names.
+    fn emit_parent_class_refs(&mut self, node: Node<'a>, parents: &[String]) {
+        let parent_set: std::collections::HashSet<&str> = parents.iter().map(|s| s.as_str()).collect();
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                match child.kind() {
+                    "string_literal" => {
+                        // Single string: 'BaseWorker' — use string_content child for span
+                        if let Some(content) = child.named_child(0) {
+                            if content.kind() == "string_content" {
+                                if let Ok(text) = content.utf8_text(self.source) {
+                                    if parent_set.contains(text) {
+                                        self.add_ref(
+                                            RefKind::PackageRef,
+                                            node_to_span(content),
+                                            text.to_string(),
+                                            AccessKind::Read,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "quoted_word_list" => {
+                        // qw(Foo Bar) — string_content may contain multiple words
+                        for j in 0..child.named_child_count() {
+                            if let Some(sc) = child.named_child(j) {
+                                if sc.kind() == "string_content" {
+                                    if let Ok(text) = sc.utf8_text(self.source) {
+                                        // Each word in the qw list — find its position
+                                        let sc_start = sc.start_position();
+                                        let mut col_offset = 0usize;
+                                        for word in text.split_whitespace() {
+                                            if let Some(pos) = text[col_offset..].find(word) {
+                                                let word_col = col_offset + pos;
+                                                if parent_set.contains(word) {
+                                                    let start = Point::new(sc_start.row, sc_start.column + word_col);
+                                                    let end = Point::new(sc_start.row, sc_start.column + word_col + word.len());
+                                                    self.add_ref(
+                                                        RefKind::PackageRef,
+                                                        Span { start, end },
+                                                        word.to_string(),
+                                                        AccessKind::Read,
+                                                    );
+                                                }
+                                                col_offset = word_col + word.len();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "parenthesized_expression" | "list_expression" => {
+                        // ('Foo', 'Bar') — walk for string_literal children
+                        self.emit_parent_refs_in_list(child, &parent_set);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Helper: emit PackageRef refs for parent names found in a list/paren expression.
+    fn emit_parent_refs_in_list(&mut self, node: Node<'a>, parent_set: &std::collections::HashSet<&str>) {
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                if child.kind() == "string_literal" {
+                    if let Some(content) = child.named_child(0) {
+                        if content.kind() == "string_content" {
+                            if let Ok(text) = content.utf8_text(self.source) {
+                                if parent_set.contains(text) {
+                                    self.add_ref(
+                                        RefKind::PackageRef,
+                                        node_to_span(content),
+                                        text.to_string(),
+                                        AccessKind::Read,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Emit FunctionCall refs for imported symbol names in use statements (for goto-def on import args).
+    /// Handles `use Foo 'bar'`, `use Foo qw(bar baz)`, and `use Foo ('bar', 'baz')`.
+    fn emit_import_symbol_refs(&mut self, node: Node<'a>, symbols: &[String]) {
+        if symbols.is_empty() { return; }
+        let sym_set: std::collections::HashSet<&str> = symbols.iter().map(|s| s.as_str()).collect();
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                match child.kind() {
+                    "string_literal" => {
+                        if let Some(content) = child.named_child(0) {
+                            if content.kind() == "string_content" {
+                                if let Ok(text) = content.utf8_text(self.source) {
+                                    if sym_set.contains(text) {
+                                        self.add_ref(
+                                            RefKind::FunctionCall,
+                                            node_to_span(content),
+                                            text.to_string(),
+                                            AccessKind::Read,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "quoted_word_list" => {
+                        for j in 0..child.named_child_count() {
+                            if let Some(sc) = child.named_child(j) {
+                                if sc.kind() == "string_content" {
+                                    if let Ok(text) = sc.utf8_text(self.source) {
+                                        let sc_start = sc.start_position();
+                                        let mut col_offset = 0usize;
+                                        for word in text.split_whitespace() {
+                                            if let Some(pos) = text[col_offset..].find(word) {
+                                                let word_col = col_offset + pos;
+                                                if sym_set.contains(word) {
+                                                    let start = Point::new(sc_start.row, sc_start.column + word_col);
+                                                    let end = Point::new(sc_start.row, sc_start.column + word_col + word.len());
+                                                    self.add_ref(
+                                                        RefKind::FunctionCall,
+                                                        Span { start, end },
+                                                        word.to_string(),
+                                                        AccessKind::Read,
+                                                    );
+                                                }
+                                                col_offset = word_col + word.len();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "parenthesized_expression" | "list_expression" => {
+                        self.emit_import_refs_in_list(child, &sym_set);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Helper: emit FunctionCall refs for imported names found in a list/paren expression.
+    fn emit_import_refs_in_list(&mut self, node: Node<'a>, sym_set: &std::collections::HashSet<&str>) {
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                if child.kind() == "string_literal" {
+                    if let Some(content) = child.named_child(0) {
+                        if content.kind() == "string_content" {
+                            if let Ok(text) = content.utf8_text(self.source) {
+                                if sym_set.contains(text) {
+                                    self.add_ref(
+                                        RefKind::FunctionCall,
+                                        node_to_span(content),
+                                        text.to_string(),
+                                        AccessKind::Read,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Extract the import list from a use statement.
@@ -3776,6 +3955,34 @@ sub transform { }
             use parent qw(Foo Bar);
         ");
         assert_eq!(fa.package_parents.get("Multi").unwrap(), &vec!["Foo".to_string(), "Bar".to_string()]);
+    }
+
+    #[test]
+    fn test_use_parent_emits_package_refs() {
+        let fa = build_fa("
+            package Child;
+            use parent 'Parent';
+        ");
+        let refs: Vec<_> = fa.refs.iter()
+            .filter(|r| matches!(r.kind, RefKind::PackageRef) && r.target_name == "Parent")
+            .collect();
+        assert_eq!(refs.len(), 1, "should emit PackageRef for parent class");
+    }
+
+    #[test]
+    fn test_use_parent_qw_emits_package_refs() {
+        let fa = build_fa("
+            package Multi;
+            use parent qw(Foo Bar);
+        ");
+        let foo_refs: Vec<_> = fa.refs.iter()
+            .filter(|r| matches!(r.kind, RefKind::PackageRef) && r.target_name == "Foo")
+            .collect();
+        let bar_refs: Vec<_> = fa.refs.iter()
+            .filter(|r| matches!(r.kind, RefKind::PackageRef) && r.target_name == "Bar")
+            .collect();
+        assert_eq!(foo_refs.len(), 1, "should emit PackageRef for Foo");
+        assert_eq!(bar_refs.len(), 1, "should emit PackageRef for Bar");
     }
 
     #[test]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -474,7 +474,7 @@ impl<'a> Builder<'a> {
         let params = self.extract_params(node);
 
         // Extract preceding POD/comment documentation
-        let doc = self.extract_preceding_doc(node);
+        let doc = self.extract_preceding_doc(node, &name);
 
         self.add_symbol(
             name.clone(),
@@ -1830,7 +1830,7 @@ impl<'a> Builder<'a> {
     /// Get the name of the enclosing sub/method, if any.
     /// Extract POD or comment documentation immediately preceding a sub node.
     /// Walks prev_sibling chain (tree-sitter CST traversal stays in builder).
-    fn extract_preceding_doc(&self, sub_node: Node<'a>) -> Option<String> {
+    fn extract_preceding_doc(&self, sub_node: Node<'a>, sub_name: &str) -> Option<String> {
         let source_str = std::str::from_utf8(self.source).ok()?;
         let mut prev = sub_node.prev_sibling();
         let mut comment_lines: Vec<String> = Vec::new();
@@ -1839,6 +1839,20 @@ impl<'a> Builder<'a> {
             match node.kind() {
                 "pod" => {
                     let text = &source_str[node.byte_range()];
+                    // Try to extract just the section for this sub (=head2 or =item)
+                    if let Some(section) = crate::pod::extract_head2_section(sub_name, text) {
+                        let md = crate::pod::pod_to_markdown(&section);
+                        if !md.is_empty() {
+                            return Some(md);
+                        }
+                    }
+                    if let Some(section) = crate::pod::extract_item_section(sub_name, text) {
+                        let md = crate::pod::pod_to_markdown(&section);
+                        if !md.is_empty() {
+                            return Some(md);
+                        }
+                    }
+                    // Fallback: convert entire POD block (e.g. single-section pod)
                     let md = crate::pod::pod_to_markdown(text);
                     if !md.is_empty() {
                         return Some(md);
@@ -3710,6 +3724,37 @@ Performs a POST request.
             });
         assert!(get_doc.is_some(), "get should have doc from =item");
         assert!(get_doc.unwrap().contains("GET request"));
+    }
+
+    #[test]
+    fn test_pod_doc_extracted_per_function() {
+        let src = "\
+package DemoUtils;
+use Exporter 'import';
+our @EXPORT_OK = qw(fetch_data transform);
+
+=head2 fetch_data
+
+Fetches data from the given URL.
+
+=head2 transform
+
+Transforms items.
+
+=cut
+
+sub fetch_data { }
+sub transform { }
+";
+        let fa = build_fa(src);
+        let fd = fa.symbols.iter().find(|s| s.name == "fetch_data").unwrap();
+        if let SymbolDetail::Sub { ref doc, .. } = fd.detail {
+            let d = doc.as_ref().expect("fetch_data should have doc");
+            assert!(d.contains("Fetches data"), "should have fetch_data doc, got: {}", d);
+            assert!(!d.contains("Transforms items"), "should NOT have transform doc, got: {}", d);
+        } else {
+            panic!("fetch_data should be a Sub");
+        }
     }
 
     // ---- Inheritance extraction tests ----

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,6 +21,7 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
         last_expr_type: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
         pod_texts: Vec::new(),
+        package_parents: std::collections::HashMap::new(),
         scope_stack: Vec::new(),
         current_package: None,
         next_scope_id: 0,
@@ -53,6 +54,7 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
         b.fold_ranges,
         b.imports,
         b.call_bindings,
+        b.package_parents,
     )
 }
 
@@ -81,6 +83,8 @@ struct Builder<'a> {
     call_bindings: Vec<CallBinding>,
     /// Raw POD text blocks collected during the walk (for tail-POD post-pass).
     pod_texts: Vec<String>,
+    /// Parent classes for each package (from use parent/base, @ISA, class :isa).
+    package_parents: std::collections::HashMap<String, Vec<String>>,
 
     // Walk state
     scope_stack: Vec<ScopeId>,
@@ -358,6 +362,14 @@ impl<'a> Builder<'a> {
                     self.collect_field_details(child, &mut field_details);
                 }
             }
+        }
+
+        // Write to package_parents for unified inheritance resolution
+        if let Some(ref p) = parent {
+            self.package_parents
+                .entry(name.clone())
+                .or_default()
+                .push(p.clone());
         }
 
         self.add_symbol(
@@ -921,6 +933,22 @@ impl<'a> Builder<'a> {
                     SymbolDetail::None,
                 );
 
+                // Extract parent classes from `use parent` / `use base`
+                if module_name == "parent" || module_name == "base" {
+                    if let Some(ref pkg) = self.current_package {
+                        let (parents, _) = self.extract_use_import_list(node);
+                        let parents: Vec<String> = parents.into_iter()
+                            .filter(|s| !s.starts_with('-')) // skip -norequire etc.
+                            .collect();
+                        if !parents.is_empty() {
+                            self.package_parents
+                                .entry(pkg.clone())
+                                .or_default()
+                                .extend(parents);
+                        }
+                    }
+                }
+
                 // Extract imported symbols from qw(...) or list
                 let (imported_symbols, qw_close_paren) = self.extract_use_import_list(node);
                 self.imports.push(Import {
@@ -971,6 +999,15 @@ impl<'a> Builder<'a> {
                             return (words, None);
                         }
                     }
+                    "string_literal" => {
+                        // bare 'Foo' (single string, no parens/qw)
+                        if let Ok(text) = child.utf8_text(self.source) {
+                            let unquoted = text.trim_matches(|c| c == '\'' || c == '"');
+                            if !unquoted.is_empty() {
+                                return (vec![unquoted.to_string()], None);
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -1004,6 +1041,47 @@ impl<'a> Builder<'a> {
     }
 
     fn visit_assignment(&mut self, node: Node<'a>) {
+        // Check for @ISA assignment: `our @ISA = (...)`
+        if let Some(left) = node.child_by_field_name("left") {
+            let lhs_text = left.utf8_text(self.source).unwrap_or("");
+            if lhs_text == "@ISA" || lhs_text.ends_with("@ISA") {
+                if let Some(ref pkg) = self.current_package {
+                    // child_by_field_name("right") returns `(` paren, not the list.
+                    // Iterate named children to find list_expression/quoted_word_list.
+                    let mut parents = Vec::new();
+                    for i in 0..node.named_child_count() {
+                        if let Some(child) = node.named_child(i) {
+                            match child.kind() {
+                                "list_expression" | "parenthesized_expression" => {
+                                    self.collect_string_values(child, &mut parents);
+                                }
+                                "quoted_word_list" => {
+                                    for j in 0..child.named_child_count() {
+                                        if let Some(sc) = child.named_child(j) {
+                                            if sc.kind() == "string_content" {
+                                                if let Ok(text) = sc.utf8_text(self.source) {
+                                                    for word in text.split_whitespace() {
+                                                        if !word.is_empty() {
+                                                            parents.push(word.to_string());
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    if !parents.is_empty() {
+                        // @ISA = replaces (not appends)
+                        self.package_parents.insert(pkg.clone(), parents);
+                    }
+                }
+            }
+        }
+
         // Check for type inference from RHS
         if let Some(left) = node.child_by_field_name("left") {
             if left.kind() == "variable_declaration" {
@@ -2362,7 +2440,7 @@ $p->;
         let source = "package main;\n1;\nuse v5.38;\nclass Point {\n    field $x :param :reader;\n    method magnitude () { }\n}\nmy $p = Point->new(x => 3);\n$p->magnitude();\n";
         let fa = build_fa(source);
         // cursor on `magnitude` in `$p->magnitude()` — line 8, col 5
-        let def = fa.find_definition(Point::new(8, 5), None, None);
+        let def = fa.find_definition(Point::new(8, 5), None, None, None);
         assert!(def.is_some(), "should find definition for magnitude");
         let span = def.unwrap();
         assert_eq!(span.start.row, 5, "should point to method declaration line, got row {}", span.start.row);
@@ -2372,7 +2450,7 @@ $p->;
     fn test_field_reader_goto_def() {
         // go-to-def on $p->x should find the reader method, which points to the field
         let fa = build_fa("use v5.38;\nclass Point {\n    field $x :param :reader;\n    method mag() { }\n}\nmy $p = Point->new(x => 1);\n$p->x;");
-        let def = fa.find_definition(Point::new(6, 5), None, None); // cursor on `x` in `$p->x`
+        let def = fa.find_definition(Point::new(6, 5), None, None, None); // cursor on `x` in `$p->x`
         assert!(def.is_some(), "should find definition for reader method");
         // The reader method's selection_span points to the field declaration
         let span = def.unwrap();
@@ -2847,7 +2925,7 @@ $p->;
         // Find the function_call_expression on line 3
         let call_node = find_node_at(tree.root_node(), Point::new(3, 0), "function_call_expression")
             .expect("should find function_call_expression");
-        let ty = fa.resolve_expression_type(call_node, src.as_bytes());
+        let ty = fa.resolve_expression_type(call_node, src.as_bytes(), None);
         assert_eq!(ty, Some(InferredType::HashRef));
     }
 
@@ -2869,7 +2947,7 @@ $p->;
         // Find the scalar $x on line 1
         let scalar_node = find_node_at(tree.root_node(), Point::new(1, 0), "scalar")
             .expect("should find scalar");
-        let ty = fa.resolve_expression_type(scalar_node, src.as_bytes());
+        let ty = fa.resolve_expression_type(scalar_node, src.as_bytes(), None);
         assert_eq!(ty, Some(InferredType::HashRef));
     }
 
@@ -2893,7 +2971,7 @@ $p->;
             };
         }
         assert_eq!(n.kind(), "method_call_expression");
-        let ty = fa.resolve_expression_type(n, src.as_bytes());
+        let ty = fa.resolve_expression_type(n, src.as_bytes(), None);
         assert_eq!(ty, Some(InferredType::HashRef));
     }
 
@@ -2904,7 +2982,7 @@ $p->;
         let fa = build(&tree, src.as_bytes());
         let call = find_node_at(tree.root_node(), Point::new(3, 0), "method_call_expression")
             .expect("should find method_call_expression");
-        let ty = fa.resolve_expression_type(call, src.as_bytes());
+        let ty = fa.resolve_expression_type(call, src.as_bytes(), None);
         assert_eq!(ty, Some(InferredType::ClassName("Foo".into())));
     }
 
@@ -2955,7 +3033,7 @@ $calc->get_self->get_config->{host};
         // The base of hash_element_expression is the method chain
         let base = n.named_child(0).expect("should have base");
         assert_eq!(base.kind(), "method_call_expression");
-        let ty = fa.resolve_expression_type(base, src.as_bytes());
+        let ty = fa.resolve_expression_type(base, src.as_bytes(), None);
         assert_eq!(ty, Some(InferredType::HashRef),
             "the chain $calc->get_self->get_config should resolve to HashRef");
     }
@@ -3010,7 +3088,7 @@ $calc->get_self->get_config->{host};
     fn test_find_def_variable() {
         let fa = build_fa("my $x = 1;\nprint $x;");
         // Cursor on the usage of $x at line 1
-        let def = fa.find_definition(Point::new(1, 7), None, None);
+        let def = fa.find_definition(Point::new(1, 7), None, None, None);
         assert!(def.is_some(), "should find definition for $x");
         let span = def.unwrap();
         assert_eq!(span.start.row, 0, "definition should be on line 0");
@@ -3020,7 +3098,7 @@ $calc->get_self->get_config->{host};
     fn test_find_def_sub() {
         let fa = build_fa("sub greet { }\ngreet();");
         // Cursor on the function call at line 1
-        let def = fa.find_definition(Point::new(1, 1), None, None);
+        let def = fa.find_definition(Point::new(1, 1), None, None, None);
         assert!(def.is_some(), "should find definition for greet");
         let span = def.unwrap();
         assert_eq!(span.start.row, 0, "definition should be on line 0");
@@ -3031,7 +3109,7 @@ $calc->get_self->get_config->{host};
         let src = "package Foo;\nsub new { bless {}, shift }\nsub hello { }\npackage main;\nmy $f = Foo->new();\n$f->hello();";
         let fa = build_fa(src);
         // Cursor on hello() call at line 5
-        let def = fa.find_definition(Point::new(5, 5), None, None);
+        let def = fa.find_definition(Point::new(5, 5), None, None, None);
         assert!(def.is_some(), "should find definition for hello method");
         let span = def.unwrap();
         assert_eq!(span.start.row, 2, "hello definition should be on line 2");
@@ -3042,7 +3120,7 @@ $calc->get_self->get_config->{host};
         let src = "my $x = 'outer';\nsub foo {\n    my $x = 'inner';\n    print $x;\n}";
         let fa = build_fa(src);
         // Cursor on $x inside sub (line 3) should resolve to inner $x (line 2)
-        let def = fa.find_definition(Point::new(3, 11), None, None);
+        let def = fa.find_definition(Point::new(3, 11), None, None, None);
         assert!(def.is_some());
         let span = def.unwrap();
         assert_eq!(span.start.row, 2, "should resolve to inner $x on line 2");
@@ -3078,7 +3156,7 @@ $calc->get_self->get_config->{host};
             .filter(|r| r.target_name == "host" && matches!(r.kind, RefKind::HashKeyAccess { .. }))
             .collect();
         assert!(!host_refs.is_empty(), "should find HashKeyAccess for 'host'");
-        let def = fa.find_definition(host_refs[0].span.start, Some(&tree), Some(src.as_bytes()));
+        let def = fa.find_definition(host_refs[0].span.start, Some(&tree), Some(src.as_bytes()), None);
         assert!(def.is_some(), "should find definition for host");
         assert_eq!(def.unwrap().start.row, 0, "host def should be on line 0");
     }
@@ -3208,7 +3286,7 @@ $calc->get_self->get_config->{host};
     fn test_hover_variable() {
         let src = "my $greeting = 'hello';\nprint $greeting;";
         let fa = build_fa(src);
-        let hover = fa.hover_info(Point::new(1, 8), src, None);
+        let hover = fa.hover_info(Point::new(1, 8), src, None, None);
         assert!(hover.is_some(), "should have hover info");
         let text = hover.unwrap();
         assert!(text.contains("$greeting"), "hover should contain variable name, got: {}", text);
@@ -3218,7 +3296,7 @@ $calc->get_self->get_config->{host};
     fn test_hover_sub() {
         let src = "sub greet { }\ngreet();";
         let fa = build_fa(src);
-        let hover = fa.hover_info(Point::new(1, 1), src, None);
+        let hover = fa.hover_info(Point::new(1, 1), src, None, None);
         assert!(hover.is_some(), "should have hover info for function call");
         let text = hover.unwrap();
         assert!(text.contains("greet"), "hover should contain sub name, got: {}", text);
@@ -3229,7 +3307,7 @@ $calc->get_self->get_config->{host};
         let src = "package Point;\nsub new { bless {}, shift }\npackage main;\nmy $p = Point->new();\n$p;";
         let fa = build_fa(src);
         // Hover on $p usage at line 4
-        let hover = fa.hover_info(Point::new(4, 1), src, None);
+        let hover = fa.hover_info(Point::new(4, 1), src, None, None);
         assert!(hover.is_some(), "should have hover info");
         let text = hover.unwrap();
         assert!(text.contains("Point"), "hover should show inferred type Point, got: {}", text);
@@ -3241,12 +3319,12 @@ $calc->get_self->get_config->{host};
         let src = "package Point;\nsub new { bless {}, shift }\npackage Foo;\nsub new { bless {}, shift }\npackage main;\nmy $x = Point->new();\n$x;\n$x = Foo->new();\n$x;";
         let fa = build_fa(src);
         // line 6: $x; — should be Point
-        let hover1 = fa.hover_info(Point::new(6, 1), src, None);
+        let hover1 = fa.hover_info(Point::new(6, 1), src, None, None);
         assert!(hover1.is_some());
         let text1 = hover1.unwrap();
         assert!(text1.contains("Point"), "at line 6 should be Point, got: {}", text1);
         // line 8: $x; — should be Foo (after reassignment)
-        let hover2 = fa.hover_info(Point::new(8, 1), src, None);
+        let hover2 = fa.hover_info(Point::new(8, 1), src, None, None);
         assert!(hover2.is_some());
         let text2 = hover2.unwrap();
         assert!(text2.contains("Foo"), "at line 8 should be Foo, got: {}", text2);
@@ -3257,7 +3335,7 @@ $calc->get_self->get_config->{host};
         let src = "package Foo;\nsub make { return Foo->new() }\nsub new { bless {}, shift }\npackage main;\nmake();";
         let fa = build_fa(src);
         // Hover on sub make definition
-        let hover = fa.hover_info(Point::new(1, 5), src, None);
+        let hover = fa.hover_info(Point::new(1, 5), src, None, None);
         assert!(hover.is_some(), "should have hover info for sub");
         let text = hover.unwrap();
         assert!(text.contains("returns"), "hover should show return type, got: {}", text);
@@ -3282,7 +3360,7 @@ $calc->get_self->get_config->{host};
         let src = "package Point;\nsub new { bless {}, shift }\npackage main;\nPoint->new();";
         let fa = build_fa(src);
         // Cursor on "new" in Point->new()
-        let def = fa.find_definition(Point::new(3, 8), None, None);
+        let def = fa.find_definition(Point::new(3, 8), None, None, None);
         assert!(def.is_some(), "should find definition for new");
     }
 
@@ -3335,12 +3413,12 @@ $calc->get_self->get_config->{host};
         let fa = build_fa(src);
 
         // $self at line 12 (push @{$self->{history}}, ...)
-        let def_self = fa.find_definition(Point::new(12, 12), None, None);
+        let def_self = fa.find_definition(Point::new(12, 12), None, None, None);
         assert!(def_self.is_some(), "should find definition for $self in deref");
         assert_eq!(def_self.unwrap().start.row, 10, "$self should resolve to declaration on line 10");
 
         // history key at line 12
-        let def_history = fa.find_definition(Point::new(12, 20), None, None);
+        let def_history = fa.find_definition(Point::new(12, 20), None, None, None);
         assert!(def_history.is_some(), "should find definition for history hash key");
         assert_eq!(def_history.unwrap().start.row, 4, "history key should resolve to definition on line 4");
     }
@@ -3428,7 +3506,7 @@ my $calc = Calculator->new(verbose => 1);
         // 0         1         2         3
         // 0123456789012345678901234567890123456789
         //                            ^27 = v of verbose
-        let def = fa.find_definition(Point::new(9, 27), Some(&tree), Some(src.as_bytes()));
+        let def = fa.find_definition(Point::new(9, 27), Some(&tree), Some(src.as_bytes()), None);
         assert!(def.is_some(), "should find definition for verbose at call site");
         // Should go to line 4: "verbose => $args{verbose} // 0,"
         assert_eq!(def.unwrap().start.row, 4,
@@ -3453,7 +3531,7 @@ my $p = Point->new(x => 3, y => 4);
         // 0123456789012345678901234
         //                    ^19 = x
 
-        let def = fa.find_definition(Point::new(6, 19), Some(&tree), Some(src.as_bytes()));
+        let def = fa.find_definition(Point::new(6, 19), Some(&tree), Some(src.as_bytes()), None);
         assert!(def.is_some(), "should find definition for x at call site");
         // Should go to line 2: "field $x :param :reader;"
         assert_eq!(def.unwrap().start.row, 2,
@@ -3634,4 +3712,309 @@ Performs a POST request.
         assert!(get_doc.unwrap().contains("GET request"));
     }
 
+    // ---- Inheritance extraction tests ----
+
+    #[test]
+    fn test_use_parent_single() {
+        let fa = build_fa("
+            package Child;
+            use parent 'Parent';
+            sub child_method { }
+        ");
+        assert_eq!(fa.package_parents.get("Child").unwrap(), &vec!["Parent".to_string()]);
+    }
+
+    #[test]
+    fn test_use_parent_multiple() {
+        let fa = build_fa("
+            package Multi;
+            use parent qw(Foo Bar);
+        ");
+        assert_eq!(fa.package_parents.get("Multi").unwrap(), &vec!["Foo".to_string(), "Bar".to_string()]);
+    }
+
+    #[test]
+    fn test_use_parent_norequire() {
+        let fa = build_fa("
+            package Local;
+            use parent -norequire, 'My::Base';
+        ");
+        assert_eq!(fa.package_parents.get("Local").unwrap(), &vec!["My::Base".to_string()]);
+    }
+
+    #[test]
+    fn test_use_base() {
+        let fa = build_fa("
+            package Old;
+            use base 'Legacy::Base';
+        ");
+        assert_eq!(fa.package_parents.get("Old").unwrap(), &vec!["Legacy::Base".to_string()]);
+    }
+
+    #[test]
+    fn test_isa_assignment() {
+        let fa = build_fa("
+            package Direct;
+            our @ISA = ('Alpha', 'Beta');
+        ");
+        assert_eq!(fa.package_parents.get("Direct").unwrap(), &vec!["Alpha".to_string(), "Beta".to_string()]);
+    }
+
+    #[test]
+    fn test_class_isa_populates_package_parents() {
+        let fa = build_fa("
+            class Child :isa(Parent) { }
+        ");
+        assert_eq!(fa.package_parents.get("Child").unwrap(), &vec!["Parent".to_string()]);
+    }
+
+    // ---- Inheritance method resolution tests ----
+
+    #[test]
+    fn test_inherited_method_completion() {
+        let fa = build_fa("
+            package Animal;
+            sub speak { }
+            sub eat { }
+
+            package Dog;
+            use parent 'Animal';
+            sub fetch { }
+        ");
+        let methods = fa.complete_methods_for_class("Dog", None);
+        let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+        assert!(names.contains(&"fetch"), "own method");
+        assert!(names.contains(&"speak"), "inherited from Animal");
+        assert!(names.contains(&"eat"), "inherited from Animal");
+    }
+
+    #[test]
+    fn test_child_method_overrides_parent() {
+        let fa = build_fa("
+            package Base;
+            sub greet { }
+
+            package Override;
+            use parent 'Base';
+            sub greet { }
+        ");
+        let methods = fa.complete_methods_for_class("Override", None);
+        let greet_count = methods.iter().filter(|c| c.label == "greet").count();
+        assert_eq!(greet_count, 1, "child override should shadow parent");
+    }
+
+    #[test]
+    fn test_find_method_in_parent() {
+        let fa = build_fa("
+            package Base;
+            sub base_method { }
+
+            package Child;
+            use parent 'Base';
+        ");
+        let span = fa.find_method_in_class("Child", "base_method");
+        assert!(span.is_some(), "should find inherited method");
+    }
+
+    #[test]
+    fn test_inherited_return_type() {
+        let fa = build_fa("
+            package Factory;
+            sub create { Factory->new(@_) }
+
+            package SpecialFactory;
+            use parent 'Factory';
+        ");
+        let rt = fa.find_method_return_type("SpecialFactory", "create", None);
+        assert!(rt.is_some(), "should find return type from parent");
+    }
+
+    #[test]
+    fn test_multi_level_inheritance() {
+        let fa = build_fa("
+            package A;
+            sub from_a { }
+
+            package B;
+            use parent 'A';
+            sub from_b { }
+
+            package C;
+            use parent 'B';
+            sub from_c { }
+        ");
+        let methods = fa.complete_methods_for_class("C", None);
+        let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+        assert!(names.contains(&"from_a"));
+        assert!(names.contains(&"from_b"));
+        assert!(names.contains(&"from_c"));
+    }
+
+    #[test]
+    fn test_class_isa_inherits_methods() {
+        let fa = build_fa("
+            class Parent {
+                method greet() { }
+            }
+            class Child :isa(Parent) {
+                method wave() { }
+            }
+        ");
+        let methods = fa.complete_methods_for_class("Child", None);
+        let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+        assert!(names.contains(&"wave"), "own method");
+        assert!(names.contains(&"greet"), "inherited from Parent");
+    }
+
+    // ---- Cross-file inheritance tests ----
+
+    #[test]
+    fn test_cross_file_inherited_method_completion() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use crate::module_index::{ModuleIndex, ModuleExports, ExportedSub};
+
+        let idx = ModuleIndex::new_for_test();
+        idx.set_workspace_root(None);
+
+        // Grandparent: DBI has `connect`
+        idx.insert_cache("DBI", Some(ModuleExports {
+            path: PathBuf::from("/fake/DBI.pm"),
+            export: vec![],
+            export_ok: vec![],
+            subs: {
+                let mut s = HashMap::new();
+                s.insert("connect".into(), ExportedSub {
+                    def_line: 10, params: vec![], is_method: true,
+                    return_type: None, hash_keys: vec![], doc: None,
+                });
+                s
+            },
+            parents: vec![],
+        }));
+
+        // Parent: DBI::db inherits from DBI, has `prepare`
+        idx.insert_cache("DBI::db", Some(ModuleExports {
+            path: PathBuf::from("/fake/DBI/db.pm"),
+            export: vec![],
+            export_ok: vec![],
+            subs: {
+                let mut s = HashMap::new();
+                s.insert("prepare".into(), ExportedSub {
+                    def_line: 5, params: vec![], is_method: true,
+                    return_type: None, hash_keys: vec![], doc: None,
+                });
+                s
+            },
+            parents: vec!["DBI".into()],
+        }));
+
+        // Local code inherits from DBI::db
+        let fa = build_fa("
+            package MyDB;
+            use parent 'DBI::db';
+            sub custom_query { }
+        ");
+
+        let methods = fa.complete_methods_for_class("MyDB", Some(&idx));
+        let names: Vec<&str> = methods.iter().map(|c| c.label.as_str()).collect();
+        assert!(names.contains(&"custom_query"), "own method");
+        assert!(names.contains(&"prepare"), "from DBI::db");
+        assert!(names.contains(&"connect"), "from DBI (grandparent)");
+    }
+
+    #[test]
+    fn test_cross_file_method_override() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use crate::module_index::{ModuleIndex, ModuleExports, ExportedSub};
+
+        let idx = ModuleIndex::new_for_test();
+        idx.set_workspace_root(None);
+
+        // Parent has `process`
+        idx.insert_cache("Base::Worker", Some(ModuleExports {
+            path: PathBuf::from("/fake/Base/Worker.pm"),
+            export: vec![],
+            export_ok: vec![],
+            subs: {
+                let mut s = HashMap::new();
+                s.insert("process".into(), ExportedSub {
+                    def_line: 1, params: vec![], is_method: true,
+                    return_type: None, hash_keys: vec![], doc: None,
+                });
+                s
+            },
+            parents: vec![],
+        }));
+
+        // Local child overrides `process`
+        let fa = build_fa("
+            package MyWorker;
+            use parent 'Base::Worker';
+            sub process { }
+        ");
+
+        let methods = fa.complete_methods_for_class("MyWorker", Some(&idx));
+        let process_count = methods.iter().filter(|c| c.label == "process").count();
+        assert_eq!(process_count, 1, "local override should shadow parent");
+    }
+
+    #[test]
+    fn test_cross_file_return_type_through_inheritance() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use crate::file_analysis::InferredType;
+        use crate::module_index::{ModuleIndex, ModuleExports, ExportedSub};
+
+        let idx = ModuleIndex::new_for_test();
+        idx.set_workspace_root(None);
+
+        idx.insert_cache("Fetcher", Some(ModuleExports {
+            path: PathBuf::from("/fake/Fetcher.pm"),
+            export: vec![],
+            export_ok: vec![],
+            subs: {
+                let mut s = HashMap::new();
+                s.insert("fetch".into(), ExportedSub {
+                    def_line: 1, params: vec![], is_method: true,
+                    return_type: Some(InferredType::HashRef),
+                    hash_keys: vec!["status".into(), "body".into()],
+                    doc: None,
+                });
+                s
+            },
+            parents: vec![],
+        }));
+
+        let fa = build_fa("
+            package MyFetcher;
+            use parent 'Fetcher';
+        ");
+
+        let rt = fa.find_method_return_type("MyFetcher", "fetch", Some(&idx));
+        assert_eq!(rt, Some(InferredType::HashRef));
+    }
+
+    #[test]
+    fn test_parents_cached() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use crate::module_index::{ModuleIndex, ModuleExports};
+
+        let idx = ModuleIndex::new_for_test();
+        idx.set_workspace_root(None);
+
+        idx.insert_cache("Child::Mod", Some(ModuleExports {
+            path: PathBuf::from("/fake/Child/Mod.pm"),
+            export: vec![],
+            export_ok: vec![],
+            subs: HashMap::new(),
+            parents: vec!["Parent::Mod".into(), "Mixin::Role".into()],
+        }));
+
+        let parents = idx.parents_cached("Child::Mod");
+        assert_eq!(parents, vec!["Parent::Mod", "Mixin::Role"]);
+        assert!(idx.parents_cached("Unknown::Mod").is_empty());
+    }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,6 +20,7 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
         return_infos: Vec::new(),
         last_expr_type: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
+        method_call_bindings: Vec::new(),
         pod_texts: Vec::new(),
         package_parents: std::collections::HashMap::new(),
         scope_stack: Vec::new(),
@@ -55,6 +56,7 @@ pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
         b.imports,
         b.call_bindings,
         b.package_parents,
+        b.method_call_bindings,
     )
 }
 
@@ -81,6 +83,8 @@ struct Builder<'a> {
     last_expr_type: std::collections::HashMap<ScopeId, Option<InferredType>>,
     /// Assignments where RHS is a function call — resolved in return-type post-pass.
     call_bindings: Vec<CallBinding>,
+    /// Assignments where RHS is a method call — resolved in FileAnalysis post-pass.
+    method_call_bindings: Vec<MethodCallBinding>,
     /// Raw POD text blocks collected during the walk (for tail-POD post-pass).
     pod_texts: Vec<String>,
     /// Parent classes for each package (from use parent/base, @ISA, class :isa).
@@ -1294,6 +1298,29 @@ impl<'a> Builder<'a> {
                             scope: self.current_scope(),
                             span: node_to_span(node),
                         });
+                    }
+                } else if right.kind() == "method_call_expression" {
+                    // RHS is a method call — record binding for return-type post-pass
+                    if let Some(method_node) = right.child_by_field_name("method") {
+                        if let Some(invocant_node) = right.child_by_field_name("invocant") {
+                            if let (Ok(method), Ok(inv)) = (
+                                method_node.utf8_text(self.source),
+                                invocant_node.utf8_text(self.source),
+                            ) {
+                                // Skip constructors — already handled by extract_constructor_class
+                                if method != "new" {
+                                    if let Some(vt) = self.get_var_text_from_lhs(left) {
+                                        self.method_call_bindings.push(MethodCallBinding {
+                                            variable: vt,
+                                            invocant_var: inv.to_string(),
+                                            method_name: method.to_string(),
+                                            scope: self.current_scope(),
+                                            span: node_to_span(node),
+                                        });
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 // Visit the RHS (may contain refs, calls, etc.)
@@ -4268,5 +4295,61 @@ sub transform { }
         let parents = idx.parents_cached("Child::Mod");
         assert_eq!(parents, vec!["Parent::Mod", "Mixin::Role"]);
         assert!(idx.parents_cached("Unknown::Mod").is_empty());
+    }
+
+    // ---- Method call return type propagation tests ----
+
+    #[test]
+    fn test_method_call_return_type_propagates() {
+        let fa = build_fa("
+package Foo;
+sub new { bless {}, shift }
+sub get_config {
+    return { host => 'localhost', port => 5432 };
+}
+package main;
+my $f = Foo->new();
+my $cfg = $f->get_config();
+$cfg;
+");
+        let ty = fa.inferred_type("$cfg", Point::new(9, 0));
+        assert_eq!(ty, Some(&InferredType::HashRef));
+    }
+
+    #[test]
+    fn test_method_call_chain_propagation() {
+        let fa = build_fa("
+package Foo;
+sub new { bless {}, shift }
+sub get_bar { return Bar->new() }
+package Bar;
+sub new { bless {}, shift }
+sub get_name { return { name => 'test' } }
+package main;
+my $f = Foo->new();
+my $bar = $f->get_bar();
+my $name = $bar->get_name();
+$name;
+");
+        let bar_ty = fa.inferred_type("$bar", Point::new(10, 0));
+        assert_eq!(bar_ty, Some(&InferredType::ClassName("Bar".into())));
+        let name_ty = fa.inferred_type("$name", Point::new(11, 0));
+        assert_eq!(name_ty, Some(&InferredType::HashRef));
+    }
+
+    #[test]
+    fn test_self_method_call_return_type() {
+        let fa = build_fa("
+package Foo;
+sub new { bless {}, shift }
+sub get_config { return { host => 1 } }
+sub run {
+    my ($self) = @_;
+    my $cfg = $self->get_config();
+    $cfg;
+}
+");
+        let ty = fa.inferred_type("$cfg", Point::new(7, 4));
+        assert_eq!(ty, Some(&InferredType::HashRef));
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3771,7 +3771,7 @@ my $p = Point->new(x => 3, y => 4);
         }
         ");
         // signature_for_call strips $self when first param is $self
-        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0), None).unwrap();
         assert!(sig.is_method, "should detect method from $self first param");
         assert_eq!(sig.params.len(), 2);
         assert_eq!(sig.params[0].name, "$file");
@@ -3799,7 +3799,7 @@ my $p = Point->new(x => 3, y => 4);
             my ($file, @opts) = @_;
         }
         ");
-        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0), None).unwrap();
         assert!(sig.is_method);
         assert_eq!(sig.params.len(), 2, "should have $file and @opts (stripped $self)");
         assert_eq!(sig.params[0].name, "$file");
@@ -3824,7 +3824,7 @@ my $p = Point->new(x => 3, y => 4);
             my $timeout = shift || 30;
         }
         ");
-        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0), None).unwrap();
         assert_eq!(sig.params.len(), 1, "stripped $self");
         assert_eq!(sig.params[0].name, "$timeout");
         assert_eq!(sig.params[0].default, Some("30".into()));
@@ -3838,7 +3838,7 @@ my $p = Point->new(x => 3, y => 4);
             my $verbose = shift // 0;
         }
         ");
-        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0), None).unwrap();
         assert_eq!(sig.params.len(), 1, "stripped $self");
         assert_eq!(sig.params[0].name, "$verbose");
         assert_eq!(sig.params[0].default, Some("0".into()));
@@ -3852,7 +3852,7 @@ my $p = Point->new(x => 3, y => 4);
             my $data = $_[1];
         }
         ");
-        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("handler", false, None, Point::new(0, 0), None).unwrap();
         assert_eq!(sig.params.len(), 1, "stripped $self");
         assert_eq!(sig.params[0].name, "$data");
     }
@@ -3865,7 +3865,7 @@ my $p = Point->new(x => 3, y => 4);
             my ($first, $file, @opts) = @_;
         }
         ");
-        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0)).unwrap();
+        let sig = fa.signature_for_call("process", false, None, Point::new(0, 0), None).unwrap();
         assert_eq!(sig.params.len(), 3);
         assert_eq!(sig.params[0].name, "$first");
         assert_eq!(sig.params[1].name, "$file");

--- a/src/cursor_context.rs
+++ b/src/cursor_context.rs
@@ -238,7 +238,7 @@ fn resolve_node_type(node: Node, source: &[u8], analysis: &FileAnalysis, point: 
             let text = node.utf8_text(source).ok()?;
             Some(InferredType::ClassName(text.to_string()))
         }
-        _ => analysis.resolve_expression_type(node, source),
+        _ => analysis.resolve_expression_type(node, source, None),
     }
 }
 

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1436,15 +1436,16 @@ impl FileAnalysis {
                     let class_name = self.resolve_method_invocant(
                         invocant, invocant_span, r.scope, point, tree, source_bytes, module_index,
                     );
-                    // Try class-specific method first
+                    // Try inheritance-aware resolution first
                     if let Some(ref cn) = class_name {
-                        for &sid in self.symbols_named(&r.target_name) {
-                            let sym = self.symbol(sid);
-                            if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                                if self.symbol_in_class(sid, cn) {
-                                    return Some((sid, true));
-                                }
+                        match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
+                            Some(MethodResolution::Local { sym_id, .. }) => {
+                                return Some((sym_id, true));
                             }
+                            Some(MethodResolution::CrossFile { .. }) => {
+                                // Cross-file: no local SymbolId, fall through to name match
+                            }
+                            None => {}
                         }
                     }
                     // Fallback: any method with that name
@@ -2320,15 +2321,12 @@ impl FileAnalysis {
             None
         };
 
-        // Try class-scoped first
+        // Try inheritance-aware class-scoped lookup first
         if let Some(ref cn) = class_name {
-            for &sid in self.symbols_named(name) {
-                let sym = self.symbol(sid);
-                if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                    if self.symbol_in_class(sid, cn) {
-                        return Some(sym);
-                    }
-                }
+            if let Some(MethodResolution::Local { sym_id, .. }) =
+                self.resolve_method_in_ancestors(cn, name, None)
+            {
+                return Some(self.symbol(sym_id));
             }
         }
 

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1555,11 +1555,13 @@ impl FileAnalysis {
     }
 
     /// Find a method definition within a class/package.
+    #[cfg(test)]
     pub(crate) fn find_method_in_class(&self, class_name: &str, method_name: &str) -> Option<Span> {
         self.find_method_in_class_with_index(class_name, method_name, None)
     }
 
     /// Find a method definition, walking the inheritance chain if needed.
+    #[cfg(test)]
     fn find_method_in_class_with_index(
         &self,
         class_name: &str,

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1935,6 +1935,18 @@ pub enum MethodResolution {
     CrossFile { class: String },
 }
 
+/// Result of resolving a sub/method call — local symbol or cross-file metadata.
+pub enum ResolvedSub<'a> {
+    /// Found locally in this file's symbols.
+    Local(&'a Symbol),
+    /// Found in a cross-file module via ModuleIndex.
+    CrossFile {
+        params: Vec<crate::module_index::ExportedParam>,
+        is_method: bool,
+        hash_keys: Vec<String>,
+    },
+}
+
 // ---- Completion types ----
 
 /// A completion candidate from FileAnalysis resolution (pure table lookup).
@@ -2194,6 +2206,7 @@ impl FileAnalysis {
         invocant: Option<&str>,
         point: Point,
         used_keys: &HashSet<String>,
+        module_index: Option<&ModuleIndex>,
     ) -> Vec<CompletionCandidate> {
         // For `new` calls on a class, check for :param fields
         if call_name == "new" {
@@ -2216,52 +2229,73 @@ impl FileAnalysis {
             }
         }
 
-        // Find the sub definition
-        let sub_sym = self.find_sub_for_call(call_name, is_method, invocant, point);
-        let sub_sym = match sub_sym {
-            Some(s) => s,
+        // Find the sub definition (local or cross-file)
+        let resolved = match self.find_sub_for_call(call_name, is_method, invocant, point, module_index) {
+            Some(r) => r,
             None => return Vec::new(),
         };
 
-        // Get params
-        let params = match &sub_sym.detail {
-            SymbolDetail::Sub { params, .. } => params,
-            _ => return Vec::new(),
-        };
+        match resolved {
+            ResolvedSub::Local(sub_sym) => {
+                let params = match &sub_sym.detail {
+                    SymbolDetail::Sub { params, .. } => params,
+                    _ => return Vec::new(),
+                };
 
-        // Find slurpy %hash param
-        let slurpy = params
-            .iter()
-            .find(|p| p.is_slurpy && p.name.starts_with('%'));
-        let slurpy_name = match slurpy {
-            Some(p) => {
-                if p.name.starts_with('%') || p.name.starts_with('$') || p.name.starts_with('@') {
-                    &p.name[1..]
-                } else {
-                    &p.name
-                }
+                // Find slurpy %hash param
+                let slurpy = params
+                    .iter()
+                    .find(|p| p.is_slurpy && p.name.starts_with('%'));
+                let slurpy_name = match slurpy {
+                    Some(p) => {
+                        if p.name.starts_with('%') || p.name.starts_with('$') || p.name.starts_with('@') {
+                            &p.name[1..]
+                        } else {
+                            &p.name
+                        }
+                    }
+                    None => return Vec::new(),
+                };
+
+                // Find hash key accesses for this param name within the sub's body scope
+                let body_scope = self.find_body_scope(sub_sym);
+                let keys = match body_scope {
+                    Some(scope_id) => self.hash_keys_in_scope(slurpy_name, scope_id),
+                    None => Vec::new(),
+                };
+
+                keys.into_iter()
+                    .filter(|k| !used_keys.contains(k))
+                    .map(|k| CompletionCandidate {
+                        label: format!("{} =>", k),
+                        kind: SymKind::Variable,
+                        detail: Some(format!("{}(%{})", call_name, slurpy_name)),
+                        insert_text: Some(format!("{} => ", k)),
+                        sort_priority: PRIORITY_LOCAL,
+                        additional_edits: vec![],
+                    })
+                    .collect()
             }
-            None => return Vec::new(),
-        };
+            ResolvedSub::CrossFile { hash_keys, params, .. } => {
+                // Check if any param is slurpy %hash
+                let has_slurpy = params.iter().any(|p| p.is_slurpy && p.name.starts_with('%'));
+                if !has_slurpy || hash_keys.is_empty() {
+                    return Vec::new();
+                }
 
-        // Find hash key accesses for this param name within the sub's body scope
-        let body_scope = self.find_body_scope(sub_sym);
-        let keys = match body_scope {
-            Some(scope_id) => self.hash_keys_in_scope(slurpy_name, scope_id),
-            None => Vec::new(),
-        };
-
-        keys.into_iter()
-            .filter(|k| !used_keys.contains(k))
-            .map(|k| CompletionCandidate {
-                label: format!("{} =>", k),
-                kind: SymKind::Variable,
-                detail: Some(format!("{}(%{})", call_name, slurpy_name)),
-                insert_text: Some(format!("{} => ", k)),
-                sort_priority: PRIORITY_LOCAL,
-                    additional_edits: vec![],
-            })
-            .collect()
+                hash_keys.into_iter()
+                    .filter(|k| !used_keys.contains(k))
+                    .map(|k| CompletionCandidate {
+                        label: format!("{} =>", k),
+                        kind: SymKind::Variable,
+                        detail: Some(format!("{}()", call_name)),
+                        insert_text: Some(format!("{} => ", k)),
+                        sort_priority: PRIORITY_LOCAL,
+                        additional_edits: vec![],
+                    })
+                    .collect()
+            }
+        }
     }
 
     /// Resolve signature info for a call (sub/method name).
@@ -2271,47 +2305,83 @@ impl FileAnalysis {
         is_method: bool,
         invocant: Option<&str>,
         point: Point,
+        module_index: Option<&ModuleIndex>,
     ) -> Option<SignatureInfo> {
-        let sub_sym = self.find_sub_for_call(name, is_method, invocant, point)?;
+        let resolved = self.find_sub_for_call(name, is_method, invocant, point, module_index)?;
 
-        let (params, sym_is_method) = match &sub_sym.detail {
-            SymbolDetail::Sub { params, is_method, .. } => (params.clone(), *is_method),
-            _ => return None,
-        };
+        match resolved {
+            ResolvedSub::Local(sub_sym) => {
+                let (params, sym_is_method) = match &sub_sym.detail {
+                    SymbolDetail::Sub { params, is_method, .. } => (params.clone(), *is_method),
+                    _ => return None,
+                };
 
-        let mut params = params;
-        let is_method = is_method
-            || sym_is_method
-            || params
-                .first()
-                .map_or(false, |p| p.name == "$self" || p.name == "$class");
+                let mut params = params;
+                let is_method = is_method
+                    || sym_is_method
+                    || params
+                        .first()
+                        .map_or(false, |p| p.name == "$self" || p.name == "$class");
 
-        // Strip $self/$class from method params
-        if is_method && !params.is_empty() {
-            let first = &params[0].name;
-            if first == "$self" || first == "$class" {
-                params.remove(0);
+                // Strip $self/$class from method params
+                if is_method && !params.is_empty() {
+                    let first = &params[0].name;
+                    if first == "$self" || first == "$class" {
+                        params.remove(0);
+                    }
+                }
+
+                Some(SignatureInfo {
+                    name: name.to_string(),
+                    params,
+                    is_method,
+                    body_end: sub_sym.span.end,
+                })
+            }
+            ResolvedSub::CrossFile { params: exported_params, is_method: cf_is_method, .. } => {
+                let mut params: Vec<ParamInfo> = exported_params
+                    .iter()
+                    .map(|p| ParamInfo {
+                        name: p.name.clone(),
+                        default: None,
+                        is_slurpy: p.is_slurpy,
+                    })
+                    .collect();
+
+                let is_method = is_method || cf_is_method
+                    || params.first().map_or(false, |p| p.name == "$self" || p.name == "$class");
+
+                // Strip $self/$class from method params
+                if is_method && !params.is_empty() {
+                    let first = &params[0].name;
+                    if first == "$self" || first == "$class" {
+                        params.remove(0);
+                    }
+                }
+
+                Some(SignatureInfo {
+                    name: name.to_string(),
+                    params,
+                    is_method,
+                    body_end: Point::new(0, 0), // no local body
+                })
             }
         }
-
-        Some(SignatureInfo {
-            name: name.to_string(),
-            params,
-            is_method,
-            body_end: sub_sym.span.end,
-        })
     }
 
     // ---- Internal completion helpers ----
 
-    /// Find a sub/method symbol by name, optionally scoped to a class.
-    fn find_sub_for_call(
-        &self,
+    /// Find a sub/method by name, optionally scoped to a class.
+    /// Returns `ResolvedSub::Local` for same-file symbols, or `ResolvedSub::CrossFile`
+    /// for inherited methods and imported functions found via `ModuleIndex`.
+    fn find_sub_for_call<'s>(
+        &'s self,
         name: &str,
         is_method: bool,
         invocant: Option<&str>,
         point: Point,
-    ) -> Option<&Symbol> {
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<ResolvedSub<'s>> {
         // Resolve class name for scoped lookup
         let class_name = if is_method {
             invocant.and_then(|inv| {
@@ -2331,18 +2401,65 @@ impl FileAnalysis {
 
         // Try inheritance-aware class-scoped lookup first
         if let Some(ref cn) = class_name {
-            if let Some(MethodResolution::Local { sym_id, .. }) =
-                self.resolve_method_in_ancestors(cn, name, None)
-            {
-                return Some(self.symbol(sym_id));
+            match self.resolve_method_in_ancestors(cn, name, module_index) {
+                Some(MethodResolution::Local { sym_id, .. }) => {
+                    return Some(ResolvedSub::Local(self.symbol(sym_id)));
+                }
+                Some(MethodResolution::CrossFile { ref class }) => {
+                    if let Some(idx) = module_index {
+                        if let Some(exports) = idx.get_exports_cached(class) {
+                            if let Some(sub_info) = exports.sub_info(name) {
+                                return Some(ResolvedSub::CrossFile {
+                                    params: sub_info.params.clone(),
+                                    is_method: sub_info.is_method,
+                                    hash_keys: sub_info.hash_keys.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+                None => {}
             }
         }
 
-        // Fallback: any sub/method with that name
+        // Fallback: any local sub/method with that name
         for &sid in self.symbols_named(name) {
             let sym = self.symbol(sid);
             if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                return Some(sym);
+                return Some(ResolvedSub::Local(sym));
+            }
+        }
+
+        // Fallback: imported function via ModuleIndex
+        if !is_method {
+            if let Some(idx) = module_index {
+                for import in &self.imports {
+                    if import.imported_symbols.iter().any(|s| s == name) {
+                        if let Some(exports) = idx.get_exports_cached(&import.module_name) {
+                            if let Some(sub_info) = exports.sub_info(name) {
+                                return Some(ResolvedSub::CrossFile {
+                                    params: sub_info.params.clone(),
+                                    is_method: sub_info.is_method,
+                                    hash_keys: sub_info.hash_keys.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+                // Also check @EXPORT (bare imports)
+                for import in &self.imports {
+                    if let Some(exports) = idx.get_exports_cached(&import.module_name) {
+                        if exports.export.iter().any(|s| s == name) {
+                            if let Some(sub_info) = exports.sub_info(name) {
+                                return Some(ResolvedSub::CrossFile {
+                                    params: sub_info.params.clone(),
+                                    is_method: sub_info.is_method,
+                                    hash_keys: sub_info.hash_keys.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -315,6 +315,17 @@ pub struct CallBinding {
     pub span: Span,
 }
 
+/// A method call binding: `$var = $invocant->method()`.
+/// Recorded during build, resolved in post-pass via `find_method_return_type`.
+#[derive(Debug, Clone)]
+pub struct MethodCallBinding {
+    pub variable: String,
+    pub invocant_var: String,
+    pub method_name: String,
+    pub scope: ScopeId,
+    pub span: Span,
+}
+
 // ---- Import ----
 
 /// A `use Foo::Bar qw(func1 func2)` statement parsed from the source.
@@ -379,6 +390,7 @@ pub struct FileAnalysis {
     pub fold_ranges: Vec<FoldRange>,
     pub imports: Vec<Import>,
     pub call_bindings: Vec<CallBinding>,
+    pub method_call_bindings: Vec<MethodCallBinding>,
 
     /// Parent classes for each package in this file.
     /// Populated by the builder from use parent/base, @ISA, and class :isa.
@@ -410,6 +422,7 @@ impl FileAnalysis {
         imports: Vec<Import>,
         call_bindings: Vec<CallBinding>,
         package_parents: HashMap<String, Vec<String>>,
+        method_call_bindings: Vec<MethodCallBinding>,
     ) -> Self {
         let mut fa = FileAnalysis {
             scopes,
@@ -419,6 +432,7 @@ impl FileAnalysis {
             fold_ranges,
             imports,
             call_bindings,
+            method_call_bindings,
             package_parents,
             imported_return_types: HashMap::new(),
             base_type_constraint_count: 0,
@@ -430,6 +444,7 @@ impl FileAnalysis {
             type_constraints_by_var: HashMap::new(),
         };
         fa.build_indices();
+        fa.resolve_method_call_types(None); // local post-pass
         fa.base_type_constraint_count = fa.type_constraints.len();
         fa.base_symbol_count = fa.symbols.len();
         fa
@@ -596,7 +611,7 @@ impl FileAnalysis {
     /// Convenience wrapper: enrich with return types only (no hash keys).
     #[cfg(test)]
     pub fn enrich_imported_types(&mut self, imported_returns: HashMap<String, InferredType>) {
-        self.enrich_imported_types_with_keys(imported_returns, HashMap::new());
+        self.enrich_imported_types_with_keys(imported_returns, HashMap::new(), None);
     }
 
     /// Resolve call bindings for imported functions and inject hash key defs.
@@ -605,6 +620,7 @@ impl FileAnalysis {
         &mut self,
         imported_returns: HashMap<String, InferredType>,
         imported_hash_keys: HashMap<String, Vec<String>>,
+        module_index: Option<&ModuleIndex>,
     ) {
         // Truncate back to baseline so repeated enrichment doesn't accumulate duplicates.
         self.type_constraints.truncate(self.base_type_constraint_count);
@@ -655,7 +671,46 @@ impl FileAnalysis {
             }
         }
 
+        // Cross-file method call return type resolution
+        self.resolve_method_call_types(module_index);
+
         self.rebuild_enrichment_indices();
+    }
+
+    /// Resolve method call bindings to type constraints.
+    /// Called in local post-pass (None) and cross-file enrichment (Some(module_index)).
+    fn resolve_method_call_types(&mut self, module_index: Option<&ModuleIndex>) {
+        let bindings = self.method_call_bindings.clone();
+        for binding in &bindings {
+            // Skip if this variable already has a type at this point
+            if self.inferred_type(&binding.variable, binding.span.start).is_some() {
+                continue;
+            }
+
+            // Resolve invocant to class name
+            let class_name = self.resolve_invocant_class(
+                &binding.invocant_var,
+                binding.scope,
+                binding.span.start,
+            );
+
+            if let Some(cn) = class_name {
+                if let Some(rt) = self.find_method_return_type(&cn, &binding.method_name, module_index) {
+                    self.type_constraints.push(TypeConstraint {
+                        variable: binding.variable.clone(),
+                        scope: binding.scope,
+                        constraint_span: binding.span,
+                        inferred_type: rt,
+                    });
+                    // Incrementally update the index so the NEXT binding can see this constraint
+                    let idx = self.type_constraints.len() - 1;
+                    self.type_constraints_by_var
+                        .entry(binding.variable.clone())
+                        .or_default()
+                        .push(idx);
+                }
+            }
+        }
     }
 
     /// Rebuild indices affected by enrichment (type constraints + symbols).
@@ -2855,6 +2910,7 @@ mod tests {
             vec![],
             vec![],
             HashMap::new(),
+            vec![],
         )
     }
 
@@ -2946,6 +3002,7 @@ mod tests {
             vec![],
             vec![],
             HashMap::new(),
+            vec![],
         );
         assert_eq!(fa.sub_return_type("get_config"), Some(&InferredType::HashRef));
         assert_eq!(fa.sub_return_type("nonexistent"), None);
@@ -3102,6 +3159,7 @@ mod tests {
                 span: Span { start: Point::new(2, 0), end: Point::new(2, 30) },
             }],
             HashMap::new(),
+            vec![],
         );
 
         let mut imported = HashMap::new();

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1124,9 +1124,17 @@ impl FileAnalysis {
                                 // can resolve it via ModuleIndex with the correct URI.
                                 return None;
                             }
-                            None => {}
+                            None => {
+                                // If the class has known parents, the method might be
+                                // inherited but the module index hasn't resolved yet.
+                                // Return None so the cross-file block in symbols.rs
+                                // gets a chance, rather than jumping to the package decl.
+                                if self.package_parents.contains_key(cn) {
+                                    return None;
+                                }
+                            }
                         }
-                        // Method not found (e.g. auto-generated "new") → go to class def
+                        // Method not found and no parents — go to class def
                         if let Some(span) = self.find_package_or_class(cn) {
                             return Some(span);
                         }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1115,8 +1115,16 @@ impl FileAnalysis {
 
                     if let Some(ref cn) = class_name {
                         // Find method in the resolved class (walks inheritance)
-                        if let Some(span) = self.find_method_in_class_with_index(cn, &r.target_name, module_index) {
-                            return Some(span);
+                        match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
+                            Some(MethodResolution::Local { sym_id, .. }) => {
+                                return Some(self.symbol(sym_id).selection_span);
+                            }
+                            Some(MethodResolution::CrossFile { .. }) => {
+                                // Cross-file method — return None so the LSP adapter
+                                // can resolve it via ModuleIndex with the correct URI.
+                                return None;
+                            }
+                            None => {}
                         }
                         // Method not found (e.g. auto-generated "new") → go to class def
                         if let Some(span) = self.find_package_or_class(cn) {

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -8,6 +8,8 @@
 use std::collections::{HashMap, HashSet};
 use tree_sitter::Point;
 
+use crate::module_index::ModuleIndex;
+
 // ---- Shared types (formerly in analysis.rs) ----
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -378,6 +380,10 @@ pub struct FileAnalysis {
     pub imports: Vec<Import>,
     pub call_bindings: Vec<CallBinding>,
 
+    /// Parent classes for each package in this file.
+    /// Populated by the builder from use parent/base, @ISA, and class :isa.
+    pub package_parents: HashMap<String, Vec<String>>,
+
     /// Return types from imported functions (populated after build from module index).
     pub imported_return_types: HashMap<String, InferredType>,
 
@@ -403,6 +409,7 @@ impl FileAnalysis {
         fold_ranges: Vec<FoldRange>,
         imports: Vec<Import>,
         call_bindings: Vec<CallBinding>,
+        package_parents: HashMap<String, Vec<String>>,
     ) -> Self {
         let mut fa = FileAnalysis {
             scopes,
@@ -412,6 +419,7 @@ impl FileAnalysis {
             fold_ranges,
             imports,
             call_bindings,
+            package_parents,
             imported_return_types: HashMap::new(),
             base_type_constraint_count: 0,
             base_symbol_count: 0,
@@ -684,7 +692,12 @@ impl FileAnalysis {
     /// - `hash_element_expression` → resolve base (for chaining)
     ///
     /// Used at query time (completion, goto-def, hover) — not during the build walk.
-    pub fn resolve_expression_type(&self, node: tree_sitter::Node, source: &[u8]) -> Option<InferredType> {
+    pub fn resolve_expression_type(
+        &self,
+        node: tree_sitter::Node,
+        source: &[u8],
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<InferredType> {
         let point = node.start_position();
         match node.kind() {
             "scalar" => {
@@ -698,7 +711,7 @@ impl FileAnalysis {
             }
             "method_call_expression" => {
                 let invocant_node = node.child_by_field_name("invocant")?;
-                let invocant_type = self.resolve_expression_type(invocant_node, source)?;
+                let invocant_type = self.resolve_expression_type(invocant_node, source, module_index)?;
                 let class_name = invocant_type.class_name()?;
                 let method_name = node.child_by_field_name("method")?;
                 let method_text = method_name.utf8_text(source).ok()?;
@@ -706,8 +719,7 @@ impl FileAnalysis {
                 if method_text == "new" {
                     return Some(InferredType::ClassName(class_name.to_string()));
                 }
-                // Find method's return type
-                self.find_method_return_type(class_name, method_text)
+                self.find_method_return_type(class_name, method_text, module_index)
             }
             "function_call_expression" | "ambiguous_function_call_expression" => {
                 let func_node = node.child_by_field_name("function")?;
@@ -722,7 +734,7 @@ impl FileAnalysis {
             "hash_element_expression" => {
                 // For chaining: resolve the base expression
                 let base = node.named_child(0)?;
-                self.resolve_expression_type(base, source)
+                self.resolve_expression_type(base, source, module_index)
             }
             _ => None,
         }
@@ -739,12 +751,13 @@ impl FileAnalysis {
         tree: &tree_sitter::Tree,
         source: &[u8],
         point: Point,
+        module_index: Option<&ModuleIndex>,
     ) -> Option<HashKeyOwner> {
         let hash_elem = tree.root_node()
             .descendant_for_point_range(point, point)
             .and_then(|n| find_ancestor(n, "hash_element_expression"))?;
         let base = hash_elem.named_child(0)?;
-        let ty = self.resolve_expression_type(base, source)?;
+        let ty = self.resolve_expression_type(base, source, module_index)?;
 
         // Extract the function/method name for Sub owner
         let sub_name = match base.kind() {
@@ -799,18 +812,29 @@ impl FileAnalysis {
         }
     }
 
-    /// Find a method's return type within a class/package.
-    fn find_method_return_type(&self, class_name: &str, method_name: &str) -> Option<InferredType> {
-        for sym in &self.symbols {
-            if sym.name == method_name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                if self.symbol_in_class(sym.id, class_name) {
-                    if let SymbolDetail::Sub { ref return_type, .. } = sym.detail {
-                        return return_type.clone();
-                    }
+    /// Find a method's return type within a class/package, walking inheritance.
+    pub(crate) fn find_method_return_type(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<InferredType> {
+        match self.resolve_method_in_ancestors(class_name, method_name, module_index) {
+            Some(MethodResolution::Local { sym_id, .. }) => {
+                if let SymbolDetail::Sub { ref return_type, .. } = self.symbol(sym_id).detail {
+                    return_type.clone()
+                } else {
+                    None
                 }
             }
+            Some(MethodResolution::CrossFile { ref class }) => {
+                module_index.and_then(|idx| {
+                    idx.get_exports_cached(class)
+                        .and_then(|e| e.subs.get(method_name)?.return_type.clone())
+                })
+            }
+            None => None,
         }
-        None
     }
 
     /// Find a `:param` field in a class by its bare name (without sigil).
@@ -836,17 +860,37 @@ impl FileAnalysis {
     }
 
     /// Format a method completion detail string, appending return type if known.
-    fn method_detail(&self, class_name: &str, method_name: &str) -> String {
-        if let Some(ref rt) = self.find_method_return_type(class_name, method_name) {
-            format!("{} → {}", class_name, format_inferred_type(rt))
+    fn method_detail(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        defining_class: Option<&str>,
+        module_index: Option<&ModuleIndex>,
+    ) -> String {
+        let base = if let Some(dc) = defining_class {
+            if dc != class_name {
+                format!("{} (from {})", class_name, dc)
+            } else {
+                class_name.to_string()
+            }
         } else {
             class_name.to_string()
+        };
+        if let Some(ref rt) = self.find_method_return_type(class_name, method_name, module_index) {
+            format!("{} → {}", base, format_inferred_type(rt))
+        } else {
+            base
         }
     }
 
-    /// Complete methods for a known class name (no invocant resolution needed).
-    pub fn complete_methods_for_class(&self, class_name: &str) -> Vec<CompletionCandidate> {
+    /// Complete methods for a known class name, walking the inheritance chain.
+    pub fn complete_methods_for_class(
+        &self,
+        class_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Vec<CompletionCandidate> {
         let mut candidates = Vec::new();
+        let mut seen_names: HashSet<String> = HashSet::new();
 
         // Check for class definition → implicit new
         for sym in &self.symbols {
@@ -854,23 +898,46 @@ impl FileAnalysis {
                 candidates.push(CompletionCandidate {
                     label: "new".to_string(),
                     kind: SymKind::Method,
-                    detail: Some(self.method_detail(class_name, "new")),
+                    detail: Some(self.method_detail(class_name, "new", None, module_index)),
                     insert_text: None,
                     sort_priority: PRIORITY_LOCAL,
                     additional_edits: vec![],
                 });
+                seen_names.insert("new".to_string());
                 break;
             }
         }
 
-        // Find all subs/methods in this class/package
+        // Collect methods from this class and all ancestors
+        self.collect_ancestor_methods(class_name, class_name, module_index, &mut candidates, &mut seen_names, 0);
+
+        candidates
+    }
+
+    /// Recursively collect methods from a class and its ancestors, deduping by name.
+    fn collect_ancestor_methods(
+        &self,
+        original_class: &str,
+        class_name: &str,
+        module_index: Option<&ModuleIndex>,
+        candidates: &mut Vec<CompletionCandidate>,
+        seen_names: &mut HashSet<String>,
+        depth: usize,
+    ) {
+        if depth > 20 {
+            return;
+        }
+
+        // Local methods in this class
         for sym in &self.symbols {
             if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                if self.symbol_in_class(sym.id, class_name) {
+                if self.symbol_in_class(sym.id, class_name) && !seen_names.contains(&sym.name) {
+                    seen_names.insert(sym.name.clone());
+                    let defining = if class_name != original_class { Some(class_name) } else { None };
                     candidates.push(CompletionCandidate {
                         label: sym.name.clone(),
                         kind: sym.kind,
-                        detail: Some(self.method_detail(class_name, &sym.name)),
+                        detail: Some(self.method_detail(original_class, &sym.name, defining, module_index)),
                         insert_text: None,
                         sort_priority: PRIORITY_LOCAL,
                         additional_edits: vec![],
@@ -879,7 +946,48 @@ impl FileAnalysis {
             }
         }
 
-        candidates
+        // Walk local parents
+        if let Some(parents) = self.package_parents.get(class_name) {
+            for parent in parents {
+                self.collect_ancestor_methods(
+                    original_class, parent, module_index, candidates, seen_names, depth + 1,
+                );
+            }
+        }
+
+        // Walk cross-file parents
+        if let Some(idx) = module_index {
+            // Methods from the cross-file module itself
+            if let Some(exports) = idx.get_exports_cached(class_name) {
+                for (name, sub_info) in &exports.subs {
+                    if !seen_names.contains(name) {
+                        seen_names.insert(name.clone());
+                        let kind = if sub_info.is_method { SymKind::Method } else { SymKind::Sub };
+                        let defining = if class_name != original_class { Some(class_name) } else { None };
+                        let detail = self.method_detail(original_class, name, defining, module_index);
+                        candidates.push(CompletionCandidate {
+                            label: name.clone(),
+                            kind,
+                            detail: Some(detail),
+                            insert_text: None,
+                            sort_priority: PRIORITY_LOCAL,
+                            additional_edits: vec![],
+                        });
+                    }
+                }
+            }
+
+            // Cross-file parents
+            let cross_parents = idx.parents_cached(class_name);
+            for parent in &cross_parents {
+                // Don't re-collect if it's a local package (already handled above)
+                if !self.package_parents.contains_key(parent.as_str()) {
+                    self.collect_ancestor_methods(
+                        original_class, parent, module_index, candidates, seen_names, depth + 1,
+                    );
+                }
+            }
+        }
     }
 
     /// Get the enclosing package name at a point.
@@ -967,7 +1075,7 @@ impl FileAnalysis {
     // ---- High-level queries ----
 
     /// Go-to-definition: resolve the symbol at cursor to its definition span.
-    pub fn find_definition(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<Span> {
+    pub fn find_definition(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>, module_index: Option<&ModuleIndex>) -> Option<Span> {
         // 1. Check if cursor is on a ref
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
@@ -985,7 +1093,7 @@ impl FileAnalysis {
                     }
                 }
                 RefKind::MethodCall { ref invocant, ref invocant_span, .. } => {
-                    let class_name = self.resolve_method_invocant(invocant, invocant_span, r.scope, point, tree, source_bytes);
+                    let class_name = self.resolve_method_invocant(invocant, invocant_span, r.scope, point, tree, source_bytes, module_index);
 
                     // Check if cursor is on a named arg key in the call args,
                     // not on the method name itself. Resolve to hash key def or :param field.
@@ -1006,8 +1114,8 @@ impl FileAnalysis {
                     }
 
                     if let Some(ref cn) = class_name {
-                        // Find method in the resolved class
-                        if let Some(span) = self.find_method_in_class(cn, &r.target_name) {
+                        // Find method in the resolved class (walks inheritance)
+                        if let Some(span) = self.find_method_in_class_with_index(cn, &r.target_name, module_index) {
                             return Some(span);
                         }
                         // Method not found (e.g. auto-generated "new") → go to class def
@@ -1031,7 +1139,7 @@ impl FileAnalysis {
                     let resolved_owner = owner.clone().or_else(|| {
                         let tree = tree?;
                         let source = source_bytes?;
-                        self.resolve_hash_owner_from_tree(tree, source, r.span.start)
+                        self.resolve_hash_owner_from_tree(tree, source, r.span.start, module_index)
                     });
                     if let Some(ref owner) = resolved_owner {
                         for def in self.hash_key_defs_for_owner(owner) {
@@ -1058,7 +1166,7 @@ impl FileAnalysis {
 
     /// Find all references to the symbol at cursor.
     pub fn find_references(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Vec<Span> {
-        if let Some((target_id, include_decl)) = self.resolve_target_at(point, tree, source_bytes) {
+        if let Some((target_id, include_decl)) = self.resolve_target_at(point, tree, source_bytes, None) {
             let mut results = self.collect_refs_for_target(target_id, include_decl, tree, source_bytes);
             results.sort_by_key(|(s, _)| (s.start.row, s.start.column));
             results.dedup_by(|a, b| a.0.start == b.0.start && a.0.end == b.0.end);
@@ -1070,7 +1178,7 @@ impl FileAnalysis {
 
     /// Document highlights: like references but with read/write annotation.
     pub fn find_highlights(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Vec<(Span, AccessKind)> {
-        if let Some((target_id, _)) = self.resolve_target_at(point, tree, source_bytes) {
+        if let Some((target_id, _)) = self.resolve_target_at(point, tree, source_bytes, None) {
             let mut results = self.collect_refs_for_target(target_id, true, tree, source_bytes);
             results.sort_by_key(|(s, _)| (s.start.row, s.start.column));
             results.dedup_by(|a, b| a.0.start == b.0.start && a.0.end == b.0.end);
@@ -1128,7 +1236,7 @@ impl FileAnalysis {
                         Some(ref ro) => ro == owner,
                         None => {
                             if let (Some(t), Some(s)) = (tree, source_bytes) {
-                                self.resolve_hash_owner_from_tree(t, s, r.span.start)
+                                self.resolve_hash_owner_from_tree(t, s, r.span.start, None)
                                     .as_ref()
                                     .map_or(false, |resolved| resolved == owner)
                             } else {
@@ -1147,7 +1255,7 @@ impl FileAnalysis {
     }
 
     /// Hover info: return display text for the symbol at cursor.
-    pub fn hover_info(&self, point: Point, source: &str, tree: Option<&tree_sitter::Tree>) -> Option<String> {
+    pub fn hover_info(&self, point: Point, source: &str, tree: Option<&tree_sitter::Tree>, module_index: Option<&ModuleIndex>) -> Option<String> {
         // Check refs first
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
@@ -1171,16 +1279,47 @@ impl FileAnalysis {
                 }
                 RefKind::MethodCall { ref invocant, ref invocant_span, .. } => {
                     let class_name = self.resolve_method_invocant(
-                        invocant, invocant_span, r.scope, point, tree, Some(source.as_bytes()),
+                        invocant, invocant_span, r.scope, point, tree, Some(source.as_bytes()), module_index,
                     );
                     if let Some(ref cn) = class_name {
-                        if let Some(span) = self.find_method_in_class(cn, &r.target_name) {
-                            let line = source_line_at(source, span.start.row);
-                            let mut text = format!("```perl\n{}\n```\n\n*class {}*", line.trim(), cn);
-                            if let Some(ref rt) = self.find_method_return_type(cn, &r.target_name) {
-                                text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(rt)));
+                        match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
+                            Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
+                                let sym = self.symbol(sym_id);
+                                let line = source_line_at(source, sym.selection_span.start.row);
+                                let class_label = if defining_class != cn {
+                                    format!("{} (from {})", cn, defining_class)
+                                } else {
+                                    cn.to_string()
+                                };
+                                let mut text = format!("```perl\n{}\n```\n\n*class {}*", line.trim(), class_label);
+                                if let Some(ref rt) = self.find_method_return_type(cn, &r.target_name, module_index) {
+                                    text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(rt)));
+                                }
+                                return Some(text);
                             }
-                            return Some(text);
+                            Some(MethodResolution::CrossFile { ref class }) => {
+                                if let Some(idx) = module_index {
+                                    if let Some(exports) = idx.get_exports_cached(class) {
+                                        if let Some(sub_info) = exports.sub_info(&r.target_name) {
+                                            let class_label = if class != cn {
+                                                format!("{} (from {})", cn, class)
+                                            } else {
+                                                cn.to_string()
+                                            };
+                                            let sig = format_cross_file_signature(&r.target_name, sub_info);
+                                            let mut text = format!("```perl\n{}\n```\n\n*class {}*", sig, class_label);
+                                            if let Some(ref rt) = sub_info.return_type {
+                                                text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(rt)));
+                                            }
+                                            if let Some(ref doc) = sub_info.doc {
+                                                text.push_str(&format!("\n\n{}", doc));
+                                            }
+                                            return Some(text);
+                                        }
+                                    }
+                                }
+                            }
+                            None => {}
                         }
                     }
                     // Fallback
@@ -1265,7 +1404,7 @@ impl FileAnalysis {
     // ---- Internal resolution helpers ----
 
     /// Find the target symbol for the thing at cursor. Returns (SymbolId, include_decl_in_refs).
-    fn resolve_target_at(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<(SymbolId, bool)> {
+    fn resolve_target_at(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>, module_index: Option<&ModuleIndex>) -> Option<(SymbolId, bool)> {
         // Check refs first
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
@@ -1287,7 +1426,7 @@ impl FileAnalysis {
                 }
                 RefKind::MethodCall { ref invocant, ref invocant_span } => {
                     let class_name = self.resolve_method_invocant(
-                        invocant, invocant_span, r.scope, point, tree, source_bytes,
+                        invocant, invocant_span, r.scope, point, tree, source_bytes, module_index,
                     );
                     // Try class-specific method first
                     if let Some(ref cn) = class_name {
@@ -1318,7 +1457,7 @@ impl FileAnalysis {
                     let resolved_owner = owner.clone().or_else(|| {
                         let tree = tree?;
                         let source = source_bytes?;
-                        self.resolve_hash_owner_from_tree(tree, source, r.span.start)
+                        self.resolve_hash_owner_from_tree(tree, source, r.span.start, module_index)
                     });
                     if let Some(ref owner) = resolved_owner {
                         for def in self.hash_key_defs_for_owner(owner) {
@@ -1339,6 +1478,20 @@ impl FileAnalysis {
         None
     }
 
+    /// Resolve a method call's invocant to a class name (public API for cross-file goto-def).
+    pub fn resolve_method_invocant_public(
+        &self,
+        invocant: &str,
+        invocant_span: &Option<Span>,
+        scope: ScopeId,
+        point: Point,
+        tree: Option<&tree_sitter::Tree>,
+        source_bytes: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<String> {
+        self.resolve_method_invocant(invocant, invocant_span, scope, point, tree, source_bytes, module_index)
+    }
+
     /// Resolve a method call's invocant to a class name, using tree-based resolution
     /// for complex expressions when available.
     fn resolve_method_invocant(
@@ -1349,13 +1502,14 @@ impl FileAnalysis {
         point: Point,
         tree: Option<&tree_sitter::Tree>,
         source_bytes: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
     ) -> Option<String> {
         // Try tree-based resolution for complex invocants, fall through on failure
         if let (Some(span), Some(tree), Some(src)) = (invocant_span, tree, source_bytes) {
             if let Some(node) = tree.root_node()
                 .descendant_for_point_range(span.start, span.end)
             {
-                if let Some(ty) = self.resolve_expression_type(node, src) {
+                if let Some(ty) = self.resolve_expression_type(node, src, module_index) {
                     if let Some(cn) = ty.class_name() {
                         return Some(cn.to_string());
                     }
@@ -1393,13 +1547,132 @@ impl FileAnalysis {
     }
 
     /// Find a method definition within a class/package.
-    fn find_method_in_class(&self, class_name: &str, method_name: &str) -> Option<Span> {
+    pub(crate) fn find_method_in_class(&self, class_name: &str, method_name: &str) -> Option<Span> {
+        self.find_method_in_class_with_index(class_name, method_name, None)
+    }
+
+    /// Find a method definition, walking the inheritance chain if needed.
+    fn find_method_in_class_with_index(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<Span> {
+        match self.resolve_method_in_ancestors(class_name, method_name, module_index) {
+            Some(MethodResolution::Local { sym_id, .. }) => {
+                Some(self.symbol(sym_id).selection_span)
+            }
+            Some(MethodResolution::CrossFile { .. }) => {
+                // Cross-file method found but no local span to return
+                // Caller should handle cross-file resolution via ModuleIndex
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// Walk the inheritance chain to find a method (DFS, matches Perl's default MRO).
+    pub fn resolve_method_in_ancestors(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<MethodResolution> {
+        self.resolve_method_in_ancestors_inner(class_name, method_name, module_index, 0)
+    }
+
+    fn resolve_method_in_ancestors_inner(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+        depth: usize,
+    ) -> Option<MethodResolution> {
+        if depth > 20 {
+            return None; // safety limit
+        }
+
+        // Check class_name directly (local symbols)
         for &sid in self.symbols_named(method_name) {
             let sym = self.symbol(sid);
             if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                 if self.symbol_in_class(sid, class_name) {
-                    return Some(sym.selection_span);
+                    return Some(MethodResolution::Local {
+                        class: class_name.to_string(),
+                        sym_id: sid,
+                    });
                 }
+            }
+        }
+
+        // Check local parents from package_parents
+        if let Some(parents) = self.package_parents.get(class_name) {
+            for parent in parents {
+                if let Some(res) = self.resolve_method_in_ancestors_inner(
+                    parent, method_name, module_index, depth + 1,
+                ) {
+                    return Some(res);
+                }
+            }
+        }
+
+        // Check cross-file parents via ModuleIndex
+        if let Some(idx) = module_index {
+            if let Some(exports) = idx.get_exports_cached(class_name) {
+                if exports.subs.contains_key(method_name) {
+                    return Some(MethodResolution::CrossFile {
+                        class: class_name.to_string(),
+                    });
+                }
+            }
+            // Walk cross-file parent chain
+            let cross_parents = idx.parents_cached(class_name);
+            for parent in &cross_parents {
+                // Check if parent is a local package first
+                if self.package_parents.contains_key(parent.as_str()) {
+                    if let Some(res) = self.resolve_method_in_ancestors_inner(
+                        parent, method_name, module_index, depth + 1,
+                    ) {
+                        return Some(res);
+                    }
+                } else {
+                    // Fully cross-file parent
+                    if let Some(res) = self.resolve_cross_file_method(
+                        parent, method_name, idx, depth + 1,
+                    ) {
+                        return Some(res);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Resolve a method through the cross-file inheritance chain only.
+    fn resolve_cross_file_method(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        module_index: &ModuleIndex,
+        depth: usize,
+    ) -> Option<MethodResolution> {
+        if depth > 20 {
+            return None;
+        }
+        if let Some(exports) = module_index.get_exports_cached(class_name) {
+            if exports.subs.contains_key(method_name) {
+                return Some(MethodResolution::CrossFile {
+                    class: class_name.to_string(),
+                });
+            }
+        }
+        let parents = module_index.parents_cached(class_name);
+        for parent in &parents {
+            if let Some(res) = self.resolve_cross_file_method(
+                parent, method_name, module_index, depth + 1,
+            ) {
+                return Some(res);
             }
         }
         None
@@ -1631,6 +1904,18 @@ pub const PRIORITY_UNIMPORTED: u8 = 25;
 /// Dynamic hash keys (may not exist).
 pub const PRIORITY_DYNAMIC: u8 = 50;
 
+// ---- Method resolution types ----
+
+/// Result of resolving a method through the inheritance chain.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum MethodResolution {
+    /// Found in a local class within this file.
+    Local { class: String, sym_id: SymbolId },
+    /// Found in a cross-file module (use ModuleIndex to get details).
+    CrossFile { class: String },
+}
+
 // ---- Completion types ----
 
 /// A completion candidate from FileAnalysis resolution (pure table lookup).
@@ -1746,7 +2031,7 @@ impl FileAnalysis {
         };
 
         if let Some(ref cn) = class_name {
-            let candidates = self.complete_methods_for_class(cn);
+            let candidates = self.complete_methods_for_class(cn, None);
             if !candidates.is_empty() {
                 return candidates;
             }
@@ -2392,6 +2677,16 @@ pub fn inferred_type_from_tag(tag: &str) -> Option<InferredType> {
     }
 }
 
+/// Format a cross-file method signature from ExportedSub metadata.
+fn format_cross_file_signature(method_name: &str, sub_info: &crate::module_index::ExportedSub) -> String {
+    if sub_info.params.is_empty() {
+        format!("sub {}()", method_name)
+    } else {
+        let params: Vec<&str> = sub_info.params.iter().map(|p| p.name.as_str()).collect();
+        format!("sub {}({})", method_name, params.join(", "))
+    }
+}
+
 pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
     match ty {
         InferredType::ClassName(name) => name.clone(),
@@ -2426,6 +2721,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            HashMap::new(),
         )
     }
 
@@ -2516,6 +2812,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            HashMap::new(),
         );
         assert_eq!(fa.sub_return_type("get_config"), Some(&InferredType::HashRef));
         assert_eq!(fa.sub_return_type("nonexistent"), None);
@@ -2671,6 +2968,7 @@ mod tests {
                 scope: ScopeId(0),
                 span: Span { start: Point::new(2, 0), end: Point::new(2, 30) },
             }],
+            HashMap::new(),
         );
 
         let mut imported = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,9 @@ async fn main() {
     // Used by the module resolver with a hard timeout to protect against
     // infinite loops in the tree-sitter external scanner.
     let args: Vec<String> = std::env::args().collect();
-    if args.len() == 3 && args[1] == "--parse-exports" {
-        module_index::subprocess_main(&args[2]);
+    if (args.len() == 3 || args.len() == 4) && args[1] == "--parse-exports" {
+        let module_name = args.get(3).map(|s| s.as_str());
+        module_index::subprocess_main(&args[2], module_name);
         return;
     }
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -14,12 +14,12 @@ use rusqlite::{params, Connection};
 use crate::file_analysis::{inferred_type_from_tag, inferred_type_to_tag};
 use crate::module_index::{ExportedParam, ExportedSub, ModuleExports};
 
-const SCHEMA_VERSION: &str = "7";
+const SCHEMA_VERSION: &str = "8";
 
 /// Bumped when extraction logic changes (new fields, better parsing).
 /// Unlike SCHEMA_VERSION, this doesn't drop the table — stale entries
 /// are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 1;
+pub const EXTRACT_VERSION: i64 = 2;
 
 pub fn cache_base_dir() -> Option<PathBuf> {
     if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
@@ -97,6 +97,7 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
             export_ok    TEXT NOT NULL,
             source       TEXT NOT NULL DEFAULT 'import',
             subs         TEXT NOT NULL DEFAULT '{}',
+            parents      TEXT NOT NULL DEFAULT '[]',
             extract_version INTEGER NOT NULL DEFAULT 0
         );",
     )?;
@@ -123,6 +124,7 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
                     export_ok    TEXT NOT NULL,
                     source       TEXT NOT NULL DEFAULT 'import',
                     subs         TEXT NOT NULL DEFAULT '{}',
+                    parents      TEXT NOT NULL DEFAULT '[]',
                     extract_version INTEGER NOT NULL DEFAULT 0
                 );",
             )?;
@@ -190,7 +192,7 @@ pub fn warm_cache(
     cache: &DashMap<String, Option<ModuleExports>>,
 ) -> (usize, Vec<String>) {
     let mut stmt = match conn.prepare(
-        "SELECT module_name, path, mtime_secs, file_size, export, export_ok, subs, extract_version FROM modules",
+        "SELECT module_name, path, mtime_secs, file_size, export, export_ok, subs, extract_version, parents FROM modules",
     ) {
         Ok(s) => s,
         Err(_) => return (0, Vec::new()),
@@ -206,6 +208,7 @@ pub fn warm_cache(
             row.get::<_, String>(5)?,
             row.get::<_, String>(6)?,
             row.get::<_, i64>(7)?,
+            row.get::<_, String>(8)?,
         ))
     }) {
         Ok(r) => r,
@@ -215,7 +218,7 @@ pub fn warm_cache(
     let mut count = 0usize;
     let mut stale_names = Vec::new();
     for row in rows.flatten() {
-        let (module_name, path_str, cached_mtime, cached_size, export_json, export_ok_json, subs_json, row_extract_version) = row;
+        let (module_name, path_str, cached_mtime, cached_size, export_json, export_ok_json, subs_json, row_extract_version, parents_json) = row;
 
         // Negative sentinel
         if path_str.is_empty() {
@@ -240,6 +243,7 @@ pub fn warm_cache(
 
         // Deserialize subs: JSON map of name → { def_line, params, is_method, return_type, hash_keys }
         let subs = deserialize_subs_json(&subs_json);
+        let parents: Vec<String> = serde_json::from_str(&parents_json).unwrap_or_default();
 
         if export.is_empty() && export_ok.is_empty() {
             cache.insert(module_name, None);
@@ -255,6 +259,7 @@ pub fn warm_cache(
                     export,
                     export_ok,
                     subs,
+                    parents,
                 }),
             );
         }
@@ -323,12 +328,13 @@ pub fn save_to_db(
     result: &Option<ModuleExports>,
     source: &str,
 ) {
-    let (path_str, mtime, size, export_json, export_ok_json, subs_json) = match result {
+    let (path_str, mtime, size, export_json, export_ok_json, subs_json, parents_json) = match result {
         Some(exports) => {
             let (mtime, size) = mtime_as_secs(&exports.path).unwrap_or((0, 0));
             let ej = serde_json::to_string(&exports.export).unwrap_or_default();
             let eoj = serde_json::to_string(&exports.export_ok).unwrap_or_default();
             let sj = serialize_subs_json(&exports.subs);
+            let pj = serde_json::to_string(&exports.parents).unwrap_or_else(|_| "[]".to_string());
             (
                 exports.path.to_string_lossy().to_string(),
                 mtime,
@@ -336,6 +342,7 @@ pub fn save_to_db(
                 ej,
                 eoj,
                 sj,
+                pj,
             )
         }
         None => (
@@ -345,13 +352,14 @@ pub fn save_to_db(
             "[]".to_string(),
             "[]".to_string(),
             "{}".to_string(),
+            "[]".to_string(),
         ),
     };
 
     let r = conn.execute(
-        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, export, export_ok, source, subs, extract_version)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        params![module_name, path_str, mtime, size, export_json, export_ok_json, source, subs_json, EXTRACT_VERSION],
+        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, export, export_ok, source, subs, parents, extract_version)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![module_name, path_str, mtime, size, export_json, export_ok_json, source, subs_json, parents_json, EXTRACT_VERSION],
     );
     if let Err(e) = r {
         log::warn!("Failed to save module cache for '{}': {}", module_name, e);
@@ -416,6 +424,7 @@ mod tests {
             export: vec!["foo".into(), "bar".into()],
             export_ok: vec!["baz".into()],
             subs: HashMap::new(),
+            parents: vec![],
         });
         save_to_db(&conn, "TestModule", &exports, "import");
 
@@ -459,6 +468,7 @@ mod tests {
             export: vec!["old".into()],
             export_ok: vec![],
             subs: HashMap::new(),
+            parents: vec![],
         });
         save_to_db(&conn, "StaleModule", &exports, "import");
 
@@ -555,6 +565,7 @@ mod tests {
             export: vec!["get_data".into()],
             export_ok: vec![],
             subs,
+            parents: vec![],
         });
         save_to_db(&conn, "MigratedModule", &exports, "import");
 
@@ -588,6 +599,7 @@ mod tests {
             export: vec!["foo".into()],
             export_ok: vec![],
             subs: HashMap::new(),
+            parents: vec![],
         });
         save_to_db(&conn, "SourceTest", &exports, "cpanfile");
 
@@ -669,6 +681,7 @@ mod tests {
             export: vec!["get_config".into()],
             export_ok: vec!["make_items".into(), "new_obj".into()],
             subs,
+            parents: vec![],
         });
         save_to_db(&conn, "SubsTest", &exports, "import");
 
@@ -735,6 +748,7 @@ mod tests {
             export: vec!["foo".into()],
             export_ok: vec![],
             subs: HashMap::new(),
+            parents: vec![],
         });
         save_to_db(&conn, "FreshExtract", &exports, "import");
 
@@ -758,6 +772,7 @@ mod tests {
             export: vec!["foo".into()],
             export_ok: vec![],
             subs: HashMap::new(),
+            parents: vec![],
         });
         save_to_db(&conn, "VersionedSave", &exports, "import");
 

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -56,6 +56,8 @@ pub struct ModuleExports {
     pub export_ok: Vec<String>,
     /// Per-function metadata for exported subs.
     pub subs: HashMap<String, ExportedSub>,
+    /// Parent classes for the primary package.
+    pub parents: Vec<String>,
 }
 
 impl ModuleExports {
@@ -197,6 +199,14 @@ impl ModuleIndex {
         self.cache
             .get(module_name)
             .and_then(|entry| entry.as_ref().map(|e| e.path.clone()))
+    }
+
+    /// Return cached parent classes for a module.
+    pub fn parents_cached(&self, module_name: &str) -> Vec<String> {
+        self.cache
+            .get(module_name)
+            .and_then(|entry| entry.as_ref().map(|e| e.parents.clone()))
+            .unwrap_or_default()
     }
 
     /// Iterate all cached module exports. Callback receives (module_name, exports).
@@ -342,8 +352,8 @@ impl ModuleIndex {
 }
 
 /// Entry point for `--parse-exports <path>` subprocess mode.
-pub fn subprocess_main(path: &str) {
-    module_resolver::subprocess_main(path);
+pub fn subprocess_main(path: &str, module_name: Option<&str>) {
+    module_resolver::subprocess_main(path, module_name);
 }
 
 #[cfg(test)]
@@ -425,6 +435,7 @@ mod tests {
                 export: vec!["alpha".into()],
                 export_ok: vec!["beta".into()],
                 subs: HashMap::new(),
+                parents: vec![],
             }),
         );
         idx.insert_cache(
@@ -434,6 +445,7 @@ mod tests {
                 export: vec![],
                 export_ok: vec!["beta".into(), "gamma".into()],
                 subs: HashMap::new(),
+                parents: vec![],
             }),
         );
 
@@ -452,6 +464,7 @@ mod tests {
                 export: vec!["foo".into()],
                 export_ok: vec!["bar".into()],
                 subs: HashMap::new(),
+                parents: vec![],
             }),
         );
 
@@ -492,6 +505,7 @@ mod tests {
                 export: vec![],
                 export_ok: vec!["get_config".into(), "make_obj".into()],
                 subs,
+                parents: vec![],
             }),
         );
 

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -419,10 +419,6 @@ fn parse_in_subprocess(inc_paths: &[PathBuf], module_name: &str) -> Option<Modul
         })
         .unwrap_or_default();
 
-    if export.is_empty() && export_ok.is_empty() {
-        return None;
-    }
-
     // Parse subs metadata from JSON
     let subs: HashMap<String, ExportedSub> = json
         .get("subs")
@@ -562,6 +558,42 @@ pub fn subprocess_main(path: &str, module_name: Option<&str>) {
                 subs_map.insert(name.clone(), sub_info.into());
             }
         }
+
+        // Also include all subs not in @EXPORT/@EXPORT_OK — needed for inheritance.
+        for sym in &analysis.symbols {
+            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
+            if subs_map.contains_key(&sym.name) { continue; }
+            let is_method = matches!(sym.detail, SymbolDetail::Sub { is_method: true, .. })
+                || sym.kind == SymKind::Method;
+            let mut sub_info = serde_json::Map::new();
+            sub_info.insert("def_line".into(), sym.span.start.row.into());
+            sub_info.insert("is_method".into(), is_method.into());
+            if let SymbolDetail::Sub { ref params, ref doc, .. } = sym.detail {
+                let params_json: Vec<serde_json::Value> = params.iter()
+                    .map(|p| serde_json::json!({
+                        "name": p.name,
+                        "is_slurpy": p.is_slurpy,
+                    }))
+                    .collect();
+                sub_info.insert("params".into(), params_json.into());
+                if let Some(ref d) = doc {
+                    sub_info.insert("doc".into(), serde_json::Value::String(d.clone()));
+                }
+            }
+            if let Some(ty) = analysis.sub_return_type(&sym.name) {
+                sub_info.insert("return_type".into(),
+                    serde_json::Value::String(inferred_type_to_tag(ty)));
+            }
+            let owner = crate::file_analysis::HashKeyOwner::Sub(sym.name.clone());
+            let keys: Vec<String> = analysis.hash_key_defs_for_owner(&owner)
+                .iter()
+                .map(|s| s.name.clone())
+                .collect();
+            if !keys.is_empty() {
+                sub_info.insert("hash_keys".into(), serde_json::json!(keys));
+            }
+            subs_map.insert(sym.name.clone(), sub_info.into());
+        }
     }
 
     let json = serde_json::json!({
@@ -652,6 +684,32 @@ pub fn resolve_and_parse(
                 .collect();
 
             subs.insert(name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys, doc });
+        }
+
+        // Also include methods not in @EXPORT/@EXPORT_OK — needed for inheritance.
+        for sym in &analysis.symbols {
+            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
+            if subs.contains_key(&sym.name) { continue; }
+            let is_method_flag = matches!(sym.detail, SymbolDetail::Sub { is_method: true, .. })
+                || sym.kind == SymKind::Method;
+            let def_line = sym.span.start.row as u32;
+            let mut params = Vec::new();
+            let mut doc = None;
+            if let SymbolDetail::Sub { params: ref p, doc: ref d, .. } = sym.detail {
+                params = p.iter()
+                    .map(|pi| ExportedParam { name: pi.name.clone(), is_slurpy: pi.is_slurpy })
+                    .collect();
+                doc = d.clone();
+            }
+            let return_type = analysis.sub_return_type(&sym.name).cloned();
+            let owner = crate::file_analysis::HashKeyOwner::Sub(sym.name.clone());
+            let hash_keys: Vec<String> = analysis.hash_key_defs_for_owner(&owner)
+                .iter()
+                .map(|s| s.name.clone())
+                .collect();
+            subs.insert(sym.name.clone(), ExportedSub {
+                def_line, params, is_method: is_method_flag, return_type, hash_keys, doc,
+            });
         }
     }
 
@@ -745,9 +803,6 @@ fn extract_exports(parser: &mut Parser, source: &str) -> Option<(Vec<String>, Ve
         }
     }
 
-    if export.is_empty() && export_ok.is_empty() {
-        return None;
-    }
     Some((export, export_ok, tree))
 }
 

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -371,6 +371,7 @@ fn parse_in_subprocess(inc_paths: &[PathBuf], module_name: &str) -> Option<Modul
     let mut child = std::process::Command::new(exe)
         .arg("--parse-exports")
         .arg(&path)
+        .arg(module_name)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -454,16 +455,28 @@ fn parse_in_subprocess(inc_paths: &[PathBuf], module_name: &str) -> Option<Modul
         })
         .unwrap_or_default();
 
+    // Extract parents from subprocess JSON
+    let parents: Vec<String> = json
+        .get("parents")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
     Some(ModuleExports {
         path,
         export,
         export_ok,
         subs,
+        parents,
     })
 }
 
-/// Entry point for `--parse-exports <path>` subprocess mode.
-pub fn subprocess_main(path: &str) {
+/// Entry point for `--parse-exports <path> [module_name]` subprocess mode.
+pub fn subprocess_main(path: &str, module_name: Option<&str>) {
     let source = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(_) => {
@@ -484,9 +497,27 @@ pub fn subprocess_main(path: &str) {
 
     // Run the builder to get full sub metadata for exported functions
     let mut subs_map = serde_json::Map::new();
+    let mut parents: Vec<String> = Vec::new();
     {
         use crate::file_analysis::{SymKind, SymbolDetail};
         let analysis = crate::builder::build(&tree, source.as_bytes());
+
+        // Extract parents for the primary package
+        // Prefer exact match on module_name (e.g. "Foo::Bar"), then stem match, then single-entry or first
+        let expected_pkg = module_name.map(|m| m.replace("::", "::"));
+        if let Some(ref pkg_name) = expected_pkg {
+            if let Some(pkg_parents) = analysis.package_parents.get(pkg_name.as_str()) {
+                parents = pkg_parents.clone();
+            }
+        }
+        if parents.is_empty() {
+            if analysis.package_parents.len() == 1 {
+                if let Some((_pkg, pkg_parents)) = analysis.package_parents.iter().next() {
+                    parents = pkg_parents.clone();
+                }
+            }
+        }
+
         for name in export.iter().chain(export_ok.iter()) {
             let mut sub_info = serde_json::Map::new();
 
@@ -537,6 +568,7 @@ pub fn subprocess_main(path: &str) {
         "export": export,
         "export_ok": export_ok,
         "subs": subs_map,
+        "parents": parents,
     });
     println!("{}", json);
 }
@@ -576,11 +608,22 @@ pub fn resolve_and_parse(
     let source = std::fs::read_to_string(&path).ok()?;
     let (export, export_ok, tree) = extract_exports(parser, &source)?;
 
-    // Extract full sub metadata from builder analysis
+    // Extract full sub metadata and parents from builder analysis
     let mut subs = HashMap::new();
+    let mut parents: Vec<String> = Vec::new();
     {
         use crate::file_analysis::{SymKind, SymbolDetail};
         let analysis = crate::builder::build(&tree, source.as_bytes());
+
+        // Extract parents for the primary package
+        if let Some(pkg_parents) = analysis.package_parents.get(module_name) {
+            parents = pkg_parents.clone();
+        } else if analysis.package_parents.len() == 1 {
+            if let Some((_pkg, pkg_parents)) = analysis.package_parents.iter().next() {
+                parents = pkg_parents.clone();
+            }
+        }
+
         for name in export.iter().chain(export_ok.iter()) {
             let mut def_line = 0u32;
             let mut params = Vec::new();
@@ -617,6 +660,7 @@ pub fn resolve_and_parse(
         export,
         export_ok,
         subs,
+        parents,
     })
 }
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -85,7 +85,7 @@ pub fn find_definition(
     let point = position_to_point(pos);
 
     // Try local definition first
-    if let Some(span) = analysis.find_definition(point, Some(tree), Some(source.as_bytes())) {
+    if let Some(span) = analysis.find_definition(point, Some(tree), Some(source.as_bytes()), Some(module_index)) {
         return Some(GotoDefinitionResponse::Scalar(Location {
             uri: uri.clone(),
             range: span_to_range(span),
@@ -133,6 +133,32 @@ pub fn find_definition(
                     uri: uri.clone(),
                     range: span_to_range(import.span),
                 }));
+            }
+        }
+
+        // Cross-file method goto-def: resolve inherited methods through module index
+        if let RefKind::MethodCall { ref invocant, ref invocant_span } = r.kind {
+            use crate::file_analysis::MethodResolution;
+            let class_name = analysis.resolve_method_invocant_public(
+                invocant, invocant_span, r.scope, point, Some(tree), Some(source.as_bytes()), Some(module_index),
+            );
+            if let Some(ref cn) = class_name {
+                if let Some(MethodResolution::CrossFile { ref class }) = analysis.resolve_method_in_ancestors(cn, &r.target_name, Some(module_index)) {
+                    if let Some(exports) = module_index.get_exports_cached(class) {
+                        if let Some(sub_info) = exports.sub_info(&r.target_name) {
+                            if let Ok(module_uri) = Url::from_file_path(&exports.path) {
+                                let def_range = Range {
+                                    start: Position { line: sub_info.def_line, character: 0 },
+                                    end: Position { line: sub_info.def_line, character: 0 },
+                                };
+                                return Some(GotoDefinitionResponse::Scalar(Location {
+                                    uri: module_uri,
+                                    range: def_range,
+                                }));
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -230,7 +256,7 @@ pub fn completion_items(
         CursorContext::Method { ref invocant_type, ref invocant_text } => {
             if let Some(ref ty) = invocant_type {
                 if let Some(cn) = ty.class_name() {
-                    analysis.complete_methods_for_class(cn)
+                    analysis.complete_methods_for_class(cn, Some(module_index))
                 } else {
                     // Ref types get deref snippet completions (handled below)
                     Vec::new()
@@ -343,7 +369,7 @@ pub fn hover_info(
     let point = position_to_point(pos);
 
     // Try local hover first
-    if let Some(markdown) = analysis.hover_info(point, source, Some(tree)) {
+    if let Some(markdown) = analysis.hover_info(point, source, Some(tree), Some(module_index)) {
         return Some(Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
@@ -1415,6 +1441,7 @@ mod tests {
                 export: vec![],
                 export_ok: vec!["first".into(), "max".into(), "min".into()],
                 subs: std::collections::HashMap::new(),
+                parents: vec![],
             }),
         );
 
@@ -1464,6 +1491,7 @@ mod tests {
                 export: vec![],
                 export_ok: vec!["first".into(), "max".into(), "min".into()],
                 subs: std::collections::HashMap::new(),
+                parents: vec![],
             }),
         );
         idx.insert_cache(
@@ -1473,6 +1501,7 @@ mod tests {
                 export: vec![],
                 export_ok: vec!["blessed".into(), "reftype".into()],
                 subs: std::collections::HashMap::new(),
+                parents: vec![],
             }),
         );
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -4,8 +4,8 @@ use tree_sitter::{Point, Tree};
 
 use crate::cursor_context::{self, CursorContext};
 use crate::file_analysis::{
-    format_inferred_type, CompletionCandidate, FileAnalysis, FoldKind, InferredType, OutlineSymbol,
-    RefKind, Span, SymKind as FaSymKind, SymbolDetail, VarModifier,
+    contains_point, format_inferred_type, CompletionCandidate, FileAnalysis, FoldKind, InferredType,
+    OutlineSymbol, RefKind, Span, SymKind as FaSymKind, SymbolDetail, VarModifier,
     PRIORITY_AUTO_ADD_QW, PRIORITY_BARE_IMPORT, PRIORITY_EXPLICIT_IMPORT, PRIORITY_UNIMPORTED,
 };
 use crate::module_index::ExportedSub;
@@ -115,6 +115,17 @@ pub fn find_definition(
                         None => Range::default(),
                     };
 
+                    let pm_location = Location {
+                        uri: module_uri,
+                        range: def_range,
+                    };
+
+                    // If cursor is inside the use statement itself (on the import name),
+                    // jump directly to the .pm definition — no need to also show the use stmt.
+                    if contains_point(&import.span, point) {
+                        return Some(GotoDefinitionResponse::Scalar(pm_location));
+                    }
+
                     return Some(GotoDefinitionResponse::Array(vec![
                         // First: the use statement in this file
                         Location {
@@ -122,10 +133,7 @@ pub fn find_definition(
                             range: span_to_range(import.span),
                         },
                         // Second: the sub definition in the .pm file
-                        Location {
-                            uri: module_uri,
-                            range: def_range,
-                        },
+                        pm_location,
                     ]));
                 }
                 // Fall back to just the use statement
@@ -133,6 +141,18 @@ pub fn find_definition(
                     uri: uri.clone(),
                     range: span_to_range(import.span),
                 }));
+            }
+        }
+
+        // Cross-file package goto-def: resolve module name via module index
+        if matches!(r.kind, RefKind::PackageRef) {
+            if let Some(path) = module_index.module_path_cached(&r.target_name) {
+                if let Ok(module_uri) = Url::from_file_path(&path) {
+                    return Some(GotoDefinitionResponse::Scalar(Location {
+                        uri: module_uri,
+                        range: Range::default(),
+                    }));
+                }
             }
         }
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -313,6 +313,7 @@ pub fn completion_items(
                         call_ctx.invocant.as_deref(),
                         point,
                         &call_ctx.used_keys,
+                        Some(module_index),
                     ));
                 }
             }
@@ -322,7 +323,7 @@ pub fn completion_items(
             items.extend(imported_function_completions(analysis, module_index));
 
             // Add completions from unimported modules (with auto-import edits)
-            items.extend(unimported_function_completions(analysis, module_index));
+            items.extend(unimported_function_completions(analysis, module_index, point));
 
             items
         }
@@ -495,12 +496,13 @@ pub fn signature_help(
     // Step 1: cursor_context finds the enclosing call
     let call_ctx = cursor_context::find_call_context(tree, text.as_bytes(), point)?;
 
-    // Step 2: file_analysis resolves the sub signature (pure table lookup)
+    // Step 2: file_analysis resolves the sub signature (local + cross-file)
     if let Some(sig_info) = analysis.signature_for_call(
         &call_ctx.name,
         call_ctx.is_method,
         call_ctx.invocant.as_deref(),
         point,
+        Some(module_index),
     ) {
         // Build param labels with inferred types
         let param_labels: Vec<String> = sig_info
@@ -545,39 +547,6 @@ pub fn signature_help(
             active_signature: Some(0),
             active_parameter: Some(call_ctx.active_param as u32),
         });
-    }
-
-    // Fallback: imported function
-    if !call_ctx.is_method {
-        if let Some((import, _)) =
-            resolve_imported_function(analysis, &call_ctx.name, module_index)
-        {
-            if let Some(exports) = module_index.get_exports_cached(&import.module_name) {
-                if let Some(sub_info) = exports.sub_info(&call_ctx.name) {
-                    let param_labels: Vec<String> =
-                        sub_info.params.iter().map(|p| p.name.clone()).collect();
-                    let params: Vec<ParameterInformation> = param_labels
-                        .iter()
-                        .map(|label| ParameterInformation {
-                            label: ParameterLabel::Simple(label.clone()),
-                            documentation: None,
-                        })
-                        .collect();
-                    let label =
-                        format!("{}({})", call_ctx.name, param_labels.join(", "));
-                    return Some(SignatureHelp {
-                        signatures: vec![SignatureInformation {
-                            label,
-                            documentation: None,
-                            parameters: Some(params),
-                            active_parameter: Some(call_ctx.active_param as u32),
-                        }],
-                        active_signature: Some(0),
-                        active_parameter: Some(call_ctx.active_param as u32),
-                    });
-                }
-            }
-        }
     }
 
     None
@@ -833,6 +802,7 @@ fn imported_function_completions(
 fn unimported_function_completions(
     analysis: &FileAnalysis,
     module_index: &ModuleIndex,
+    point: Point,
 ) -> Vec<CompletionCandidate> {
     use crate::file_analysis::Span;
     let mut candidates = Vec::new();
@@ -844,7 +814,7 @@ fn unimported_function_completions(
         .map(|i| i.module_name.as_str())
         .collect();
 
-    let insert_pos = find_use_insertion_position(analysis);
+    let insert_pos = find_use_insertion_position(analysis, point);
     let insert_span = Span {
         start: tree_sitter::Point {
             row: insert_pos.line as usize,
@@ -1157,15 +1127,34 @@ pub fn collect_diagnostics(analysis: &FileAnalysis, module_index: &ModuleIndex) 
 
 // ---- Code actions ----
 
-/// Find the position to insert a new `use` statement.
-/// Returns the start of the line after the last existing `use`.
-fn find_use_insertion_position(analysis: &FileAnalysis) -> Position {
-    if let Some(last_import) = analysis.imports.last() {
+/// Find the position to insert a new `use` statement, scoped to the package at `point`.
+/// Returns the start of the line after the last existing `use` in the same package.
+fn find_use_insertion_position(analysis: &FileAnalysis, point: Point) -> Position {
+    let target_pkg = analysis.package_at(point);
+
+    // Find the last import in the same package
+    let last_in_pkg = analysis.imports.iter().rev().find(|imp| {
+        analysis.package_at(imp.span.start) == target_pkg
+    });
+
+    if let Some(last_import) = last_in_pkg {
         Position {
             line: last_import.span.end.row as u32 + 1,
             character: 0,
         }
     } else {
+        // No imports in this package — find the package statement and insert after it
+        if let Some(pkg_name) = target_pkg {
+            for sym in &analysis.symbols {
+                if matches!(sym.kind, FaSymKind::Package | FaSymKind::Class) && sym.name == pkg_name {
+                    return Position {
+                        line: sym.selection_span.end.row as u32 + 1,
+                        character: 0,
+                    };
+                }
+            }
+        }
+        // Fallback: beginning of file
         Position {
             line: 0,
             character: 0,
@@ -1209,7 +1198,8 @@ pub fn code_actions(
 
         // Case 2: New import — add `use Module qw(func);` statement
         if let Some(modules) = data.get("modules").and_then(|v| v.as_array()) {
-            let insert_pos = find_use_insertion_position(analysis);
+            let diag_point = position_to_point(diag.range.start);
+            let insert_pos = find_use_insertion_position(analysis, diag_point);
             for (i, module_val) in modules.iter().enumerate() {
                 if let Some(module_name) = module_val.as_str() {
                     let new_text = format!("use {} qw({});\n", module_name, func_name);

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1114,13 +1114,8 @@ pub fn collect_diagnostics(analysis: &FileAnalysis, module_index: &ModuleIndex) 
             continue;
         }
 
-        // Check if the method exists in the class
-        let method_exists = analysis.symbols.iter().any(|s| {
-            matches!(s.kind, FaSymKind::Sub | FaSymKind::Method)
-                && s.name == *method_name
-                && analysis.symbol_in_class(s.id, &class_name)
-        });
-        if method_exists {
+        // Check if the method exists in the class (walks inheritance chain)
+        if analysis.resolve_method_in_ancestors(&class_name, method_name, Some(module_index)).is_some() {
             continue;
         }
 

--- a/test_e2e_cross_file.lua
+++ b/test_e2e_cross_file.lua
@@ -108,6 +108,21 @@ t.test("completion: $cfg->{} offers hash keys from get_config", function()
   end
 end)
 
+-- ── 4. Goto-def on imported function name in use statement ───────────
+
+t.test("goto-def: 'get_config' in use qw() jumps to TestExporter.pm", function()
+  local N = "goto-def: 'get_config' in use qw() jumps to TestExporter.pm"
+  local line, col = b.find_pos(buf, "use TestExporter qw(get_config")
+  if not t.ok(N, line, "couldn't find use TestExporter line") then return end
+  -- Position cursor on "get_config" inside qw() — col + 20 lands inside the word
+  local loc = lsp.def_location(buf, line, col + 20)
+  if not t.ok(N, loc, "no definition result") then return end
+  if t.ok(N, loc.uri and loc.uri:find("TestExporter.pm", 1, true),
+    "uri should point to TestExporter.pm, got: " .. tostring(loc.uri)) then
+    t.pass(N)
+  end
+end)
+
 -- ── done ─────────────────────────────────────────────────────────────
 
 t.finish()

--- a/test_e2e_inheritance.lua
+++ b/test_e2e_inheritance.lua
@@ -1,0 +1,170 @@
+-- E2E tests for inheritance chain resolution.
+-- Tests local multi-level inheritance AND cross-file parent resolution.
+--
+-- Usage:
+--   cargo build --release
+--   PERL5LIB=$PWD/test_files/lib nvim --headless --clean -u test_nvim_init.lua -l test_e2e_inheritance.lua
+
+vim.opt.rtp:prepend(".")
+
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+local b   = require("test.buf")
+
+local buf = lsp.open_and_attach("test_files/inheritance.pl")
+
+-- Wait for cross-file types (BaseWorker) to resolve.
+-- Poll by checking completion on $worker-> for "process" from BaseWorker.
+local function wait_for_cross_file(max_secs)
+  for _ = 1, max_secs * 4 do
+    local line, col = b.find_pos(buf, "$worker->run()")
+    if line then
+      local labels = lsp.completion_labels(buf, line, col + 9)
+      for _, l in ipairs(labels) do
+        if l == "process" then return true end
+      end
+    end
+    vim.wait(250)
+  end
+  return false
+end
+
+local cross_file_ready = wait_for_cross_file(15)
+if not cross_file_ready then
+  io.write("\27[33mWARN: cross-file inheritance did not resolve within 15s — some tests may fail\27[0m\n")
+  io.write("      Make sure PERL5LIB includes test_files/lib\n\n")
+end
+
+-- ── 1. Local: completion through inheritance ─────────────────────────
+
+t.test("completion: $dog-> offers own method fetch", function()
+  local N = "completion: $dog-> offers own method fetch"
+  local line, col = b.find_pos(buf, "$dog->fetch()")
+  if not t.ok(N, line, "couldn't find '$dog->fetch()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "fetch", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $dog-> offers inherited speak from Animal (overridden in Dog)", function()
+  local N = "completion: $dog-> offers inherited speak from Animal (overridden in Dog)"
+  local line, col = b.find_pos(buf, "$dog->speak()")
+  if not t.ok(N, line, "couldn't find '$dog->speak()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "speak", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $golden-> offers multi-level inherited breathe from Animal", function()
+  local N = "completion: $golden-> offers multi-level inherited breathe from Animal"
+  local line, col = b.find_pos(buf, "$golden->breathe()")
+  if not t.ok(N, line, "couldn't find '$golden->breathe()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 10)
+  if not t.ok(N, #labels > 0, "no completions") then return end
+  local ok = t.contains(N, labels, "breathe", "completions")
+  ok = t.contains(N, labels, "be_friendly", "completions") and ok
+  ok = t.contains(N, labels, "speak", "completions") and ok
+  if ok then t.pass(N) end
+end)
+
+-- ── 2. Local: goto-def to inherited method ───────────────────────────
+
+t.test("goto-def: $golden->breathe() jumps to Animal::breathe", function()
+  local N = "goto-def: $golden->breathe() jumps to Animal::breathe"
+  local line, col = b.find_pos(buf, "$golden->breathe()")
+  if not t.ok(N, line, "couldn't find '$golden->breathe()'") then return end
+  local def = lsp.def_line(buf, line, col + 10)
+  local expected = b.find_line(buf, "^sub breathe")
+  if t.eq(N, expected, def, "definition line") then t.pass(N) end
+end)
+
+t.test("goto-def: $dog->speak() jumps to Dog::speak (override, not Animal)", function()
+  local N = "goto-def: $dog->speak() jumps to Dog::speak (override, not Animal)"
+  local line, col = b.find_pos(buf, "$dog->speak()")
+  if not t.ok(N, line, "couldn't find '$dog->speak()'") then return end
+  local def = lsp.def_line(buf, line, col + 6)
+  -- Dog::speak is the second "sub speak", Animal::speak is the first
+  local animal_speak = b.find_line(buf, "^sub speak")
+  local dog_speak = b.find_line(buf, "^sub speak", (animal_speak or 0) + 2)
+  if not t.ok(N, dog_speak, "couldn't find Dog::speak line") then return end
+  if t.eq(N, dog_speak, def, "definition line (should be Dog, not Animal)") then t.pass(N) end
+end)
+
+-- ── 3. Local: hover shows provenance ─────────────────────────────────
+
+t.test("hover: $golden->breathe() shows '(from Animal)'", function()
+  local N = "hover: $golden->breathe() shows '(from Animal)'"
+  local line, col = b.find_pos(buf, "$golden->breathe()")
+  if not t.ok(N, line, "couldn't find '$golden->breathe()'") then return end
+  local text = lsp.hover_text(buf, line, col + 10)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, text:find("Animal", 1, true), "hover should mention 'Animal', got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+t.test("hover: $dog->speak() does NOT show '(from Animal)' since Dog overrides", function()
+  local N = "hover: $dog->speak() does NOT show '(from Animal)' since Dog overrides"
+  local line, col = b.find_pos(buf, "$dog->speak()")
+  if not t.ok(N, line, "couldn't find '$dog->speak()'") then return end
+  local text = lsp.hover_text(buf, line, col + 6)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, not text:find("from Animal", 1, true),
+    "hover should NOT mention 'from Animal' since Dog overrides, got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+-- ── 4. Cross-file: completion from inherited BaseWorker ──────────────
+
+t.test("completion: $worker-> offers process from BaseWorker", function()
+  local N = "completion: $worker-> offers process from BaseWorker"
+  local line, col = b.find_pos(buf, "$worker->process()")
+  if not t.ok(N, line, "couldn't find '$worker->process()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 10)
+  if not t.ok(N, #labels > 0, "no completions") then return end
+  local ok = t.contains(N, labels, "process", "completions")
+  ok = t.contains(N, labels, "run", "completions") and ok
+  if ok then t.pass(N) end
+end)
+
+t.test("completion: $worker-> offers status from BaseWorker", function()
+  local N = "completion: $worker-> offers status from BaseWorker"
+  local line, col = b.find_pos(buf, "$worker->process()")
+  if not t.ok(N, line, "couldn't find '$worker->process()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 10)
+  if t.contains(N, labels, "status", "completions") then t.pass(N) end
+end)
+
+-- ── 5. Cross-file: goto-def to BaseWorker::process ───────────────────
+
+t.test("goto-def: $worker->process() jumps to BaseWorker.pm", function()
+  local N = "goto-def: $worker->process() jumps to BaseWorker.pm"
+  local line, col = b.find_pos(buf, "$worker->process()")
+  if not t.ok(N, line, "couldn't find '$worker->process()'") then return end
+  local loc = lsp.def_location(buf, line, col + 10)
+  if not t.ok(N, loc, "no definition result") then return end
+  if not t.ok(N, loc.uri and loc.uri:find("BaseWorker.pm", 1, true),
+    "uri should point to BaseWorker.pm, got: " .. tostring(loc.uri)) then return end
+  -- process is defined around line 12 in BaseWorker.pm (0-indexed)
+  if t.ok(N, loc.line and loc.line >= 10 and loc.line <= 15,
+    "def_line should be ~12, got: " .. tostring(loc.line)) then
+    t.pass(N)
+  end
+end)
+
+-- ── 6. Cross-file: hover shows provenance ────────────────────────────
+
+t.test("hover: $worker->process() shows BaseWorker provenance", function()
+  local N = "hover: $worker->process() shows BaseWorker provenance"
+  local line, col = b.find_pos(buf, "$worker->process()")
+  if not t.ok(N, line, "couldn't find '$worker->process()'") then return end
+  local text = lsp.hover_text(buf, line, col + 10)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, text:find("BaseWorker", 1, true),
+    "hover should mention 'BaseWorker', got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+-- ── done ─────────────────────────────────────────────────────────────
+
+t.finish()

--- a/test_e2e_inheritance.lua
+++ b/test_e2e_inheritance.lua
@@ -165,6 +165,21 @@ t.test("hover: $worker->process() shows BaseWorker provenance", function()
   end
 end)
 
+-- ── 7. Goto-def on parent class name in use parent ──────────────────
+
+t.test("goto-def: 'BaseWorker' in use parent opens BaseWorker.pm", function()
+  local N = "goto-def: 'BaseWorker' in use parent opens BaseWorker.pm"
+  local line, col = b.find_pos(buf, "use parent 'BaseWorker'")
+  if not t.ok(N, line, "couldn't find 'use parent BaseWorker'") then return end
+  -- Position cursor on "BaseWorker" inside the string (col + 12 = inside the string content)
+  local loc = lsp.def_location(buf, line, col + 12)
+  if not t.ok(N, loc, "no definition result") then return end
+  if t.ok(N, loc.uri and loc.uri:find("BaseWorker.pm", 1, true),
+    "uri should point to BaseWorker.pm, got: " .. tostring(loc.uri)) then
+    t.pass(N)
+  end
+end)
+
 -- ── done ─────────────────────────────────────────────────────────────
 
 t.finish()

--- a/test_files/inheritance.pl
+++ b/test_files/inheritance.pl
@@ -1,0 +1,58 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# ── Local inheritance chain: Animal → Dog → GoldenRetriever ──
+
+package Animal;
+sub new { bless {}, shift }
+sub speak {
+    my ($self) = @_;
+    return "...";
+}
+sub breathe { return 1; }
+
+package Dog;
+use parent -norequire, 'Animal';
+sub fetch {
+    my ($self) = @_;
+    return "stick";
+}
+sub speak {
+    my ($self) = @_;
+    return "Woof!";
+}
+
+package GoldenRetriever;
+use parent -norequire, 'Dog';
+sub be_friendly {
+    my ($self) = @_;
+    return "tail wag";
+}
+
+# ── Cross-file inheritance: MyWorker → BaseWorker ──
+
+package MyWorker;
+use parent 'BaseWorker';
+sub run {
+    my ($self) = @_;
+    return $self->process({ input => 1 });
+}
+
+# ── Usage lines for testing ──
+
+package main;
+my $dog = Dog->new();
+$dog->speak();
+$dog->fetch();
+
+my $golden = GoldenRetriever->new();
+$golden->speak();
+$golden->be_friendly();
+$golden->breathe();
+
+my $worker = MyWorker->new();
+$worker->run();
+$worker->process();
+
+1;

--- a/test_files/lib/BaseWorker.pm
+++ b/test_files/lib/BaseWorker.pm
@@ -1,0 +1,22 @@
+package BaseWorker;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw();
+
+sub new {
+    my ($class, %args) = @_;
+    return bless { name => $args{name}, status => 'idle' }, $class;
+}
+
+sub process {
+    my ($self, $data) = @_;
+    return { result => 'ok', count => 42 };
+}
+
+sub status {
+    my ($self) = @_;
+    return $self->{status};
+}
+
+1;


### PR DESCRIPTION
## Summary

- **Inheritance chain resolution**: DFS parent walk (matching Perl's default MRO) across `use parent`, `use base`, `@ISA`, and `class :isa()` — both same-file and cross-file via ModuleIndex
- **Cross-file method intelligence**: completion, goto-def, hover, diagnostics, signature help, and keyval completion all resolve through inheritance chains
- **Method call return type propagation**: `my $cfg = $f->get_config()` now creates TypeConstraints, enabling hash key completion, inlay hints, and deref snippets on method call results
- **Goto-def for parent classes and import names**: `use parent 'BaseWorker'` and `use DemoUtils 'fetch_data'` jump to the .pm file
- **Scoped auto-import**: `use` insertions land in the correct package in multi-package files
- **ResolvedSub enum**: unified local/cross-file sub resolution — signature help and keyval completion work for imported functions and inherited methods

## Changes

| Area | Details |
|------|---------|
| `builder.rs` | `emit_parent_class_refs`, `emit_import_symbol_refs`, `MethodCallBinding` recording, inheritance source extraction |
| `file_analysis.rs` | `package_parents`, `resolve_method_in_ancestors`, `MethodResolution` enum, `ResolvedSub` enum, `resolve_method_call_types`, `find_method_return_type` |
| `module_resolver.rs` | Extract `parents` from `FileAnalysis`, subprocess JSON + SQLite persistence |
| `module_index.rs` | `parents_cached()`, `ModuleExports.parents` |
| `module_cache.rs` | Schema v8 with `parents` JSON column |
| `symbols.rs` | Cross-file goto-def fallback, scoped `find_use_insertion_position`, pass `module_index` through to signature/keyval |
| `backend.rs` | Pass `module_index` to enrichment for cross-file method call type resolution |

## Test plan

- [x] 251 unit tests pass (`cargo test`)
- [x] Release build succeeds
- [ ] E2e: `$worker->process()` goto-def jumps to BaseWorker.pm
- [ ] E2e: `use parent 'BaseWorker'` goto-def opens BaseWorker.pm
- [ ] E2e: `$worker->` completes inherited methods
- [ ] E2e: `$cfg = $f->get_config()` shows inlay hint `: HashRef`
- [ ] E2e: `$cfg->{` offers hash key completion from method return

🤖 Generated with [Claude Code](https://claude.com/claude-code)