### PR TITLE
refactor: bag-residual D2 — one Expr(Span) attachment for every expression

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ Four docs, one engine:
 ```
 staircase 1–4 (LANDED, PR #27) ─┐
                                  ├─▶ bag-residual D1 redo (LANDED dc4315f, with residue → D3)
-                                 ├─▶ bag-residual D2 (one expression attachment)
+                                 ├─▶ bag-residual D2 (LANDED — one expression attachment)
                                  ├─▶ bag-residual D3 (one attachment per fact, +D1 residue)
                                  ├─▶ bag-residual D4 (residual canonical-store cleanup)
                                  │       │
@@ -85,19 +85,30 @@ staircase 1–4 (LANDED, PR #27) ─┐
    (`refactor/bag-residual-d1-method-on-class`, commit `c322178`) was
    abandoned for being additive — its cautionary value preserved in
    the directive's "what NOT to repeat" section.
-2. **Bag-residual D2** — one `Expr(Span)` attachment for every expression value.
-   Kills `arm_payload`'s node-kind dispatch, `ReturnArm`, `last_expr_type`.
-   Unblocks sequence-types.
+2. **Bag-residual D2** — **LANDED** on
+   `refactor/bag-residual-d2-expr-attachment`. One `Expr(Span)`
+   attachment for every expression value. Killed `arm_payload`,
+   `ReturnArm`, `ReturnArmReturn`, `last_expr_type`,
+   `arm_types_per_ri` / `returns_by_scope` plumbing,
+   `collect_return_arm_types`. Added `expr_payload` (single
+   dispatch), `emit_expr_witness` (recursive arm population), and
+   `SymbolReturnArmFold` (1+-arm `resolve_return_type` for
+   Symbol-attached return arms; `BranchArmFold` keeps the ≥2 rule
+   for ternary RHS on Variable/Expr). Tests: 509 unit + 93 e2e
+   green. Unblocks sequence-types.
 3. **Bag-residual D3** — one attachment per fact, no source-tag claims. Kills
    `WitnessAttachment::NamedSub` and the source-tag claim filters in
    `SubReturnReducer` / `FrameworkAwareTypeFold`.
 4. **Bag-residual D4** (now smaller) — kill `FileAnalysis.type_constraints`
    as a write target, walk-time bag is live (no `pending_witnesses` staging,
-   no walk-time TC-first read), kill `last_expr_type` /
+   no walk-time TC-first read), kill the `last_expr_span` /
    `sub_return_delegations` / `self_method_tails` Builder maps as
-   bag-emit inputs. The field-deletion bullets that lived here moved
-   to D1 (and a "lazy cache" rebuild is explicitly **not** scheduled —
-   only add if profiling later shows the bag query is hot).
+   bag-emit inputs (D2 already replaced the type-typed `last_expr_type`
+   map with the structural `last_expr_span`; D4 routes that through
+   bag emissions too). The field-deletion bullets that lived here
+   moved to D1 (and a "lazy cache" rebuild is explicitly **not**
+   scheduled — only add if profiling later shows the bag query is
+   hot).
 5. **Sequence-types phases 1-3** on the clean foundation.
 6. **Residual Parts** (start with whichever is hurting most — likely Part 5b
    narrowing or Part 5c parametric types for DBIC, depending on workload).

--- a/docs/working-bag-residual.md
+++ b/docs/working-bag-residual.md
@@ -436,6 +436,25 @@ everything else is at most a derived index rebuilt from it.
       gets its own bag-routed answer (a `HashKeyOwnerEdge`?) or stays
       procedural and explicitly NOT a type-inference path.
 
+- [ ] **Collapse the per-arm Edge expansion in
+      `publish_return_arm_witnesses` and
+      `emit_branch_arm_witnesses_for_ternary`.** D2 left a residual
+      duplication of mechanism: when the return body (or the RHS of
+      `my $x = $c ? A : B`) is a ternary, the walker emits per-arm
+      `branch_arm` Edges *both* on `Expr(ternary_span)` (via
+      `emit_expr_witness`) *and* on the consumer attachment
+      (`Symbol(sub_id)` / `Variable($x)`). A single
+      `Edge(Expr(body_span))` from the consumer would be enough —
+      the registry's edge chase calls `BranchArmFold` on `Expr(_)`,
+      which already handles per-arm agreement. Both agreement and
+      disagreement traces fold to the same answer either way (today
+      and post-collapse), so this is purely a cleanup. After the
+      change, `publish_return_arm_witnesses` becomes
+      `emit_expr_witness(body); push Symbol(sid) ← Edge(Expr(body_span))`
+      with no ternary special-case, and
+      `emit_branch_arm_witnesses_for_ternary` becomes one Edge from
+      `Variable($x)` to `Expr(ternary_span)`.
+
 ---
 
 ## Roadmap — separate design session

--- a/docs/working-bag-residual.md
+++ b/docs/working-bag-residual.md
@@ -195,85 +195,83 @@ work. ROADMAP.md's rule applies: do not split a directive across PRs.
 
 ---
 
-## Directive 2 — All expressions are the same thing
+## Directive 2 — All expressions are the same thing — **LANDED**
 
-Arms aren't a separate concept. `return $x`, `return Foo->new`,
-`return $self->method`, `42 if cond else "x"` — every one of these is
-"the value of an expression." The current code special-cases:
+> **Status:** landed on `refactor/bag-residual-d2-expr-attachment`.
+> Every action item below shipped. The walker now publishes through
+> a single `Expr(Span)` attachment, the per-RI `arm_types_per_ri` /
+> `returns_by_scope` plumbing is gone, and `fold_per_sub_return_arms`
+> is one `query(Symbol(sid))` plus the implicit-last-expr fallback.
 
-- `arm_payload` (builder.rs:3591) dispatches on node kind to decide
-  bake-vs-Edge per arm shape. Strings, numbers, anon hashes,
-  arithmetic, regexp get baked; variables, method calls, function
-  calls get Edges; ternaries are recursed into; everything else
-  returns `None`.
-- `ReturnArm(Span)` is its own attachment kind, with its own reducer
-  (`ReturnArmReturn`).
-- The chain typer's `arm_types_per_ri` array threads bag-resolved arm
-  types alongside `ReturnInfo` records.
-- Variable reads, method-call results, and function-call results each
-  publish to a different attachment shape (`Variable`, `Expression(RefIdx)`,
-  `NamedSub`).
+### What landed
 
-The fix is one attachment that means "the value of the expression at
-this span," with every expression — literal, ref-bearing, or compound —
-publishing to it.
+- [x] **One expression attachment.** `WitnessAttachment::Expr(Span)`
+      replaces `ReturnArm(Span)` and is the new "value of this
+      expression" key. `Expression(RefIdx)` survives as ref metadata
+      (the method-call chain typer still reads it for receiver
+      resolution); the type answer for any rvalue expression rides
+      `Expr(span)`.
 
-**Action items.** Probably needs a short design session before
-implementation; flag the open questions inline.
+- [x] **Walker emits `Expr` witnesses uniformly.** `expr_payload`
+      is the single dispatch — literals bake `InferredType`, names
+      push `Edge(Variable{...})` / `Edge(NamedSub)` /
+      `Edge(Expression(refidx))`, ternaries push two `branch_arm`
+      Edges to each arm's `Expr(span)` and recurse so chained
+      ternaries each carry their own arm payloads.
 
-- [ ] **One expression attachment.** Candidate shape: `Expr(Span)` (or
-      `Node(NodeId)` if we want to key by AST node identity). Replaces
-      both `ReturnArm(Span)` and `Expression(RefIdx)`. Refs that are
-      expressions (method calls in rvalue position) keep their RefIdx
-      as metadata for non-type lookups (rename, ref_at) but the type
-      answer rides `Expr(span)`.
+- [x] **Killed `arm_payload`.** Replaced by `expr_payload` (every
+      rvalue node, not just return arms) and `emit_expr_witness`.
 
-- [ ] **Walker emits `Expr` witnesses uniformly.** Literals push
-      `InferredType` (closed under syntax — `42` is `Numeric`). Refs
-      push `Edge(Variable{...})` / `Edge(NamedSub)` / `Edge(MethodOnClass(...))`
-      to the resolution target. Compound exprs (ternary, do-block,
-      block-as-rvalue) push `Edge`s to each component's `Expr(span)`
-      and let `BranchArmFold` agree across them.
+- [x] **Killed `ReturnArm` and `ReturnArmReturn`.** `return EXPR` now
+      emits `Edge(Expr(body_span))` source `branch_arm` on
+      `Symbol(sub_id)`. Ternary returns expand to per-arm Edges so
+      BranchArmFold has the ≥2 arms it needs; non-ternary returns
+      go through the new `SymbolReturnArmFold` which accepts 1+ arms
+      via `resolve_return_type` (replaces the per-RI Vec fold).
 
-- [ ] **Kill `arm_payload`.** Its job is "given a node, what witness
-      shape?" — but every node in rvalue position needs the same shape
-      (an `Expr(span)` witness). The dispatch becomes one walker
-      callback that runs on every expression node.
+- [x] **Killed `last_expr_type`.** Replaced with `last_expr_span:
+      HashMap<ScopeId, Span>` — the fold reads `Expr(last_expr_span)`
+      via the bag, no side-channel type cache.
 
-- [ ] **Kill `ReturnArm` and `ReturnArmReturn`.** A `return EXPR`
-      becomes `Edge(Expr(expr_span))` on `Symbol(sub_id)` —
-      `BranchArmFold` already handles agreement across multiple
-      `branch_arm`-source witnesses on a sub.
+- [x] **Killed the `arm_types_per_ri` / `returns_by_scope` plumbing.**
+      `emit_arity_return_witnesses` queries `Expr(body_span)` per RI
+      inline; `fold_per_sub_return_arms` queries `Symbol(sub_id)`
+      directly with `last_expr_span` as the implicit-return fallback.
+      `collect_return_arm_types` and its tuple return are gone.
 
-- [ ] **Kill `last_expr_type`.** Implicit-last-expression-as-return is
-      just one more branch_arm-source `Edge(Expr(last_stmt_span))` on
-      `Symbol(sub_id)`. Same machinery as explicit returns; no
-      side-channel map.
+### Reducer shape
 
-- [ ] **Kill the `arm_types_per_ri` / `returns_by_scope` plumbing.**
-      Once arms are `Edge`s, `fold_per_sub_return_arms` is just
-      `query(Symbol(sid))` — the registry materializes the edges and
-      `BranchArmFold` agrees them.
+`SymbolReturnArmFold` is the new home for "this sub's return type
+agreed across its arms." It's distinct from `BranchArmFold` because
+the two have different agreement rules:
 
-**Open design questions, decide before starting.**
+- `BranchArmFold` (Variable + Expr): ≥2 arms must agree. A single
+  arm = inference fell short; surface ambiguity.
+- `SymbolReturnArmFold` (Symbol): 1+ arms via `resolve_return_type`.
+  A single `return X` IS the answer; multiple agreeing arms collapse
+  to that type; disagreement → None (with HashRef subsumed by Object).
 
-1. **`Span` vs `NodeId` keying.** Spans are stable across
-   serialize/deserialize and align with how `ReturnArm` is keyed today.
-   NodeIds are tighter against the AST but die at the cache boundary.
-   Recommend `Span`.
+Registered before `BranchArmFold` so the registry's first-match
+dispatch routes Symbol-attached witnesses through the Symbol-fold.
+Both reducers claim source `branch_arm` + payload `InferredType`,
+but their `claims` predicates filter by attachment shape, so they
+never fight over the same witness set.
 
-2. **Do refs keep `Expression(RefIdx)`?** Rename and "find references"
-   need ref-keyed lookup. Easiest: keep `RefIdx` as a non-type
-   side-index, route the type answer through `Expr(span)`, and let
-   `Expression(RefIdx)` fade to "the ref's metadata," not "the
-   expression's type."
+### Open design questions, resolved
 
-3. **Anonymous expressions that aren't refs** (a bare arithmetic
-   subexpression nested inside a return). Today they don't have an
-   attachment because no consumer asks. After the unification they
-   would — but only if something Edges to them. Lazy emission (only
-   when needed) is fine; the walker doesn't need to publish for every
-   span unconditionally.
+1. **`Span` vs `NodeId` keying.** Spans. They survive the cache
+   boundary; NodeIds don't.
+
+2. **Do refs keep `Expression(RefIdx)`?** Yes. The method-call chain
+   typer reads receiver-and-method-resolved types through it.
+   `expr_payload` Edges from `Expr(span)` to `Expression(refidx)` for
+   method-call rvalues, so the type answer still rides `Expr` —
+   `Expression(refidx)` is an internal hop, not a parallel attachment.
+
+3. **Anonymous compound expressions.** Lazy: the walker only emits
+   `Expr(span)` for nodes that have a payload via `expr_payload` (or
+   for ternaries via the `emit_expr_witness` recursion). Bare
+   subexpressions only get witnesses when something Edges to them.
 
 ---
 
@@ -418,9 +416,16 @@ everything else is at most a derived index rebuilt from it.
       route through `sub_return_type_at_arity(bare, Some(0))`. Becomes
       trivial after Directive 1 lands the unified attachment shape.
 
-- [ ] **Kill the Builder's `last_expr_type` map.** Already listed
-      under Directive 2 — repeated here because it's a dual-store, not
-      just an arm-special-case.
+- [x] **Kill the Builder's `last_expr_type` map.** Landed in
+      Directive 2. Replaced with `last_expr_span: HashMap<ScopeId, Span>`
+      whose value is the structural pointer to the implicit-return
+      span; the type rides the bag via `Expr(last_expr_span)`. D4
+      can still kill `last_expr_span` itself by emitting an
+      `Edge(Expr(span))` source `branch_arm` on `Symbol(sub_id)`
+      from the walker (so the implicit-return is just one more
+      arm), but that requires deciding when to flush "this is the
+      last statement we saw" — easiest at sub-body-close, which
+      means a small visit hook.
 
 - [ ] **Kill `sub_return_delegations` and `self_method_tails` Builder
       maps** as inputs to bag emission. After Directive 2, each return

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -718,7 +718,8 @@ fn raw_mid_op(node: tree_sitter::Node, source: &[u8]) -> String {
 /// left in this struct is what consumers still need at a glance:
 /// which sub the return belongs to, where it is, the arity bucket it
 /// gates on (for `emit_arity_return_witnesses`), and the body span
-/// (for the per-RI Expr query in `collect_return_arm_types`).
+/// (the `Expr(span)` key both `emit_arity_return_witnesses` and
+/// `fold_per_sub_return_arms` query inline via `bag_query_expr_span`).
 struct ReturnInfo {
     /// The scope (Sub/Method) this return belongs to.
     scope: ScopeId,
@@ -878,11 +879,12 @@ struct Builder<'a> {
     return_infos: Vec<ReturnInfo>,
     /// For each Sub/Method scope, the body span of the last
     /// top-level expression statement. Used as the implicit-return
-    /// query key — `collect_return_arm_types` reads `Expr(span)` for
-    /// scopes without an explicit `return`. Replaces the old
-    /// `last_expr_type: HashMap<ScopeId, Option<InferredType>>`
-    /// dual-store: types now ride the bag, this map only carries
-    /// the structural pointer to the source span.
+    /// query key — `fold_per_sub_return_arms` reads `Expr(span)` via
+    /// `bag_query_expr_span` for scopes without an explicit `return`.
+    /// Replaces the old `last_expr_type: HashMap<ScopeId,
+    /// Option<InferredType>>` dual-store: types now ride the bag,
+    /// this map only carries the structural pointer to the source
+    /// span.
     last_expr_span: std::collections::HashMap<ScopeId, Span>,
     /// For each Sub/Method scope whose last body statement is
     /// `shift->M(...)` or `$self->M(...)`: the method name M.
