### PR TITLE
feat: trace roles, mixins, and DBIC components as parents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Post-build enrichment propagates imported return types and hash keys into the lo
 ### Inheritance chain resolution
 
 - `FileAnalysis.package_parents: HashMap<String, Vec<String>>` — unified parent map from all inheritance sources
-- Sources: `use parent`, `use base`, `@ISA = (...)`, `class :isa(Parent)` — all feed `package_parents` during builder walk
+- Sources: `use parent`, `use base`, `@ISA = (...)`, `class :isa(Parent)`, `class :does(Role)`, `with 'Role'` (Moo/Moose), `__PACKAGE__->load_components(...)` (DBIC) — all feed `package_parents` during builder walk
 - `resolve_method_in_ancestors()` does DFS parent walk (matching Perl's default MRO), depth limit 20
 - `MethodResolution` enum: `Local { class, sym_id }` for same-file, `CrossFile { class }` for module index lookup
 - `complete_methods_for_class` walks ancestors, deduplicates by name (child methods shadow parent)

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export PERL5LIB="${PERL5LIB:-$PWD/test_files/lib}"
 
 failed=0
-for test in test_e2e.lua test_e2e_types.lua test_e2e_cross_file.lua test_e2e_inheritance.lua; do
+for test in test_e2e.lua test_e2e_types.lua test_e2e_cross_file.lua test_e2e_inheritance.lua test_e2e_frameworks.lua; do
   echo "── $test ──"
   if ! nvim --headless --clean -u test_nvim_init.lua -l "$test"; then
     failed=1

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -401,6 +401,13 @@ impl<'a> Builder<'a> {
                 .or_default()
                 .push(p.clone());
         }
+        // Roles via :does(Role) are also parents for method resolution
+        if !roles.is_empty() {
+            self.package_parents
+                .entry(name.clone())
+                .or_default()
+                .extend(roles.iter().cloned());
+        }
 
         self.add_symbol(
             name.clone(),
@@ -1751,6 +1758,14 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
+                // Moose/Moo `with 'Role'` — register roles as parents for method resolution
+                if name == "with" {
+                    if let Some(pkg) = self.current_package.clone() {
+                        if self.framework_modes.contains_key(&pkg) {
+                            self.visit_extends_call(node, &pkg);
+                        }
+                    }
+                }
             }
         }
         self.visit_children(node);
