### PR TITLE
feat: workspace indexing + subprocess removal + workspace/symbol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,22 +29,37 @@ The codebase has four layers. Data flows **down** only. Each layer may only depe
 
 **Rules:**
 
-1. **All tree-sitter CST traversal happens inside `build()`.** No other file should walk tree-sitter nodes, call `child_by_field_name`, iterate children, or use `TreeCursor`. The `build()` function in `builder.rs` is the single entry point that takes a `Tree` and returns a `FileAnalysis` — everything that needs the CST lives inside that call. **To add new CST-derived data:** add extraction to the relevant `visit_*` method in `builder.rs` and store the result in `FileAnalysis` (as a field on `Symbol`, a new map, etc.). The builder already visits every sub, package, class, and variable node — use that pass, don't create a second one. If the builder grows too monolithic, we can introduce builder plugins (separate functions called from `build()` that take `&mut FileAnalysis` + `&Tree` + `&[u8]`) to decouple concerns while preserving the single-entry-point invariant.
+1. **All tree-sitter CST traversal happens inside `build()`.** No other file should walk tree-sitter nodes, call `child_by_field_name`, iterate children, or use `TreeCursor`. The `build()` function in `builder.rs` is the single entry point that takes a `Tree` and returns a `FileAnalysis` — everything that needs the CST lives inside that call. **To add new CST-derived data:** add extraction to the relevant `visit_*` method in `builder.rs` and store the result in `FileAnalysis` (as a field on `Symbol`, a new map, etc.). The builder already visits every sub, package, class, and variable node — use that pass, don't create a second one. Builder plugins (separate modules called from `build()` that take `&mut FileAnalysis` + `&Tree` + `&[u8]`) can decouple framework-specific concerns while preserving the single-entry-point invariant.
 
 2. **`file_analysis.rs` is the single source of truth.** All analysis results — symbols, refs, scopes, types, documentation, parameters — live in `FileAnalysis`. Query methods belong here. No `tree_sitter` imports allowed in this file.
 
 3. **`symbols.rs` is a thin adapter.** It converts `FileAnalysis` types to LSP protocol types. It does NOT perform analysis, walk trees, or make decisions about Perl semantics. If you find yourself writing an `if` about Perl language behavior in `symbols.rs`, it belongs in `builder.rs` or `file_analysis.rs`.
 
-4. **`module_resolver.rs` calls the builder, then queries `FileAnalysis`.** It should never walk the tree directly. The resolver's job is: find `.pm` file → call `builder::build()` → extract what it needs from the resulting `FileAnalysis` via query methods → serialize to `ExportedSub`/JSON.
+4. **`module_resolver.rs` calls the builder, then queries `FileAnalysis`.** It should never walk the tree directly. The resolver's job is: find `.pm` file → call `builder::build()` → extract what it needs from the resulting `FileAnalysis` via query methods.
 
-5. **DRY: shared extraction logic goes on `FileAnalysis`.** If two code paths (e.g., subprocess JSON serialization and direct parsing) need the same data from a `FileAnalysis`, add a method to `FileAnalysis` that both call. Never duplicate the extraction loop.
+5. **DRY: shared extraction logic goes on `FileAnalysis`.** If two code paths need the same data from a `FileAnalysis`, add a method to `FileAnalysis` that both call. Never duplicate the extraction loop.
 
 6. **`cursor_context.rs` is the exception:** it receives a tree + source for cursor-position analysis (completion context, signature help context). This is acceptable because cursor context is inherently position-dependent and runs on the already-parsed tree. It should NOT modify `FileAnalysis`.
 
+7. **Every meaningful token gets a ref.** Every token the user might put their cursor on should have a `Ref` that explains what it means in context. If a token is meaningful but `ref_at()` returns nothing (or returns a wrong/too-broad ref), the builder is missing a ref emission. This is how completion, goto-def, hover, rename, and references all work — they start with the ref at the cursor position.
+
+   Common gaps to watch for: fat-comma keys in call arguments (`connect(timeout => 30)` — `timeout` needs its own `HashKeyAccess` ref, not just the enclosing `MethodCall`), hash literal keys (`{ status => 'ok' }` — the `HashKeyDef` must be findable via `symbol_at`/`ref_at`), and framework-synthesized entities (Moo `has name` should produce `HashKeyDef` entries for the constructor, not just accessor methods).
+
+   When multiple refs overlap at a position, `ref_at` must return the **most specific** (narrowest span). A `HashKeyAccess` for `timeout` inside a `MethodCall` for `connect` should win over the `MethodCall`.
+
+8. **Provenance: refs should trace back to their source.** When a ref is derived from another value (constant folding, import re-export, framework synthesis), the derivation chain should be traceable for rename and cross-referencing. Key provenance chains:
+
+   - **Constant folding:** `my $m = 'process'; $self->$m()` → the `MethodCall` ref targeting `"process"` was derived from the string literal `'process'`. Renaming `process` should update the source string.
+   - **`has` declarations:** `has name => (is => 'ro')` is a single source of truth that produces: an accessor Method symbol, a `HashKeyDef` for the constructor (`->new(name => ...)`), and a `HashKeyDef` for the internal hash (`$self->{name}`). Renaming any one should update all.
+   - **Import lists:** `use Foo qw(bar)` — the string `bar` in the import list should rename when `sub bar` in Foo is renamed.
+   - **Return hash keys → caller derefs:** `sub get_config { return { host => ... } }` then `$cfg->{host}` — the key `host` in the caller is derived from the return hash. `HashKeyOwner::Sub("get_config")` links them.
+   - **Package name → file path:** Renaming `MyApp::Controller::Users` could offer to rename/move the `.pm` file.
+   - **Inherited overrides:** Renaming `Animal::speak` should surface `Dog::speak` for coordinated rename.
+
 ### File map
 
-- `src/main.rs` — Entry point, stdio transport, `--parse-exports` subprocess mode
-- `src/backend.rs` — `LanguageServer` trait implementation (tower-lsp), request routing
+- `src/main.rs` — Entry point, stdio transport, CLI modes (`--rename`, `--workspace-symbol`, `--version`)
+- `src/backend.rs` — `LanguageServer` trait implementation (tower-lsp), request routing, workspace indexing
 - `src/document.rs` — Document store with tree-sitter parsing
 - `src/file_analysis.rs` — Data model: scopes, symbols, refs, imports, type inference, priority constants
 - `src/builder.rs` — Single-pass CST → FileAnalysis builder (the ONLY tree-sitter consumer)
@@ -52,7 +67,7 @@ The codebase has four layers. Data flows **down** only. Each layer may only depe
 - `src/cursor_context.rs` — Cursor position analysis: completion/signature/selection context
 - `src/symbols.rs` — LSP adapter layer (converts FileAnalysis types to LSP types)
 - `src/module_index.rs` — Cross-file: public API, reverse index (`func → modules`), concurrent cache
-- `src/module_resolver.rs` — Background resolver thread, subprocess isolation, export extraction
+- `src/module_resolver.rs` — Background resolver thread, in-process parsing, workspace indexing (Rayon)
 - `src/module_cache.rs` — SQLite persistence, schema migrations, mtime validation
 - `src/cpanfile.rs` — cpanfile parsing via tree-sitter queries
 
@@ -93,7 +108,7 @@ E2e tests use Neovim headless mode. They exercise the full LSP protocol over std
 - `ModuleIndex` uses a dedicated `std::thread` for filesystem I/O (never blocks tokio)
 - `Arc<DashMap>` shared between resolver thread and async LSP handlers
 - Reverse index: `DashMap<func_name, Vec<module_name>>` for O(1) exporter lookup
-- Export extraction uses tree-sitter in isolated subprocesses (5s timeout + SIGKILL)
+- Export extraction runs in-process (no subprocess isolation — tree-sitter-perl grammar is stable)
 - Subprocess runs the full builder on each module, then queries `FileAnalysis` for per-export metadata
 - `ModuleExports` stores `subs: HashMap<String, ExportedSub>` — unified per-export metadata (def_line, params, is_method, return_type, hash_keys, doc) — and `parents: Vec<String>` for inheritance chain
 - cpanfile parsed with tree-sitter queries at startup, deps pre-resolved with progress reporting