@@ -2069,7 +2071,7 @@ impl<'a> Builder<'a> {
                 }
                 self.visit_children(node);
                 if let Some(scope) = scope {
-                    self.publish_return_arm_witnesses(node, scope, span);
+                    self.publish_return_arm_witnesses(node, scope);
                 }
             }
 
@@ -3715,12 +3717,7 @@ impl<'a> Builder<'a> {
     ///   `bag_query_expr` (single-arm + multi-arm both go through
     ///   `resolve_return_type`, which accepts the single-arm case
     ///   that BranchArmFold deliberately rejects).
-    fn publish_return_arm_witnesses(
-        &mut self,
-        return_node: Node<'a>,
-        scope: ScopeId,
-        _span: Span,
-    ) {
+    fn publish_return_arm_witnesses(&mut self, return_node: Node<'a>, scope: ScopeId) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
         let body = match return_node.named_child(0) {
             Some(b) => b,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -172,7 +172,7 @@ fn build_with_plugins_inner(
         fold_ranges: Vec::new(),
         imports: Vec::new(),
         return_infos: Vec::new(),
-        last_expr_type: std::collections::HashMap::new(),
+        last_expr_span: std::collections::HashMap::new(),
         self_method_tails: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
         method_call_bindings: Vec::new(),
@@ -711,14 +711,14 @@ fn raw_mid_op(node: tree_sitter::Node, source: &[u8]) -> String {
 }
 
 /// Structural index of one return-expression in a sub body. Type
-/// information has moved to the bag — per-arm via
-/// `ReturnArm(span)`, per-sub via `Symbol(sub_id)`'s `branch_arm`
-/// witnesses (which are `Edge`s pointing at the per-arm attachment,
-/// chased by registry materialization at query time). What's left
-/// in this struct is the structure consumers still need to see at a
-/// glance: which sub the return belongs to, where it is, and which
-/// arity bucket it gates on (so `emit_arity_return_witnesses` can
-/// pair each arm's bag-resolved type with its arg-count).
+/// information lives in the bag: the body expression carries its own
+/// `Expr(body_span)` witnesses (literal types, Edges to Variable /
+/// NamedSub / Expression / nested Expr), and `Symbol(sub_id)` collects
+/// per-arm `branch_arm`-source `Edge(Expr(...))` witnesses. What's
+/// left in this struct is what consumers still need at a glance:
+/// which sub the return belongs to, where it is, the arity bucket it
+/// gates on (for `emit_arity_return_witnesses`), and the body span
+/// (for the per-RI Expr query in `collect_return_arm_types`).
 struct ReturnInfo {
     /// The scope (Sub/Method) this return belongs to.
     scope: ScopeId,
@@ -727,10 +727,13 @@ struct ReturnInfo {
     /// the bag-resolved arm type AT REDUCTION TIME. `None` for
     /// returns that aren't arity-gated.
     arity_branch: Option<ArityBranch>,
-    /// Span of the return-expression node. Doubles as the
-    /// `WitnessAttachment::ReturnArm(span)` key for per-arm bag
-    /// queries (collect_return_arm_types reads this).
+    /// Span of the return-expression node — kept for diagnostics and
+    /// for matching against arity-classification anchors.
     span: Span,
+    /// Span of the inner body expression (the `EXPR` in `return EXPR`).
+    /// Doubles as the `WitnessAttachment::Expr(span)` key the per-RI
+    /// fold reads. `None` for bare `return;` — those have no value.
+    body_span: Option<Span>,
 }
 
 /// If `return_node` is `return CALL`, where CALL is a simple named function
@@ -873,8 +876,14 @@ struct Builder<'a> {
     imports: Vec<Import>,
     /// Return values collected during the walk (explicit `return` + implicit last expr).
     return_infos: Vec<ReturnInfo>,
-    /// For each Sub/Method scope, the type of the last expression (implicit return).
-    last_expr_type: std::collections::HashMap<ScopeId, Option<InferredType>>,
+    /// For each Sub/Method scope, the body span of the last
+    /// top-level expression statement. Used as the implicit-return
+    /// query key — `collect_return_arm_types` reads `Expr(span)` for
+    /// scopes without an explicit `return`. Replaces the old
+    /// `last_expr_type: HashMap<ScopeId, Option<InferredType>>`
+    /// dual-store: types now ride the bag, this map only carries
+    /// the structural pointer to the source span.
+    last_expr_span: std::collections::HashMap<ScopeId, Span>,
     /// For each Sub/Method scope whose last body statement is
     /// `shift->M(...)` or `$self->M(...)`: the method name M.
     /// Perl's last statement returns, so if M is another method on
@@ -1334,7 +1343,7 @@ impl<'a> Builder<'a> {
             "method_call_expression" => {
                 // Constructor pattern is closed under syntax — bake
                 // before consulting the bag. Same shape the walker's
-                // `arm_payload` uses for return arms.
+                // `expr_payload` uses for every rvalue expression.
                 if let Some(class) = self.extract_constructor_class(node) {
                     return Some(InferredType::ClassName(class));
                 }
@@ -2031,14 +2040,15 @@ impl<'a> Builder<'a> {
             }
 
             // Return expressions → record structural facts pre-visit
-            // (scope, arity branch, span); emit per-arm + per-sub
-            // witnesses POST visit_children so the body's refs are
-            // already allocated. `arm_payload` for method-call arms
-            // returns `Edge(Expression(refidx))`; finding refidx
-            // requires the ref to exist, which requires the walker
-            // to have visited the method-call expression.
+            // (scope, arity branch, body span); emit per-expression +
+            // per-sub witnesses POST visit_children so the body's refs
+            // are already allocated. `expr_payload` for method-call
+            // bodies returns `Edge(Expression(refidx))`; finding
+            // refidx requires the ref to exist, which requires the
+            // walker to have visited the method-call expression.
             "return_expression" => {
                 let span = node_to_span(node);
+                let body_span = node.named_child(0).map(node_to_span);
                 let scope = self.enclosing_sub_scope();
                 if let Some(scope) = scope {
                     let arity_branch = classify_arity_branch(node, self.source);
@@ -2046,6 +2056,7 @@ impl<'a> Builder<'a> {
                         scope,
                         arity_branch,
                         span,
+                        body_span,
                     });
                     // If the return body is `return other()` (a direct call),
                     // record the delegation so hash-key ownership can walk
@@ -2059,35 +2070,21 @@ impl<'a> Builder<'a> {
                 self.visit_children(node);
                 if let Some(scope) = scope {
                     self.publish_return_arm_witnesses(node, scope, span);
-                    // Ternary returns: `return $c ? A : B;` — emit
-                    // per-arm branch_arm witnesses on the sub's
-                    // Symbol so BranchArmFold sees both arms
-                    // explicitly (agreement / disagreement surface
-                    // even when arm types are bag-resolved Edges).
-                    if let Some(child) = node.named_child(0) {
-                        if child.kind() == "conditional_expression" {
-                            if let Some(sub_name) = self.enclosing_sub_name() {
-                                if let Some(sym_id) = self.find_sub_symbol_for(&sub_name, scope) {
-                                    self.emit_branch_arm_witnesses(
-                                        child,
-                                        crate::witnesses::WitnessAttachment::Symbol(sym_id),
-                                        node,
-                                    );
-                                }
-                            }
-                        }
-                    }
                 }
             }
 
             // Expression statements inside sub bodies → track last
-            // expression type. Perl returns the last statement's
-            // value, so this IS the sub's implicit return.
+            // expression's body span for the implicit-return path.
+            // Perl returns the last statement's value, so this IS
+            // the sub's implicit return when there's no explicit
+            // `return`. Each top-level statement we visit overwrites
+            // the prior entry, so when the walk leaves the sub the
+            // map points at the genuinely-last statement.
             //
             // IMPORTANT: only statements at the sub body's TOP
             // level count. A `$self->M(...)` call buried inside a
             // `grep { … }` or an `if`-block is not the sub's
-            // return. Both `last_expr_type` and `self_method_tails`
+            // return. Both `last_expr_span` and `self_method_tails`
             // are gated on this — the outer block must be the
             // sub/method's direct body.
             "expression_statement" => {
@@ -2107,11 +2104,15 @@ impl<'a> Builder<'a> {
                         })
                         .unwrap_or(false);
                     if is_body_top_level {
-                        let child = node.named_child(0);
-                        let expr_type = child.and_then(|c| self.infer_expression_type(c));
-                        self.last_expr_type.insert(scope, expr_type);
-                        if let Some(c) = child {
-                            if let Some(method_name) = self.self_method_call_name(c) {
+                        if let Some(child) = node.named_child(0) {
+                            // Make sure the expression has Expr(span)
+                            // witnesses populated — `bag_query_expr_span`
+                            // resolves through them in the implicit-return
+                            // fallback. No-op for compound nodes whose
+                            // payload doesn't bake to a witness shape.
+                            self.emit_expr_witness(child);
+                            self.last_expr_span.insert(scope, node_to_span(child));
+                            if let Some(method_name) = self.self_method_call_name(child) {
                                 self.self_method_tails.insert(scope, method_name);
                             } else {
                                 // A non-self-method-tail top-level
@@ -3478,11 +3479,12 @@ impl<'a> Builder<'a> {
                 // Visit the RHS (may contain refs, calls, etc.)
                 self.visit_node(right);
 
-                // Branch-arm detection: if RHS is a ternary, emit one
-                // BranchArm witness per arm on the LHS variable. POST
-                // visit_node — needs the arms' refs to exist so
-                // arm_payload can resolve `Edge(Expression(refidx))`
-                // for method-call arms.
+                // Branch-arm detection: if RHS is a ternary, emit
+                // per-arm `branch_arm`-source `Edge(Expr(arm_span))`
+                // witnesses on the LHS variable, plus the arms' own
+                // Expr(span) payloads. POST visit_node — needs the
+                // arms' refs to exist so `expr_payload` can resolve
+                // `Edge(Expression(refidx))` for method-call arms.
                 if right.kind() == "conditional_expression" {
                     if let Some(vt) = self.get_var_text_from_lhs(left) {
                         self.emit_branch_arm_witnesses_for_ternary(&vt, right, node);
@@ -3556,59 +3558,23 @@ impl<'a> Builder<'a> {
         None
     }
 
-    /// Generic branch-arm emission. Walks both arms of a
-    /// `conditional_expression`, infers each arm's type, and pushes
-    /// `BranchArm` observations onto `attachment`. Use for:
-    ///   - `my $x = $c ? A : B;`        → Variable($x)
-    ///   - `if ($c) { return A } else { return B }` → Symbol(sub)
-    ///   - `return $c ? A : B;`         → Symbol(sub)
-    ///   - any chained ternary that feeds into an attachment-able
-    ///     consumer.
-    /// The reducer handles the agreement/disagreement policy — this
-    /// just emits evidence.
-    fn emit_branch_arm_witnesses(
-        &mut self,
-        cond_expr: Node<'a>,
-        attachment: crate::witnesses::WitnessAttachment,
-        context: Node<'a>,
-    ) {
-        use crate::witnesses::{Witness, WitnessSource};
-        let consequent = cond_expr.child_by_field_name("consequent");
-        let alternative = cond_expr.child_by_field_name("alternative");
-        let span = node_to_span(context);
-        for arm in [consequent, alternative].into_iter().flatten() {
-            let payload = self.arm_payload(arm);
-            if let Some(p) = payload {
-                self.pending_witnesses.push(Witness {
-                    attachment: attachment.clone(),
-                    source: WitnessSource::Builder("branch_arm".into()),
-                    payload: p,
-                    span,
-                });
-            }
-        }
-    }
-
-    /// Compute the right `WitnessPayload` shape for one arm of a
-    /// branch (ternary / if-else / arity-gated return). Direct
-    /// dispatch on node kind — no recursion through walker
-    /// inference. Three categories:
+    /// Compute the right `WitnessPayload` shape for an expression node.
+    /// Single dispatch — every rvalue node, whether it appears as a
+    /// return body, ternary arm, RHS of assignment, or anywhere else,
+    /// runs through here. Two categories:
     ///
     /// - **Closed under syntax** (literals, constructors, arithmetic,
     ///   regexp): walker bakes `InferredType(t)` from the node kind
     ///   alone. There's nothing to resolve — `42` is `Numeric` no
     ///   matter what.
-    /// - **Name-dependent** (variables, method calls, function
-    ///   calls): walker emits `Edge(...)` to the attachment that
-    ///   carries the resolved type. Registry materialization
-    ///   chases.
-    /// - **Compound** (ternary): returns `None`; the per-arm
-    ///   emission is handled by the caller via
-    ///   `emit_branch_arm_witnesses` (which loops over arms calling
-    ///   `arm_payload` recursively).
-    fn arm_payload(&self, arm: Node<'a>) -> Option<crate::witnesses::WitnessPayload> {
+    /// - **Name-dependent / compound** (variables, calls, ternaries):
+    ///   walker emits `Edge(...)` to the attachment that carries the
+    ///   resolved type. Registry materialization chases at query
+    ///   time. Ternaries Edge to their own `Expr(span)` since the
+    ///   per-arm witnesses live there.
+    fn expr_payload(&self, node: Node<'a>) -> Option<crate::witnesses::WitnessPayload> {
         use crate::witnesses::{RefIdx, WitnessAttachment, WitnessPayload};
-        match arm.kind() {
+        match node.kind() {
             // Closed-under-syntax — bake.
             "string_literal" | "interpolated_string_literal" => {
                 Some(WitnessPayload::InferredType(InferredType::String))
@@ -3631,14 +3597,14 @@ impl<'a> Builder<'a> {
             | "preinc_expression"
             | "func0op_call_expression"
             | "func1op_call_expression" => self
-                .infer_expression_result_type(arm)
+                .infer_expression_result_type(node)
                 .map(WitnessPayload::InferredType),
 
             // Variable — Edge to its Variable attachment. Registry
             // materialization routes through `query_variable_type`
             // (scope-walking + framework-aware fold).
             "scalar" => {
-                let name = arm.utf8_text(self.source).ok()?;
+                let name = node.utf8_text(self.source).ok()?;
                 Some(WitnessPayload::Edge(WitnessAttachment::Variable {
                     name: name.to_string(),
                     scope: self.current_scope(),
@@ -3651,10 +3617,10 @@ impl<'a> Builder<'a> {
             // populate_witness_bag has pushed `Edge(NamedSub(method))`
             // there, so the chase resolves through.
             "method_call_expression" => {
-                if let Some(class) = self.extract_constructor_class(arm) {
+                if let Some(class) = self.extract_constructor_class(node) {
                     return Some(WitnessPayload::InferredType(InferredType::ClassName(class)));
                 }
-                let span = node_to_span(arm);
+                let span = node_to_span(node);
                 let idx = self.refs.iter().position(|r| {
                     matches!(r.kind, RefKind::MethodCall { .. }) && r.span == span
                 })?;
@@ -3667,7 +3633,7 @@ impl<'a> Builder<'a> {
             // chases NamedSub which carries InferredType from
             // writeback (locals) or enrichment (imports).
             "function_call_expression" | "ambiguous_function_call_expression" => {
-                let func = arm.child_by_field_name("function")?;
+                let func = node.child_by_field_name("function")?;
                 let name = func.utf8_text(self.source).ok()?;
                 Some(WitnessPayload::Edge(WitnessAttachment::NamedSub(
                     name.to_string(),
@@ -3677,78 +3643,159 @@ impl<'a> Builder<'a> {
             // Bareword / scoped-identifier as expression — same as
             // function call (calling a sub by name without parens).
             "bareword" | "scoped_identifier" => {
-                let name = arm.utf8_text(self.source).ok()?;
+                let name = node.utf8_text(self.source).ok()?;
                 Some(WitnessPayload::Edge(WitnessAttachment::NamedSub(
                     name.to_string(),
                 )))
             }
 
-            // Ternary — caller handles per-arm via
-            // `emit_branch_arm_witnesses`.
-            "conditional_expression" => None,
+            // Ternary — Edge to its own Expr(span). The per-arm
+            // `branch_arm`-source witnesses live on that attachment;
+            // the registry's edge chase + BranchArmFold agree them.
+            "conditional_expression" => Some(WitnessPayload::Edge(WitnessAttachment::Expr(
+                node_to_span(node),
+            ))),
 
             _ => None,
         }
     }
 
-    /// Publish bag witnesses for one return: per-arm type on
-    /// `ReturnArm(span)` if the walker can bake it (`arm_payload`),
-    /// and an unconditional per-sub `branch_arm`-source
-    /// `Edge(ReturnArm(span))` on `Symbol(sub_id)`. The per-sub edge
-    /// is unconditional so post-walk refresh
-    /// (`apply_chain_typing_return_arms`) can fill in the
-    /// `ReturnArm` later — the edge resolves to the eventual type
-    /// once chain typing or variable lookup completes.
-    /// `BranchArmFold` claims by `branch_arm` source; registry
-    /// materialization chases the edge through `ReturnArm(span)` so
-    /// the reducer sees a resolved `InferredType` after the bag
-    /// converges.
+    /// Emit the `Expr(span)` witnesses for `node` and (recursively)
+    /// its sub-arms. For a non-ternary node: one witness on
+    /// `Expr(span)` with the node's `expr_payload` (literal type, or
+    /// Edge to Variable/NamedSub/Expression). For a ternary: two
+    /// `branch_arm`-source `Edge(Expr(arm_span))` witnesses on
+    /// `Expr(span)`, plus a recursive call per arm so each arm's own
+    /// `Expr(span)` is populated. Idempotent on span — multiple
+    /// callers (return arm + chain typing + RHS-of-assignment) firing
+    /// against the same node produce duplicate witnesses but don't
+    /// change query answers, since the latest-wins reducers fold
+    /// them all the same way.
+    fn emit_expr_witness(&mut self, node: Node<'a>) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        let span = node_to_span(node);
+        if node.kind() == "conditional_expression" {
+            let arms = [
+                node.child_by_field_name("consequent"),
+                node.child_by_field_name("alternative"),
+            ];
+            for arm in arms.into_iter().flatten() {
+                // Make sure the arm's own Expr(span) carries its
+                // payload — consumers Edge into it from
+                // Variable($n)/Symbol(sid) for the `my $n = $c ? A : B`
+                // and ternary-return paths.
+                self.emit_expr_witness(arm);
+                self.pending_witnesses.push(Witness {
+                    attachment: WitnessAttachment::Expr(span),
+                    source: WitnessSource::Builder("branch_arm".into()),
+                    payload: WitnessPayload::Edge(WitnessAttachment::Expr(node_to_span(arm))),
+                    span: node_to_span(arm),
+                });
+            }
+            return;
+        }
+        if let Some(payload) = self.expr_payload(node) {
+            self.pending_witnesses.push(Witness {
+                attachment: WitnessAttachment::Expr(span),
+                source: WitnessSource::Builder("expression".into()),
+                payload,
+                span,
+            });
+        }
+    }
+
+    /// Publish witnesses for one explicit `return EXPR`:
+    /// - `Expr(expr_span)` carries the return body's resolved type
+    ///   (literal, variable Edge, call Edge, or recursively-emitted
+    ///   ternary).
+    /// - `Symbol(sub_id)` gets one or more `branch_arm`-source
+    ///   `Edge(Expr(arm_span))` witnesses. Ternary returns expand to
+    ///   per-arm Edges so BranchArmFold sees ≥2 arms; non-ternary
+    ///   returns produce a single Edge that the per-RI fold reads via
+    ///   `bag_query_expr` (single-arm + multi-arm both go through
+    ///   `resolve_return_type`, which accepts the single-arm case
+    ///   that BranchArmFold deliberately rejects).
     fn publish_return_arm_witnesses(
         &mut self,
         return_node: Node<'a>,
         scope: ScopeId,
-        span: Span,
+        _span: Span,
     ) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        if let Some(body) = return_node.named_child(0) {
-            if let Some(payload) = self.arm_payload(body) {
-                self.pending_witnesses.push(Witness {
-                    attachment: WitnessAttachment::ReturnArm(span),
-                    source: WitnessSource::Builder("return_arm".into()),
-                    payload,
-                    span,
-                });
-            }
-        }
-        if let Some(sub_name) = self.enclosing_sub_name() {
-            if let Some(sym_id) = self.find_sub_symbol_for(&sub_name, scope) {
+        let body = match return_node.named_child(0) {
+            Some(b) => b,
+            None => return,
+        };
+        let body_span = node_to_span(body);
+        // Always emit the body's own Expr witnesses first so anything
+        // pointing here resolves.
+        self.emit_expr_witness(body);
+
+        let Some(sub_name) = self.enclosing_sub_name() else { return };
+        let Some(sym_id) = self.find_sub_symbol_for(&sub_name, scope) else { return };
+
+        if body.kind() == "conditional_expression" {
+            // Ternary return: per-arm Edges on Symbol(sid) so
+            // BranchArmFold can disambiguate the ≥2 arms that the
+            // syntax guarantees exist.
+            let arms = [
+                body.child_by_field_name("consequent"),
+                body.child_by_field_name("alternative"),
+            ];
+            for arm in arms.into_iter().flatten() {
                 self.pending_witnesses.push(Witness {
                     attachment: WitnessAttachment::Symbol(sym_id),
                     source: WitnessSource::Builder("branch_arm".into()),
-                    payload: WitnessPayload::Edge(WitnessAttachment::ReturnArm(span)),
-                    span,
+                    payload: WitnessPayload::Edge(WitnessAttachment::Expr(node_to_span(arm))),
+                    span: body_span,
                 });
             }
+        } else {
+            // Plain return: one Edge to the body's Expr(span). The
+            // per-RI fold (`bag_query_expr` + `resolve_return_type`)
+            // handles single-arm and multi-arm uniformly.
+            self.pending_witnesses.push(Witness {
+                attachment: WitnessAttachment::Symbol(sym_id),
+                source: WitnessSource::Builder("branch_arm".into()),
+                payload: WitnessPayload::Edge(WitnessAttachment::Expr(body_span)),
+                span: body_span,
+            });
         }
     }
 
-    /// RHS-ternary convenience wrapper: `my $x = $c ? A : B` →
-    /// BranchArm on Variable($x).
+    /// RHS-ternary convenience: `my $x = $c ? A : B` → per-arm
+    /// `branch_arm` Edges on Variable($x). Each Edge points at the
+    /// arm's `Expr(arm_span)`, which `emit_expr_witness` populates
+    /// with the arm's resolved payload.
     fn emit_branch_arm_witnesses_for_ternary(
         &mut self,
         lhs_var: &str,
         cond_expr: Node<'a>,
         context: Node<'a>,
     ) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
         let scope = self.current_scope();
-        self.emit_branch_arm_witnesses(
-            cond_expr,
-            crate::witnesses::WitnessAttachment::Variable {
-                name: lhs_var.to_string(),
-                scope,
-            },
-            context,
-        );
+        let attachment = WitnessAttachment::Variable {
+            name: lhs_var.to_string(),
+            scope,
+        };
+        let context_span = node_to_span(context);
+        // Make sure the ternary's Expr(span) is populated even though
+        // the per-arm Edges below skip it — keeps query points
+        // resolving against the ternary span working downstream.
+        self.emit_expr_witness(cond_expr);
+        let arms = [
+            cond_expr.child_by_field_name("consequent"),
+            cond_expr.child_by_field_name("alternative"),
+        ];
+        for arm in arms.into_iter().flatten() {
+            self.pending_witnesses.push(Witness {
+                attachment: attachment.clone(),
+                source: WitnessSource::Builder("branch_arm".into()),
+                payload: WitnessPayload::Edge(WitnessAttachment::Expr(node_to_span(arm))),
+                span: context_span,
+            });
+        }
     }
 
     /// Closed-under-syntax type observation for an expression node.
@@ -3760,7 +3807,7 @@ impl<'a> Builder<'a> {
     /// - Constructor pattern `Bareword->new` → `ClassName`.
     ///
     /// Variables, function calls, name-driven method calls — all
-    /// excluded. They go through `arm_payload` as `Edge` payloads
+    /// excluded. They go through `expr_payload` as `Edge` payloads
     /// pointing at attachments the bag knows.
     fn infer_expression_type(&self, node: Node<'a>) -> Option<InferredType> {
         match node.kind() {
@@ -6301,56 +6348,27 @@ impl<'a> Builder<'a> {
     /// in `witnesses.rs` and carry the same logic — Phase 6's worklist
     /// driver will switch the loop bodies below to registry calls.
     fn resolve_return_types(&mut self) {
-        let (returns_by_scope, arm_types_per_ri) = self.collect_return_arm_types();
-        self.emit_arity_return_witnesses(&arm_types_per_ri);
+        self.emit_arity_return_witnesses();
         self.emit_delegation_edges();
-        let (mut return_types, mut return_provenance) =
-            self.fold_per_sub_return_arms(&returns_by_scope);
+        let (mut return_types, mut return_provenance) = self.fold_per_sub_return_arms();
         self.seed_plugin_overrides_into_return_types(&mut return_types, &mut return_provenance);
         self.write_back_sub_return_types(&return_types, &return_provenance);
         self.propagate_call_bindings_to_constraints(&return_types);
         self.fixup_call_bound_hash_key_owners(&return_types);
     }
 
-    /// Step 1: read each return arm's resolved type from the bag.
-    /// The walker already published per-arm payloads on
-    /// `ReturnArm(span)` (Type for bakeable arms, Edge for variable
-    /// arms); registry materialization chases the edges through
-    /// `Variable{...}` to a framework-aware fold every time we ask.
-    /// `returns_by_scope` feeds step 3's per-sub agreement fold;
-    /// `arm_types_per_ri` feeds step 2's arity-witness emission.
-    fn collect_return_arm_types(
-        &self,
-    ) -> (
-        std::collections::HashMap<ScopeId, Vec<InferredType>>,
-        Vec<Option<InferredType>>,
-    ) {
-        let mut returns_by_scope: std::collections::HashMap<ScopeId, Vec<InferredType>> =
-            std::collections::HashMap::new();
-        let mut arm_types_per_ri: Vec<Option<InferredType>> =
-            Vec::with_capacity(self.return_infos.len());
-        for ri in &self.return_infos {
-            let arm_type = self.bag_query_return_arm(ri.span);
-            if let Some(t) = arm_type.clone() {
-                returns_by_scope.entry(ri.scope).or_default().push(t);
-            }
-            arm_types_per_ri.push(arm_type);
-        }
-        (returns_by_scope, arm_types_per_ri)
-    }
-
-    /// Single-attachment registry query for `ReturnArm(span)`. Used
-    /// by `collect_return_arm_types` and the chain-typing return-arm
-    /// refresh to read whatever the bag currently knows about an
-    /// arm. Threads the file's scope topology + per-package
-    /// framework as a `BagContext` so Edge chases through
-    /// `Variable{...}` use scope-chain + framework-aware semantics.
-    fn bag_query_return_arm(&self, span: Span) -> Option<InferredType> {
+    /// Single-attachment registry query for `Expr(span)`. Used by
+    /// `emit_arity_return_witnesses` (per-RI) and the implicit-last-
+    /// expression fallback in `fold_per_sub_return_arms`. Threads the
+    /// file's scope topology + per-package framework as a `BagContext`
+    /// so Edge chases through `Variable{...}` use scope-chain +
+    /// framework-aware semantics.
+    fn bag_query_expr_span(&self, span: Span) -> Option<InferredType> {
         use crate::witnesses::{
             BagContext, FrameworkFact, ReducedValue, ReducerQuery, ReducerRegistry,
             WitnessAttachment,
         };
-        let att = WitnessAttachment::ReturnArm(span);
+        let att = WitnessAttachment::Expr(span);
         let reg = ReducerRegistry::with_defaults();
         let ctx = BagContext {
             scopes: &self.scopes,
@@ -6461,15 +6479,15 @@ impl<'a> Builder<'a> {
     /// `FluentArityDispatch` would answer with one arm even when the
     /// per-arm fold says "agreement failed" (different arms differ).
     /// Walk-time arity classification stays a `Some(_)` enum on
-    /// `ReturnInfo`; only the fold consults the bag-resolved arm type
-    /// from step 1.
+    /// `ReturnInfo`; the type is read out per-RI by querying the
+    /// body's `Expr(span)` against the current bag.
     ///
     /// Idempotent across re-runs — clears every prior `arity_detection`
     /// witness from the bag before re-emitting. The worklist driver
     /// calls `resolve_return_types` repeatedly until fixed point;
     /// without this clear-and-emit, each iteration would duplicate
     /// every arity witness in the bag.
-    fn emit_arity_return_witnesses(&mut self, arm_types_per_ri: &[Option<InferredType>]) {
+    fn emit_arity_return_witnesses(&mut self) {
         use crate::witnesses::{
             TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
         };
@@ -6488,12 +6506,14 @@ impl<'a> Builder<'a> {
         }
 
         let mut arity_witnesses: Vec<Witness> = Vec::new();
-        for (ri, arm_type) in self.return_infos.iter().zip(arm_types_per_ri.iter()) {
+        for ri in &self.return_infos {
             let Some(branch) = ri.arity_branch else { continue };
             if !arity_discriminated_scopes.contains(&ri.scope) {
                 continue;
             }
-            let Some(t) = arm_type.clone() else { continue };
+            let Some(t) = ri.body_span.and_then(|sp| self.bag_query_expr_span(sp)) else {
+                continue;
+            };
             let Some(sym_id) = self.find_sub_symbol_for_scope(ri.scope) else { continue };
             let arg_count = match branch {
                 ArityBranch::Zero => Some(0u32),
@@ -6538,14 +6558,13 @@ impl<'a> Builder<'a> {
 
     /// Step 3: fold each Sub/Method scope's return arms into a single
     /// type via `resolve_return_type` (1+ arms agree → `Some(t)`,
-    /// disagreement → `None`). Falls back to `last_expr_type` for subs
-    /// without explicit `return`s — Perl's last statement is the
-    /// implicit return. Provenance is recorded as `ReducerFold {
-    /// reducer: "return_arms" }` so `--dump-package` can answer "why
-    /// does this return X?".
+    /// disagreement → `None`). Falls back to `last_expr_span`'s
+    /// Expr(span) query for subs without explicit `return`s — Perl's
+    /// last statement is the implicit return. Provenance is recorded
+    /// as `ReducerFold { reducer: "return_arms" }` so `--dump-package`
+    /// can answer "why does this return X?".
     fn fold_per_sub_return_arms(
         &mut self,
-        returns_by_scope: &std::collections::HashMap<ScopeId, Vec<InferredType>>,
     ) -> (
         std::collections::HashMap<String, InferredType>,
         std::collections::HashMap<String, crate::file_analysis::TypeProvenance>,
@@ -6595,48 +6614,45 @@ impl<'a> Builder<'a> {
                 })
                 .map(|s| s.id);
 
-            // Three sources, in priority order:
-            //   1. Per-arm fold via `returns_by_scope` — direct arms
-            //      from explicit `return EXPR` statements, agreed via
-            //      `resolve_return_type`. Wins when present.
-            //   2. Bag query on `Symbol(sub_id)` — picks up arms
-            //      pushed by `emit_branch_arm_witnesses` (ternary
-            //      arms, if/else arms) that don't naturally land in
-            //      `returns_by_scope`. `BranchArmFold` agrees them.
-            //   3. `last_expr_type` for subs without explicit returns.
-            let (resolved, evidence) = if let Some(arms) =
-                returns_by_scope.get(&scope.id).filter(|a| !a.is_empty())
-            {
-                let r = resolve_return_type(arms);
-                let ev = vec![format!("return_arms={}", arms.len())];
-                (r, ev)
-            } else {
-                let bag_answer = sub_sym_id.and_then(|id| {
-                    let att = WitnessAttachment::Symbol(id);
-                    let q = ReducerQuery {
-                        attachment: &att,
-                        point: None,
-                        framework: FrameworkFact::Plain,
-                        arity_hint: None,
-                        context: Some(&ctx),
-                    };
-                    if let ReducedValue::Type(t) = reg.query(&self.bag, &q) {
-                        Some(t)
-                    } else {
-                        None
-                    }
-                });
-                if let Some(t) = bag_answer {
-                    (Some(t), vec!["symbol_bag".into()])
+            // Two sources, in priority order:
+            //   1. Bag query on `Symbol(sub_id)` — covers explicit
+            //      `return EXPR` arms (each emits one `branch_arm`
+            //      Edge to `Expr(body_span)` on Symbol) and ternary
+            //      returns (each arm emits its own Edge). Both
+            //      `SymbolReturnArmFold` (1+ arms via
+            //      `resolve_return_type`) and `BranchArmFold` (≥2
+            //      arms agree) can answer here; the registered order
+            //      gives the Symbol-fold first refusal.
+            //   2. `Expr(last_expr_span)` for subs without explicit
+            //      returns — Perl's implicit-last-statement return.
+            let bag_answer = sub_sym_id.and_then(|id| {
+                let att = WitnessAttachment::Symbol(id);
+                let q = ReducerQuery {
+                    attachment: &att,
+                    point: None,
+                    framework: FrameworkFact::Plain,
+                    arity_hint: None,
+                    context: Some(&ctx),
+                };
+                if let ReducedValue::Type(t) = reg.query(&self.bag, &q) {
+                    Some(t)
                 } else {
-                    let r = self.last_expr_type.get(&scope.id).and_then(|t| t.clone());
-                    let ev = if r.is_some() {
-                        vec!["last_expr".into()]
-                    } else {
-                        Vec::new()
-                    };
-                    (r, ev)
+                    None
                 }
+            });
+            let (resolved, evidence) = if let Some(t) = bag_answer {
+                (Some(t), vec!["symbol_bag".into()])
+            } else {
+                let r = self
+                    .last_expr_span
+                    .get(&scope.id)
+                    .and_then(|sp| self.bag_query_expr_span(*sp));
+                let ev = if r.is_some() {
+                    vec!["last_expr".into()]
+                } else {
+                    Vec::new()
+                };
+                (r, ev)
             };
 
             if let (Some(rt), Some(sid)) = (resolved, sub_sym_id) {

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 18;
+pub const EXTRACT_VERSION: i64 = 19;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -64,17 +64,20 @@ pub enum WitnessAttachment {
     HashKey { owner: HashKeyOwner, name: String },
     /// Package-level facts (isa edges, framework mode).
     Package(String),
-    /// One return-arm of a sub, identified by the return expression's
-    /// span. Carries the arm's resolved type as either a direct
-    /// `InferredType(t)` (literals, constructors) or an `Edge` to the
-    /// arm-source attachment (a variable's `Variable{name, scope}` for
-    /// `return $foo`). The per-sub fold queries `Symbol(sub_id)` whose
-    /// `branch_arm` witnesses are themselves edges to per-arm
-    /// `ReturnArm` attachments — registry materialization chases the
-    /// edges, so `BranchArmFold` sees each arm's resolved type
-    /// uniformly. Arity dispatch (`emit_arity_return_witnesses`)
-    /// queries each `ReturnArm` directly to read per-arm types.
-    ReturnArm(Span),
+    /// The value of an expression at this span. One attachment shape
+    /// for every rvalue: literals, variable reads, function calls,
+    /// method calls, ternaries, return-arm bodies, implicit-last
+    /// statements. Witnesses on an `Expr` are either a direct
+    /// `InferredType(t)` (literals, constructors, builtin returns) or
+    /// an `Edge` to the resolution target (`Variable{name, scope}` for
+    /// `$foo`, `NamedSub(name)` for a function call,
+    /// `Expression(refidx)` for a method call's
+    /// receiver-and-method-resolved type, or another `Expr(inner_span)`
+    /// for compound expressions). Replaces both the old
+    /// `ReturnArm(Span)` and the per-arm dispatch in `arm_payload`:
+    /// every node in rvalue position takes the same shape now, and the
+    /// per-sub fold reads `Edge(Expr(span))` arms via Symbol(sub_id).
+    Expr(Span),
     /// Class-keyed method dispatch: "what does method `name` return on
     /// class `class`?" — the cross-class disambiguation `NamedSub(name)`
     /// can't carry. Inheritance composes through `Edge(MethodOnClass(parent, name))`
@@ -623,17 +626,17 @@ fn merge_rep(existing: Option<Rep>, new: Rep) -> Option<Rep> {
     }
 }
 
-// ---- Branch-arm fold reducer (ternary + explicit if/else arms) ----
+// ---- Branch-arm fold reducer (ternary RHS + Expr-attached arms) ----
 
-/// Generic branch-arm reduction: collects `BranchArm` observations
-/// across any attachment kind (Variable, Symbol, Expression). Same
-/// semantics as the ternary fold inside FrameworkAwareTypeFold —
-/// agreement → that type; disagreement → None.
-///
-/// Registered alongside FrameworkAwareTypeFold so *any* attachment
-/// can carry branch-arm witnesses — ternary into a variable, if/else
-/// returns on a Symbol (sub), chain-collapsing expressions on an
-/// Expression, etc.
+/// Branch-arm reduction for `Variable` and `Expr` attachments —
+/// `my $x = $c ? A : B` and the per-arm Expr witnesses a ternary's
+/// own `Expr(span)` carries. Agreement across ≥2 arms → that type;
+/// single arm → None (ternaries always carry both arms by syntax,
+/// so a single witness here means inference for one arm failed and
+/// we shouldn't claim the other arm represents the whole
+/// expression). Symbol-attached return arms go through
+/// `SymbolReturnArmFold` instead — single-return subs DO carry their
+/// answer via one witness, so the ≥2 rule is wrong there.
 pub struct BranchArmFold;
 
 impl WitnessReducer for BranchArmFold {
@@ -642,16 +645,17 @@ impl WitnessReducer for BranchArmFold {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        // Source-tag claim — the walker (and any downstream pass that
-        // wants to contribute a branch-arm fact) emits with source
-        // `Builder("branch_arm")`. After registry materialization,
-        // every claimed witness has an `InferredType` payload (the
-        // walker pushed `Type(t)` directly for bakeable arms; the
-        // registry chased `Edge(target)` arms through to a resolved
-        // type and replaced them with synthetic `InferredType`
-        // witnesses preserving source + span). Reducer needs only
-        // the values.
-        matches!(&w.source, WitnessSource::Builder(s) if s == "branch_arm")
+        // Source-tag + attachment claim — the walker (and any
+        // downstream pass that wants to contribute a branch-arm fact)
+        // emits with source `Builder("branch_arm")`. After registry
+        // materialization, every claimed witness has an
+        // `InferredType` payload. We restrict to Variable/Expr here;
+        // Symbol attachments are owned by `SymbolReturnArmFold`,
+        // which uses `resolve_return_type` semantics (1+ arms).
+        matches!(
+            w.attachment,
+            WitnessAttachment::Variable { .. } | WitnessAttachment::Expr(_)
+        ) && matches!(&w.source, WitnessSource::Builder(s) if s == "branch_arm")
             && matches!(w.payload, WitnessPayload::InferredType(_))
     }
 
@@ -663,12 +667,6 @@ impl WitnessReducer for BranchArmFold {
                 _ => None,
             })
             .collect();
-        // A single arm is not "agreement" — `if (cond) { return X }`
-        // alone leaves the alternative undetermined. The fold only
-        // produces a type when at least two arms exist AND they all
-        // agree. Otherwise yield to the next reducer / fallback (e.g.
-        // `Symbol.return_type` carries the agreement across every
-        // return arm via `resolve_return_type`).
         if arms.len() < 2 {
             return ReducedValue::None;
         }
@@ -677,6 +675,47 @@ impl WitnessReducer for BranchArmFold {
             return ReducedValue::Type(first.clone());
         }
         ReducedValue::None
+    }
+}
+
+// ---- Symbol-attached return-arm fold ----
+//
+// Claims `Symbol(sub_id)` attachments carrying `branch_arm`-source
+// `InferredType` payloads (Edges materialized into types). Each
+// witness is one return arm — a `return EXPR` body, an explicit
+// if/else arm pushed onto Symbol, or an implicit-last-expression
+// edge. `resolve_return_type` agrees them: 1 arm → that type,
+// agreeing arms → that type, disagreeing → None (with HashRef
+// subsumed by Object). Replaces the per-RI `returns_by_scope` Vec
+// fold the builder used to do by hand. Registered before BranchArmFold
+// so the Symbol case is handled here even though both reducers
+// claim source `branch_arm`.
+
+pub struct SymbolReturnArmFold;
+
+impl WitnessReducer for SymbolReturnArmFold {
+    fn name(&self) -> &str {
+        "symbol_return_arm_fold"
+    }
+
+    fn claims(&self, w: &Witness) -> bool {
+        matches!(w.attachment, WitnessAttachment::Symbol(_))
+            && matches!(&w.source, WitnessSource::Builder(s) if s == "branch_arm")
+            && matches!(w.payload, WitnessPayload::InferredType(_))
+    }
+
+    fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
+        let arms: Vec<InferredType> = ws
+            .iter()
+            .filter_map(|w| match &w.payload {
+                WitnessPayload::InferredType(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect();
+        match crate::file_analysis::resolve_return_type(&arms) {
+            Some(t) => ReducedValue::Type(t),
+            None => ReducedValue::None,
+        }
     }
 }
 
@@ -802,28 +841,36 @@ impl WitnessReducer for NamedSubReturn {
     }
 }
 
-// ---- Return-arm reducer ----
+// ---- Expression reducer ----
 //
-// Claims `InferredType` payloads on `ReturnArm(_)` attachments —
-// the per-arm storage that every `return X` in a sub body
-// publishes. The walker pushes either `Type(t)` directly (literals,
-// constructors) or `Edge(target)` (variable returns). Edge witnesses
-// get materialized by the registry into synthetic `Type` witnesses
-// before any reducer claims, so this reducer always sees plain
-// types. Latest-wins: chain typing's post-walk refresh pass pushes
-// updated `Type` witnesses on a different source tag, and we want
-// that latest value to dominate the original walk-time push.
+// Claims `InferredType` payloads on `Expr(_)` attachments — the unified
+// expression-result attachment that every rvalue node publishes
+// through. The walker pushes either `Type(t)` directly (literals,
+// constructors, builtin-determined returns) or `Edge(target)` for
+// name-keyed resolution (Variable lookups, NamedSub for plain-named
+// calls, Expression for method-call receivers, or recursive Expr edges
+// for compound expressions). Edge witnesses get materialized by the
+// registry into synthetic `Type` witnesses before any reducer claims,
+// so this reducer always sees plain types. Latest-wins: post-walk
+// chain typing refresh re-derives Expr witnesses on a different
+// source tag, and we want the most recently published type to
+// dominate the original walk-time push.
 
-pub struct ReturnArmReturn;
+pub struct ExprReturn;
 
-impl WitnessReducer for ReturnArmReturn {
+impl WitnessReducer for ExprReturn {
     fn name(&self) -> &str {
-        "return_arm_return"
+        "expr_return"
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        matches!(w.attachment, WitnessAttachment::ReturnArm(_))
+        matches!(w.attachment, WitnessAttachment::Expr(_))
             && matches!(w.payload, WitnessPayload::InferredType(_))
+            // BranchArmFold (registered earlier) handles `branch_arm`-source
+            // witnesses on Expr — ternary arms agree under its rule. This
+            // reducer covers the remaining "this expr just has a type"
+            // case (a literal, a variable read, a chased call result).
+            && !matches!(&w.source, WitnessSource::Builder(s) if s == "branch_arm")
     }
 
     fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
@@ -1057,11 +1104,19 @@ impl ReducerRegistry {
         // `Symbol(_)` attachments — different attachment shape than
         // BranchArmFold's typical Variable / Symbol-via-edge claims).
         r.register(Box::new(PluginOverrideReducer));
+        // SymbolReturnArmFold runs before BranchArmFold because both
+        // claim `branch_arm`-source InferredType witnesses; the
+        // Symbol-attached case allows single-arm answers (a sub with
+        // one `return X`) which BranchArmFold rejects. Keeping them
+        // distinct (rather than making BranchArmFold attachment-aware)
+        // makes the source-tag / attachment-shape rule clear: each
+        // reducer claims its own (attachment, source) pair.
+        r.register(Box::new(SymbolReturnArmFold));
         r.register(Box::new(BranchArmFold));
         r.register(Box::new(FrameworkAwareTypeFold));
         r.register(Box::new(FluentArityDispatch));
         r.register(Box::new(NamedSubReturn));
-        r.register(Box::new(ReturnArmReturn));
+        r.register(Box::new(ExprReturn));
         // MethodOnClass primary-fallback runs after the arity-aware
         // dispatch (FluentArityDispatch claims MethodOnClass +
         // ArityReturn) so per-arity facts win when the caller has an

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -851,10 +851,11 @@ impl WitnessReducer for NamedSubReturn {
 // calls, Expression for method-call receivers, or recursive Expr edges
 // for compound expressions). Edge witnesses get materialized by the
 // registry into synthetic `Type` witnesses before any reducer claims,
-// so this reducer always sees plain types. Latest-wins: post-walk
-// chain typing refresh re-derives Expr witnesses on a different
-// source tag, and we want the most recently published type to
-// dominate the original walk-time push.
+// so this reducer always sees plain types. Latest-wins:
+// `emit_expr_witness` is called from multiple walk sites (return
+// body, top-level expression statement, ternary parent that recurses
+// into its arms), so the same node may receive several witnesses;
+// reading from the back picks the most recently published.
 
 pub struct ExprReturn;
 


### PR DESCRIPTION
## Summary

**D2 of the bag-residual cleanup.** Every rvalue node now publishes
through a single `Expr(Span)` attachment. The directive's framing —
"the bag is the only truth" — is the structural change here:
return-arm types and the implicit-last-expression type cache used to
ride dual paths (a typed `ReturnArm(span)` attachment for declared
returns, a `last_expr_type: ScopeId → Option<InferredType>` side
channel for implicit returns); both collapse into the same
`Expr(span)` shape. Net: per-arm node-kind dispatch is gone, the
side-channel type cache is gone, and `arm_payload` /
`collect_return_arm_types` / `arm_types_per_ri` / `returns_by_scope`
plumbing is gone with them.

QA reports faster wall-clock vs main on the bench corpus. No specific
numbers attached in this PR (cold/warm timings haven't been re-baked
on this branch); willing to add them if you want.

## What landed (in order)

**1. The unified attachment.** `WitnessAttachment::Expr(Span)`
replaces `ReturnArm(Span)`. Every rvalue — literal, variable read,
function call, method call, ternary, return body, implicit-last
statement — publishes through it. `Expression(RefIdx)` survives as
ref-keyed metadata for the method-call chain typer (it edges into
`Expr(span)`, so the type answer rides the unified attachment).

**2. Walker emits uniformly.** `expr_payload` (single dispatch)
replaces `arm_payload` (per-arm dispatch). `emit_expr_witness`
recursively populates a node's `Expr(span)`, expanding ternaries
into per-arm `branch_arm` Edges so chained ternaries each carry
their own arm payloads.

**3. Return arms route through the bag.** `return EXPR` pushes
`Symbol(sub_id) ← Edge(Expr(body_span))` source `branch_arm`.
Ternary returns expand to per-arm Edges so `BranchArmFold` has the
≥2 arms it requires for ternary RHS disambiguation. Non-ternary
returns produce a single Edge that the new `SymbolReturnArmFold`
folds via `resolve_return_type` (1+ arms — the case BranchArmFold
deliberately rejects).

**4. Implicit returns through the bag.** `last_expr_type: ScopeId →
Option<InferredType>` becomes `last_expr_span: ScopeId → Span` — a
structural pointer to the source span; the type rides
`Expr(last_expr_span)` and the per-sub fold reads it via
`bag_query_expr_span`. No more side-channel type cache.

**5. Reducer split.** `SymbolReturnArmFold` (Symbol attachments,
`branch_arm` source, 1+ arms via `resolve_return_type`) registered
before `BranchArmFold` (Variable/Expr attachments, `branch_arm`
source, ≥2 arms must agree). Disjoint by attachment shape;
registry's first-match dispatch routes correctly. `ExprReturn`
replaces `ReturnArmReturn` for plain `InferredType` payloads on
`Expr(_)` (the chased non-`branch_arm` case).

**6. Plumbing collapse.** `collect_return_arm_types` deleted.
`emit_arity_return_witnesses` queries `Expr(body_span)` per RI
inline. `fold_per_sub_return_arms` drops the `returns_by_scope`
parameter and routes through `query(Symbol(sid))` plus the
implicit-last-expr fallback. `ReturnInfo.body_span: Option<Span>`
keys per-RI bag queries on the inner expression rather than the
outer return statement's span.

**7. Cache shape bump.** `EXTRACT_VERSION` 18 → 19. Witnesses ride
the bincode+zstd blob; the attachment enum changed shape.

## What collapsed (totality)

- `WitnessAttachment::ReturnArm(Span)` → folded into `Expr(Span)`
- `arm_payload` (per-arm node-kind dispatch) → `expr_payload` (single dispatch)
- `ReturnArmReturn` reducer → `ExprReturn`
- `last_expr_type: HashMap<ScopeId, Option<InferredType>>` (typed cache)
  → `last_expr_span: HashMap<ScopeId, Span>` (structural pointer)
- `collect_return_arm_types` (returned the `(returns_by_scope, arm_types_per_ri)` tuple)
- `arm_types_per_ri` parameter on `emit_arity_return_witnesses`
- `returns_by_scope` parameter on `fold_per_sub_return_arms`
- `emit_branch_arm_witnesses(node, attachment, context)` generic helper
- The `visit_node` ternary-return special-case ("if RHS is ternary,
  emit per-arm BranchArm on Symbol") — now folded into
  `publish_return_arm_witnesses`'s ternary branch
- Three doc-rot fixes in the cleanup commit (dead `_span: Span` parameter,
  stale `collect_return_arm_types` references in two doc comments, false
  chain-typing claim in `ExprReturn`'s justification)

## Reducer shape

Two reducers now claim `branch_arm`-source `InferredType` witnesses;
they're disjoint by attachment, and the registration order makes the
first-match dispatch correct:

- **`SymbolReturnArmFold`** — `Symbol(sub_id)` attachments. 1+ arms
  via `resolve_return_type` (single `return X` IS the answer;
  multiple agreeing arms collapse; disagreement → None with HashRef
  subsumed by Object).
- **`BranchArmFold`** — `Variable{...}` and `Expr(_)` attachments.
  ≥2 arms must agree. Single arm = inference fell short for the
  other arm; surface ambiguity rather than guess.

Both reducers' `claims` predicates are pairwise disjoint by
attachment shape, so they never fight over the same witness set.
Registration order is `SymbolReturnArmFold` first (Symbol case),
then `BranchArmFold` (Variable/Expr case).

## Open design questions, resolved

1. **Span vs NodeId keying** — Spans (NodeIds don't survive cache).
2. **Does `Expression(RefIdx)` survive?** Yes — for the method-call
   chain typer's receiver-and-method-resolved type. `expr_payload`
   Edges from `Expr(span)` to `Expression(refidx)` for method-call
   rvalues, so the type answer rides `Expr` either way.
3. **Anonymous compound expressions** — Lazy. `Expr(span)` is only
   emitted for nodes that have a payload via `expr_payload` (or
   ternaries via the recursion). Bare subexpressions only get
   witnesses when something Edges to them.

## Subsumes

Closes Directive 2 of `docs/working-bag-residual.md` in full. Every
action item under D2 shipped; the directive section is updated to
reflect "LANDED" status.

## Routed forward

One residual duplication of mechanism is captured in the cleanup
commit and routed to D4 in `docs/working-bag-residual.md`: when a
return body (or RHS of `my $x = $c ? A : B`) is a ternary, the
walker emits per-arm `branch_arm` Edges *both* on `Expr(ternary_span)`
*and* on the consumer attachment (`Symbol(sid)` / `Variable($x)`).
A single `Edge(Expr(body_span))` from the consumer would let the
registry's edge chase + `BranchArmFold` on `Expr(_)` produce the
same answer (traced both agreement and disagreement cases — they
fold identically). Latest-wins handles the current double-emit, so
not a defect; pure cleanup.

## Test plan

- [x] `cargo test` — 509/509 pass on D2 commit; still 509/509 after
      the cleanup commit
- [x] `./run_e2e.sh` — 93 passed (per the D2 commit message; not
      re-run for the cleanup commit since it touches only doc
      comments and a dead parameter)
- [x] `EXTRACT_VERSION` bumped 18 → 19 — witness shape change
- [x] Cleanup commit limited to: dead parameter removal, doc-comment
      updates, new D4 bullet — no behavior change

## Cross-refs

- `docs/working-bag-residual.md` D2 — marked LANDED; D4 picks up the
  per-arm-edge collapse follow-up
- `docs/ROADMAP.md` — D2 entry moved to landed; sequence-types phases
  1-3 unblock from here

🤖 Generated with [Claude Code](https://claude.com/claude-code)