@@ -1793,6 +1808,57 @@ impl<'a> Builder<'a> {
                 .entry(pkg.to_string())
                 .or_default()
                 .extend(parents);
+        }
+    }
+
+    /// Handle `__PACKAGE__->load_components('+Full::Name', 'Short::Name')`.
+    /// Bare names are prefixed with `DBIx::Class::`, `+` prefix means fully qualified.
+    fn visit_load_components(&mut self, node: Node<'a>) {
+        let pkg = match self.current_package.clone() {
+            Some(p) => p,
+            None => return,
+        };
+        let args = match node.child_by_field_name("arguments") {
+            Some(a) => a,
+            None => return,
+        };
+        let mut components: Vec<String> = Vec::new();
+        let nodes: Vec<Node> = if args.kind() == "list_expression" || args.kind() == "parenthesized_expression" {
+            (0..args.child_count()).filter_map(|i| args.child(i)).collect()
+        } else {
+            vec![args]
+        };
+        for child in &nodes {
+            if !child.is_named() { continue; }
+            match child.kind() {
+                "string_literal" | "interpolated_string_literal" => {
+                    if let Some(text) = self.extract_string_content(*child) {
+                        if let Some(stripped) = text.strip_prefix('+') {
+                            components.push(stripped.to_string());
+                        } else {
+                            components.push(format!("DBIx::Class::{}", text));
+                        }
+                    }
+                }
+                "quoted_word_list" => {
+                    let mut names = Vec::new();
+                    self.extract_qw_words(*child, &mut names);
+                    for (name, _) in names {
+                        if let Some(stripped) = name.strip_prefix('+') {
+                            components.push(stripped.to_string());
+                        } else {
+                            components.push(format!("DBIx::Class::{}", name));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if !components.is_empty() {
+            self.package_parents
+                .entry(pkg)
+                .or_default()
+                .extend(components);
         }
     }
 
@@ -2255,9 +2321,17 @@ impl<'a> Builder<'a> {
         let is_pkg_call = invocant_text.as_deref() == Some("__PACKAGE__")
             || (invocant_node.map(|n| n.kind()) == Some("package")
                 && invocant_text.as_ref() == self.current_package.as_ref());
-        if is_pkg_call && self.is_dbic_class() {
+        if is_pkg_call {
             if let Some(ref name) = method_name {
-                self.visit_dbic_class_method(node, name);
+                // load_components — register components as parents for method resolution
+                // Works for any class (DBIC, Catalyst, etc.) — components are mixins
+                if name == "load_components" {
+                    self.visit_load_components(node);
+                }
+                // DBIC accessor synthesis
+                if self.is_dbic_class() {
+                    self.visit_dbic_class_method(node, name);
+                }
             }
         }
 
@@ -4796,6 +4870,84 @@ sub transform { }
             class Child :isa(Parent) { }
         ");
         assert_eq!(fa.package_parents.get("Child").unwrap(), &vec!["Parent".to_string()]);
+    }
+
+    #[test]
+    fn test_class_does_populates_package_parents() {
+        let fa = build_fa("
+            class MyClass :does(Printable) :does(Serializable) { }
+        ");
+        let parents = fa.package_parents.get("MyClass").unwrap();
+        assert!(parents.contains(&"Printable".to_string()));
+        assert!(parents.contains(&"Serializable".to_string()));
+    }
+
+    #[test]
+    fn test_class_isa_and_does_combined() {
+        let fa = build_fa("
+            class Child :isa(Parent) :does(Role) { }
+        ");
+        let parents = fa.package_parents.get("Child").unwrap();
+        assert_eq!(parents, &vec!["Parent".to_string(), "Role".to_string()]);
+    }
+
+    #[test]
+    fn test_with_role_populates_package_parents() {
+        let fa = build_fa("
+            package MyApp;
+            use Moo;
+            with 'My::Role::Logging';
+        ");
+        let parents = fa.package_parents.get("MyApp").unwrap();
+        assert!(parents.contains(&"My::Role::Logging".to_string()));
+    }
+
+    #[test]
+    fn test_with_multiple_roles() {
+        let fa = build_fa("
+            package MyApp;
+            use Moose;
+            with 'Role::A', 'Role::B';
+        ");
+        let parents = fa.package_parents.get("MyApp").unwrap();
+        assert!(parents.contains(&"Role::A".to_string()));
+        assert!(parents.contains(&"Role::B".to_string()));
+    }
+
+    #[test]
+    fn test_load_components_bare() {
+        let fa = build_fa("
+            package MySchema::Result::User;
+            use base 'DBIx::Class::Core';
+            __PACKAGE__->load_components('InflateColumn::DateTime', 'TimeStamp');
+        ");
+        let parents = fa.package_parents.get("MySchema::Result::User").unwrap();
+        assert!(parents.contains(&"DBIx::Class::Core".to_string()));
+        assert!(parents.contains(&"DBIx::Class::InflateColumn::DateTime".to_string()));
+        assert!(parents.contains(&"DBIx::Class::TimeStamp".to_string()));
+    }
+
+    #[test]
+    fn test_load_components_plus_prefix() {
+        let fa = build_fa("
+            package MySchema::Result::User;
+            use base 'DBIx::Class::Core';
+            __PACKAGE__->load_components('+My::Custom::Component');
+        ");
+        let parents = fa.package_parents.get("MySchema::Result::User").unwrap();
+        assert!(parents.contains(&"My::Custom::Component".to_string()));
+    }
+
+    #[test]
+    fn test_load_components_qw() {
+        let fa = build_fa("
+            package MySchema::ResultSet::User;
+            use base 'DBIx::Class::Core';
+            __PACKAGE__->load_components(qw(Helper::ResultSet::Shortcut Helper::ResultSet::Me));
+        ");
+        let parents = fa.package_parents.get("MySchema::ResultSet::User").unwrap();
+        assert!(parents.contains(&"DBIx::Class::Helper::ResultSet::Shortcut".to_string()));
+        assert!(parents.contains(&"DBIx::Class::Helper::ResultSet::Me".to_string()));
     }
 
     // ---- Inheritance method resolution tests ----

--- a/test_e2e_frameworks.lua
+++ b/test_e2e_frameworks.lua
@@ -1,0 +1,193 @@
+-- E2E tests for framework intelligence: Moo/Moose accessors, roles,
+-- Mojo::Base defaults, DBIC load_components, class :does.
+--
+-- Usage:
+--   cargo build --release
+--   PERL5LIB=$PWD/test_files/lib nvim --headless --clean -u test_nvim_init.lua -l test_e2e_frameworks.lua
+
+vim.opt.rtp:prepend(".")
+
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+local b   = require("test.buf")
+
+local buf = lsp.open_and_attach("test_files/frameworks.pl")
+
+-- Wait for cross-file resolution (MyRole::Logging, DBIC Shortcut).
+-- Poll by checking completion on $moo-> for "log_info" from the role.
+local function wait_for_cross_file(max_secs)
+  for _ = 1, max_secs * 4 do
+    local line, col = b.find_pos(buf, '$moo->log_info("started")')
+    if line then
+      local labels = lsp.completion_labels(buf, line, col + 6)
+      for _, l in ipairs(labels) do
+        if l == "log_info" then return true end
+      end
+    end
+    vim.wait(250)
+  end
+  return false
+end
+
+local cross_file_ready = wait_for_cross_file(15)
+if not cross_file_ready then
+  io.write("\27[33mWARN: cross-file resolution did not complete within 15s — some tests may fail\27[0m\n")
+  io.write("      Make sure PERL5LIB includes test_files/lib\n\n")
+end
+
+-- ── 1. Moo accessor completion ───────────────────────────────────────
+
+t.test("completion: $moo-> offers accessor 'name'", function()
+  local N = "completion: $moo-> offers accessor 'name'"
+  local line, col = b.find_pos(buf, "$moo->name();")
+  if not t.ok(N, line, "couldn't find '$moo->name()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "name", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $moo-> offers accessor 'count'", function()
+  local N = "completion: $moo-> offers accessor 'count'"
+  local line, col = b.find_pos(buf, "$moo->name();")
+  if not t.ok(N, line, "couldn't find '$moo->name()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "count", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $moo-> offers own method 'greet'", function()
+  local N = "completion: $moo-> offers own method 'greet'"
+  local line, col = b.find_pos(buf, "$moo->greet();")
+  if not t.ok(N, line, "couldn't find '$moo->greet()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "greet", "completions") then t.pass(N) end
+end)
+
+-- ── 2. Moo role methods via `with` ──────────────────────────────────
+
+t.test("completion: $moo-> offers log_info from MyRole::Logging", function()
+  local N = "completion: $moo-> offers log_info from MyRole::Logging"
+  local line, col = b.find_pos(buf, '$moo->log_info("started")')
+  if not t.ok(N, line, "couldn't find '$moo->log_info()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "log_info", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $moo-> offers log_error from MyRole::Logging", function()
+  local N = "completion: $moo-> offers log_error from MyRole::Logging"
+  local line, col = b.find_pos(buf, '$moo->log_info("started")')
+  if not t.ok(N, line, "couldn't find '$moo->log_info()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 6)
+  if t.contains(N, labels, "log_error", "completions") then t.pass(N) end
+end)
+
+t.test("hover: $moo->log_info() shows MyRole::Logging provenance", function()
+  local N = "hover: $moo->log_info() shows MyRole::Logging provenance"
+  local line, col = b.find_pos(buf, '$moo->log_info("started")')
+  if not t.ok(N, line, "couldn't find '$moo->log_info()'") then return end
+  local text = lsp.hover_text(buf, line, col + 6)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, text:find("Logging", 1, true),
+    "hover should mention 'Logging', got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+-- ── 3. Mojo::Base accessor completion ────────────────────────────────
+
+t.test("completion: $mojo-> offers accessor 'title'", function()
+  local N = "completion: $mojo-> offers accessor 'title'"
+  local line, col = b.find_pos(buf, "$mojo->title();")
+  if not t.ok(N, line, "couldn't find '$mojo->title()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 7)
+  if t.contains(N, labels, "title", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $mojo-> offers accessor 'items'", function()
+  local N = "completion: $mojo-> offers accessor 'items'"
+  local line, col = b.find_pos(buf, "$mojo->title();")
+  if not t.ok(N, line, "couldn't find '$mojo->title()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 7)
+  if t.contains(N, labels, "items", "completions") then t.pass(N) end
+end)
+
+-- ── 4. Mojo::Base default type inference ─────────────────────────────
+
+t.test("hover: $mojo->title() mentions String (from default)", function()
+  local N = "hover: $mojo->title() mentions String (from default)"
+  local line, col = b.find_pos(buf, "$mojo->title();")
+  if not t.ok(N, line, "couldn't find '$mojo->title()'") then return end
+  local text = lsp.hover_text(buf, line, col + 7)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, text:find("String", 1, true),
+    "hover should mention 'String', got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+t.test("hover: $mojo->items() mentions ArrayRef (from sub default)", function()
+  local N = "hover: $mojo->items() mentions ArrayRef (from sub default)"
+  local line, col = b.find_pos(buf, "$mojo->items();")
+  if not t.ok(N, line, "couldn't find '$mojo->items()'") then return end
+  local text = lsp.hover_text(buf, line, col + 7)
+  if not t.ok(N, text, "no hover result") then return end
+  if t.ok(N, text:find("ArrayRef", 1, true),
+    "hover should mention 'ArrayRef', got: " .. text) then
+    t.pass(N)
+  end
+end)
+
+-- ── 5. DBIC load_components ──────────────────────────────────────────
+
+t.test("completion: $rs-> offers 'columns' from Shortcut component", function()
+  local N = "completion: $rs-> offers 'columns' from Shortcut component"
+  local line, col = b.find_pos(buf, "$rs->columns();")
+  if not t.ok(N, line, "couldn't find '$rs->columns()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 5)
+  if t.contains(N, labels, "columns", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $rs-> offers 'order_by' from Shortcut component", function()
+  local N = "completion: $rs-> offers 'order_by' from Shortcut component"
+  local line, col = b.find_pos(buf, "$rs->columns();")
+  if not t.ok(N, line, "couldn't find '$rs->columns()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 5)
+  if t.contains(N, labels, "order_by", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $rs-> offers own method 'active'", function()
+  local N = "completion: $rs-> offers own method 'active'"
+  local line, col = b.find_pos(buf, "$rs->active();")
+  if not t.ok(N, line, "couldn't find '$rs->active()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 5)
+  if t.contains(N, labels, "active", "completions") then t.pass(N) end
+end)
+
+-- ── 6. class :does ───────────────────────────────────────────────────
+
+t.test("completion: $report-> offers 'generate' (own method)", function()
+  local N = "completion: $report-> offers 'generate' (own method)"
+  local line, col = b.find_pos(buf, "$report->generate();")
+  if not t.ok(N, line, "couldn't find '$report->generate()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 9)
+  if t.contains(N, labels, "generate", "completions") then t.pass(N) end
+end)
+
+t.test("completion: $report-> offers 'to_string' from :does(Printable)", function()
+  local N = "completion: $report-> offers 'to_string' from :does(Printable)"
+  local line, col = b.find_pos(buf, "$report->to_string();")
+  if not t.ok(N, line, "couldn't find '$report->to_string()'") then return end
+  local labels = lsp.completion_labels(buf, line, col + 9)
+  if t.contains(N, labels, "to_string", "completions") then t.pass(N) end
+end)
+
+t.test("goto-def: $report->to_string() jumps to Printable::to_string", function()
+  local N = "goto-def: $report->to_string() jumps to Printable::to_string"
+  local line, col = b.find_pos(buf, "$report->to_string();")
+  if not t.ok(N, line, "couldn't find '$report->to_string()'") then return end
+  local def = lsp.def_line(buf, line, col + 9)
+  local expected = b.find_line(buf, "method to_string")
+  if t.eq(N, expected, def, "definition line") then t.pass(N) end
+end)
+
+-- ── done ─────────────────────────────────────────────────────────────
+
+t.finish()

--- a/test_files/frameworks.pl
+++ b/test_files/frameworks.pl
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# ── Moo class with accessor and role ──
+
+package MooApp;
+use Moo;
+with 'MyRole::Logging';
+
+has name => (is => 'ro');
+has count => (is => 'rw');
+
+sub greet {
+    my ($self) = @_;
+    return "Hello, " . $self->name;
+}
+
+# ── Mojo::Base class with has defaults ──
+
+package MojoApp;
+use Mojo::Base -base;
+
+has title => 'Untitled';
+has items => sub { [] };
+
+sub describe {
+    my ($self) = @_;
+    return $self->title;
+}
+
+# ── DBIC ResultSet with load_components ──
+
+package MySchema::ResultSet::User;
+use base 'DBIx::Class::Core';
+__PACKAGE__->load_components('Helper::ResultSet::Shortcut');
+
+sub active {
+    my ($self) = @_;
+    return $self;
+}
+
+# ── Perl class keyword with :does ──
+
+class Printable {
+    method to_string() { return "printable" }
+}
+
+class Report :does(Printable) {
+    method generate() { return "report" }
+}
+
+# ── Usage lines for testing ──
+
+package main;
+
+my $moo = MooApp->new(name => 'alice', count => 0);
+$moo->name();
+$moo->count(5);
+$moo->greet();
+$moo->log_info("started");
+
+my $mojo = MojoApp->new();
+$mojo->title();
+$mojo->items();
+$mojo->describe();
+
+my $rs = MySchema::ResultSet::User->new();
+$rs->active();
+$rs->columns();
+
+my $report = Report->new();
+$report->generate();
+$report->to_string();
+
+1;

--- a/test_files/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
+++ b/test_files/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
@@ -1,0 +1,22 @@
+package DBIx::Class::Helper::ResultSet::Shortcut;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw();
+
+sub columns {
+    my ($self, @cols) = @_;
+    return $self;
+}
+
+sub order_by {
+    my ($self, @cols) = @_;
+    return $self;
+}
+
+sub limit {
+    my ($self, $count) = @_;
+    return $self;
+}
+
+1;

--- a/test_files/lib/MyRole/Logging.pm
+++ b/test_files/lib/MyRole/Logging.pm
@@ -1,0 +1,17 @@
+package MyRole::Logging;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw();
+
+sub log_info {
+    my ($self, $msg) = @_;
+    print "[INFO] $msg\n";
+}
+
+sub log_error {
+    my ($self, $msg) = @_;
+    print "[ERROR] $msg\n";
+}
+
+1;


### PR DESCRIPTION
## Summary
- **`with 'Role'`** (Moo/Moose): roles now registered in `package_parents` for method resolution
- **`class :does(Role)`**: already parsed from attributes but wasn't feeding `package_parents` — fixed
- **`__PACKAGE__->load_components(...)`**: DBIC components expanded and registered as parents (bare names get `DBIx::Class::` prefix, `+` prefix = fully qualified)

All three flow through the existing `package_parents` → `ModuleExports.parents` pipeline, so cross-file inheritance walking, method completion, goto-def, and hover all work automatically for role/mixin methods.

## Test plan
- [x] 7 new unit tests covering all three patterns (286 total, all pass)
- [ ] CI: Rust tests + e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)