### PR TITLE
feat: rich semantic tokens — 10 token types, 9 modifiers

### DIFF
--- a/docs/prompt-release-distribution.md
+++ b/docs/prompt-release-distribution.md
@@ -389,6 +389,75 @@ Publish with `vsce package && vsce publish`. Requires a marketplace publisher ac
 
 You own the plugin. Update it to point to the binary from GitHub Releases. The extension implements `language_server_command()` in Rust WASM to download the appropriate platform binary.
 
+### 3h. Claude Code plugin
+
+Claude Code has a plugin marketplace with LSP support. Two JSON files in a repo:
+
+Create repo `tree-sitter-perl/perl-lsp-claude-code` (or subdirectory `editors/claude-code/`):
+
+**`.claude-plugin/plugin.json`:**
+```json
+{
+  "name": "perl-lsp",
+  "description": "Perl language intelligence — type inference, cross-file resolution, framework support (Moo/Moose/Mojo/DBIC), semantic diagnostics",
+  "version": "0.1.0",
+  "author": { "name": "tree-sitter-perl" },
+  "homepage": "https://github.com/tree-sitter-perl/perl-tree-sitter-lsp",
+  "repository": "https://github.com/tree-sitter-perl/perl-tree-sitter-lsp",
+  "lspServers": {
+    "perl": {
+      "command": "perl-lsp",
+      "args": [],
+      "extensionToLanguage": {
+        ".pl": "perl",
+        ".pm": "perl",
+        ".t": "perl"
+      }
+    }
+  }
+}
+```
+
+**`.lsp.json`:**
+```json
+{
+  "perl": {
+    "command": "perl-lsp",
+    "args": [],
+    "extensionToLanguage": { ".pl": "perl", ".pm": "perl", ".t": "perl" }
+  }
+}
+```
+
+Users install with:
+```bash
+cargo install perl-lsp             # get the binary
+# then in Claude Code:
+/plugin install perl-lsp            # enable the plugin
+```
+
+Claude Code will start perl-lsp automatically when opening Perl files and use:
+- Diagnostics for edit-diagnose-fix loops (catches typos in method names, unresolved imports)
+- Goto-def and references for understanding code before modifying it
+- Hover for type info and POD docs
+- Workspace symbols for navigating large codebases
+
+This is high-value for Claude Code's Perl comprehension — semantic understanding instead of pattern-matching on source text.
+
+### 3i. AI agent compatibility (Cursor, Windsurf, Continue, Cline, Aider)
+
+The VS Code extension (3f) automatically covers **five AI coding tools**:
+
+| Tool | How they get perl-lsp | What they use |
+|------|----------------------|---------------|
+| **Cursor** | VS Code extension (Cursor is a fork) | All 17 LSP features + AI uses diagnostics as context |
+| **Windsurf** | VS Code extension (also a fork) | All LSP features |
+| **Continue** | VS Code extension (inherits via host editor) | Diagnostics via `@problems` context, symbols |
+| **Cline** | VS Code extension (inherits via host editor) | Diagnostics for agentic edit-diagnose-fix loops |
+| **Aider** | `--lint-cmd "perl-lsp --check ."` config | Diagnostics via CLI (already built) |
+
+No extra work needed for Cursor/Windsurf/Continue/Cline — the VS Code extension is sufficient. For Aider, users configure `--lint-cmd` to point at our `--check` CLI mode.
+
 ---
 
 ## Phase 4: Project polish for release
@@ -436,7 +505,9 @@ Add MIT LICENSE file to the repo root if not already present.
 | **7** | Helix PR | Helix users |
 | **8** | Emacs lsp-mode PR | Emacs users |
 | **9** | Homebrew tap | macOS/Linux users |
-| **10** | VS Code extension | VS Code users (biggest audience) |
+| **10** | VS Code extension | VS Code + Cursor + Windsurf + Continue + Cline users |
 | **11** | Zed extension update | Zed users |
+| **12** | Claude Code plugin | Claude Code users |
+| **13** | Aider docs | Aider users (just docs — `--check` CLI already works) |
 
