### PR TITLE
feat: use-line completion — module names + import lists

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -344,7 +344,27 @@ impl LanguageServer for Backend {
         if items.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(CompletionResponse::Array(items)))
+            // If any item is a loading placeholder (empty insert_text), mark as incomplete
+            // so the editor re-requests on next keystroke after the module resolves.
+            let is_incomplete = items.iter().any(|i| i.insert_text.as_deref() == Some(""));
+            if is_incomplete {
+                // Trigger resolution for the module being loaded
+                for i in &items {
+                    if i.insert_text.as_deref() == Some("") {
+                        if let Some(ref label) = Some(&i.label) {
+                            if let Some(name) = label.strip_prefix("loading ").and_then(|s| s.strip_suffix("...")) {
+                                self.module_index.request_resolve(name);
+                            }
+                        }
+                    }
+                }
+                Ok(Some(CompletionResponse::List(CompletionList {
+                    is_incomplete: true,
+                    items,
+                })))
+            } else {
+                Ok(Some(CompletionResponse::Array(items)))
+            }
         }
     }
 

--- a/src/cursor_context.rs
+++ b/src/cursor_context.rs
@@ -21,6 +21,15 @@ pub enum CursorContext {
     Method { invocant_type: Option<InferredType>, invocant_text: String },
     /// After `$var->{` or `$hash{` — hash key completion. Type is resolved when available.
     HashKey { owner_type: Option<InferredType>, var_text: String, source_sub: Option<String> },
+    /// On a `use`/`require` line — completing module name or import list.
+    UseStatement {
+        /// Module name typed so far (e.g. "Mojo::Ba" or "" if just "use ")
+        module_prefix: String,
+        /// If true, cursor is inside the import list (qw, parens, or bare string after module)
+        in_import_list: bool,
+        /// The fully typed module name (only set when in_import_list is true)
+        module_name: Option<String>,
+    },
     /// No specific trigger — general completion.
     General,
 }
@@ -59,6 +68,28 @@ pub fn detect_cursor_context(source: &str, point: Point, analysis: Option<&FileA
         line
     };
     let trimmed = before.trim_end();
