### PR TITLE
fix: route framework-synthesized accessors through the witness bag

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4277,6 +4277,83 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Publish a framework-synthesized accessor's return type into the
+    /// witness bag instead of relying solely on `Symbol.return_type`.
+    ///
+    /// `apply_type_overrides` (the plugin path) writes Plugin-priority
+    /// witnesses on `Symbol(_)` so the bag — the spec's "single
+    /// type-query path" — answers consistently with the symbol's
+    /// stored type. Framework accessors used to skip this and only set
+    /// `Symbol.return_type` directly. The dump-package round of QA
+    /// caught two consequences:
+    ///
+    ///   1. `symbol_witness_count: 0` for every Mojo::Base / Moo / DBIC
+    ///      accessor — bag-level introspection couldn't see them.
+    ///   2. Multi-arity sisters (Mojo::Base getter `name()` + writer
+    ///      `name($v)`) share a method name. `query_sub_return_type`
+    ///      finds the first `Symbol` by name and folds witnesses on
+    ///      that id; the writer's distinct return type was never
+    ///      visible. `level(1)` returned the getter's `String` instead
+    ///      of the invocant's `Mojo::Log`.
+    ///
+    /// This helper publishes both witnesses and the per-symbol
+    /// provenance entry. The two attachments cover the two query
+    /// shapes:
+    ///   - `Symbol(sym_id)` — bumps the symbol's witness count and
+    ///     handles per-symbol queries with an arity hint (e.g. the
+    ///     dump-package iteration).
+    ///   - `NamedSub(name)` — handles cross-symbol arity dispatch via
+    ///     `FluentArityDispatch`. The writer's `Some(1)` and the
+    ///     getter's `Some(0)` both attach here, and the reducer picks
+    ///     by `arity_hint` regardless of which sister `find()` returned.
+    ///
+    /// Source is `Builder("framework_accessor")` — core synthesis,
+    /// not a Plugin override. Provenance is `FrameworkSynthesis`
+    /// for the same reason; plugins are user-installed and
+    /// configurable, framework `has` synthesis is part of the
+    /// analyzer itself.
+    fn record_framework_accessor_witness(
+        &mut self,
+        sym_id: SymbolId,
+        name: &str,
+        arity: Option<u32>,
+        return_type: Option<InferredType>,
+        framework: &str,
+        reason: String,
+    ) {
+        use crate::witnesses::{
+            TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
+        };
+        let Some(rt) = return_type else { return };
+        let zero = Span {
+            start: Point { row: 0, column: 0 },
+            end: Point { row: 0, column: 0 },
+        };
+        let observation = TypeObservation::ArityReturn {
+            arg_count: arity,
+            return_type: rt,
+        };
+        self.bag.push(Witness {
+            attachment: WitnessAttachment::Symbol(sym_id),
+            source: WitnessSource::Builder("framework_accessor".to_string()),
+            payload: WitnessPayload::Observation(observation.clone()),
+            span: zero,
+        });
+        self.bag.push(Witness {
+            attachment: WitnessAttachment::NamedSub(name.to_string()),
+            source: WitnessSource::Builder("framework_accessor".to_string()),
+            payload: WitnessPayload::Observation(observation),
+            span: zero,
+        });
+        self.type_provenance.insert(
+            sym_id,
+            TypeProvenance::FrameworkSynthesis {
+                framework: framework.to_string(),
+                reason,
+            },
+        );
+    }
+
     fn visit_has_call(&mut self, node: Node<'a>, mode: FrameworkMode) {
         // Extract attribute names and options from the `has` call arguments.
         // CST: ambiguous_function_call_expression
@@ -4379,9 +4456,14 @@ impl<'a> Builder<'a> {
                 let is_rw = matches!(is, Some("rw"));
                 let is_rwp = matches!(is, Some("rwp"));
 
+                let framework = match mode {
+                    FrameworkMode::Moo => "Moo",
+                    FrameworkMode::Moose => "Moose",
+                    FrameworkMode::MojoBase => unreachable!(),
+                };
                 for (name, sel_span) in &attr_names {
                     // Getter (always present for ro/rw/lazy/rwp)
-                    self.add_symbol(
+                    let getter_id = self.add_symbol(
                         name.clone(),
                         SymKind::Method,
                         node_to_span(node),
@@ -4397,9 +4479,17 @@ impl<'a> Builder<'a> {
                     return_self_method: None,
                         },
                     );
+                    self.record_framework_accessor_witness(
+                        getter_id,
+                        name,
+                        Some(0),
+                        return_type.clone(),
+                        framework,
+                        format!("{} `has '{}'` getter (isa)", framework, name),
+                    );
                     // Setter for rw
                     if is_rw {
-                        self.add_symbol(
+                        let writer_id = self.add_symbol(
                             name.clone(),
                             SymKind::Method,
                             node_to_span(node),
@@ -4420,12 +4510,20 @@ impl<'a> Builder<'a> {
                     return_self_method: None,
                             },
                         );
+                        self.record_framework_accessor_witness(
+                            writer_id,
+                            name,
+                            Some(1),
+                            return_type.clone(),
+                            framework,
+                            format!("{} `has '{}'` rw writer", framework, name),
+                        );
                     }
                     // Private writer for rwp (Moo only)
                     if is_rwp {
                         let writer_name = format!("_set_{}", name);
-                        self.add_symbol(
-                            writer_name,
+                        let writer_id = self.add_symbol(
+                            writer_name.clone(),
                             SymKind::Method,
                             node_to_span(node),
                             *sel_span,
@@ -4445,6 +4543,14 @@ impl<'a> Builder<'a> {
                     return_self_method: None,
                             },
                         );
+                        self.record_framework_accessor_witness(
+                            writer_id,
+                            &writer_name,
+                            Some(1),
+                            return_type.clone(),
+                            framework,
+                            format!("{} `has '{}'` rwp private writer", framework, name),
+                        );
                     }
                 }
             }
@@ -4452,11 +4558,16 @@ impl<'a> Builder<'a> {
                 // Infer getter return type from default value if present
                 let getter_type = mojo_default_node
                     .and_then(|n| self.infer_expression_type(n, true));
+                let fluent_type = self
+                    .current_package
+                    .as_ref()
+                    .map(|pkg| InferredType::ClassName(pkg.clone()));
+                let framework = "Mojo::Base";
 
                 // Mojo::Base `has` produces getter + setter (two symbols)
                 for (name, sel_span) in &attr_names {
                     // Getter: no params, return type from default value (or None)
-                    self.add_symbol(
+                    let getter_id = self.add_symbol(
                         name.clone(),
                         SymKind::Method,
                         node_to_span(node),
@@ -4472,8 +4583,16 @@ impl<'a> Builder<'a> {
                     return_self_method: None,
                         },
                     );
+                    self.record_framework_accessor_witness(
+                        getter_id,
+                        name,
+                        Some(0),
+                        getter_type.clone(),
+                        framework,
+                        format!("Mojo::Base `has '{}'` getter (default-value type)", name),
+                    );
                     // Setter: fluent, returns $self for chaining
-                    self.add_symbol(
+                    let writer_id = self.add_symbol(
                         name.clone(),
                         SymKind::Method,
                         node_to_span(node),
@@ -4486,14 +4605,21 @@ impl<'a> Builder<'a> {
                     is_invocant: false,
                             }],
                             is_method: true,
-                            return_type: self.current_package.as_ref()
-                                .map(|pkg| InferredType::ClassName(pkg.clone())),
+                            return_type: fluent_type.clone(),
                             doc: None,
                             display: None,
                     hide_in_outline: false,
                     opaque_return: false,
                     return_self_method: None,
                         },
+                    );
+                    self.record_framework_accessor_witness(
+                        writer_id,
+                        name,
+                        Some(1),
+                        fluent_type.clone(),
+                        framework,
+                        format!("Mojo::Base `has '{}'` fluent writer (returns invocant)", name),
                     );
                 }
             }
@@ -4994,20 +5120,32 @@ impl<'a> Builder<'a> {
                 related_class.map(|c| InferredType::ClassName(c))
             };
 
-            self.add_symbol(
-                name,
+            let sym_id = self.add_symbol(
+                name.clone(),
                 SymKind::Method,
                 node_to_span(node),
                 sel_span,
                 SymbolDetail::Sub {
                     params: vec![],
                     is_method: true,
-                    return_type,
+                    return_type: return_type.clone(),
                     doc: None,
                     display: None,
                     hide_in_outline: false,
                     opaque_return: false,
                     return_self_method: None,
+                },
+            );
+            self.record_framework_accessor_witness(
+                sym_id,
+                &name,
+                Some(0),
+                return_type,
+                "DBIx::Class",
+                if is_resultset {
+                    format!("DBIx::Class resultset relationship `{}`", name)
+                } else {
+                    format!("DBIx::Class row relationship `{}`", name)
                 },
             );
         }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -3194,6 +3194,144 @@ has 'name';
     }
 }
 
+/// Regression test for QA finding B1 (refer to qa-workspace/qa-findings.md):
+/// Mojo::Base writer accessors lost their fluent invocant return type
+/// when queried through the bag at arity=1. The QA dump for
+/// `Mojo::Log::level` showed:
+///
+///   getter (params=0): raw=String,    bag=String     ← OK
+///   writer (params=1): raw=Mojo::Log, bag=String     ← BUG, getter's type
+///
+/// `query_sub_return_type` finds the *first* same-named symbol by name
+/// (the getter, since synthesis adds it first), folds witnesses on that
+/// id, and answers from the getter's stored `return_type`. The writer's
+/// distinct fluent type was never visible at the bag level — every
+/// `$ua->ca($f)->cert(...)` chain lost its receiver type at the second
+/// hop.
+///
+/// Fix: framework synthesis now publishes per-arity `ArityReturn`
+/// observations on `NamedSub(name)`, and `FluentArityDispatch` claims
+/// `NamedSub` so the right arm wins regardless of which sister
+/// `find()` returned. Also publishes the same observations on
+/// `Symbol(id)` so per-symbol introspection (`witness_count`,
+/// arity-aware queries on a specific id) works.
+#[test]
+fn test_mojo_base_writer_returns_invocant_via_bag() {
+    use crate::file_analysis::TypeProvenance;
+
+    let fa = build_fa(
+        "
+package MyLog;
+use Mojo::Base -base;
+
+has level => 'info';   # default value gives getter type = String
+has app;               # no default; getter has no return type
+",
+    );
+
+    // arity=1 → fluent writer must return the package class for chaining.
+    // Pre-fix this returned String (the getter's type) — that's the bug.
+    assert_eq!(
+        fa.sub_return_type_at_arity("level", Some(1)),
+        Some(InferredType::ClassName("MyLog".into())),
+        "Mojo::Base writer at arity=1 must return the invocant class for fluent chaining"
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("app", Some(1)),
+        Some(InferredType::ClassName("MyLog".into())),
+        "Mojo::Base writer with no default still returns the invocant class"
+    );
+
+    // arity=0 → getter returns its scalar accessor type.
+    assert_eq!(
+        fa.sub_return_type_at_arity("level", Some(0)),
+        Some(InferredType::String),
+        "Mojo::Base getter at arity=0 returns the default-value type"
+    );
+
+    // Both sister symbols carry per-symbol witnesses now (was 0 across
+    // every Mojo::* dump in the QA sweep).
+    let getter = fa
+        .symbols
+        .iter()
+        .find(|s| s.name == "level" && matches!(&s.detail, SymbolDetail::Sub { params, .. } if params.is_empty()))
+        .expect("getter symbol");
+    let writer = fa
+        .symbols
+        .iter()
+        .find(|s| s.name == "level" && matches!(&s.detail, SymbolDetail::Sub { params, .. } if params.len() == 1))
+        .expect("writer symbol");
+    let getter_witnesses = fa
+        .witnesses
+        .for_attachment(&crate::witnesses::WitnessAttachment::Symbol(getter.id))
+        .len();
+    let writer_witnesses = fa
+        .witnesses
+        .for_attachment(&crate::witnesses::WitnessAttachment::Symbol(writer.id))
+        .len();
+    assert!(getter_witnesses > 0, "getter must have at least one bag witness");
+    assert!(writer_witnesses > 0, "writer must have at least one bag witness");
+
+    // Provenance: each accessor flushes a FrameworkSynthesis entry, not
+    // PluginOverride (Mojo::Base synthesis is core, not a plugin).
+    match fa.return_type_provenance(writer.id) {
+        TypeProvenance::FrameworkSynthesis { framework, reason } => {
+            assert_eq!(framework, "Mojo::Base");
+            assert!(reason.contains("level"), "reason names the attribute");
+            assert!(
+                reason.contains("fluent") || reason.contains("writer"),
+                "reason describes the writer role"
+            );
+        }
+        other => panic!("writer provenance must be FrameworkSynthesis, got {other:?}"),
+    }
+    match fa.return_type_provenance(getter.id) {
+        TypeProvenance::FrameworkSynthesis { framework, .. } => {
+            assert_eq!(framework, "Mojo::Base");
+        }
+        other => panic!("getter provenance must be FrameworkSynthesis, got {other:?}"),
+    }
+}
+
+/// Mirror of B1 for Moo `is => 'rw'` writers — same shape, isa-typed
+/// rather than fluent. The writer reads back the isa type at arity=1.
+#[test]
+fn test_moo_rw_writer_returns_isa_type_via_bag() {
+    use crate::file_analysis::TypeProvenance;
+
+    let fa = build_fa(
+        "
+package Thing;
+use Moo;
+has size => (is => 'rw', isa => 'Int');
+",
+    );
+
+    // Both arities resolve to the isa-derived type.
+    assert_eq!(
+        fa.sub_return_type_at_arity("size", Some(0)),
+        Some(InferredType::Numeric),
+        "Moo getter returns isa type"
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("size", Some(1)),
+        Some(InferredType::Numeric),
+        "Moo rw writer returns isa type"
+    );
+
+    let writer = fa
+        .symbols
+        .iter()
+        .find(|s| s.name == "size" && matches!(&s.detail, SymbolDetail::Sub { params, .. } if params.len() == 1))
+        .expect("writer symbol");
+    match fa.return_type_provenance(writer.id) {
+        TypeProvenance::FrameworkSynthesis { framework, .. } => {
+            assert_eq!(framework, "Moo");
+        }
+        other => panic!("Moo writer provenance must be FrameworkSynthesis, got {other:?}"),
+    }
+}
+
 #[test]
 fn test_mojo_base_parent_inheritance() {
     let fa = build_fa(

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -560,6 +560,18 @@ pub enum TypeProvenance {
     /// _generate_route which the framework-aware reducer typed as
     /// ClassName(Route)".
     Delegation { kind: String, via: String },
+    /// Core framework synthesis — Mojo::Base / Moo / Moose `has`,
+    /// DBIx::Class `add_columns` / `has_many` / etc. The accessor
+    /// has no source body to fold; the type comes directly from the
+    /// declaration shape (Mojo writers always return the invocant;
+    /// Moo getters honour `isa`; DBIC relationships return the
+    /// related class). `framework` names the rule set
+    /// ("Mojo::Base" / "Moo" / "Moose" / "DBIx::Class") and
+    /// `reason` describes the specific accessor ("`has 'level'`
+    /// fluent writer", "DBIx::Class row relationship `book`").
+    /// Distinct from `PluginOverride` because plugins are user-installed
+    /// and configurable; framework synthesis is built into the analyzer.
+    FrameworkSynthesis { framework: String, reason: String },
 }
 
 /// Resolve a return type from a list of inferred types (one per return statement).

--- a/src/main.rs
+++ b/src/main.rs
@@ -811,6 +811,13 @@ fn cli_dump_package(root: &str, package_name: &str) {
                     "via": via,
                 }))
             }
+            file_analysis::TypeProvenance::FrameworkSynthesis { framework, reason } => {
+                Some(serde_json::json!({
+                    "kind": "FrameworkSynthesis",
+                    "framework": framework,
+                    "reason": reason,
+                }))
+            }
         };
 
         // Variables typed inside this sub's scope. Surfaces chain

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 13;
+pub const EXTRACT_VERSION: i64 = 14;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/type_inference_invariants_tests.rs
+++ b/src/type_inference_invariants_tests.rs
@@ -372,6 +372,10 @@ fn provenance_accessor_and_round_trip() {
             kind: "self_method_tail".into(),
             via: "_route".into(),
         },