@@ -121,7 +136,7 @@ Post-build enrichment propagates imported return types and hash keys into the lo
 - `resolve_method_in_ancestors()` does DFS parent walk (matching Perl's default MRO), depth limit 20
 - `MethodResolution` enum: `Local { class, sym_id }` for same-file, `CrossFile { class }` for module index lookup
 - `complete_methods_for_class` walks ancestors, deduplicates by name (child methods shadow parent)
-- Cross-file: `ModuleExports.parents` stored in SQLite `parents` TEXT column (JSON array) and subprocess JSON output
+- Cross-file: `ModuleExports.parents` stored in SQLite `parents` TEXT column (JSON array)
 - `ModuleIndex.parents_cached(module_name)` returns parent list for cross-file inheritance walking
 
 ### Framework accessor synthesis
@@ -132,13 +147,21 @@ Post-build enrichment propagates imported return types and hash keys into the lo
 - Mojo::Base: `has 'name'` produces rw accessor with fluent return type `ClassName(current_package)`; `use Mojo::Base 'Parent'` also feeds `package_parents`
 - DBIC: `__PACKAGE__->add_columns(...)` synthesizes column accessors; `has_many`/`belongs_to`/`has_one`/`might_have` synthesize relationship accessors with typed returns
 - Synthesized methods are standard symbols — completion, hover, goto-def, inheritance all work automatically
-- Cross-file: subprocess runs full builder, so framework accessors appear in `ModuleExports.subs` for cross-file resolution
+- Cross-file: resolver runs full builder on each module, so framework accessors appear in `ModuleExports.subs` for cross-file resolution
 
 ### Cross-file param types
 
 - `ExportedParam.inferred_type: Option<String>` carries body-inferred param types across file boundaries
-- Subprocess serializes param type as `"type"` field in JSON; deserialized in both subprocess and direct-parse paths
-- `SignatureInfo.param_types` delivers pre-resolved types for cross-file signature help (avoids meaningless `body_end` query)
+- Param type serialized as `"type"` field in JSON for SQLite storage; `SignatureInfo.param_types` delivers pre-resolved types for cross-file signature help
+
+### Workspace indexing
+
+- `workspace_index: Arc<DashMap<PathBuf, FileAnalysis>>` — full `FileAnalysis` for every `.pm`/`.pl`/`.t` in the workspace
+- Indexed at startup with Rayon `par_iter` + `ignore` crate for `.gitignore` respect. `catch_unwind` per file, 1MB size cap
+- File watcher via `workspace/didChangeWatchedFiles` for incremental re-indexing (runs in `spawn_blocking`)
+- Query priority: `documents` (open files, freshest) → `workspace_index` (all project files) → `module_index` (external `@INC` modules)
+- Enables `workspace/symbol` search and cross-file rename across all project files, not just open ones
+- Benchmarks: 274-file Mojolicious in 204ms, 657-file DBIx-Class in 167ms (release build)
 
 ## LSP Capabilities
 
@@ -146,14 +169,17 @@ Post-build enrichment propagates imported return types and hash keys into the lo
 - `textDocument/definition` — go-to-def for variables (scope-aware), subs, methods (type-inferred), packages/classes, hash keys; resolves through expression chains
 - `textDocument/references` — scope-aware for variables, file-wide for functions/packages/hash keys; resolves through expression chains
 - `textDocument/hover` — shows declaration line, inferred types, return types, class-aware for methods
-- `textDocument/rename` — scope-aware for variables, file-wide for functions/packages/hash keys
-- `textDocument/completion` — scope-aware variables (cross-sigil forms), subs, methods (type-inferred with return type detail), packages, hash keys, auto-import from cached modules, deref snippets for typed references
+- `textDocument/rename` — scope-aware for variables; cross-file for functions/methods/packages (searches documents + workspace index); `prepareRename` support
+- `textDocument/completion` — scope-aware variables (cross-sigil forms), subs, methods (type-inferred with return type detail), packages, hash keys, auto-import from cached modules, deref snippets for typed references, module names on `use` lines, import lists inside `qw()`
 - `textDocument/signatureHelp` — parameter info with inferred types for subs/methods (signature syntax + legacy @_ pattern), triggers on `(` and `,`
 - `textDocument/inlayHint` — type annotations for variables (Object/HashRef/ArrayRef/CodeRef) and sub return types
 - `textDocument/documentHighlight` — highlight all occurrences with read/write distinction
 - `textDocument/selectionRange` — expand/shrink selection via tree-sitter node hierarchy
 - `textDocument/foldingRange` — blocks, subs, classes, pod sections
 - `textDocument/formatting` — shells out to perltidy (respects .perltidyrc)
+- `textDocument/rangeFormatting` — perltidy on selected line range
 - `textDocument/semanticTokens/full` — variable tokens with modifiers: scalar/array/hash, declaration, modification
 - `textDocument/codeAction` — auto-import for unresolved functions
+- `textDocument/linkedEditingRange` — simultaneous editing of all references in scope
+- `workspace/symbol` — search symbols across all workspace-indexed files
 - Diagnostics — unresolved function/method warnings (skips builtins, local subs, imported functions)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +144,25 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -178,6 +207,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -322,6 +357,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +499,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -614,7 +678,9 @@ version = "0.1.0"
 dependencies = [
  "dashmap 6.1.0",
  "env_logger",
+ "ignore",
  "log",
+ "rayon",
  "rusqlite",
  "serde_json",
  "tokio",
@@ -699,6 +765,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +834,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1109,10 +1204,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ ts-parser-pod = "1"
 dashmap = "6"
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
+rayon = "1"
+ignore = "0.4"
 log = "0.4"
 env_logger = "0.11"

--- a/docs/prompt-ref-coverage-provenance.md
+++ b/docs/prompt-ref-coverage-provenance.md
@@ -1,0 +1,376 @@
+# Ref Coverage + Provenance: Builder Improvements
+
+## Motivation
+
+CLAUDE.md Rules 7 and 8 identify two architectural principles that aren't fully implemented:
+
+**Rule 7 (Every meaningful token gets a ref):** Several token positions are meaningful but have no ref, causing rename, goto-def, and completion to fail silently. These are gaps in the builder's ref emission.
+
+**Rule 8 (Provenance):** Some refs are derived from other values (constant folding, framework synthesis, import re-export), but the derivation chain isn't traceable. Rename can find the derived ref but can't update the source.
+
+This spec addresses both with concrete builder changes.
+
+---
+
+## Part 1: Ref Coverage Gaps
+
+### Gap A: `ref_at()` specificity — narrowest span wins
+
+**Problem:** When cursor is on `timeout` in `connect(timeout => 30)`, `ref_at()` returns the enclosing `MethodCall` ref (spans the whole expression `$obj->connect(timeout => 30)`), not the individual key. Every LSP feature that starts with `ref_at()` gets the wrong answer.
+
+**Fix:** `ref_at()` currently returns the first ref whose span contains the point. Change to return the **narrowest** ref:
+
+```rust
+pub fn ref_at(&self, point: Point) -> Option<&Ref> {
+    self.refs.iter()
+        .filter(|r| contains_point(&r.span, point))
+        .min_by_key(|r| {
+            let span = r.span;
+            (span.end.row - span.start.row, span.end.column - span.start.column)
+        })
+}
+```
+
+This is a prerequisite for all other gaps — without it, adding narrower refs won't help because the broad `MethodCall` ref will still win.
+
+**Impact:** Affects all `ref_at()` callers (rename, goto-def, hover, references, highlight). Should be a no-op for positions where only one ref exists. Needs careful testing to ensure existing behavior isn't degraded when multiple refs overlap.
+
+### Gap B: Fat-comma keys in call arguments
+
+**Problem:** `connect(timeout => 30)` — `timeout` is meaningful (it's a named parameter) but has no ref. The builder sees the `list_expression` inside the call arguments, sees the `autoquoted_bareword` `timeout`, but doesn't emit a ref for it.
+
+**Fix:** During `visit_method_call` and `visit_function_call`, when processing arguments, detect fat-comma pairs and emit `HashKeyAccess` refs for the keys:
+
+```rust
+// In visit_method_call / visit_function_call, after extracting the call name:
+if let Some(args) = node.child_by_field_name("arguments") {
+    self.emit_call_arg_key_refs(args, &call_name);
+}
+
+fn emit_call_arg_key_refs(&mut self, args: Node<'a>, call_name: &str) {
+    let owner = HashKeyOwner::Sub(call_name.to_string());
+    let pairs = self.extract_fat_comma_pairs(args);
+    for (key, _val) in pairs {
+        // Find the key node's span (need to locate the autoquoted_bareword)
+        // Emit HashKeyAccess ref
+        self.add_ref(
+            RefKind::HashKeyAccess { owner: owner.clone() },
+            key_span,
+            key.clone(),
+            AccessKind::Read,
+        );
+    }
+}
+```
+
+**Complication:** `extract_fat_comma_pairs` currently returns `(String, String)` — it strips spans. Need a variant that returns `(String, Span, String)` or emit refs inline during the pair extraction.
+
+**Scoping:** The `HashKeyOwner::Sub(call_name)` scopes these keys to the called function. When `connect` has `my ($self, %opts) = @_`, the `timeout` key access resolves to the `HashKeyDef` for `timeout` in `connect`'s body (from `$opts{timeout}` or `return { timeout => ... }`). This is the existing `HashKeyOwner` resolution chain.
+
+**For Moo/Moose constructor args:** `Foo->new(username => ...)` — the call name is `new`, and Bug D already synthesizes `HashKeyDef` entries owned by `Sub("new")`. So once Gap B is fixed, constructor arg keys automatically resolve to the `has` declaration via the `new` owner chain.
+
+### Gap C: Fat-comma keys in hash literals not findable
+
+**Problem:** `return { status => 'ok' }` — the `status` key has a `HashKeyDef` symbol, but `symbol_at()` doesn't find it at the cursor position because the selection span may not be set up correctly.
+
+**Fix:** Verify that `HashKeyDef` symbols have `selection_span` set to the key text span (not the whole hash expression). The builder's `add_hash_key_def` (or wherever HashKeyDef symbols are created) should use the key's node span as the selection span. Then `symbol_at()` — which searches by selection_span — will find them.
+
+Also ensure `ref_at()` can find `HashKeyDef` positions. Currently `ref_at` only searches `self.refs`, not `self.symbols`. For consistency with Rule 7 ("cursor on a token → ref explains it"), either:
+- Emit a `HashKeyAccess` self-ref at the def site (pointing to itself), or
+- Have `rename_kind_at` fall through to `symbol_at` for HashKeyDef symbols (it already does for Sub/Method/Package — just needs to also handle HashKeyDef)
+
+### Gap D: `find_references` for hash keys
+
+**Problem:** `rename_kind_at` correctly returns `HashKey("timeout")`, but `rename_at` → `find_references` returns empty for hash keys. The `find_references` path for hash keys needs to collect all `HashKeyDef` symbols + `HashKeyAccess` refs matching the name within the owner scope.
+
+**Fix:** In `find_references`, when the target is a hash key:
+
+```rust
+// Collect all HashKeyDef symbols with matching name + owner
+for sym in &self.symbols {
+    if sym.name == key_name && matches!(sym.detail, SymbolDetail::HashKeyDef { ref owner, .. } if *owner == target_owner) {
+        spans.push(sym.selection_span);
+    }
+}
+// Collect all HashKeyAccess refs with matching name + owner
+for r in &self.refs {
+    if r.target_name == key_name && matches!(r.kind, RefKind::HashKeyAccess { ref owner } if *owner == target_owner) {
+        spans.push(r.span);
+    }
+}
+```
+
+The `target_owner` comes from the ref/symbol at the cursor position. For `$opts{timeout}` → owner is `Sub("connect")`. For `$result->{status}` → owner is `Sub("get_result")`.
+
+### Gap E: Hash deref keys (`$obj->{verbose}`)
+
+**Problem:** `$obj->{verbose}` — the `verbose` key inside `{}` deref should resolve to the hash key owner based on `$obj`'s type. If `$obj` was constructed with `bless { verbose => ... }`, the key should link to that def.
+
+**Current state:** The builder already emits `HashKeyAccess` refs for `$obj->{key}` patterns (this is how hash key completion works). The gap is specifically in how `find_references` collects them for rename. Once Gap D is fixed, this should work automatically.
+
+---
+
+## Part 2: Provenance
+
+### What is provenance?
+
+Provenance = the ability to trace a ref back to the source value that produced it. Currently refs point forward (usage → definition) but not backward through derivation chains.
+
+### Provenance Chain 1: Constant folding
+
+**Current state:** `my $m = 'process'; $self->$m()` — the builder folds `$m` to `"process"` and emits a `MethodCall` ref targeting `"process"`. Rename finds the ref. But the rename replaces the `$m` variable span at the call site, NOT the string literal `'process'` in the assignment.
+
+**The right behavior:** Renaming `process` should:
+1. Find the `sub process` definition → rename it
+2. Find all `MethodCall`/`FunctionCall` refs targeting `"process"` → rename them
+3. For refs that were DERIVED from constant folding, trace back to the source string and rename it too
+
+**Data model addition:**
+
+```rust
+pub struct Ref {
+    // ... existing fields ...
+    /// If this ref was derived from constant folding, the source string literal's span.
+    /// Rename should update the source span in addition to (or instead of) this ref's span.
+    pub folded_from: Option<Span>,
+}
+```
+
+When the builder emits a ref from a constant-folded value, it stores the span of the source string literal:
+
+```rust
+// In visit_method_call, when resolving $method via constant_strings:
+if let Some(resolved) = self.resolve_constant_strings(method_var, 0) {
+    for rname in resolved {
+        self.add_ref_with_provenance(
+            RefKind::MethodCall { ... },
+            node_to_span(node),
+            rname,
+            AccessKind::Read,
+            Some(source_string_span),  // span of 'process' in my $m = 'process'
+        );
+    }
+}
+```
+
+The `rename_sub` function then checks `folded_from`:
+
+```rust
+for r in &self.refs {
+    if r.target_name == old_name {
+        match &r.kind {
+            RefKind::FunctionCall => edits.push((r.span, new_name.to_string())),
+            RefKind::MethodCall { method_name_span, .. } => {
+                edits.push((*method_name_span, new_name.to_string()));
+            }
+            _ => {}
+        }
+        // Also rename the source string if this ref was constant-folded
+        if let Some(source_span) = r.folded_from {
+            edits.push((source_span, new_name.to_string()));
+        }
+    }
+}
+```
+
+**Tracking the source span:** The builder needs to propagate source spans through the constant folding chain. When `constant_strings` is populated, store the span alongside the value:
+
+```rust
+/// Known compile-time string values with their source locations.
+constant_strings: HashMap<String, Vec<(String, Span)>>,
+//                                       ^^^^^^  ^^^^^
+//                                       value    where the value was defined
+```
+
+When resolving, the span follows the value through the chain.
+
+### Provenance Chain 2: Import list rename
+
+**Current state:** `use Foo qw(bar)` — the builder emits a `FunctionCall` ref for `bar` via `emit_refs_for_strings`. When `sub bar` in Foo is renamed, `rename_sub` searches for `FunctionCall` refs targeting `"bar"` — and SHOULD find the import list ref.
+
+**Test needed:** Verify this actually works. If `emit_refs_for_strings` correctly emits `FunctionCall` refs with the right span (the string content span inside `qw()`), then rename should update the import list automatically. This may already work — needs QA.
+
+### Provenance Chain 3: `has` → accessor → constructor → internal hash
+
+**Current state after Bug D fix:** `has name => (is => 'ro')` produces:
+- Method symbol `name` (accessor) ✓
+- `HashKeyDef` `name` owned by `Sub("new")` ✓ (Bug D fix)
+- `HashKeyDef` `name` owned by the class (internal `$self->{name}`) — only if bless hash has it
+
+**What's missing:** These three manifestations of `name` aren't linked. Renaming the method doesn't rename the hash keys. Renaming a hash key doesn't rename the accessor.
+
+**Fix:** When `rename_kind_at` identifies a rename target that corresponds to a `has` attribute (detected by: the symbol was synthesized by framework accessor code, or the HashKeyDef is owned by `Sub("new")` in a Moo/Moose class), the rename should expand to cover ALL manifestations:
+
+```rust
+// In the rename handler (backend.rs or file_analysis.rs):
+if is_framework_attribute(analysis, &name) {
+    // Rename the accessor method (rename_sub handles this)
+    // ALSO rename hash key defs owned by "new" with this name
+    // ALSO rename hash key accesses with this name owned by the class
+}
+```
+
+This is a special case of provenance: the `has` declaration is the source of truth, and all derived symbols/refs should rename together.
+
+**Implementation approach:** Add a `rename_framework_attribute` method on `FileAnalysis` that collects:
+1. All symbols named `old_name` with `SymKind::Method` in the class (accessor)
+2. All `HashKeyDef` symbols named `old_name` owned by `Sub("new")` (constructor)
+3. All `HashKeyDef` symbols named `old_name` owned by the class (internal hash)
+4. All `MethodCall` refs targeting `old_name` (method calls)
+5. All `FunctionCall` refs targeting `old_name` (function-style calls)
+6. All `HashKeyAccess` refs targeting `old_name` with matching owner (hash derefs + constructor args)
+
+Return all spans. The backend handler uses this instead of `rename_sub` when the rename target is a framework attribute.
+
+### Provenance Chain 4: Return hash key → caller deref
+
+**Current state:** `sub get_config { return { host => ... } }` then `$cfg->{host}` in caller. The `host` key in the return hash has owner `Sub("get_config")`. The `host` in `$cfg->{host}` also resolves to owner `Sub("get_config")` (via return type → hash key propagation in the enrichment pass).
+
+**This should work already** once Gap D (find_references for hash keys) is fixed. The `HashKeyOwner::Sub("get_config")` links them. The rename would collect all HashKeyDef + HashKeyAccess entries with matching name + owner.
+
+**Cross-file:** The enrichment pass (`enrich_imported_types_with_keys`) already propagates hash keys across files. Cross-file hash key rename would need to search workspace_index for matching owner + name. This is a natural extension of the cross-file rename pattern.
+
+### Provenance Chain 5: Package name → file path
+
+**Problem:** Renaming `MyApp::Controller::Users` should offer to rename/move `lib/MyApp/Controller/Users.pm`.
+
+**LSP support:** `WorkspaceEdit` supports `documentChanges` with `RenameFile` operations:
+
+```rust
+WorkspaceEdit {
+    document_changes: Some(vec![
+        DocumentChangeOperation::Op(ResourceOp::Rename(RenameFile {
+            old_uri: old_path_uri,
+            new_uri: new_path_uri,
+            options: None,
+            annotation_id: None,
+        })),
+        // ... text edits ...
+    ]),
+}
+```
+
+**Implementation:** When `rename_kind_at` returns `Package(name)`:
+1. Compute the expected file path: `name.replace("::", "/") + ".pm"` relative to workspace root
+2. If the file exists, include a `RenameFile` operation in the `WorkspaceEdit`
+3. Also include text edits for all `PackageRef` refs + package declarations across the workspace
+
+**Scope:** This is a stretch goal. The text-level package rename already works. The file rename is a UX enhancement.
+
+### Provenance Chain 6: Inherited override tracking
+
+**Problem:** Renaming `Animal::speak` should surface `Dog::speak` for coordinated rename.
+
+**Current state:** `rename_sub` searches ALL files for any method named `speak` — it doesn't distinguish classes. So renaming `speak` in `Animal` would also rename `speak` in `Dog`, `Cat`, and any unrelated class that happens to have a `speak` method.
+
+**Better behavior:** When renaming a method, check the inheritance chain:
+1. Find all subclasses of the defining class (via `package_parents` reverse lookup)
+2. For each subclass, check if it has an override of the same method
+3. Include overrides in the rename (they're intentionally the same API)
+4. Optionally warn if unrelated classes also have a method with the same name
+
+**Implementation:** This requires a reverse parent lookup (`child_classes_of(parent_name)`) across the workspace index. The data is already there — `package_parents` maps child → parents. Building the reverse is a scan of all `FileAnalysis` entries.
+
+**Scope:** Defer. The current behavior (rename all methods with the same name) is aggressive but not wrong for most cases. Scoped rename is a refinement.
+
+---
+
+## Implementation ordering
+
+| Phase | Work | Depends on |
+|-------|------|-----------|
+| **1a** | `ref_at()` specificity — narrowest span wins | Nothing |
+| **1b** | Emit `HashKeyAccess` refs for fat-comma keys in call args (Gap B) | 1a |
+| **1c** | Fix `find_references` for hash keys (Gap D) | Nothing |
+| **1d** | Verify `HashKeyDef` findable by `symbol_at` (Gap C) | Nothing |
+| **2a** | Constant folding provenance — `folded_from: Option<Span>` on Ref | Nothing |
+| **2b** | `rename_framework_attribute` — unified has/accessor/key rename | 1b, 1c |
+| **2c** | Verify import list rename works (Provenance Chain 2) | Nothing (may already work) |
+| **2d** | Cross-file hash key rename via workspace_index | 1c |
+| **3a** | Package rename → file rename (Provenance Chain 5) | Nothing |
+| **3b** | Inherited override tracking (Provenance Chain 6) | Nothing |
+
+Phases 1a-1d are the "every token gets a ref" foundation. Phase 2 is provenance. Phase 3 is stretch.
+
+---
+
+## Tests
+
+### Ref coverage
+```rust
+#[test]
+fn test_ref_at_narrowest_span() {
+    // $obj->connect(timeout => 30)
+    // Cursor on 'timeout' → should get HashKeyAccess, not MethodCall
+}
+
+#[test]
+fn test_call_arg_fat_comma_has_ref() {
+    // $obj->connect(timeout => 30, host => 'localhost')
+    // 'timeout' and 'host' should each have HashKeyAccess refs
+}
+
+#[test]
+fn test_moo_constructor_arg_has_ref() {
+    // Foo->new(username => 'alice')
+    // 'username' should have HashKeyAccess ref owned by Sub("new")
+    // Should resolve to HashKeyDef from has declaration
+}
+
+#[test]
+fn test_hash_key_rename_from_access() {
+    // my $t = $opts{timeout};
+    // Rename 'timeout' → should update $opts{timeout}, return { timeout => ... }, and connect(timeout => ...)
+}
+
+#[test]
+fn test_hash_key_rename_from_deref() {
+    // $result->{status}
+    // Rename 'status' → should update return { status => 'ok' } and all $result->{status} accesses
+}
+```
+
+### Provenance
+```rust
+#[test]
+fn test_constant_fold_rename_updates_source_string() {
+    // my $m = 'process'; $self->$m()
+    // Rename 'process' → should update sub def, the $self->$m() call site, AND 'process' string literal
+}
+
+#[test]
+fn test_import_list_renamed_with_sub() {
+    // use Foo qw(bar); bar();
+    // Rename sub bar in Foo → should update 'bar' in qw(), bar() call, and sub bar def
+}
+
+#[test]
+fn test_framework_attribute_unified_rename() {
+    // package Foo; use Moo; has name => (is => 'ro');
+    // Foo->new(name => 'x'); $foo->name; $self->{name}
+    // Rename from any position → updates all four
+}
+```
+
+### E2E
+```lua
+t.test("rename: hash key from $opts{timeout} updates call site + return hash", function() end)
+t.test("rename: Moo has name → updates accessor + constructor + hash deref", function() end)
+t.test("rename: constant-folded method updates source string", function() end)
+t.test("rename: sub rename updates import list qw()", function() end)
+```
+
+### CLI QA
+```bash
+# Hash key rename
+perl-lsp --rename /tmp/test lib/Thorough.pm 6 19 max_wait
+# Should show edits for $opts{timeout}, return { timeout => }, connect(timeout =>)
+
+# Moo attribute rename
+perl-lsp --rename /tmp/test lib/Foo.pm 3 4 display_name
+# Should show edits for has username, $self->username, ->new(username =>), $self->{username}
+
+# Constant fold rename
+perl-lsp --rename /tmp/test lib/Const.pm 18 4 handle
+# Should show edits for sub process, $self->$method() call, AND 'process' string literal
+```

--- a/lua/test/lsp.lua
+++ b/lua/test/lsp.lua
@@ -114,6 +114,18 @@ function M.signature_label(buf, line, col)
   return result.signatures[1].label
 end
 
+--- Execute a rename at (line, col) with new_name. Returns the WorkspaceEdit or nil.
+function M.rename(buf, line, col, new_name)
+  local params = M.pos_params(buf, line, col)
+  params.newName = new_name
+  return M.request(buf, "textDocument/rename", params)
+end
+
+--- Apply a WorkspaceEdit to the current buffer.
+function M.apply_workspace_edit(edit)
+  vim.lsp.util.apply_workspace_edit(edit, "utf-16")
+end
+
 --- Get diagnostics for the buffer.
 function M.diagnostics(buf)
   return vim.diagnostic.get(buf)

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
+use tower_lsp::lsp_types::{notification, request};
 use tower_lsp::{Client, LanguageServer};
 
 use crate::document::Document;
@@ -214,7 +215,7 @@ impl LanguageServer for Backend {
         }];
         let _ = self.client.register_capability(registrations).await;
 
-        // Spawn workspace indexing in background
+        // Spawn workspace indexing in background with progress reporting
         let ws_index = Arc::clone(&self.workspace_index);
         let client = self.client.clone();
         let root = self.module_index.workspace_root();
@@ -222,11 +223,39 @@ impl LanguageServer for Backend {
             if let Some(root_uri) = root {
                 if let Some(root_path) = root_uri.strip_prefix("file://") {
                     let root_path = PathBuf::from(root_path);
-                    let count = crate::module_resolver::index_workspace(&root_path, &ws_index);
                     let rt = tokio::runtime::Handle::current();
-                    rt.block_on(client.log_message(
-                        MessageType::INFO,
-                        format!("Indexed {} workspace files", count),
+                    let token = NumberOrString::String("perl-lsp/workspace-index".to_string());
+
+                    // Start progress
+                    let _ = rt.block_on(client.send_request::<request::WorkDoneProgressCreate>(
+                        WorkDoneProgressCreateParams { token: token.clone() },
+                    ));
+                    rt.block_on(client.send_notification::<notification::Progress>(
+                        ProgressParams {
+                            token: token.clone(),
+                            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
+                                WorkDoneProgressBegin {
+                                    title: "Indexing workspace".into(),
+                                    cancellable: Some(false),
+                                    message: Some("Scanning files...".into()),
+                                    percentage: Some(0),
+                                },
+                            )),
+                        },
+                    ));
+
+                    let count = crate::module_resolver::index_workspace(&root_path, &ws_index);
+
+                    // End progress
+                    rt.block_on(client.send_notification::<notification::Progress>(
+                        ProgressParams {
+                            token,
+                            value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
+                                WorkDoneProgressEnd {
+                                    message: Some(format!("Indexed {} files", count)),
+                                },
+                            )),
+                        },
                     ));
                 }
             }
@@ -649,26 +678,29 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        for change in params.changes {
-            let path = match change.uri.to_file_path() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            match change.typ {
-                FileChangeType::DELETED => {
-                    self.workspace_index.remove(&path);
-                }
-                _ => {
-                    // Re-index the file (created or changed)
-                    if let Ok(source) = std::fs::read_to_string(&path) {
-                        let mut parser = crate::module_resolver::create_parser();
-                        if let Some(tree) = parser.parse(&source, None) {
-                            let analysis = crate::builder::build(&tree, source.as_bytes());
-                            self.workspace_index.insert(path, analysis);
+        let ws_index = Arc::clone(&self.workspace_index);
+        tokio::task::spawn_blocking(move || {
+            for change in params.changes {
+                let path = match change.uri.to_file_path() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                match change.typ {
+                    FileChangeType::DELETED => {
+                        ws_index.remove(&path);
+                    }
+                    _ => {
+                        // Re-index the file (created or changed)
+                        if let Ok(source) = std::fs::read_to_string(&path) {
+                            let mut parser = crate::module_resolver::create_parser();
+                            if let Some(tree) = parser.parse(&source, None) {
+                                let analysis = crate::builder::build(&tree, source.as_bytes());
+                                ws_index.insert(path, analysis);
+                            }
                         }
                     }
                 }
             }
-        }
+        });
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -7,7 +8,7 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
 use crate::document::Document;
-use crate::file_analysis::InferredType;
+use crate::file_analysis::{FileAnalysis, InferredType};
 use crate::module_index::ModuleIndex;
 use crate::symbols;
 
@@ -15,6 +16,7 @@ pub struct Backend {
     client: Client,
     documents: Arc<DashMap<Url, Document>>,
     module_index: Arc<ModuleIndex>,
+    workspace_index: Arc<DashMap<PathBuf, FileAnalysis>>,
 }
 
 impl Backend {
@@ -57,11 +59,13 @@ impl Backend {
 
         let module_index = Arc::new(ModuleIndex::new(client.clone(), on_refresh));
         let _ = module_index_holder.set(Arc::clone(&module_index));
+        let workspace_index: Arc<DashMap<PathBuf, FileAnalysis>> = Arc::new(DashMap::new());
 
         Backend {
             module_index,
             client,
             documents,
+            workspace_index,
         }
     }
 
@@ -180,6 +184,11 @@ impl LanguageServer for Backend {
                         },
                     ),
                 ),
+                workspace_symbol_provider: Some(OneOf::Left(true)),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: None,
+                    file_operations: None,
+                }),
                 ..ServerCapabilities::default()
             },
             ..Default::default()
@@ -190,6 +199,38 @@ impl LanguageServer for Backend {
         self.client
             .log_message(MessageType::INFO, "perl-lsp initialized")
             .await;
+
+        // Register file watchers for workspace indexing
+        let registrations = vec![Registration {
+            id: "perl-file-watcher".to_string(),
+            method: "workspace/didChangeWatchedFiles".to_string(),
+            register_options: Some(serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
+                watchers: vec![
+                    FileSystemWatcher { glob_pattern: GlobPattern::String("**/*.pm".into()), kind: None },
+                    FileSystemWatcher { glob_pattern: GlobPattern::String("**/*.pl".into()), kind: None },
+                    FileSystemWatcher { glob_pattern: GlobPattern::String("**/*.t".into()), kind: None },
+                ],
+            }).unwrap()),
+        }];
+        let _ = self.client.register_capability(registrations).await;
+
+        // Spawn workspace indexing in background
+        let ws_index = Arc::clone(&self.workspace_index);
+        let client = self.client.clone();
+        let root = self.module_index.workspace_root();
+        tokio::task::spawn_blocking(move || {
+            if let Some(root_uri) = root {
+                if let Some(root_path) = root_uri.strip_prefix("file://") {
+                    let root_path = PathBuf::from(root_path);
+                    let count = crate::module_resolver::index_workspace(&root_path, &ws_index);
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(client.log_message(
+                        MessageType::INFO,
+                        format!("Indexed {} workspace files", count),
+                    ));
+                }
+            }
+        });
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -559,6 +600,75 @@ impl LanguageServer for Backend {
             Ok(None)
         } else {
             Ok(Some(hints))
+        }
+    }
+
+    async fn symbol(
+        &self,
+        params: WorkspaceSymbolParams,
+    ) -> Result<Option<Vec<SymbolInformation>>> {
+        let query = params.query.to_lowercase();
+        let mut results = Vec::new();
+        let mut seen_paths = std::collections::HashSet::new();
+
+        // Search open documents first (freshest analysis)
+        for entry in self.documents.iter() {
+            let uri = entry.key().clone();
+            if let Ok(path) = uri.to_file_path() {
+                seen_paths.insert(path);
+            }
+            for sym in &entry.value().analysis.symbols {
+                if sym.name.to_lowercase().contains(&query) {
+                    if let Some(info) = symbols::symbol_to_workspace_info(sym, uri.clone()) {
+                        results.push(info);
+                    }
+                }
+            }
+        }
+
+        // Then workspace index (skip files already covered by open docs)
+        for entry in self.workspace_index.iter() {
+            if seen_paths.contains(entry.key()) { continue; }
+            let uri = Url::from_file_path(entry.key()).unwrap_or_else(|_| {
+                Url::parse(&format!("file://{}", entry.key().display())).unwrap()
+            });
+            for sym in &entry.value().symbols {
+                if sym.name.to_lowercase().contains(&query) {
+                    if let Some(info) = symbols::symbol_to_workspace_info(sym, uri.clone()) {
+                        results.push(info);
+                    }
+                }
+            }
+        }
+
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(results))
+        }
+    }
+
+    async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
+        for change in params.changes {
+            let path = match change.uri.to_file_path() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            match change.typ {
+                FileChangeType::DELETED => {
+                    self.workspace_index.remove(&path);
+                }
+                _ => {
+                    // Re-index the file (created or changed)
+                    if let Ok(source) = std::fs::read_to_string(&path) {
+                        let mut parser = crate::module_resolver::create_parser();
+                        if let Some(tree) = parser.parse(&source, None) {
+                            let analysis = crate::builder::build(&tree, source.as_bytes());
+                            self.workspace_index.insert(path, analysis);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -147,7 +147,12 @@ impl LanguageServer for Backend {
                 definition_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
-                rename_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Right(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                })),
+                document_range_formatting_provider: Some(OneOf::Left(true)),
+                linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(true)),
                 completion_provider: Some(CompletionOptions {
                     trigger_characters: Some(vec![
                         "$".to_string(),
@@ -367,6 +372,30 @@ impl LanguageServer for Backend {
         }
     }
 
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        let doc = match self.documents.get(&params.text_document.uri) {
+            Some(doc) => doc,
+            None => return Ok(None),
+        };
+        let point = symbols::position_to_point(params.position);
+        if let Some(sym) = doc.analysis.symbol_at(point) {
+            return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
+                range: symbols::span_to_range(sym.selection_span),
+                placeholder: sym.name.clone(),
+            }));
+        }
+        if let Some(r) = doc.analysis.ref_at(point) {
+            return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
+                range: symbols::span_to_range(r.span),
+                placeholder: r.target_name.clone(),
+            }));
+        }
+        Ok(None)
+    }
+
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let uri = &params.text_document_position.text_document.uri;
         let pos = params.text_document_position.position;