+
+    // Check for use/require line — module name or import list completion
+    {
+        let line_trimmed = line.trim_start();
+        if line_trimmed.starts_with("use ") || line_trimmed.starts_with("require ") {
+            let keyword = if line_trimmed.starts_with("use ") { "use " } else { "require " };
+            let after_keyword = line_trimmed.strip_prefix(keyword).unwrap_or("");
+            // How much of the line is before the cursor?
+            let leading_ws = line.len() - line.trim_start().len();
+            let cursor_in_line = if point.column > leading_ws + keyword.len() {
+                point.column - leading_ws - keyword.len()
+            } else {
+                0
+            };
+            let before_cursor_in_after = if cursor_in_line <= after_keyword.len() {
+                &after_keyword[..cursor_in_line]
+            } else {
+                after_keyword
+            };
+            return detect_use_context(before_cursor_in_after, keyword == "require ");
+        }
+    }
 
     // Check for hash key completion: $hash{ or $self->{ (including mid-word: $var->{ho)
     {
@@ -146,6 +177,44 @@ fn strip_trailing_identifier(s: &str) -> &str {
 }
 
 /// Extract the invocant token from the text before `->` or `{`.
+/// Detect whether we're completing a module name or an import list on a use/require line.
+/// `text` is the content after "use " / "require ", up to the cursor position.
+fn detect_use_context(text: &str, is_require: bool) -> CursorContext {
+    // Skip special pragmas that don't take module-style arguments
+    if text.starts_with("strict") || text.starts_with("warnings") || text.starts_with("utf8")
+        || text.starts_with("feature") || text.starts_with("constant ")
+        || text.starts_with("lib ") || text.starts_with("v5")
+    {
+        return CursorContext::General;
+    }
+
+    // Find the module name: sequence of word chars and :: up to whitespace/paren/quote/semicolon
+    let module_end = text.find(|c: char| c.is_whitespace() || c == '(' || c == '\'' || c == '"' || c == ';')
+        .unwrap_or(text.len());
+    let module_prefix = &text[..module_end];
+
+    // If there's content after the module name, we're in the import list
+    let rest = text[module_end..].trim_start();
+    if !rest.is_empty() && !module_prefix.is_empty() && !is_require {
+        // Skip use parent/base — those take class names, handled elsewhere
+        if module_prefix == "parent" || module_prefix == "base" {
+            return CursorContext::General;
+        }
+        return CursorContext::UseStatement {
+            module_prefix: String::new(),
+            in_import_list: true,
+            module_name: Some(module_prefix.to_string()),
+        };
+    }
+
+    // Still typing the module name
+    CursorContext::UseStatement {
+        module_prefix: module_prefix.to_string(),
+        in_import_list: false,
+        module_name: None,
+    }
+}
+
 fn extract_invocant_from_prefix(prefix: &str) -> &str {
     let bytes = prefix.as_bytes();
     let end = bytes.len();
@@ -915,5 +984,67 @@ $calc->get_self->get_config->{";
                 invocant_text: "$obj".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_use_context_module_prefix() {
+        let source = "use Mojo::Ba";
+        let ctx = detect_cursor_context(source, Point::new(0, 12), None);
+        assert_eq!(ctx, CursorContext::UseStatement {
+            module_prefix: "Mojo::Ba".to_string(),
+            in_import_list: false,
+            module_name: None,
+        });
+    }
+
+    #[test]
+    fn test_use_context_empty_prefix() {
+        let source = "use ";
+        let ctx = detect_cursor_context(source, Point::new(0, 4), None);
+        assert_eq!(ctx, CursorContext::UseStatement {
+            module_prefix: String::new(),
+            in_import_list: false,
+            module_name: None,
+        });
+    }
+
+    #[test]
+    fn test_use_context_import_list_qw() {
+        let source = "use List::Util qw(ma";
+        let ctx = detect_cursor_context(source, Point::new(0, 20), None);
+        assert_eq!(ctx, CursorContext::UseStatement {
+            module_prefix: String::new(),
+            in_import_list: true,
+            module_name: Some("List::Util".to_string()),
+        });
+    }
+
+    #[test]
+    fn test_use_context_import_list_bare_string() {
+        let source = "use Foo 'ba";
+        let ctx = detect_cursor_context(source, Point::new(0, 11), None);
+        assert_eq!(ctx, CursorContext::UseStatement {
+            module_prefix: String::new(),
+            in_import_list: true,
+            module_name: Some("Foo".to_string()),
+        });
+    }
+
+    #[test]
+    fn test_use_context_skips_pragmas() {
+        let source = "use strict";
+        let ctx = detect_cursor_context(source, Point::new(0, 10), None);
+        assert_eq!(ctx, CursorContext::General);
+    }
+
+    #[test]
+    fn test_require_context_module_prefix() {
+        let source = "require DBI";
+        let ctx = detect_cursor_context(source, Point::new(0, 11), None);
+        assert_eq!(ctx, CursorContext::UseStatement {
+            module_prefix: "DBI".to_string(),
+            in_import_list: false,
+            module_name: None,
+        });
     }
 }

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -320,6 +320,7 @@ impl ModuleIndex {
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
             Arc::clone(&stale_modules),
+            Arc::clone(&available_modules),
             Arc::clone(&queue),
             Arc::clone(&resolved),
             Arc::clone(&workspace_root),

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -121,6 +121,8 @@ pub struct ModuleIndex {
     /// Modules loaded from cache with an old extract_version.
     /// Eligible for priority re-resolution when requested.
     stale_modules: Arc<DashMap<String, ()>>,
+    /// Known module names from @INC scan. Name → path. No exports until resolved.
+    available_modules: Arc<DashMap<String, std::path::PathBuf>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -133,6 +135,7 @@ impl ModuleIndex {
         let cache: Arc<DashMap<String, Option<ModuleExports>>> = Arc::new(DashMap::new());
         let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
         let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
+        let available_modules: Arc<DashMap<String, std::path::PathBuf>> = Arc::new(DashMap::new());
         let queue = Arc::new(ResolveQueue {
             priority: Mutex::new(Vec::new()),
             pending: Mutex::new(Vec::new()),
@@ -154,6 +157,7 @@ impl ModuleIndex {
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
             Arc::clone(&stale_modules),
+            Arc::clone(&available_modules),
             Arc::clone(&queue),
             Arc::clone(&resolved),
             Arc::clone(&workspace_root),
@@ -165,6 +169,7 @@ impl ModuleIndex {
             cache,
             reverse_index,
             stale_modules,
+            available_modules,
             queue,
             resolved,
             workspace_root,
@@ -230,6 +235,34 @@ impl ModuleIndex {
         }
     }
 
+    /// Collect module names matching a prefix for completion.
+    /// Returns (name, is_resolved) — resolved modules have export data.
+    pub fn complete_module_names(&self, prefix: &str) -> Vec<(String, bool)> {
+        let prefix_lower = prefix.to_lowercase();
+        let mut seen = std::collections::HashSet::new();
+        let mut results = Vec::new();
+
+        // Tier 1: resolved modules (have full export data)
+        for entry in self.cache.iter() {
+            if entry.value().is_some() {
+                let name = entry.key();
+                if name.to_lowercase().starts_with(&prefix_lower) && seen.insert(name.clone()) {
+                    results.push((name.clone(), true));
+                }
+            }
+        }
+
+        // Tier 2: @INC scan (name only, no exports yet)
+        for entry in self.available_modules.iter() {
+            let name = entry.key();
+            if name.to_lowercase().starts_with(&prefix_lower) && seen.insert(name.clone()) {
+                results.push((name.clone(), false));
+            }
+        }
+
+        results
+    }
+
     /// Look up the return type of an imported function. Zero I/O.
     #[cfg(test)]
     pub fn get_return_type_cached(&self, func_name: &str) -> Option<InferredType> {
@@ -268,6 +301,7 @@ impl ModuleIndex {
         let cache: Arc<DashMap<String, Option<ModuleExports>>> = Arc::new(DashMap::new());
         let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
         let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
+        let available_modules: Arc<DashMap<String, std::path::PathBuf>> = Arc::new(DashMap::new());
         let queue = Arc::new(ResolveQueue {
             priority: Mutex::new(Vec::new()),
             pending: Mutex::new(Vec::new()),
@@ -295,6 +329,7 @@ impl ModuleIndex {
             cache,
             reverse_index,
             stale_modules,
+            available_modules,
             queue,
             resolved,
             workspace_root,

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -36,6 +36,7 @@ pub fn spawn_resolver(
     cache: Arc<DashMap<String, Option<ModuleExports>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
     stale_modules: Arc<DashMap<String, ()>>,
+    available_modules: Arc<DashMap<String, PathBuf>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -48,6 +49,10 @@ pub fn spawn_resolver(
         .name("module-resolver".into())
         .spawn(move || {
             let inc_paths = discover_inc_paths();
+
+            // Scan @INC for available module names (fast, no parsing — just readdir)
+            scan_inc_module_names(&inc_paths, &available_modules);
+            log::info!("@INC scan: {} modules available", available_modules.len());
 
             // Wait for workspace root from initialize() for per-project cache path.
             let ws_root = wait_for_workspace_root(&workspace_root);
@@ -758,6 +763,37 @@ pub fn discover_inc_paths() -> Vec<PathBuf> {
     }
 }
 
+
+/// Scan @INC directories for .pm files, populating the available_modules map.
+/// Fast — no file reads, just directory traversal + path→module name conversion.
+fn scan_inc_module_names(inc_paths: &[PathBuf], available: &DashMap<String, PathBuf>) {
+    for inc in inc_paths {
+        if inc.is_dir() {
+            scan_dir_recursive(inc, inc, available, 0);
+        }
+    }
+}
+
+fn scan_dir_recursive(base: &std::path::Path, dir: &std::path::Path, available: &DashMap<String, PathBuf>, depth: u32) {
+    if depth > 15 { return; } // prevent symlink loops
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_dir_recursive(base, &path, available, depth + 1);
+        } else if path.extension().map(|e| e == "pm").unwrap_or(false) {
+            if let Ok(rel) = path.strip_prefix(base) {
+                let module_name = rel.to_string_lossy()
+                    .trim_end_matches(".pm")
+                    .replace(std::path::MAIN_SEPARATOR, "::");
+                available.insert(module_name, path.clone());
+            }
+        }
+    }
+}
 
 fn uri_to_path(uri: &str) -> Option<PathBuf> {
     uri.strip_prefix("file://").map(PathBuf::from)

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -236,6 +236,7 @@ pub fn spawn_test_resolver(
     cache: Arc<DashMap<String, Option<ModuleExports>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
     stale_modules: Arc<DashMap<String, ()>>,
+    available_modules: Arc<DashMap<String, PathBuf>>,
     queue: Arc<ResolveQueue>,
     resolved: Arc<ResolveNotify>,
     workspace_root: Arc<WorkspaceRootChannel>,
@@ -244,6 +245,7 @@ pub fn spawn_test_resolver(
         .name("module-resolver-test".into())
         .spawn(move || {
             let inc_paths = discover_inc_paths();
+            scan_inc_module_names(&inc_paths, &available_modules);
             let ws_root = wait_for_workspace_root(&workspace_root);
 
             let db = module_cache::open_cache_db(ws_root.as_deref());

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -300,6 +300,16 @@ pub fn completion_items(
                 analysis.complete_hash_keys(var_text, point)
             }
         }
+        CursorContext::UseStatement { ref module_prefix, in_import_list, ref module_name } => {
+            if in_import_list {
+                if let Some(ref name) = module_name {
+                    return complete_import_list(name, module_index);
+                }
+            } else {
+                return complete_module_names(module_prefix, module_index);
+            }
+            Vec::new()
+        }
         CursorContext::General => {
             let mut items = Vec::new();
             // Keyval arg completions if inside a call at key position
@@ -340,6 +350,76 @@ pub fn completion_items(
             if !ty.is_object() {
                 items.extend(ref_type_snippet_completions(ty));
             }
+        }
+    }
+
+    items
+}
+
+/// Complete module names on `use` lines from resolved + @INC-scanned modules.
+fn complete_module_names(prefix: &str, module_index: &ModuleIndex) -> Vec<CompletionItem> {
+    let modules = module_index.complete_module_names(prefix);
+    modules.into_iter().map(|(name, is_resolved)| {
+        let (detail, priority) = if is_resolved {
+            (Some("indexed".to_string()), 10u8)
+        } else {
+            (Some("available".to_string()), 50u8)
+        };
+        CompletionItem {
+            label: name.clone(),
+            kind: Some(CompletionItemKind::MODULE),
+            detail,
+            sort_text: Some(format!("{:03}{}", priority, name)),
+            ..Default::default()
+        }
+    }).collect()
+}
+
+/// Complete import list items for `use Module qw(|)`.
+fn complete_import_list(module_name: &str, module_index: &ModuleIndex) -> Vec<CompletionItem> {
+    let exports = match module_index.get_exports_cached(module_name) {
+        Some(e) => e,
+        None => return vec![CompletionItem {
+            label: format!("loading {}...", module_name),
+            kind: Some(CompletionItemKind::TEXT),
+            detail: Some("Module is being indexed".to_string()),
+            insert_text: Some(String::new()),
+            sort_text: Some("999".to_string()),
+            ..Default::default()
+        }],
+    };
+
+    let mut items = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for name in &exports.export {
+        if seen.insert(name.clone()) {
+            let detail = exports.sub_info(name)
+                .and_then(|s| s.return_type.as_ref())
+                .map(|rt| format!("@EXPORT → {}", format_inferred_type(rt)))
+                .or(Some("@EXPORT".to_string()));
+            items.push(CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::FUNCTION),
+                detail,
+                sort_text: Some(format!("010{}", name)),
+                ..Default::default()
+            });
+        }
+    }
+
+    for name in &exports.export_ok {
+        if seen.insert(name.clone()) {
+            let detail = exports.sub_info(name)
+                .and_then(|s| s.return_type.as_ref())
+                .map(|rt| format!("→ {}", format_inferred_type(rt)));
+            items.push(CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::FUNCTION),
+                detail,
+                sort_text: Some(format!("020{}", name)),
+                ..Default::default()
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- **Module name completion**: `use Mo|` offers all known modules from resolved cache + @INC scan
- **Import list completion**: `use List::Util qw(|)` shows @EXPORT/@EXPORT_OK with return type detail
- **@INC module scan**: fast startup scan (readdir only, no parsing) populates available module names
- **UseStatement cursor context**: detects module prefix vs import list position, skips pragmas

## Test plan
- [x] 302 unit tests pass (6 new for cursor context detection)
- [x] 89 e2e tests pass (all 5 suites)
- [x] Zero warnings
- [ ] CI: Rust tests + e2e tests
- [ ] Manual: `./dev.sh` → type `use List::` and verify module completion
- [ ] Manual: type `use List::Util qw(` and verify import list completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)