+        TypeProvenance::FrameworkSynthesis {
+            framework: "Mojo::Base".into(),
+            reason: "fluent writer".into(),
+        },
     ];
     for orig in cases {
         let encoded = serde_json::to_string(&orig).expect("serialize");

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -226,11 +226,44 @@ impl FrameworkFact {
 /// Lightweight attachment-indexed bag. Kept separate from the raw
 /// witness vec so callers can iterate all witnesses for one attachment
 /// without scanning. Indexes are rebuilt on demand.
-#[derive(Debug, Default, Serialize, Deserialize)]
+///
+/// `index` is `serde(skip)` (cheap to recompute, redundant on disk),
+/// but every consumer that loads a `FileAnalysis` from bincode (the
+/// SQLite cache, the dump-package debug tool, the cross-file enrichment
+/// pass, …) routes through `Deserialize`. The custom `Deserialize` impl
+/// rebuilds the index so `for_attachment` queries answer correctly on
+/// the deserialized bag — without it, every reducer claims an empty
+/// witness slice and the bag silently returns `None`. Symptom: a
+/// freshly-built `FileAnalysis` answers correctly, but the same bytes
+/// after a serialize/deserialize round-trip don't. `--dump-package`'s
+/// own bincode copy hit exactly this.
+#[derive(Debug, Default, Serialize)]
 pub struct WitnessBag {
     witnesses: Vec<Witness>,
-    #[serde(skip, default)]
+    #[serde(skip)]
     index: HashMap<WitnessAttachment, Vec<usize>>,
+}
+
+impl<'de> Deserialize<'de> for WitnessBag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Helper struct mirrors the on-disk shape (just the witness
+        // vec — `index` is recomputed). Without an explicit helper the
+        // derived impl would expect both fields and fail bincode loads.
+        #[derive(Deserialize)]
+        struct WitnessBagOnDisk {
+            witnesses: Vec<Witness>,
+        }
+        let on_disk = WitnessBagOnDisk::deserialize(deserializer)?;
+        let mut bag = WitnessBag {
+            witnesses: on_disk.witnesses,
+            index: HashMap::new(),
+        };
+        bag.rebuild_index();
+        Ok(bag)
+    }
 }
 
 impl WitnessBag {
@@ -683,11 +716,23 @@ impl WitnessReducer for FluentArityDispatch {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        matches!(w.attachment, WitnessAttachment::Symbol(_))
-            && matches!(
-                w.payload,
-                WitnessPayload::Observation(TypeObservation::ArityReturn { .. })
-            )
+        // Two attachment shapes carry `ArityReturn` observations:
+        //   - `Symbol(_)` — single sub with internal arity branches
+        //     (`return X unless @_; return Y;`), one Symbol id, one
+        //     witness per arm.
+        //   - `NamedSub(_)` — multiple Symbol ids share a logical name
+        //     (Mojo::Base / Moo `has` synthesizes a getter and writer
+        //     under the same method name). Per-Symbol witnesses can't
+        //     dispatch across distinct symbols, so the framework
+        //     synthesis publishes name-keyed observations and this
+        //     reducer folds them at query time.
+        matches!(
+            w.attachment,
+            WitnessAttachment::Symbol(_) | WitnessAttachment::NamedSub(_)
+        ) && matches!(
+            w.payload,
+            WitnessPayload::Observation(TypeObservation::ArityReturn { .. })
+        )
     }
 
     fn reduce(&self, ws: &[&Witness], q: &ReducerQuery) -> ReducedValue {
@@ -1003,17 +1048,16 @@ pub fn query_sub_return_type(
         if let ReducedValue::Type(t) = reg.query(bag, &q) {
             return Some(t);
         }
-        // Fall back to the symbol's stored `return_type` — written
-        // by the bag-aware fold during build, so this is consistent.
-        if let crate::file_analysis::SymbolDetail::Sub { return_type, .. } = &sym.detail {
-            if let Some(t) = return_type {
-                return Some(t.clone());
-            }
-        }
     }
-    // Imported / cross-file: NamedSub attachment carries the type
-    // pushed by `enrich_imported_types_with_keys`. Same registry,
-    // same reducers — no parallel lookup.
+    // Name-keyed multi-dispatch and cross-file imports both ride
+    // `NamedSub` — frameworks like Mojo::Base publish per-arity
+    // observations on the logical name (one getter + one writer share
+    // it), and `enrich_imported_types_with_keys` mirrors imported
+    // return types here. We query this BEFORE falling back to the
+    // local symbol's stored `return_type`, otherwise the first matching
+    // Symbol's type would pre-empt the multi-dispatch answer (e.g.
+    // `level(1)` would return the getter's String instead of the
+    // writer's invocant ClassName).
     let att = WitnessAttachment::NamedSub(sub_name.to_string());
     let q = ReducerQuery {
         attachment: &att,
@@ -1024,6 +1068,17 @@ pub fn query_sub_return_type(
     };
     if let ReducedValue::Type(t) = reg.query(bag, &q) {
         return Some(t);
+    }
+    // Final fallback: the local symbol's stored `return_type`. This
+    // covers plain subs whose return came from the per-arm fold and
+    // got written back to `Symbol.return_type` directly, with no
+    // name-keyed observations published.
+    if let Some(sym) = local_sym {
+        if let crate::file_analysis::SymbolDetail::Sub { return_type, .. } = &sym.detail {
+            if let Some(t) = return_type {
+                return Some(t.clone());
+            }
+        }
     }
     None
 }


### PR DESCRIPTION
## Summary

- Mojo::Base / Moo / Moose / DBIC `has` accessors now publish per-arity `ArityReturn` observations into the witness bag. Fluent writers like `$ua->ca($f)->cert(...)` keep the receiver type at every hop — at the bag level, not just on `Symbol.return_type`. (Fixes QA finding **B1**: 69 broken Mojo::Base writers across the workspace sweep.)
- New `TypeProvenance::FrameworkSynthesis { framework, reason }` so `--dump-package` can answer "why does this return X?" for synthesized accessors. (`PluginOverride` would be misleading — framework synthesis is core, not a user plugin.)
- `WitnessBag::index` is `#[serde(skip)]`, which silently produced an empty index after every bincode round-trip (`--dump-package`, the SQLite cache loader). Custom `Deserialize` rebuilds it. This explains why the QA dumps reported `symbol_witness_count: 0` everywhere.

## Mechanism

The bug: `query_sub_return_type` does `symbols.iter().find(name match)` and folds witnesses for that one id. Mojo::Base synthesizes a getter (`params=0`) and writer (`params=1`) sharing the same method name; `find()` returns the getter, the writer's fluent type is invisible.

The fix is purely witness-shaped, no symbol-picking heuristics:
- Synthesis publishes `Observation(ArityReturn { arg_count, return_type })` on `Symbol(id)` and on `NamedSub(name)` — same shape any other multi-dispatch path can reuse.
- `FluentArityDispatch` now claims `NamedSub` too. With `arity_hint=Some(1)`, the writer's arm wins regardless of which sister `find()` returned.
- `query_sub_return_type` tries Symbol-attached witnesses → NamedSub-attached witnesses → stored `Symbol.return_type` fallback. Previously the stored fallback pre-empted the NamedSub query, so cross-symbol dispatch never got a turn.

`EXTRACT_VERSION` bumped 13 → 14 so cached modules re-resolve under the new shape.

## End-to-end check

```
=== level (params=0) ===
  bag_return_type_at_arity:  {'0': 'String', '1': 'MyLog'}
  symbol_witness_count:      1
  return_type_provenance:    FrameworkSynthesis (Mojo::Base, "has 'level' getter")

=== level (params=1) ===
  raw_return_type:           'MyLog'
  bag_return_type_at_arity:  {'0': 'String', '1': 'MyLog'}      ← was '1': 'String'
  symbol_witness_count:      1                                  ← was 0
  return_type_provenance:    FrameworkSynthesis (Mojo::Base, "fluent writer")
```

## Test plan

- [x] `cargo test` — 508 passed (was 506, +2 new direct regressions).
- [x] New `test_mojo_base_writer_returns_invocant_via_bag` reproduces the QA finding directly: asserts `level(1) → ClassName(MyLog)`, `level(0) → String`, `witness_count > 0`, provenance is `FrameworkSynthesis`.
- [x] Mirror `test_moo_rw_writer_returns_isa_type_via_bag` for Moo `is => 'rw'`.
- [x] Extended `TypeProvenance` serde round-trip with the new variant.
- [x] `--dump-package` against a fresh Mojo::Base workspace shows correct arity-dispatched bag types and provenance for getter, writer, and no-default cases.
- [ ] Re-run the QA `qa-workspace/` sweep against the cached @INC modules to confirm B1 cases are gone in the wild (cache will lazily re-resolve on `EXTRACT_VERSION` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)