@@ -375,7 +404,73 @@ impl LanguageServer for Backend {
             Some(doc) => doc,
             None => return Ok(None),
         };
-        Ok(symbols::rename(&doc.analysis, pos, uri, new_name))
+
+        let point = symbols::position_to_point(pos);
+        let rename_kind = doc.analysis.rename_kind_at(point);
+
+        match rename_kind {
+            Some(crate::file_analysis::RenameKind::Variable) => {
+                // Single-file only — lexical scope doesn't cross files
+                Ok(symbols::rename(&doc.analysis, pos, uri, new_name))
+            }
+            Some(crate::file_analysis::RenameKind::Function(ref name))
+            | Some(crate::file_analysis::RenameKind::Method(ref name))
+            | Some(crate::file_analysis::RenameKind::Package(ref name))
+            | Some(crate::file_analysis::RenameKind::HashKey(ref name)) => {
+                let rename_fn: fn(&FileAnalysis, &str, &str) -> Vec<(crate::file_analysis::Span, String)> = match &rename_kind {
+                    Some(crate::file_analysis::RenameKind::Function(_)) => FileAnalysis::rename_function,
+                    Some(crate::file_analysis::RenameKind::Package(_)) => FileAnalysis::rename_package,
+                    Some(crate::file_analysis::RenameKind::Method(_)) => FileAnalysis::rename_method,
+                    Some(crate::file_analysis::RenameKind::HashKey(_)) => {
+                        // Hash keys: single-file for now
+                        return Ok(symbols::rename(&doc.analysis, pos, uri, new_name));
+                    }
+                    _ => unreachable!(),
+                };
+
+                let mut all_changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+
+                let mut collect = |uri: Url, analysis: &FileAnalysis| {
+                    let edits = rename_fn(analysis, name, new_name);
+                    if !edits.is_empty() {
+                        all_changes.entry(uri).or_default().extend(
+                            edits.into_iter().map(|(span, text)| TextEdit {
+                                range: symbols::span_to_range(span),
+                                new_text: text,
+                            })
+                        );
+                    }
+                };
+
+                // Search open documents
+                let mut seen_paths = std::collections::HashSet::new();
+                for entry in self.documents.iter() {
+                    if let Ok(path) = entry.key().to_file_path() {
+                        seen_paths.insert(path);
+                    }
+                    collect(entry.key().clone(), &entry.value().analysis);
+                }
+
+                // Search workspace index
+                for entry in self.workspace_index.iter() {
+                    if seen_paths.contains(entry.key()) { continue; }
+                    let ws_uri = Url::from_file_path(entry.key()).unwrap_or_else(|_| {
+                        Url::parse(&format!("file://{}", entry.key().display())).unwrap()
+                    });
+                    collect(ws_uri, entry.value());
+                }
+
+                if all_changes.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(WorkspaceEdit {
+                        changes: Some(all_changes),
+                        ..Default::default()
+                    }))
+                }
+            }
+            None => Ok(None),
+        }
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
@@ -702,5 +797,89 @@ impl LanguageServer for Backend {
                 }
             }
         });