-Steps 1-4 are the critical path. Steps 5-11 are all independent and can be done in any order / in parallel.
+Steps 1-4 are the critical path. Steps 5-13 are all independent and can be done in parallel. Step 10 (VS Code extension) has the highest reach — it covers 5 AI coding tools in one shot.

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2169,6 +2169,20 @@ impl FileAnalysis {
                         modifiers: 0,
                     });
                 }
+                SymKind::Sub => {
+                    tokens.push(PerlSemanticToken {
+                        span: sym.selection_span,
+                        token_type: TOK_FUNCTION,
+                        modifiers: 1 << MOD_DECLARATION,
+                    });
+                }
+                SymKind::Method => {
+                    tokens.push(PerlSemanticToken {
+                        span: sym.selection_span,
+                        token_type: TOK_METHOD,
+                        modifiers: 1 << MOD_DECLARATION,
+                    });
+                }
                 _ => {}
             }
         }
@@ -2179,6 +2193,10 @@ impl FileAnalysis {
             .collect();
 
         for r in &self.refs {
+            // Skip declaration refs — the symbol loop already emits tokens for declarations
+            if matches!(r.access, AccessKind::Declaration) {
+                continue;
+            }
             match &r.kind {
                 RefKind::Variable | RefKind::ContainerAccess => {
                     let sigil = r.target_name.chars().next().unwrap_or('$');
@@ -2227,6 +2245,8 @@ impl FileAnalysis {
         }
 
         tokens.sort_by_key(|t| (t.span.start.row, t.span.start.column));
+        // Dedup by position — if two tokens start at the same (row, col), keep the first
+        tokens.dedup_by(|b, a| a.span.start.row == b.span.start.row && a.span.start.column == b.span.start.column);
         tokens
     }
 }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2151,7 +2151,9 @@ impl FileAnalysis {
                         _ => continue,
                     };
                     let token_type = if is_self { TOK_KEYWORD } else if is_param { TOK_PARAMETER } else { TOK_VARIABLE };
-                    let mut mods = sigil_modifier(sigil) | (1 << MOD_DECLARATION);
+                    // Don't add sigil modifier for $self/$class — it would override the keyword color
+                    let mut mods = if is_self { 0 } else { sigil_modifier(sigil) };
+                    mods |= 1 << MOD_DECLARATION;
                     if is_readonly { mods |= 1 << MOD_READONLY; }
                     tokens.push(PerlSemanticToken { span: sym.selection_span, token_type, modifiers: mods });
                 }
@@ -2202,7 +2204,8 @@ impl FileAnalysis {
                     let sigil = r.target_name.chars().next().unwrap_or('$');
                     let is_self = r.target_name == "$self" || r.target_name == "$class";
                     let token_type = if is_self { TOK_KEYWORD } else { TOK_VARIABLE };
-                    let mut mods = sigil_modifier(sigil);
+                    // Don't add sigil modifier for $self/$class — it would override the keyword color
+                    let mut mods = if is_self { 0 } else { sigil_modifier(sigil) };
                     if matches!(r.access, AccessKind::Write) { mods |= 1 << MOD_MODIFICATION; }
                     tokens.push(PerlSemanticToken { span: r.span, token_type, modifiers: mods });
                 }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -369,27 +369,41 @@ pub struct OutlineSymbol {
 
 // ---- Semantic tokens ----
 
+// Token type/modifier indices — must match the order in semantic_token_types/modifiers().
+// Some are forward-declared for future phases.
+pub const TOK_VARIABLE: u32 = 0;
+pub const TOK_PARAMETER: u32 = 1;
+pub const TOK_FUNCTION: u32 = 2;
+pub const TOK_METHOD: u32 = 3;
+pub const TOK_MACRO: u32 = 4;
+pub const TOK_PROPERTY: u32 = 5;
+pub const TOK_NAMESPACE: u32 = 6;
+#[allow(dead_code)] pub const TOK_REGEXP: u32 = 7;
+#[allow(dead_code)] pub const TOK_ENUM_MEMBER: u32 = 8;
+pub const TOK_KEYWORD: u32 = 9;
+
+pub const MOD_DECLARATION: u32 = 0;
+pub const MOD_READONLY: u32 = 1;
+pub const MOD_MODIFICATION: u32 = 2;
+pub const MOD_DEFAULT_LIBRARY: u32 = 3;
+#[allow(dead_code)] pub const MOD_DEPRECATED: u32 = 4;
+#[allow(dead_code)] pub const MOD_STATIC: u32 = 5;
+pub const MOD_SCALAR: u32 = 6;
+pub const MOD_ARRAY: u32 = 7;
+pub const MOD_HASH: u32 = 8;
+
 #[derive(Debug, Clone)]
-pub struct SemanticVarToken {
+pub struct PerlSemanticToken {
     pub span: Span,
-    pub var_type: VarModifier,
-    pub is_declaration: bool,
-    pub is_modification: bool,
-    pub is_readonly: bool,
+    pub token_type: u32,
+    pub modifiers: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VarModifier {
-    Scalar,
-    Array,
-    Hash,
-}
-
-fn sigil_to_var_modifier(sigil: char) -> VarModifier {
+fn sigil_modifier(sigil: char) -> u32 {
     match sigil {
-        '@' => VarModifier::Array,
-        '%' => VarModifier::Hash,
-        _ => VarModifier::Scalar,
+        '@' => 1 << MOD_ARRAY,
+        '%' => 1 << MOD_HASH,
+        _ => 1 << MOD_SCALAR,
     }
 }
 
@@ -2116,51 +2130,100 @@ impl FileAnalysis {
     // ---- Semantic tokens ----
 
     /// Collect semantic tokens for all variable references and declarations.
-    pub fn semantic_tokens(&self) -> Vec<SemanticVarToken> {
-        let mut tokens: Vec<SemanticVarToken> = Vec::new();
+    pub fn semantic_tokens(&self) -> Vec<PerlSemanticToken> {
+        let mut tokens: Vec<PerlSemanticToken> = Vec::new();
 
-        // Variable declarations (from symbols)
+        // ---- Variable/parameter/self declarations from symbols ----
         for sym in &self.symbols {
-            if !matches!(sym.kind, SymKind::Variable | SymKind::Field) {
-                continue;
+            match sym.kind {
+                SymKind::Variable | SymKind::Field => {
+                    let (sigil, is_readonly, is_param, is_self) = match &sym.detail {
+                        SymbolDetail::Variable { sigil, decl_kind } => {
+                            let readonly = matches!(decl_kind, DeclKind::Field);
+                            let is_param = matches!(decl_kind, DeclKind::Param | DeclKind::ForVar);
+                            let is_self = (sym.name == "$self" || sym.name == "$class") && is_param;
+                            (*sigil, readonly, is_param, is_self)
+                        }
+                        SymbolDetail::Field { sigil, attributes } => {
+                            let readonly = !attributes.iter().any(|a| a == "writer" || a == "mutator" || a == "accessor");
+                            (*sigil, readonly, true, false)
+                        }
+                        _ => continue,
+                    };
+                    let token_type = if is_self { TOK_KEYWORD } else if is_param { TOK_PARAMETER } else { TOK_VARIABLE };
+                    let mut mods = sigil_modifier(sigil) | (1 << MOD_DECLARATION);
+                    if is_readonly { mods |= 1 << MOD_READONLY; }
+                    tokens.push(PerlSemanticToken { span: sym.selection_span, token_type, modifiers: mods });
+                }
+                SymKind::Package | SymKind::Class => {
+                    tokens.push(PerlSemanticToken {
+                        span: sym.selection_span,
+                        token_type: TOK_NAMESPACE,
+                        modifiers: 1 << MOD_DECLARATION,
+                    });
+                }
+                SymKind::Module => {
+                    tokens.push(PerlSemanticToken {
+                        span: sym.selection_span,
+                        token_type: TOK_NAMESPACE,
+                        modifiers: 0,
+                    });
+                }
+                _ => {}
             }
-            let (sigil, is_readonly) = match &sym.detail {
-                SymbolDetail::Variable { sigil, decl_kind } => {
-                    let readonly = matches!(decl_kind, DeclKind::Field);
-                    (*sigil, readonly)
-                }
-                SymbolDetail::Field { sigil, attributes } => {
-                    let readonly = !attributes.iter().any(|a| a == "writer" || a == "mutator" || a == "accessor");
-                    (*sigil, readonly)
-                }
-                _ => continue,
-            };
-            tokens.push(SemanticVarToken {
-                span: sym.selection_span,
-                var_type: sigil_to_var_modifier(sigil),
-                is_declaration: true,
-                is_modification: false,
-                is_readonly,
-            });
         }
 
-        // Variable references (from refs)
+        // ---- Refs: variables, functions, methods, properties, namespaces ----
+        let imported_names: std::collections::HashSet<&str> = self.imports.iter()
+            .flat_map(|imp| imp.imported_symbols.iter().map(|s| s.as_str()))
+            .collect();
+
         for r in &self.refs {
-            let sigil = match &r.kind {
-                RefKind::Variable => r.target_name.chars().next().unwrap_or('$'),
-                RefKind::ContainerAccess => {
-                    // Container access sigil is the displayed sigil, not the underlying
-                    r.target_name.chars().next().unwrap_or('$')
+            match &r.kind {
+                RefKind::Variable | RefKind::ContainerAccess => {
+                    let sigil = r.target_name.chars().next().unwrap_or('$');
+                    let is_self = r.target_name == "$self" || r.target_name == "$class";
+                    let token_type = if is_self { TOK_KEYWORD } else { TOK_VARIABLE };
+                    let mut mods = sigil_modifier(sigil);
+                    if matches!(r.access, AccessKind::Write) { mods |= 1 << MOD_MODIFICATION; }
+                    tokens.push(PerlSemanticToken { span: r.span, token_type, modifiers: mods });
                 }
-                _ => continue,
-            };
-            tokens.push(SemanticVarToken {
-                span: r.span,
-                var_type: sigil_to_var_modifier(sigil),
-                is_declaration: false,
-                is_modification: matches!(r.access, AccessKind::Write),
-                is_readonly: false,
-            });
+                RefKind::FunctionCall => {
+                    // Framework DSL keywords → macro, otherwise function
+                    let token_type = if self.framework_imports.contains(r.target_name.as_str()) {
+                        TOK_MACRO
+                    } else {
+                        TOK_FUNCTION
+                    };
+                    let mut mods = 0;
+                    if imported_names.contains(r.target_name.as_str()) {
+                        mods |= 1 << MOD_DEFAULT_LIBRARY;
+                    }
+                    tokens.push(PerlSemanticToken { span: r.span, token_type, modifiers: mods });
+                }
+                RefKind::MethodCall { method_name_span, .. } => {
+                    // Use method_name_span for precise highlighting of just the method name
+                    let mods = 0; // TODO: readonly for ro accessors, static for class methods
+                    tokens.push(PerlSemanticToken { span: *method_name_span, token_type: TOK_METHOD, modifiers: mods });
+                }
+                RefKind::PackageRef => {
+                    tokens.push(PerlSemanticToken { span: r.span, token_type: TOK_NAMESPACE, modifiers: 0 });
+                }
+                RefKind::HashKeyAccess { .. } => {
+                    tokens.push(PerlSemanticToken { span: r.span, token_type: TOK_PROPERTY, modifiers: 0 });
+                }
+            }
+        }
+
+        // ---- HashKeyDef symbols → property tokens ----
+        for sym in &self.symbols {
+            if matches!(sym.kind, SymKind::HashKeyDef) {
+                tokens.push(PerlSemanticToken {
+                    span: sym.selection_span,
+                    token_type: TOK_PROPERTY,
+                    modifiers: 1 << MOD_DECLARATION,
+                });
+            }
         }
 
         tokens.sort_by_key(|t| (t.span.start.row, t.span.start.column));

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2137,16 +2137,16 @@ impl FileAnalysis {
         for sym in &self.symbols {
             match sym.kind {
                 SymKind::Variable | SymKind::Field => {
-                    let (sigil, is_readonly, is_param, is_self) = match &sym.detail {
+                    let is_self = sym.name == "$self" || sym.name == "$class";
+                    let (sigil, is_readonly, is_param) = match &sym.detail {
                         SymbolDetail::Variable { sigil, decl_kind } => {
                             let readonly = matches!(decl_kind, DeclKind::Field);
                             let is_param = matches!(decl_kind, DeclKind::Param | DeclKind::ForVar);
-                            let is_self = (sym.name == "$self" || sym.name == "$class") && is_param;
-                            (*sigil, readonly, is_param, is_self)
+                            (*sigil, readonly, is_param)
                         }
                         SymbolDetail::Field { sigil, attributes } => {
                             let readonly = !attributes.iter().any(|a| a == "writer" || a == "mutator" || a == "accessor");
-                            (*sigil, readonly, true, false)
+                            (*sigil, readonly, true)
                         }
                         _ => continue,
                     };

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -5,7 +5,7 @@ use tree_sitter::{Point, Tree};
 use crate::cursor_context::{self, CursorContext};
 use crate::file_analysis::{
     contains_point, format_inferred_type, CompletionCandidate, FileAnalysis, FoldKind, InferredType,
-    OutlineSymbol, RefKind, Span, SymKind as FaSymKind, SymbolDetail, VarModifier,
+    OutlineSymbol, RefKind, Span, SymKind as FaSymKind, SymbolDetail,
     PRIORITY_AUTO_ADD_QW, PRIORITY_BARE_IMPORT, PRIORITY_EXPLICIT_IMPORT, PRIORITY_UNIMPORTED,
 };
 use crate::module_index::ExportedSub;
@@ -667,28 +667,34 @@ pub fn signature_help(
 
 // ---- Semantic tokens ----
 
-// Legend indices — must match the order in SEMANTIC_TOKEN_TYPES / SEMANTIC_TOKEN_MODIFIERS
-pub const TOKEN_TYPE_VARIABLE: u32 = 0;
-
-pub const TOKEN_MOD_DECLARATION: u32 = 0; // bit 0
-pub const TOKEN_MOD_READONLY: u32 = 1;    // bit 1
-pub const TOKEN_MOD_MODIFICATION: u32 = 2; // bit 2
-pub const TOKEN_MOD_SCALAR: u32 = 3;       // bit 3
-pub const TOKEN_MOD_ARRAY: u32 = 4;        // bit 4
-pub const TOKEN_MOD_HASH: u32 = 5;         // bit 5
+// Token type/modifier indices are defined in file_analysis.rs (TOK_*, MOD_*).
 
 pub fn semantic_token_types() -> Vec<SemanticTokenType> {
-    vec![SemanticTokenType::VARIABLE]
+    vec![
+        SemanticTokenType::VARIABLE,       // 0: variables
+        SemanticTokenType::PARAMETER,      // 1: sub parameters
+        SemanticTokenType::FUNCTION,       // 2: function calls
+        SemanticTokenType::METHOD,         // 3: method calls
+        SemanticTokenType::MACRO,          // 4: framework DSL keywords
+        SemanticTokenType::PROPERTY,       // 5: hash keys
+        SemanticTokenType::NAMESPACE,      // 6: package/class names
+        SemanticTokenType::REGEXP,         // 7: regex literals
+        SemanticTokenType::ENUM_MEMBER,    // 8: constants
+        SemanticTokenType::KEYWORD,        // 9: $self/$class
+    ]
 }
 
 pub fn semantic_token_modifiers() -> Vec<SemanticTokenModifier> {
     vec![
-        SemanticTokenModifier::DECLARATION,
-        SemanticTokenModifier::READONLY,
-        SemanticTokenModifier::MODIFICATION,
-        SemanticTokenModifier::new("scalar"),
-        SemanticTokenModifier::new("array"),
-        SemanticTokenModifier::new("hash"),
+        SemanticTokenModifier::DECLARATION,      // 0
+        SemanticTokenModifier::READONLY,         // 1
+        SemanticTokenModifier::MODIFICATION,     // 2
+        SemanticTokenModifier::DEFAULT_LIBRARY,  // 3
+        SemanticTokenModifier::DEPRECATED,       // 4
+        SemanticTokenModifier::STATIC,           // 5
+        SemanticTokenModifier::new("scalar"),    // 6
+        SemanticTokenModifier::new("array"),     // 7
+        SemanticTokenModifier::new("hash"),      // 8
     ]
 }
 
@@ -757,50 +763,34 @@ pub fn inlay_hints(analysis: &FileAnalysis, range: Range) -> Vec<InlayHint> {
 }
 
 pub fn semantic_tokens(analysis: &FileAnalysis) -> Vec<SemanticToken> {
-    let var_tokens = analysis.semantic_tokens();
+    let tokens = analysis.semantic_tokens();
 
     let mut result = Vec::new();
     let mut prev_line: u32 = 0;
     let mut prev_start: u32 = 0;
 
-    for vt in &var_tokens {
-        let line = vt.span.start.row as u32;
-        let start = vt.span.start.column as u32;
-        let length = if vt.span.start.row == vt.span.end.row {
-            vt.span.end.column as u32 - start
+    for t in &tokens {
+        let line = t.span.start.row as u32;
+        let start = t.span.start.column as u32;
+        let length = if t.span.start.row == t.span.end.row {
+            (t.span.end.column as u32).saturating_sub(start).max(1)
         } else {
-            1 // multi-line token, shouldn't happen for variables
+            1
         };
 
         let delta_line = line - prev_line;
         let delta_start = if delta_line == 0 {
-            start - prev_start
+            start.saturating_sub(prev_start)
         } else {
             start
         };
-
-        let mut modifiers: u32 = 0;
-        if vt.is_declaration {
-            modifiers |= 1 << TOKEN_MOD_DECLARATION;
-        }
-        if vt.is_readonly {
-            modifiers |= 1 << TOKEN_MOD_READONLY;
-        }
-        if vt.is_modification {
-            modifiers |= 1 << TOKEN_MOD_MODIFICATION;
-        }
-        match vt.var_type {
-            VarModifier::Scalar => modifiers |= 1 << TOKEN_MOD_SCALAR,
-            VarModifier::Array => modifiers |= 1 << TOKEN_MOD_ARRAY,
-            VarModifier::Hash => modifiers |= 1 << TOKEN_MOD_HASH,
-        }
 
         result.push(SemanticToken {
             delta_line,
             delta_start,
             length,
-            token_type: TOKEN_TYPE_VARIABLE,
-            token_modifiers_bitset: modifiers,
+            token_type: t.token_type,
+            token_modifiers_bitset: t.modifiers,
         });
 
         prev_line = line;

--- a/test_nvim_init.lua
+++ b/test_nvim_init.lua
@@ -213,6 +213,9 @@ vim.api.nvim_create_autocmd("LspAttach", {
 -- Semantic token highlight groups for perl-lsp
 -- Loud and distinct for QA — you should see every token type clearly.
 
+-- Boost semantic token priority so LSP tokens always win over base syntax
+vim.highlight.priorities.semantic_tokens = 200
+
 -- Token types — each gets a unique, bright, unmistakable color
 vim.api.nvim_set_hl(0, "@lsp.type.variable.perl", { fg = "#61afef" })         -- blue — scalars/arrays/hashes
 vim.api.nvim_set_hl(0, "@lsp.type.parameter.perl", { fg = "#ff9e64", bold = true }) -- orange bold — sub params

--- a/test_nvim_init.lua
+++ b/test_nvim_init.lua
@@ -221,7 +221,9 @@ vim.api.nvim_set_hl(0, "@lsp.type.method.perl", { fg = "#7dcfff" })           --
 vim.api.nvim_set_hl(0, "@lsp.type.macro.perl", { fg = "#bb9af7", bold = true }) -- purple bold — has/with/extends
 vim.api.nvim_set_hl(0, "@lsp.type.property.perl", { fg = "#73daca" })         -- teal — hash keys
 vim.api.nvim_set_hl(0, "@lsp.type.namespace.perl", { fg = "#e0af68", bold = true }) -- gold bold — Foo::Bar
-vim.api.nvim_set_hl(0, "@lsp.type.keyword.perl", { fg = "#ff007c", bold = true })  -- hot pink bold — $self/$class
+-- $self/$class: force hot pink even when base syntax tries to override (e.g. inside `my()`)
+vim.api.nvim_set_hl(0, "@lsp.type.keyword.perl", { fg = "#ff007c", bold = true })
+vim.api.nvim_set_hl(0, "@lsp.typemod.keyword.declaration.perl", { fg = "#ff007c", bold = true, underline = true })
 vim.api.nvim_set_hl(0, "@lsp.type.enumMember.perl", { fg = "#ff9e64", italic = true }) -- orange italic — constants
 vim.api.nvim_set_hl(0, "@lsp.type.regexp.perl", { fg = "#9ece6a" })           -- green — regex
 

--- a/test_nvim_init.lua
+++ b/test_nvim_init.lua
@@ -210,11 +210,21 @@ vim.api.nvim_create_autocmd("LspAttach", {
   end,
 })
 
--- Semantic token highlight groups for perl-lsp custom modifiers
--- These map @lsp.mod.<modifier>.perl to colors.
--- Adjust colors to taste — these are sensible defaults.
+-- Semantic token highlight groups for perl-lsp
+-- Token types
+vim.api.nvim_set_hl(0, "@lsp.type.macro.perl", { link = "Keyword" })      -- has, with, extends
+vim.api.nvim_set_hl(0, "@lsp.type.property.perl", { link = "Identifier" }) -- hash keys
+vim.api.nvim_set_hl(0, "@lsp.type.namespace.perl", { link = "Type" })     -- Foo::Bar
+vim.api.nvim_set_hl(0, "@lsp.type.parameter.perl", { link = "Special" })  -- sub params
+vim.api.nvim_set_hl(0, "@lsp.type.keyword.perl", { link = "Constant" })   -- $self/$class
+vim.api.nvim_set_hl(0, "@lsp.type.enumMember.perl", { link = "Constant" })-- constants
+vim.api.nvim_set_hl(0, "@lsp.type.regexp.perl", { link = "String" })      -- regex
+-- Custom modifiers
 vim.api.nvim_set_hl(0, "@lsp.mod.scalar.perl", { fg = "#61afef" })  -- blue
 vim.api.nvim_set_hl(0, "@lsp.mod.array.perl", { fg = "#c678dd" })  -- purple
 vim.api.nvim_set_hl(0, "@lsp.mod.hash.perl", { fg = "#e5c07b" })   -- gold
 vim.api.nvim_set_hl(0, "@lsp.mod.modification.perl", { fg = "#e06c75" })  -- red for writes
 vim.api.nvim_set_hl(0, "@lsp.mod.declaration.perl", { bold = true })
+vim.api.nvim_set_hl(0, "@lsp.mod.readonly.perl", { italic = true })
+vim.api.nvim_set_hl(0, "@lsp.mod.deprecated.perl", { strikethrough = true })
+vim.api.nvim_set_hl(0, "@lsp.mod.defaultLibrary.perl", { italic = true })

--- a/test_nvim_init.lua
+++ b/test_nvim_init.lua
@@ -211,20 +211,28 @@ vim.api.nvim_create_autocmd("LspAttach", {
 })
 
 -- Semantic token highlight groups for perl-lsp
--- Token types
-vim.api.nvim_set_hl(0, "@lsp.type.macro.perl", { link = "Keyword" })      -- has, with, extends
-vim.api.nvim_set_hl(0, "@lsp.type.property.perl", { link = "Identifier" }) -- hash keys
-vim.api.nvim_set_hl(0, "@lsp.type.namespace.perl", { link = "Type" })     -- Foo::Bar
-vim.api.nvim_set_hl(0, "@lsp.type.parameter.perl", { link = "Special" })  -- sub params
-vim.api.nvim_set_hl(0, "@lsp.type.keyword.perl", { link = "Constant" })   -- $self/$class
-vim.api.nvim_set_hl(0, "@lsp.type.enumMember.perl", { link = "Constant" })-- constants
-vim.api.nvim_set_hl(0, "@lsp.type.regexp.perl", { link = "String" })      -- regex
--- Custom modifiers
-vim.api.nvim_set_hl(0, "@lsp.mod.scalar.perl", { fg = "#61afef" })  -- blue
-vim.api.nvim_set_hl(0, "@lsp.mod.array.perl", { fg = "#c678dd" })  -- purple
-vim.api.nvim_set_hl(0, "@lsp.mod.hash.perl", { fg = "#e5c07b" })   -- gold
-vim.api.nvim_set_hl(0, "@lsp.mod.modification.perl", { fg = "#e06c75" })  -- red for writes
-vim.api.nvim_set_hl(0, "@lsp.mod.declaration.perl", { bold = true })
+-- Loud and distinct for QA — you should see every token type clearly.
+
+-- Token types — each gets a unique, bright, unmistakable color
+vim.api.nvim_set_hl(0, "@lsp.type.variable.perl", { fg = "#61afef" })         -- blue — scalars/arrays/hashes
+vim.api.nvim_set_hl(0, "@lsp.type.parameter.perl", { fg = "#ff9e64", bold = true }) -- orange bold — sub params
+vim.api.nvim_set_hl(0, "@lsp.type.function.perl", { fg = "#7aa2f7" })         -- bright blue — function calls
+vim.api.nvim_set_hl(0, "@lsp.type.method.perl", { fg = "#7dcfff" })           -- cyan — method calls
+vim.api.nvim_set_hl(0, "@lsp.type.macro.perl", { fg = "#bb9af7", bold = true }) -- purple bold — has/with/extends
+vim.api.nvim_set_hl(0, "@lsp.type.property.perl", { fg = "#73daca" })         -- teal — hash keys
+vim.api.nvim_set_hl(0, "@lsp.type.namespace.perl", { fg = "#e0af68", bold = true }) -- gold bold — Foo::Bar
+vim.api.nvim_set_hl(0, "@lsp.type.keyword.perl", { fg = "#ff007c", bold = true })  -- hot pink bold — $self/$class
+vim.api.nvim_set_hl(0, "@lsp.type.enumMember.perl", { fg = "#ff9e64", italic = true }) -- orange italic — constants
+vim.api.nvim_set_hl(0, "@lsp.type.regexp.perl", { fg = "#9ece6a" })           -- green — regex
+
+-- Modifiers — layer on top of type colors
+vim.api.nvim_set_hl(0, "@lsp.mod.declaration.perl", { bold = true, underline = true })
+vim.api.nvim_set_hl(0, "@lsp.mod.modification.perl", { fg = "#f7768e" })  -- red for writes
 vim.api.nvim_set_hl(0, "@lsp.mod.readonly.perl", { italic = true })
-vim.api.nvim_set_hl(0, "@lsp.mod.deprecated.perl", { strikethrough = true })
 vim.api.nvim_set_hl(0, "@lsp.mod.defaultLibrary.perl", { italic = true })
+vim.api.nvim_set_hl(0, "@lsp.mod.deprecated.perl", { strikethrough = true })
+
+-- Sigil overrides (these take priority over type colors for variables)
+vim.api.nvim_set_hl(0, "@lsp.mod.scalar.perl", { fg = "#61afef" })  -- blue
+vim.api.nvim_set_hl(0, "@lsp.mod.array.perl", { fg = "#c678dd" })   -- purple
+vim.api.nvim_set_hl(0, "@lsp.mod.hash.perl", { fg = "#e5c07b" })    -- gold


### PR DESCRIPTION
## Summary

Semantic tokens expanded from 1 type (variable) to 10 types with 9 modifiers. Perl code in any editor with LSP semantic highlighting now gets:

- **\$self/\$class** styled as keywords (like `self`/`this` in other languages)
- **Parameters** visually distinct from local variables
- **Framework DSL** (`has`, `with`, `extends`) highlighted as macros
- **Method calls** distinct from function calls
- **Hash keys** styled as properties (like field access in OOP languages)
- **Package names** colored as types/namespaces
- **Imported functions** get `defaultLibrary` modifier (italic in most themes)

### Token types
| Type | What |
|------|------|
| variable | `$x`, `@arr`, `%hash` |
| parameter | `$name` in `my ($self, $name) = @_` |
| keyword | `$self`, `$class` |
| function | `format_date()`, `croak()` |
| method | `$obj->process()` |
| macro | `has`, `with`, `extends`, `around` |
| property | `$obj->{name}`, `name => 'val'` |
| namespace | `Foo::Bar` in `use`/`package`/`class` |
| regexp | (forward-declared) |
| enumMember | (forward-declared) |

## Test plan
- [x] 317 unit tests pass
- [x] 93 e2e tests pass
- [x] Zero warnings
- [x] Nvim highlight config updated
- [ ] CI
- [ ] Manual: `./dev.sh test_files/frameworks.pl` — verify colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)