+    }
+
+    async fn range_formatting(
+        &self,
+        params: DocumentRangeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let uri = &params.text_document.uri;
+        let doc = match self.documents.get(uri) {
+            Some(doc) => doc,
+            None => return Ok(None),
+        };
+
+        // Extract lines for the range
+        let start_line = params.range.start.line as usize;
+        let end_line = params.range.end.line as usize;
+        let lines: Vec<&str> = doc.text.lines().collect();
+        if start_line >= lines.len() { return Ok(None); }
+        let end = (end_line + 1).min(lines.len());
+        let range_text: String = lines[start_line..end].join("\n") + "\n";
+
+        // Shell out to perltidy on the range
+        let result = tokio::process::Command::new("perltidy")
+            .arg("--standard-output")
+            .arg("--standard-error-output")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn();
+
+        let mut child = match result {
+            Ok(c) => c,
+            Err(_) => return Ok(None),
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            let _ = stdin.write_all(range_text.as_bytes()).await;
+            drop(stdin);
+        }
+
+        let output = match child.wait_with_output().await {
+            Ok(o) if o.status.success() => o,
+            _ => return Ok(None),
+        };
+
+        let formatted = String::from_utf8_lossy(&output.stdout).to_string();
+        if formatted == range_text {
+            return Ok(None);
+        }
+
+        Ok(Some(vec![TextEdit {
+            range: Range {
+                start: Position { line: start_line as u32, character: 0 },
+                end: Position { line: end as u32, character: 0 },
+            },
+            new_text: formatted,
+        }]))
+    }
+
+    async fn linked_editing_range(
+        &self,
+        params: LinkedEditingRangeParams,
+    ) -> Result<Option<LinkedEditingRanges>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        let doc = match self.documents.get(uri) {
+            Some(doc) => doc,
+            None => return Ok(None),
+        };
+
+        let point = symbols::position_to_point(pos);
+        let refs = doc.analysis.find_references(point, None, None);
+        if refs.len() < 2 {
+            return Ok(None);
+        }
+
+        let ranges: Vec<Range> = refs.into_iter()
+            .map(|span| symbols::span_to_range(span))
+            .collect();
+
+        Ok(Some(LinkedEditingRanges {
+            ranges,
+            word_pattern: None,
+        }))
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -418,9 +418,9 @@ impl LanguageServer for Backend {
             | Some(crate::file_analysis::RenameKind::Package(ref name))
             | Some(crate::file_analysis::RenameKind::HashKey(ref name)) => {
                 let rename_fn: fn(&FileAnalysis, &str, &str) -> Vec<(crate::file_analysis::Span, String)> = match &rename_kind {
-                    Some(crate::file_analysis::RenameKind::Function(_)) => FileAnalysis::rename_function,
+                    Some(crate::file_analysis::RenameKind::Function(_)) => FileAnalysis::rename_sub,
                     Some(crate::file_analysis::RenameKind::Package(_)) => FileAnalysis::rename_package,
-                    Some(crate::file_analysis::RenameKind::Method(_)) => FileAnalysis::rename_method,
+                    Some(crate::file_analysis::RenameKind::Method(_)) => FileAnalysis::rename_sub,
                     Some(crate::file_analysis::RenameKind::HashKey(_)) => {
                         // Hash keys: single-file for now
                         return Ok(symbols::rename(&doc.analysis, pos, uri, new_name));

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -411,7 +411,7 @@ impl LanguageServer for Backend {
         match rename_kind {
             Some(crate::file_analysis::RenameKind::Variable) => {
                 // Single-file only — lexical scope doesn't cross files
-                Ok(symbols::rename(&doc.analysis, pos, uri, new_name))
+                Ok(symbols::rename(&doc.analysis, pos, uri, new_name, Some(&doc.tree), Some(&doc.text)))
             }
             Some(crate::file_analysis::RenameKind::Function(ref name))
             | Some(crate::file_analysis::RenameKind::Method(ref name))
@@ -423,7 +423,7 @@ impl LanguageServer for Backend {
                     Some(crate::file_analysis::RenameKind::Method(_)) => FileAnalysis::rename_sub,
                     Some(crate::file_analysis::RenameKind::HashKey(_)) => {
                         // Hash keys: single-file for now
-                        return Ok(symbols::rename(&doc.analysis, pos, uri, new_name));
+                        return Ok(symbols::rename(&doc.analysis, pos, uri, new_name, Some(&doc.tree), Some(&doc.text)));
                     }
                     _ => unreachable!(),
                 };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2349,9 +2349,12 @@ impl<'a> Builder<'a> {
     }
 
     fn visit_method_call(&mut self, node: Node<'a>) {
-        let method_name = node.child_by_field_name("method")
+        let method_node = node.child_by_field_name("method");
+        let method_name = method_node
             .and_then(|n| n.utf8_text(self.source).ok())
             .map(|s| s.to_string());
+        let method_name_span = method_node.map(|n| node_to_span(n))
+            .unwrap_or_else(|| node_to_span(node));
         let invocant_node = node.child_by_field_name("invocant");
         let invocant_text = invocant_node
             .and_then(|n| n.utf8_text(self.source).ok())
@@ -2378,6 +2381,7 @@ impl<'a> Builder<'a> {
                             RefKind::MethodCall {
                                 invocant: invocant.clone().unwrap_or_default(),
                                 invocant_span,
+                                method_name_span,
                             },
                             node_to_span(node),
                             rname,
@@ -2390,6 +2394,7 @@ impl<'a> Builder<'a> {
                     RefKind::MethodCall {
                         invocant: invocant.clone().unwrap_or_default(),
                         invocant_span,
+                        method_name_span,
                     },
                     node_to_span(node),
                     name.clone(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4491,7 +4491,7 @@ $calc->get_self->get_config->{host};
     fn test_rename_variable() {
         let src = "my $x = 1;\nprint $x;";
         let fa = build_fa(src);
-        let edits = fa.rename_at(Point::new(0, 4), "y");
+        let edits = fa.rename_at(Point::new(0, 4), "y", None, None);
         assert!(edits.is_some(), "should produce rename edits");
         let edits = edits.unwrap();
         assert!(edits.len() >= 2, "should rename at least declaration + usage");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2166,6 +2166,23 @@ impl<'a> Builder<'a> {
                 }
             }
         }
+
+        // Synthesize HashKeyDef entries so Foo->new(name => ...) connects to the attribute.
+        if let Some(ref _pkg) = self.current_package {
+            let owner = HashKeyOwner::Sub("new".to_string());
+            for (name, sel_span) in &attr_names {
+                self.add_symbol(
+                    name.clone(),
+                    SymKind::HashKeyDef,
+                    node_to_span(node),
+                    *sel_span,
+                    SymbolDetail::HashKeyDef {
+                        owner: owner.clone(),
+                        is_dynamic: false,
+                    },
+                );
+            }
+        }
     }
 
     /// Extract arguments from `use Mojo::Base ...` including barewords like -strict, -base.
@@ -4500,6 +4517,27 @@ sub test {
             "rename_sub should find def + function call + method call, got {} edits", edits.len());
         for (_, text) in &edits {
             assert_eq!(text, "fire");
+        }
+    }
+
+    #[test]
+    fn test_moo_has_creates_constructor_hash_key_def() {
+        let fa = build_fa("
+package MyApp;
+use Moo;
+has username => (is => 'ro');
+has password => (is => 'rw');
+");
+        // Should have HashKeyDef symbols owned by "new" for each has attribute
+        let key_defs: Vec<_> = fa.symbols.iter()
+            .filter(|s| matches!(s.detail, SymbolDetail::HashKeyDef { .. }))
+            .collect();
+        let names: Vec<&str> = key_defs.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"username"), "should have HashKeyDef for username, got: {:?}", names);
+        assert!(names.contains(&"password"), "should have HashKeyDef for password, got: {:?}", names);
+        // Verify owner is "new"
+        if let SymbolDetail::HashKeyDef { ref owner, .. } = key_defs[0].detail {
+            assert_eq!(owner, &HashKeyOwner::Sub("new".to_string()));
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4484,6 +4484,26 @@ $calc->get_self->get_config->{host};
     }
 
     #[test]
+    fn test_rename_sub_finds_both_function_and_method_calls() {
+        let fa = build_fa("
+package Foo;
+sub emit { }
+sub test {
+    my $self = shift;
+    emit('event');
+    $self->emit('done');
+}
+");
+        let edits = fa.rename_sub("emit", "fire");
+        // Should find: 1 symbol def + 1 FunctionCall + 1 MethodCall = 3 edits
+        assert!(edits.len() >= 3,
+            "rename_sub should find def + function call + method call, got {} edits", edits.len());
+        for (_, text) in &edits {
+            assert_eq!(text, "fire");
+        }
+    }
+
+    #[test]
     fn test_find_def_bareword_class() {
         let src = "package Point;\nsub new { bless {}, shift }\npackage main;\nPoint->new();";
         let fa = build_fa(src);

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -193,6 +193,16 @@ pub struct Ref {
     pub resolves_to: Option<SymbolId>,
 }
 
+/// What kind of entity is being renamed — determines single-file vs cross-file scope.
+#[derive(Debug)]
+pub enum RenameKind {
+    Variable,
+    Function(String),
+    Package(String),
+    Method(String),
+    HashKey(String),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum RefKind {
@@ -1603,6 +1613,77 @@ impl FileAnalysis {
         };
 
         Some(edits)
+    }
+
+    /// Determine what kind of rename is appropriate for the cursor position.
+    pub fn rename_kind_at(&self, point: Point) -> Option<RenameKind> {
+        if let Some(r) = self.ref_at(point) {
+            return Some(match &r.kind {
+                RefKind::Variable | RefKind::ContainerAccess => RenameKind::Variable,
+                RefKind::FunctionCall => RenameKind::Function(r.target_name.clone()),
+                RefKind::MethodCall { .. } => RenameKind::Method(r.target_name.clone()),
+                RefKind::PackageRef => RenameKind::Package(r.target_name.clone()),
+                RefKind::HashKeyAccess { .. } => RenameKind::HashKey(r.target_name.clone()),
+            });
+        }
+        if let Some(sym) = self.symbol_at(point) {
+            return match sym.kind {
+                SymKind::Variable | SymKind::Field => Some(RenameKind::Variable),
+                SymKind::Sub => Some(RenameKind::Function(sym.name.clone())),
+                SymKind::Method => Some(RenameKind::Method(sym.name.clone())),
+                SymKind::Package | SymKind::Class => Some(RenameKind::Package(sym.name.clone())),
+                _ => None,
+            };
+        }
+        None
+    }
+
+    /// Find all occurrences of a function name (def + refs) for cross-file rename.
+    pub fn rename_function(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
+        let mut edits = Vec::new();
+        for sym in &self.symbols {
+            if sym.name == old_name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                edits.push((sym.selection_span, new_name.to_string()));
+            }
+        }
+        for r in &self.refs {
+            if r.target_name == old_name && matches!(r.kind, RefKind::FunctionCall) {
+                edits.push((r.span, new_name.to_string()));
+            }
+        }
+        edits
+    }
+
+    /// Find all occurrences of a method name (def + call refs) for cross-file rename.
+    pub fn rename_method(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
+        let mut edits = Vec::new();
+        for sym in &self.symbols {
+            if sym.name == old_name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                edits.push((sym.selection_span, new_name.to_string()));
+            }
+        }
+        for r in &self.refs {
+            if r.target_name == old_name && matches!(r.kind, RefKind::MethodCall { .. }) {
+                edits.push((r.span, new_name.to_string()));
+            }
+        }
+        edits
+    }
+
+    /// Find all occurrences of a package name (def + refs + use statements) for cross-file rename.
+    pub fn rename_package(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
+        let mut edits = Vec::new();
+        for sym in &self.symbols {
+            if sym.name == old_name && matches!(sym.kind, SymKind::Package | SymKind::Class | SymKind::Module) {
+                edits.push((sym.selection_span, new_name.to_string()));
+            }
+        }
+        for r in &self.refs {
+            if r.target_name == old_name && matches!(r.kind, RefKind::PackageRef) {
+                edits.push((r.span, new_name.to_string()));
+            }
+        }
+        edits
     }
 
     // ---- Internal resolution helpers ----

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1583,11 +1583,7 @@ impl FileAnalysis {
     }
 
     /// Rename: return all spans + new text for renaming the symbol at cursor.
-    pub fn rename_at(&self, point: Point, new_name: &str) -> Option<Vec<(Span, String)>> {
-        self.rename_at_with_tree(point, new_name, None, None)
-    }
-
-    pub fn rename_at_with_tree(&self, point: Point, new_name: &str, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<Vec<(Span, String)>> {
+    pub fn rename_at(&self, point: Point, new_name: &str, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<Vec<(Span, String)>> {
         let refs = self.find_references(point, tree, source_bytes);
         if refs.is_empty() {
             return None;

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1640,24 +1640,9 @@ impl FileAnalysis {
         None
     }
 
-    /// Find all occurrences of a function name (def + refs) for cross-file rename.
-    pub fn rename_function(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
-        let mut edits = Vec::new();
-        for sym in &self.symbols {
-            if sym.name == old_name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                edits.push((sym.selection_span, new_name.to_string()));
-            }
-        }
-        for r in &self.refs {
-            if r.target_name == old_name && matches!(r.kind, RefKind::FunctionCall) {
-                edits.push((r.span, new_name.to_string()));
-            }
-        }
-        edits
-    }
-
-    /// Find all occurrences of a method name (def + call refs) for cross-file rename.
-    pub fn rename_method(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
+    /// Find all occurrences of a sub name (def + ALL call refs) for cross-file rename.
+    /// Searches both FunctionCall and MethodCall refs because Perl subs can be called either way.
+    pub fn rename_sub(&self, old_name: &str, new_name: &str) -> Vec<(Span, String)> {
         let mut edits = Vec::new();
         for sym in &self.symbols {
             if sym.name == old_name && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
@@ -1666,8 +1651,14 @@ impl FileAnalysis {
         }
         for r in &self.refs {
             if r.target_name == old_name {
-                if let RefKind::MethodCall { method_name_span, .. } = &r.kind {
-                    edits.push((*method_name_span, new_name.to_string()));
+                match &r.kind {
+                    RefKind::FunctionCall => {
+                        edits.push((r.span, new_name.to_string()));
+                    }
+                    RefKind::MethodCall { method_name_span, .. } => {
+                        edits.push((*method_name_span, new_name.to_string()));
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -212,6 +212,8 @@ pub enum RefKind {
         invocant: String,
         /// Span of the invocant node (for complex expressions needing tree resolution).
         invocant_span: Option<Span>,
+        /// Span of just the method name (for rename — r.span covers the whole expression).
+        method_name_span: Span,
     },
     PackageRef,
     HashKeyAccess {
@@ -1663,8 +1665,10 @@ impl FileAnalysis {
             }
         }
         for r in &self.refs {
-            if r.target_name == old_name && matches!(r.kind, RefKind::MethodCall { .. }) {
-                edits.push((r.span, new_name.to_string()));
+            if r.target_name == old_name {
+                if let RefKind::MethodCall { method_name_span, .. } = &r.kind {
+                    edits.push((*method_name_span, new_name.to_string()));
+                }
             }
         }
         edits
@@ -1709,7 +1713,7 @@ impl FileAnalysis {
                         }
                     }
                 }
-                RefKind::MethodCall { ref invocant, ref invocant_span } => {
+                RefKind::MethodCall { ref invocant, ref invocant_span, .. } => {
                     let class_name = self.resolve_method_invocant(
                         invocant, invocant_span, r.scope, point, tree, source_bytes, module_index,
                     );

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1584,7 +1584,11 @@ impl FileAnalysis {
 
     /// Rename: return all spans + new text for renaming the symbol at cursor.
     pub fn rename_at(&self, point: Point, new_name: &str) -> Option<Vec<(Span, String)>> {
-        let refs = self.find_references(point, None, None);
+        self.rename_at_with_tree(point, new_name, None, None)
+    }
+
+    pub fn rename_at_with_tree(&self, point: Point, new_name: &str, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<Vec<(Span, String)>> {
+        let refs = self.find_references(point, tree, source_bytes);
         if refs.is_empty() {
             return None;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,11 @@ fn cli_rename(root: &str, file: &str, line_str: &str, col_str: &str, new_name: &
 
     let rename_fn: fn(&file_analysis::FileAnalysis, &str, &str) -> Vec<(file_analysis::Span, String)> = match &rename_kind {
         file_analysis::RenameKind::Variable | file_analysis::RenameKind::HashKey(_) => {
-            // Single-file rename
-            if let Some(edits) = analysis_ref.rename_at(point, new_name) {
+            // Single-file rename — parse tree for hash key owner resolution
+            let source = std::fs::read_to_string(&file_path).expect("cannot read file");
+            let mut parser = module_resolver::create_parser();
+            let tree = parser.parse(&source, None).expect("parse failed");
+            if let Some(edits) = analysis_ref.rename_at(point, new_name, Some(&tree), Some(source.as_bytes())) {
                 let json_edits: Vec<_> = edits.into_iter()
                     .map(|(span, text)| span_to_json(span, text))
                     .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,30 @@ use tower_lsp::{LspService, Server};
 
 #[tokio::main]
 async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_usage();
+        return;
+    }
+
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("perl-lsp {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
+    // CLI mode: --rename <root> <file> <line> <col> <new_name>
+    if args.len() == 7 && args[1] == "--rename" {
+        cli_rename(&args[2], &args[3], &args[4], &args[5], &args[6]);
+        return;
+    }
+
+    // CLI mode: --workspace-symbol <root> <query>
+    if args.len() == 4 && args[1] == "--workspace-symbol" {
+        cli_workspace_symbol(&args[2], &args[3]);
+        return;
+    }
+
     env_logger::init();
 
     let stdin = tokio::io::stdin();
@@ -24,4 +48,133 @@ async fn main() {
     let (service, socket) = LspService::new(Backend::new);
 
     Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+fn print_usage() {
+    eprintln!("perl-lsp {} — Perl Language Server", env!("CARGO_PKG_VERSION"));
+    eprintln!();
+    eprintln!("USAGE:");
+    eprintln!("  perl-lsp                                          Start LSP server (stdio)");
+    eprintln!("  perl-lsp --rename <root> <file> <line> <col> <new_name>");
+    eprintln!("                                                    Cross-file rename, outputs JSON");
+    eprintln!("  perl-lsp --workspace-symbol <root> <query>        Search symbols, outputs JSON");
+    eprintln!("  perl-lsp --version                                Print version");
+}
+
+fn span_to_json(span: file_analysis::Span, text: String) -> serde_json::Value {
+    serde_json::json!({
+        "line": span.start.row, "col": span.start.column,
+        "end_line": span.end.row, "end_col": span.end.column,
+        "new_text": text
+    })
+}
+
+/// CLI: index a workspace, perform a rename, output JSON edits.
+fn cli_rename(root: &str, file: &str, line_str: &str, col_str: &str, new_name: &str) {
+    use std::path::{Path, PathBuf};
+    use std::collections::HashMap;
+    use dashmap::DashMap;
+
+    let root_path = Path::new(root).canonicalize().unwrap_or_else(|_| PathBuf::from(root));
+    let file_path = Path::new(file).canonicalize().unwrap_or_else(|_| PathBuf::from(file));
+    let line: usize = line_str.parse().expect("line must be a number");
+    let col: usize = col_str.parse().expect("col must be a number");
+    let point = tree_sitter::Point::new(line, col);
+
+    // Index workspace
+    let workspace_index: DashMap<PathBuf, file_analysis::FileAnalysis> = DashMap::new();
+    let count = module_resolver::index_workspace(&root_path, &workspace_index);
+    eprintln!("Indexed {} files", count);
+
+    // Ensure target file is in the workspace index (it should be, but parse fresh if not)
+    if !workspace_index.contains_key(&file_path) {
+        let source = std::fs::read_to_string(&file_path).expect("cannot read file");
+        let mut parser = module_resolver::create_parser();
+        let tree = parser.parse(&source, None).expect("parse failed");
+        let analysis = builder::build(&tree, source.as_bytes());
+        workspace_index.insert(file_path.clone(), analysis);
+    }
+    let analysis_ref = workspace_index.get(&file_path).unwrap();
+
+    // Determine rename kind
+    let rename_kind = match analysis_ref.rename_kind_at(point) {
+        Some(k) => k,
+        None => {
+            eprintln!("Nothing renameable at {}:{}", line, col);
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!("Rename kind: {:?}", rename_kind);
+
+    let mut all_edits: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+
+    let rename_fn: fn(&file_analysis::FileAnalysis, &str, &str) -> Vec<(file_analysis::Span, String)> = match &rename_kind {
+        file_analysis::RenameKind::Variable | file_analysis::RenameKind::HashKey(_) => {
+            // Single-file rename
+            if let Some(edits) = analysis_ref.rename_at(point, new_name) {
+                let json_edits: Vec<_> = edits.into_iter()
+                    .map(|(span, text)| span_to_json(span, text))
+                    .collect();
+                all_edits.insert(file_path.display().to_string(), json_edits);
+            }
+            println!("{}", serde_json::to_string_pretty(&serde_json::json!(all_edits)).unwrap());
+            return;
+        }
+        file_analysis::RenameKind::Function(_) | file_analysis::RenameKind::Method(_) => {
+            file_analysis::FileAnalysis::rename_sub
+        }
+        file_analysis::RenameKind::Package(_) => {
+            file_analysis::FileAnalysis::rename_package
+        }
+    };
+
+    let name = match &rename_kind {
+        file_analysis::RenameKind::Function(n) | file_analysis::RenameKind::Method(n) | file_analysis::RenameKind::Package(n) => n.clone(),
+        _ => unreachable!(),
+    };
+
+    // Search all workspace files
+    for entry in workspace_index.iter() {
+        let edits = rename_fn(entry.value(), &name, new_name);
+        if !edits.is_empty() {
+            let json_edits: Vec<_> = edits.into_iter()
+                .map(|(span, text)| span_to_json(span, text))
+                .collect();
+            all_edits.insert(entry.key().display().to_string(), json_edits);
+        }
+    }
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!(all_edits)).unwrap());
+}
+
+/// CLI: index a workspace and search for symbols.
+fn cli_workspace_symbol(root: &str, query: &str) {
+    use std::path::{Path, PathBuf};
+    use dashmap::DashMap;
+
+    let root_path = Path::new(root).canonicalize().unwrap_or_else(|_| PathBuf::from(root));
+    let workspace_index: DashMap<PathBuf, file_analysis::FileAnalysis> = DashMap::new();
+    let count = module_resolver::index_workspace(&root_path, &workspace_index);
+    eprintln!("Indexed {} files", count);
+
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for entry in workspace_index.iter() {
+        for sym in &entry.value().symbols {
+            if sym.name.to_lowercase().contains(&query_lower) {
+                results.push(serde_json::json!({
+                    "name": sym.name,
+                    "kind": format!("{:?}", sym.kind),
+                    "file": entry.key().display().to_string(),
+                    "line": sym.selection_span.start.row,
+                    "col": sym.selection_span.start.column,
+                }));
+            }
+        }
+    }
+
+    eprintln!("{} symbols matching '{}'", results.len(), query);
+    println!("{}", serde_json::to_string_pretty(&results).unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,16 +16,6 @@ use tower_lsp::{LspService, Server};
 
 #[tokio::main]
 async fn main() {
-    // Subprocess mode: parse a .pm file and print exports as JSON.
-    // Used by the module resolver with a hard timeout to protect against
-    // infinite loops in the tree-sitter external scanner.
-    let args: Vec<String> = std::env::args().collect();
-    if (args.len() == 3 || args.len() == 4) && args[1] == "--parse-exports" {
-        let module_name = args.get(3).map(|s| s.as_str());
-        module_index::subprocess_main(&args[2], module_name);
-        return;
-    }
-
     env_logger::init();
 
     let stdin = tokio::io::stdin();

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -187,6 +187,12 @@ impl ModuleIndex {
         self.workspace_root.condvar.notify_one();
     }
 
+    /// Get the workspace root URI if set.
+    pub fn workspace_root(&self) -> Option<String> {
+        self.workspace_root.root.lock().ok()
+            .and_then(|guard| guard.as_ref().and_then(|opt| opt.clone()))
+    }
+
     /// Request background resolution for a module. Non-blocking.
     /// Stale modules (old extract version) are queued with priority.
     pub fn request_resolve(&self, module_name: &str) {

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -399,10 +399,6 @@ impl ModuleIndex {
     }
 }
 
-/// Entry point for `--parse-exports <path>` subprocess mode.
-pub fn subprocess_main(path: &str, module_name: Option<&str>) {
-    module_resolver::subprocess_main(path, module_name);
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -1,7 +1,7 @@
 //! Module resolver: background thread that resolves Perl modules from `@INC`.
 //!
-//! Discovers `@INC` paths, locates `.pm` files, extracts `@EXPORT`/`@EXPORT_OK`,
-//! and handles subprocess isolation for safe parsing (tree-sitter hangs → SIGKILL).
+//! Discovers `@INC` paths, locates `.pm` files, parses them in-process with
+//! tree-sitter-perl, and extracts export metadata for the module index.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -15,15 +15,9 @@ use tower_lsp::Client;
 use tree_sitter::Parser;
 
 use crate::cpanfile;
-#[cfg(not(test))]
-use crate::file_analysis::inferred_type_from_tag;
 use crate::file_analysis::inferred_type_to_tag;
 use crate::module_cache;
 use crate::module_index::{ExportedOverload, ExportedParam, ExportedSub, ModuleExports, ResolveNotify, ResolveQueue, WorkspaceRootChannel};
-
-/// Hard timeout for parsing a single .pm file in a child process.
-#[cfg(not(test))]
-const PARSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Callback invoked after each module is resolved. Used to trigger diagnostic refresh.
 pub type OnResolved = Box<dyn Fn() + Send + Sync>;
@@ -340,162 +334,13 @@ fn rebuild_reverse_index(
 
 // ---- Module parsing ----
 
-/// In production: subprocess isolation with hard timeout (SIGKILL on hang).
-/// In tests: direct parsing (the test binary doesn't handle --parse-exports).
-#[cfg(not(test))]
-fn parse_module(inc_paths: &[PathBuf], module_name: &str) -> Option<ModuleExports> {
-    parse_in_subprocess(inc_paths, module_name)
-}
-
-#[cfg(test)]
+/// Parse a module file directly in-process.
+/// tree-sitter-perl is stable — no subprocess isolation needed.
 fn parse_module(inc_paths: &[PathBuf], module_name: &str) -> Option<ModuleExports> {
     let mut parser = create_parser();
     resolve_and_parse(inc_paths, module_name, &mut parser)
 }
 
-#[cfg(not(test))]
-fn parse_in_subprocess(inc_paths: &[PathBuf], module_name: &str) -> Option<ModuleExports> {
-    let path = resolve_module_path(inc_paths, module_name)?;
-    let metadata = std::fs::metadata(&path).ok()?;
-    let file_size = metadata.len();
-    if file_size > 1_000_000 {
-        log::warn!(
-            "Skipping '{}' — file too large ({} bytes): {:?}",
-            module_name,
-            file_size,
-            path
-        );
-        return None;
-    }
-    log::info!(
-        "Subprocess parse '{}' ({} bytes): {:?}",
-        module_name,
-        file_size,
-        path
-    );
-
-    let exe = std::env::current_exe().ok()?;
-    let mut child = std::process::Command::new(exe)
-        .arg("--parse-exports")
-        .arg(&path)
-        .arg(module_name)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let stdout = child.stdout.take()?;
-    let (tx, rx) = std::sync::mpsc::sync_channel(1);
-    std::thread::Builder::new()
-        .name(format!("read-{}", module_name))
-        .spawn(move || {
-            let result = std::io::read_to_string(stdout);
-            let _ = tx.send(result);
-        })
-        .ok()?;
-
-    let output = match rx.recv_timeout(PARSE_TIMEOUT) {
-        Ok(Ok(s)) => s,
-        _ => {
-            let _ = child.kill();
-            let _ = child.wait();
-            log::warn!("Timed out parsing module '{}'", module_name);
-            return None;
-        }
-    };
-    let _ = child.wait();
-
-    let json: serde_json::Value = serde_json::from_str(&output).ok()?;
-    let export: Vec<String> = json
-        .get("export")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-    let export_ok: Vec<String> = json
-        .get("export_ok")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Parse subs metadata from JSON
-    let subs: HashMap<String, ExportedSub> = json
-        .get("subs")
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter().filter_map(|(name, val)| {
-                let def_line = val.get("def_line").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-                let is_method = val.get("is_method").and_then(|v| v.as_bool()).unwrap_or(false);
-                let params = val.get("params")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().filter_map(|p| {
-                        Some(ExportedParam {
-                            name: p.get("name")?.as_str()?.to_string(),
-                            is_slurpy: p.get("is_slurpy").and_then(|v| v.as_bool()).unwrap_or(false),
-                            inferred_type: p.get("type").and_then(|v| v.as_str()).map(|s| s.to_string()),
-                        })
-                    }).collect())
-                    .unwrap_or_default();
-                let return_type = val.get("return_type")
-                    .and_then(|v| v.as_str())
-                    .and_then(inferred_type_from_tag);
-                let hash_keys = val.get("hash_keys")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                    .unwrap_or_default();
-                let doc = val.get("doc")
-                    .and_then(|v| v.as_str())
-                    .map(String::from);
-                let overloads = val.get("overloads")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().filter_map(|o| {
-                        let ol_params = o.get("params")
-                            .and_then(|p| p.as_array())
-                            .map(|pa| pa.iter().filter_map(|pv| {
-                                let pname = pv.get("name")?.as_str()?.to_string();
-                                let slurpy = pv.get("is_slurpy").and_then(|v| v.as_bool()).unwrap_or(false);
-                                let inferred_type = pv.get("type").and_then(|v| v.as_str()).map(String::from);
-                                Some(ExportedParam { name: pname, is_slurpy: slurpy, inferred_type })
-                            }).collect())
-                            .unwrap_or_default();
-                        let ol_rt = o.get("return_type")
-                            .and_then(|v| v.as_str())
-                            .and_then(inferred_type_from_tag);
-                        Some(ExportedOverload { params: ol_params, return_type: ol_rt })
-                    }).collect())
-                    .unwrap_or_default();
-                Some((name.clone(), ExportedSub { def_line, params, is_method, return_type, hash_keys, doc, overloads }))
-            }).collect()
-        })
-        .unwrap_or_default();
-
-    // Extract parents from subprocess JSON
-    let parents: Vec<String> = json
-        .get("parents")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    Some(ModuleExports {
-        path,
-        export,
-        export_ok,
-        subs,
-        parents,
-    })
-}
 
 /// Collect export metadata from a FileAnalysis for a set of export names.
 /// Returns (subs, parents) ready for serialization or direct use.
@@ -622,86 +467,6 @@ fn collect_export_metadata(
     (subs, parents)
 }
 
-/// Entry point for `--parse-exports <path> [module_name]` subprocess mode.
-pub fn subprocess_main(path: &str, module_name: Option<&str>) {
-    let source = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(_) => {
-            println!("{{}}");
-            return;
-        }
-    };
-    let mut parser = create_parser();
-
-    let tree = match parser.parse(&source, None) {
-        Some(t) => t,
-        None => {
-            println!("{{}}");
-            return;
-        }
-    };
-
-    let analysis = crate::builder::build(&tree, source.as_bytes());
-    let export = &analysis.export;
-    let export_ok = &analysis.export_ok;
-    let (subs, parents) = collect_export_metadata(&analysis, export, export_ok, module_name);
-
-    // Serialize to JSON for subprocess IPC
-    let mut subs_map = serde_json::Map::new();
-    for (name, sub) in &subs {
-        let mut sub_info = serde_json::Map::new();
-        sub_info.insert("def_line".into(), sub.def_line.into());
-        sub_info.insert("is_method".into(), sub.is_method.into());
-        let params_json: Vec<serde_json::Value> = sub.params.iter()
-            .map(|p| {
-                let mut obj = serde_json::json!({ "name": p.name, "is_slurpy": p.is_slurpy });
-                if let Some(ref ty) = p.inferred_type {
-                    obj["type"] = serde_json::Value::String(ty.clone());
-                }
-                obj
-            })
-            .collect();
-        sub_info.insert("params".into(), params_json.into());
-        if let Some(ref d) = sub.doc {
-            sub_info.insert("doc".into(), serde_json::Value::String(d.clone()));
-        }
-        if let Some(ref ty) = sub.return_type {
-            sub_info.insert("return_type".into(),
-                serde_json::Value::String(inferred_type_to_tag(ty)));
-        }
-        if !sub.hash_keys.is_empty() {
-            sub_info.insert("hash_keys".into(), serde_json::json!(sub.hash_keys));
-        }
-        if !sub.overloads.is_empty() {
-            let overloads: Vec<serde_json::Value> = sub.overloads.iter().map(|ol| {
-                let ol_params: Vec<serde_json::Value> = ol.params.iter()
-                    .map(|p| {
-                        let mut obj = serde_json::json!({ "name": p.name, "is_slurpy": p.is_slurpy });
-                        if let Some(ref ty) = p.inferred_type {
-                            obj["type"] = serde_json::Value::String(ty.clone());
-                        }
-                        obj
-                    })
-                    .collect();
-                let mut overload = serde_json::json!({ "params": ol_params });
-                if let Some(ref rt) = ol.return_type {
-                    overload["return_type"] = serde_json::Value::String(inferred_type_to_tag(rt));
-                }
-                overload
-            }).collect();
-            sub_info.insert("overloads".into(), serde_json::json!(overloads));
-        }
-        subs_map.insert(name.clone(), sub_info.into());
-    }
-
-    let json = serde_json::json!({
-        "export": export,
-        "export_ok": export_ok,
-        "subs": subs_map,
-        "parents": parents,
-    });
-    println!("{}", json);
-}
 
 pub fn create_parser() -> Parser {
     let mut parser = Parser::new();

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -531,6 +531,58 @@ pub fn discover_inc_paths() -> Vec<PathBuf> {
 }
 
 
+/// Index all Perl files in a workspace directory using Rayon for parallelism.
+/// Returns the number of successfully indexed files.
+pub fn index_workspace(
+    root: &std::path::Path,
+    index: &DashMap<PathBuf, crate::file_analysis::FileAnalysis>,
+) -> usize {
+    use ignore::types::TypesBuilder;
+    use ignore::WalkBuilder;
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let mut types_builder = TypesBuilder::new();
+    types_builder.add("perl", "*.pm").unwrap();
+    types_builder.add("perl", "*.pl").unwrap();
+    types_builder.add("perl", "*.t").unwrap();
+    types_builder.select("perl");
+    let types = types_builder.build().unwrap();
+
+    let files: Vec<PathBuf> = WalkBuilder::new(root)
+        .types(types)
+        .build()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|e| e.metadata().map(|m| m.len() < 1_000_000).unwrap_or(false))
+        .map(|e| e.into_path())
+        .collect();
+
+    let count = AtomicUsize::new(0);
+
+    files.par_iter().for_each(|path| {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let source = std::fs::read_to_string(path).ok()?;
+            let mut parser = create_parser();
+            let tree = parser.parse(&source, None)?;
+            Some(crate::builder::build(&tree, source.as_bytes()))
+        }));
+
+        match result {
+            Ok(Some(analysis)) => {
+                index.insert(path.clone(), analysis);
+                count.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(None) => { /* parse failed, skip */ }
+            Err(_) => {
+                log::warn!("Panic while indexing {:?}, skipping", path);
+            }
+        }
+    });
+
+    count.load(Ordering::Relaxed)
+}
+
 /// Scan @INC directories for .pm files, populating the available_modules map.
 /// Fast — no file reads, just directory traversal + path→module name conversion.
 fn scan_inc_module_names(inc_paths: &[PathBuf], available: &DashMap<String, PathBuf>) {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -222,8 +222,12 @@ pub fn rename(
     pos: Position,
     uri: &Url,
     new_name: &str,
+    tree: Option<&tree_sitter::Tree>,
+    source: Option<&str>,
 ) -> Option<WorkspaceEdit> {
-    let edits = analysis.rename_at(position_to_point(pos), new_name)?;
+    let edits = analysis.rename_at_with_tree(
+        position_to_point(pos), new_name, tree, source.map(|s| s.as_bytes()),
+    )?;
 
     let text_edits: Vec<TextEdit> = edits
         .into_iter()

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -20,11 +20,11 @@ fn point_to_position(p: Point) -> Position {
     }
 }
 
-fn position_to_point(pos: Position) -> Point {
+pub fn position_to_point(pos: Position) -> Point {
     Point::new(pos.line as usize, pos.character as usize)
 }
 
-fn span_to_range(span: Span) -> Range {
+pub fn span_to_range(span: Span) -> Range {
     Range {
         start: point_to_position(span.start),
         end: point_to_position(span.end),

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -74,6 +74,27 @@ pub fn extract_symbols(analysis: &FileAnalysis) -> Vec<DocumentSymbol> {
         .collect()
 }
 
+#[allow(deprecated)]
+pub fn symbol_to_workspace_info(sym: &crate::file_analysis::Symbol, uri: Url) -> Option<SymbolInformation> {
+    use crate::file_analysis::SymKind as FaSymKind;
+    // Only include significant symbols (subs, methods, packages, classes)
+    match sym.kind {
+        FaSymKind::Sub | FaSymKind::Method | FaSymKind::Package | FaSymKind::Class => {}
+        _ => return None,
+    }
+    Some(SymbolInformation {
+        name: sym.name.clone(),
+        kind: fa_sym_kind_to_lsp(&sym.kind),
+        tags: None,
+        deprecated: None,
+        location: Location {
+            uri,
+            range: span_to_range(sym.selection_span),
+        },
+        container_name: sym.package.clone(),
+    })
+}
+
 pub fn find_definition(
     analysis: &FileAnalysis,
     pos: Position,

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -225,7 +225,7 @@ pub fn rename(
     tree: Option<&tree_sitter::Tree>,
     source: Option<&str>,
 ) -> Option<WorkspaceEdit> {
-    let edits = analysis.rename_at_with_tree(
+    let edits = analysis.rename_at(
         position_to_point(pos), new_name, tree, source.map(|s| s.as_bytes()),
     )?;
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -178,7 +178,7 @@ pub fn find_definition(
         }
 
         // Cross-file method goto-def: resolve inherited methods through module index
-        if let RefKind::MethodCall { ref invocant, ref invocant_span } = r.kind {
+        if let RefKind::MethodCall { ref invocant, ref invocant_span, .. } = r.kind {
             use crate::file_analysis::MethodResolution;
             let class_name = analysis.resolve_method_invocant_public(
                 invocant, invocant_span, r.scope, point, Some(tree), Some(source.as_bytes()), Some(module_index),
@@ -1187,7 +1187,7 @@ pub fn collect_diagnostics(analysis: &FileAnalysis, module_index: &ModuleIndex) 
     ];
     for r in &analysis.refs {
         let (invocant, _invocant_span) = match &r.kind {
-            RefKind::MethodCall { invocant, invocant_span } => (invocant, invocant_span),
+            RefKind::MethodCall { invocant, invocant_span, .. } => (invocant, invocant_span),
             _ => continue,
         };
         let method_name = &r.target_name;

--- a/test_e2e.lua
+++ b/test_e2e.lua
@@ -301,6 +301,38 @@ t.test("completion detail: $calc->get_self shows return type", function()
   if t.ok(N, found, "no 'get_self' completion with Calculator detail") then t.pass(N) end
 end)
 
+-- ── rename ───────────────────────────────────────────────────────────
+
+t.test("rename: $pi → $tau updates all occurrences", function()
+  local N = "rename: $pi → $tau updates all occurrences"
+  local line, col = b.find_pos(buf, "my $pi = 3.14159")
+  if not t.ok(N, line, "couldn't find '$pi' declaration") then return end
+
+  -- Perform the rename
+  local edit = lsp.rename(buf, line, col + 3, "tau")
+  if not t.ok(N, edit, "rename returned no edit") then return end
+
+  -- Apply + verify
+  lsp.apply_workspace_edit(edit)
+  b.invalidate()
+  local lines = b.get_lines(buf)
+  local found_old = false
+  local found_new = false
+  for _, l in ipairs(lines) do
+    if l:find("$pi", 1, true) and not l:find("$pid", 1, true) then found_old = true end
+    if l:find("$tau", 1, true) then found_new = true end
+  end
+
+  -- Undo to restore original content
+  vim.cmd("silent undo")
+  b.invalidate()
+  -- Wait for the LSP to re-parse after undo
+  vim.wait(500)
+
+  if not t.ok(N, not found_old, "old name $pi still found after rename") then return end
+  if t.ok(N, found_new, "new name $tau should appear after rename") then t.pass(N) end
+end)
+
 -- ── diagnostics ──────────────────────────────────────────────────────
 
 lsp.assert_no_diagnostics(t, buf)

--- a/test_e2e.lua
+++ b/test_e2e.lua
@@ -333,6 +333,27 @@ t.test("rename: $pi → $tau updates all occurrences", function()
   if t.ok(N, found_new, "new name $tau should appear after rename") then t.pass(N) end
 end)
 
+t.test("rename: host → hostname from deref access site", function()
+  local N = "rename: host → hostname from deref access site"
+  -- Cursor on "host" in $db_config->{host} — the access side has a HashKeyAccess ref
+  local line, col = b.find_pos(buf, "$db_config->{host}")
+  if not t.ok(N, line, "couldn't find '$db_config->{host}'") then return end
+
+  -- Position on "host" inside the braces (col + 13)
+  local edit = lsp.rename(buf, line, col + 13, "hostname")
+  if not t.ok(N, edit, "rename returned no edit") then return end
+  if not t.ok(N, edit.changes, "rename has no changes") then return end
+
+  local total = 0
+  for _, edits in pairs(edit.changes) do
+    total = total + #edits
+  end
+  -- Should find: hash key def (host =>) + access ($db_config->{host}) + chained access
+  if t.ok(N, total >= 2, string.format("should have ≥2 edits (def + access), got %d", total)) then
+    t.pass(N)
+  end
+end)
+
 -- ── diagnostics ──────────────────────────────────────────────────────
 
 lsp.assert_no_diagnostics(t, buf)

--- a/test_e2e_frameworks.lua
+++ b/test_e2e_frameworks.lua
@@ -216,7 +216,30 @@ t.test("hover: $dynamic_title from $mojo->$get_title() shows String", function()
   end
 end)
 
--- ── 8. No unexpected diagnostics ─────────────────────────────────────
+-- ── 8. Moo constructor arg rename ────────────────────────────────────
+
+t.test("rename: 'name' constructor arg produces edits at has + call site", function()
+  local N = "rename: 'name' constructor arg produces edits at has + call site"
+  -- Cursor on "name" in MooApp->new(name => 'alice', ...)
+  local line, col = b.find_pos(buf, "MooApp->new(name =>")
+  if not t.ok(N, line, "couldn't find constructor call") then return end
+
+  -- Position on "name" key — col + 12 puts us on 'name' after 'MooApp->new('
+  local edit = lsp.rename(buf, line, col + 12, "display_name")
+  if not t.ok(N, edit, "rename returned no edit") then return end
+  if not t.ok(N, edit.changes, "rename has no changes") then return end
+
+  local total = 0
+  for _, edits in pairs(edit.changes) do
+    total = total + #edits
+  end
+  -- Should find at least: constructor arg (name =>) + has name definition = 2
+  if t.ok(N, total >= 2, string.format("should have ≥2 edits (has def + constructor arg), got %d", total)) then
+    t.pass(N)
+  end
+end)
+
+-- ── 9. No unexpected diagnostics ─────────────────────────────────────
 
 lsp.assert_no_diagnostics(t, buf)
 

--- a/test_e2e_inheritance.lua
+++ b/test_e2e_inheritance.lua
@@ -180,6 +180,31 @@ t.test("goto-def: 'BaseWorker' in use parent opens BaseWorker.pm", function()
   end
 end)
 
+-- ── 8. Cross-file rename ─────────────────────────────────────────────
+
+t.test("rename: process → execute produces edits in both files", function()
+  local N = "rename: process → execute produces edits in both files"
+  local line, col = b.find_pos(buf, "$worker->process()")
+  if not t.ok(N, line, "couldn't find '$worker->process()'") then return end
+
+  -- Request rename but DON'T apply — just check the edit structure
+  local edit = lsp.rename(buf, line, col + 10, "execute")
+  if not t.ok(N, edit, "rename returned no edit") then return end
+  if not t.ok(N, edit.changes, "rename has no changes") then return end
+
+  -- Should have edits in at least the current file
+  local has_local = false
+  local has_cross_file = false
+  for uri, _ in pairs(edit.changes) do
+    if uri:find("inheritance.pl", 1, true) then has_local = true end
+    if uri:find("BaseWorker.pm", 1, true) then has_cross_file = true end
+  end
+
+  local ok = t.ok(N, has_local, "should have edits in inheritance.pl")
+  ok = t.ok(N, has_cross_file, "should have edits in BaseWorker.pm (cross-file)") and ok
+  if ok then t.pass(N) end
+end)
+
 -- ── diagnostics ──────────────────────────────────────────────────────
 
 lsp.assert_no_diagnostics(t, buf)


### PR DESCRIPTION
## Summary

### Part D: Remove subprocess isolation (-253 lines)
- `parse_in_subprocess()`, `subprocess_main()`, `--parse-exports` CLI all deleted
- One unified `parse_module()` path for production and tests
- No more JSON serialization boundary, no more 5s timeout + SIGKILL

### Part A: Workspace indexing
- Parallel `index_workspace()` with Rayon across all `*.pm`/`*.pl`/`*.t` files
- `ignore` crate for `.gitignore` respect (skips `blib/`, `node_modules/`, etc.)
- `catch_unwind` per file, 1MB cap, background-spawned from `initialized()`
- File watchers for `workspace/didChangeWatchedFiles` (create/change/delete)

### Part B: `workspace/symbol`
- Searches open documents then workspace index
- Substring match on symbol name
- Returns subs, methods, packages, classes with location

## Test plan
- [x] 315 unit tests pass
- [x] 89 e2e tests pass (all 5 suites)
- [x] Zero warnings
- [ ] CI: Rust tests + e2e tests
- [ ] Manual: open workspace, verify "Go to Symbol in Workspace" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)