### PR TITLE
refactor: bag-residual D3 — kill WitnessAttachment::NamedSub variant

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,7 +34,7 @@ Four docs, one engine:
 staircase 1–4 (LANDED, PR #27) ─┐
                                  ├─▶ bag-residual D1 redo (LANDED dc4315f, with residue → D3)
                                  ├─▶ bag-residual D2 (LANDED — one expression attachment)
-                                 ├─▶ bag-residual D3 (one attachment per fact, +D1 residue)
+                                 ├─▶ bag-residual D3 (LANDED — NamedSub variant gone)
                                  ├─▶ bag-residual D4 (residual canonical-store cleanup)
                                  │       │
                                  │       └─▶ sequence-types phases 1-3
@@ -96,9 +96,23 @@ staircase 1–4 (LANDED, PR #27) ─┐
    Symbol-attached return arms; `BranchArmFold` keeps the ≥2 rule
    for ternary RHS on Variable/Expr). Tests: 509 unit + 93 e2e
    green. Unblocks sequence-types.
-3. **Bag-residual D3** — one attachment per fact, no source-tag claims. Kills
-   `WitnessAttachment::NamedSub` and the source-tag claim filters in
-   `SubReturnReducer` / `FrameworkAwareTypeFold`.
+3. **Bag-residual D3** — **LANDED** on `refactor/bag-residual-d3`.
+   Killed `WitnessAttachment::NamedSub` outright (compiler-driven
+   subtractive deletion of 17 consumer sites). Dual writeback
+   collapsed to `Symbol(sym_id)` + `MethodOnClass{class, name}`.
+   Cross-file imports route through `module_index.find_exporters` +
+   recursive `Symbol(cached_sid)` query in
+   `query_sub_return_type`. `build_imported_return_types` deleted;
+   `enrich_imported_types_with_keys` derives its inputs inline.
+   Build-time + enrichment-time `Edge(MethodOnClass(parent, name))`
+   inheritance edges replace the eager half of `query_rec`'s
+   structural walk; the walk stays as a fallback for hand-crafted
+   FAs and cross-file plugin bridges (where build-time pre-emission
+   would be N×N). Method-call `Expression(refidx)` edges now key on
+   class via a re-emittable worklist pass. Source-tag claim filters
+   on `SubReturnReducer` collapsed to a single `branch_arm`
+   exclusion. Cache `EXTRACT_VERSION` bumped 19 → 20. Tests: 507
+   unit + 93 e2e green.
 4. **Bag-residual D4** (now smaller) — kill `FileAnalysis.type_constraints`
    as a write target, walk-time bag is live (no `pending_witnesses` staging,
    no walk-time TC-first read), kill the `last_expr_span` /

--- a/docs/prompt-cleanups.md
+++ b/docs/prompt-cleanups.md
@@ -30,18 +30,32 @@ which means we maintain bag-and-map in sync inside the worklist.
 
 **How to apply:** at every site that currently writes
 `resolved_returns.insert(sid, rt)`, push the bag witness directly
-(`Symbol(sid)` plain `InferredType`, plus the matching `NamedSub` /
-`MethodOnClass{class, name}` mirrors). Writeback's job becomes
-"ensure the canonical witnesses are present" rather than "iterate the
-map." `fold_state_snapshot`'s second tuple element switches from
-"reading the map" to "querying `Symbol(sid)` via the registry" — the
-worklist's fixed-point detection then watches what consumers actually
-see, which is the snapshot's intent.
+(`Symbol(sid)` plain `InferredType`; plus the `MethodOnClass{class,
+name}` primary-slot mirror — see "Watch out for" #2 for the
+primary-dedup question that blocked this in D3). Writeback's job
+becomes "ensure the canonical witnesses are present" rather than
+"iterate the map." `fold_state_snapshot`'s first tuple element
+switches from "reading the map" to "querying `Symbol(sid)` via the
+registry" — the worklist's fixed-point detection then watches what
+consumers actually see, which is the snapshot's intent.
 
-**Watch out for:** the worklist re-runs each iteration. The bag
-already has `remove_by_source_tag` for re-emittable passes — use it
-before pushing the writeback witnesses on every iteration so we don't
-accumulate stale `Symbol(sid)` entries from earlier rounds.
+**Watch out for:**
+
+1. The worklist re-runs each iteration. The bag already has
+   `remove_by_source_tag` for re-emittable passes — use it before
+   pushing the writeback witnesses on every iteration so we don't
+   accumulate stale `Symbol(sid)` entries from earlier rounds.
+
+2. `MethodOnClass` primary-dedup is what kept `resolved_returns` alive
+   through D3. The current writeback walks symbols in declaration
+   order and the FIRST `(class, name)` pair wins the primary slot.
+   Walk-time direct emit needs an equivalent rule. Two viable shapes:
+   (a) push at synthesis but stamp the witness with a sequence number
+   the reducer reads to pick first-seen, or (b) accept latest-wins on
+   `MethodOnClass` and ensure the primary's witness is published last
+   by ordering the synthesis sites. (b) is simpler if it works for the
+   Mojo getter/writer test (`builder_tests.rs::test_mojo_arity_resolution`)
+   — verify before committing to it.
 
 ---
 
@@ -65,11 +79,12 @@ reads are:
 - `src/symbols_tests.rs` — test assertions on the dump format.
 
 **How to apply:** delete the field. Replace `--dump-package` JSON
-output with a query to the bag for `Edge(NamedSub(_))` /
-`Edge(MethodOnClass{...})` payloads on the sub's `Symbol(sid)`
-attachment — that's where the tail-call edge actually lives now.
-Tests that assert on the field move to asserting on the edge witness
-in the bag.
+output with a query to the bag for `Edge(MethodOnClass{...})`
+payloads on the sub's `Symbol(sid)` attachment — that's where the
+tail-call edge actually lives now (post-D3, name-keyed sub edges
+were collapsed into the class-keyed `MethodOnClass` shape). Tests
+that assert on the field move to asserting on the edge witness in
+the bag.
 
 **Watch out for:** `fold_state_snapshot` currently includes
 `return_self_method` as the third tuple element. Drop it from the
@@ -127,6 +142,44 @@ and the diff churn is easier to land while these sites are fresh.
 
 **How to apply:** run `cargo fmt` and inspect the diff to ensure no
 unrelated changes; commit just the indentation fix.
+
+---
+
+## 5. Replace `fold_state_snapshot` ad-hoc tuple with bag generation counter
+
+**Where:** `src/builder.rs:6075-6103` — the hand-coded
+`(answers, type_constraints.len(), invocant_filled)` tuple that
+`fold_to_fixed_point` uses to detect convergence.
+
+**Why:** the snapshot is a maintainability hazard. Every re-emittable
+pass that produces an observable signal needs a manual entry in the
+tuple, or the worklist terminates early. D3 had to add the
+`invocant_filled` term specifically because
+`emit_method_call_return_edges` produced no other change visible to
+the snapshot — an iteration that only filled new `invocant_class`
+slots would otherwise return the same `(answers, tc_len)` and the
+loop would exit before chain typing finished propagating. This is the
+kind of trap that bites later, after the person who knew about it
+moves on.
+
+**How to apply:** replace the tuple with a single monotonically
+increasing `bag_generation: u64` on `WitnessBag`, bumped by every
+`push` and `remove_by_source_tag`. `fold_state_snapshot` returns
+`(generation, type_constraints.len())` and convergence is
+"two consecutive iterations with the same pair." Any future
+re-emittable pass automatically participates because every bag write
+bumps the counter; no per-pass bookkeeping. The existing comment at
+`fold_state_snapshot` documenting the "what registers as movement?"
+trap can then be deleted — the structure prevents the trap.
+
+**Watch out for:** `populate_witness_bag` runs once before the loop,
+so the loop's first iteration already sees the seeded generation.
+`apply_type_overrides` runs even earlier — same. The fixed point
+detector compares only across loop iterations, so initial pushes
+don't matter. But re-emittable passes that `remove_by_source_tag`
+before re-pushing will bump the generation TWICE per iteration
+(remove + push); that's still fine — it just means the snapshot
+strictly grows when work happens. The convergence rule is unchanged.
 
 ---
 

--- a/docs/working-bag-residual.md
+++ b/docs/working-bag-residual.md
@@ -485,6 +485,39 @@ everything else is at most a derived index rebuilt from it.
       `emit_branch_arm_witnesses_for_ternary` becomes one Edge from
       `Variable($x)` to `Expr(ternary_span)`.
 
+- [ ] **Drop `SubReturnReducer`'s `arity_hint.is_some()` short-circuit
+      and the matching `branch_arm` source-tag exclusion**
+      (witnesses.rs:863-902). These are the last source-tag claim
+      filters in the registry — D3 collapsed four to one for
+      `SubReturnReducer`, but the one stayed because two distinct
+      facts still share `Symbol(_)`:
+
+      1. The per-symbol stored return ("if you ask THIS sym, ignoring
+         arity, this is the answer").
+      2. Per-arm `branch_arm` witnesses materialized onto `Symbol(_)`
+         after edge chase (one synthetic `InferredType` per arm,
+         source preserved). `SymbolReturnArmFold` claims those for
+         agreement / disagreement; `SubReturnReducer` must NOT
+         paper-over their `None` with a latest-wins pick.
+
+      The `arity_hint.is_some()` guard is the same compromise on the
+      other axis: at `arity=Some`, we want the per-class arm dispatch
+      via `MethodOnClass{class, name}`, not a single sym's stored
+      return (otherwise Mojo getter-vs-writer wrong-answers — the
+      getter sym surfaces String when level(1) was asked).
+
+      **Real fix:** move per-arm branch witnesses off `Symbol(_)` to
+      a dedicated attachment shape (`SymbolReturnArm(SymbolId)` or
+      reuse `Expr(body_span)` per the per-arm-Edge collapse above),
+      and route arity dispatch through `MethodOnClass` exclusively
+      so `Symbol(_)` carries only one fact family. After that, both
+      the source-tag filter and the arity_hint short-circuit can
+      go — `SubReturnReducer::claims` becomes plain
+      "Symbol + InferredType, period" and `reduce` becomes
+      unconditional latest-wins. **Until this lands the
+      "claim by attachment shape, not source tag" rule has one
+      documented exception.**
+
 ---
 
 ## Roadmap — separate design session
@@ -502,10 +535,13 @@ everything else is at most a derived index rebuilt from it.
   context). Until then, leave the bolt-on alone — but do NOT ship more
   arity-shaped facts that need their own reducer.
 
-- **Reducer-claim discipline.** After Directive 3 lands, write down
-  the rule: "a reducer claims by attachment-shape, not by source tag.
+- **Reducer-claim discipline.** D3 landed with the rule almost
+  enforced: "a reducer claims by attachment-shape, not by source tag.
   If you need source-tag disambiguation, you're modeling two facts —
-  give them two attachments."
+  give them two attachments." One documented exception remains
+  (`SubReturnReducer`'s `branch_arm` filter + `arity_hint`
+  short-circuit) and is tracked in the D4 list above; the rule
+  becomes unconditional once that item lands.
 
 ---
 

--- a/docs/working-bag-residual.md
+++ b/docs/working-bag-residual.md
@@ -275,103 +275,133 @@ never fight over the same witness set.
 
 ---
 
-## Directive 3 — One attachment per fact, no source-tag claims
+## Directive 3 — One attachment per fact, no source-tag claims — **LANDED (with residue)**
 
-Multiple reducers claim `Symbol(_)` + `InferredType` today. They
-disambiguate by `WitnessSource` tag: `PluginOverrideReducer` claims
-priority>10, `BranchArmFold` claims `branch_arm`, `SubReturnReducer`
-claims `local_return` / `imported_return` / `delegation` /
-`self_method_tail` (the last two added by D1's writeback rewrite),
-`FluentArityDispatch` claims a different payload. A new push that
-lands on the same attachment with a new source tag silently bypasses
-the gate that the original author of the source filter wrote.
+> **Status:** landed on `refactor/bag-residual-d3`. The variant
+> `WitnessAttachment::NamedSub` is gone, the dual writeback collapsed
+> to `Symbol(sid)` + `MethodOnClass{class, name}` only, cross-file
+> imports route through `module_index.find_exporters` + recursive
+> `Symbol(cached_sid)` query, and source-tag claim filters on
+> `SubReturnReducer` collapsed to a single `branch_arm` exclusion.
+> Two design choices departed from the original directive — see
+> "Residue" below.
 
-This is the "fill in the hack somewhere else" pattern. Kill it by
-giving each semantic category its own attachment shape. **D3 also
-absorbs two bullets from D1 that did not land as the directive
-required.**
+### What landed
 
-**Action items.**
+- [x] **Killed `WitnessAttachment::NamedSub`** entirely. `cargo build`
+      enumerated 17 consumers; each was migrated to `Symbol(sid)`
+      (id-keyed) or `MethodOnClass{class, name}` (class-keyed) or
+      deleted outright (writeback's name-keyed mirror,
+      `record_framework_accessor_witness`'s name-keyed observation,
+      `emit_delegation_edges`' name-keyed primary).
 
-- [ ] **Inheritance via `Edge(MethodOnClass(parent, name))` witnesses.**
-      *(Routed from D1.)* Today `query_rec` chases inheritance
-      structurally — for a `MethodOnClass{C, m}` query the local bag
-      can't answer, the registry consults `ctx.package_parents`,
-      `ctx.module_index.parents_cached`, and
-      `idx.for_each_entity_bridged_to(class, ...)` and recurses on
-      `MethodOnClass{P, m}`. That's a hand-rolled walker over a graph
-      that's about to be unified by `prompt-graph-walking.md`. Replace
-      it with build-time emission: for each `package_parents[C] = [P1,
-      P2, ...]`, push `MethodOnClass(C, m) → Edge(MethodOnClass(P_i, m))`
-      witnesses; for each PluginNamespace bridged to `class`, push
-      `MethodOnClass(class, name) → Edge(Symbol(entity_id))`
-      witnesses (the bridge half already lands in
-      `write_back_sub_return_types`'s plugin-bridge pass — extend it
-      to also cover cross-file bridges by reading
-      `module_index.workspace_namespaces()` or equivalent). Then
-      delete the structural fallback in `query_rec` — the registry's
-      existing edge-chase machinery handles MRO and bridge walking
-      without further code. Cross-file primary lookup
-      (`module_index.get_cached(class)`) can stay as a single
-      cross-bag recursion or move to a `MethodOnClass(class, _) →
-      Edge(... in cached bag)` shape; pick whichever the residual
-      `query_rec` code reduces to most cleanly.
+- [x] **Drop the dual `Symbol(_)` + `NamedSub(_)` writeback.** Local
+      subs publish on `Symbol(sym_id)` + `MethodOnClass{class, name}`
+      only. Plugin synth (`Method` and `Symbol` arms) drops the
+      free-function `NamedSub` push and relies on `Symbol(sid)`.
 
-- [ ] **Delete `build_imported_return_types`** (backend.rs:134) and
-      the imported-return push inside
-      `FileAnalysis::enrich_imported_types_with_keys`. *(Routed from
-      D1.)* The cross-file `MethodOnClass` query subsumes both —
-      `BagContext.module_index` is wired through, so registry queries
-      against a bag without local `NamedSub("foo")` witnesses already
-      reach the cached module's bag for `foo`'s return type. Keep the
-      `HashKeyDef` synthesis half of
-      `enrich_imported_types_with_keys` (it's a separate concern —
-      injecting synthetic symbols for fat-comma key completion). The
-      `imported_returns` HashMap parameter on
-      `enrich_imported_types_with_keys` becomes vestigial once the
-      function only synthesizes hash keys; either drop the parameter
-      or rename the function to reflect its narrower scope.
+- [x] **Cross-file imports stop riding `NamedSub`.**
+      `query_sub_return_type` walks `idx.find_exporters(name)` and
+      recurses into the cached module's bag with
+      `Symbol(cached_sid)`. Same registry, same arity dispatch, same
+      framework rules — only the bag and symbols change.
 
-- [ ] **Drop the dual `Symbol(_)` + `NamedSub(_)` writeback** in
-      `write_back_sub_return_types` (builder.rs around the
-      `writeback_witnesses` push). Pick one attachment per sub. For
-      local subs that's `Symbol(sym_id)`. The registry exposes a
-      name→sym_id resolver (built from the symbols table) so
-      name-keyed callers (cross-file imports, plugin overrides on
-      names that haven't been resolved to ids yet) hit the right id
-      without a parallel attachment. `MethodOnClass{class, name}`
-      stays — it's the class-keyed shape that earned its keep in D1.
+- [x] **Delete `build_imported_return_types`** (backend.rs) and the
+      `imported_returns` / `imported_hash_keys` parameters on
+      `enrich_imported_types_with_keys`. The function now derives
+      `imported_hash_keys` inline from `self.imports` +
+      `module_index`. Imported return types are reached lazily by
+      the bag-query path; no local mirror is needed.
 
-- [ ] **Cross-file imports stop riding `NamedSub`.** Imported subs
-      do have a sym_id once enrichment runs
-      (`enrich_imported_types_with_keys` synthesizes HashKeyDef
-      symbols already; do the same for the sub itself, or extend the
-      registry's name-resolver to chase across `module_index`).
-      Combines with the bullet above to remove the last `NamedSub`
-      consumer.
+- [x] **Build-time `Edge(MethodOnClass(parent, name))` inheritance
+      witnesses.** *(Routed from D1.)* Local writeback emits
+      `MethodOnClass(child, m) → Edge(MethodOnClass(parent, m))` for
+      every method `m` declared on a *local* parent, with
+      first-parent-wins dedup so DFS-MRO order is preserved.
+      `enrich_imported_types_with_keys` does the same projection for
+      *cross-file* parents (their methods are read from the cached
+      analysis). Tag `inheritance` (writeback) and
+      `inheritance_cross` (enrichment).
 
-- [ ] **Kill `WitnessAttachment::NamedSub`.** Once the two callers
-      above migrate, the variant goes away.
+- [x] **Method-call expression edges keyed on class.** D2 left
+      `Edge(NamedSub(method))` on `Expression(refidx)` as the
+      chain-typer's bootstrap. D3 replaces it with a re-emittable
+      pass `emit_method_call_return_edges` that publishes
+      `Edge(MethodOnClass{class, method})` for every `MethodCall` ref
+      whose `invocant_class` is currently filled. Re-emission inside
+      the worklist driver picks up newly-resolvable invocants each
+      iteration; `apply_chain_typing_invocants` now runs in PreFold
+      too (was PostFold-only) so the variable-typed receivers'
+      classes land in the bag while the worklist is still iterating.
+      Snapshot extended to track filled-`invocant_class` count so
+      the loop registers the progression as movement.
 
-- [ ] **Kill source-tag claim filters.** `SubReturnReducer::claims`
-      currently matches `local_return` / `imported_return` /
-      `delegation` / `self_method_tail` (four filters; D1 added the
-      latter two). Should match by attachment-shape disjointness
-      instead. After arms move to `Expr` attachments (Directive 2),
-      branch_arm witnesses no longer land on `Symbol(_)` — the
-      source-tag exclusion in `FrameworkAwareTypeFold::claims` and
-      `SubReturnReducer::claims` becomes unnecessary. Delegation /
-      self-method-tail edges already ride `Edge(...)` payloads; the
-      tag-filter on the `InferredType` payload exists only because
-      writeback also pushes plain `InferredType` on the same
-      attachment under those tags — and that goes away when the
-      writeback collapses to one attachment per sub (bullet above).
+- [x] **Source-tag claim filters collapsed.** `SubReturnReducer::claims`
+      now matches by attachment shape + the single `branch_arm`
+      exclusion (which still must stay — see residue). The four-way
+      filter on `local_return` / `delegation` / `self_method_tail` /
+      `imported_return` is gone.
 
-- [ ] **Kill `SubReturnReducer`'s `if q.arity_hint.is_some()`
-      short-circuit** (witnesses.rs around line 875). With distinct
-      attachments for "stored return" vs "guarded arm," the
-      registry's first-match dispatch handles ordering naturally —
-      no reducer needs to know another reducer exists.
+### Residue
+
+Two pieces of the original directive shipped differently than the
+plan called for; both were design adjustments forced by the "what
+if the caller bypasses enrichment?" question and the "build-time
+edges N×N for cross-file plugin bridges" question.
+
+1. **`query_rec`'s structural inheritance + bridge fallback was
+   NOT deleted.** Build-time edges optimize the common path
+   (writeback handles every local-parent method; enrichment handles
+   every cross-file-parent method), but tests and tools that build
+   a `FileAnalysis` without going through enrichment (hand-crafted
+   FAs in unit tests, isolated builders) need *some* path to find
+   inherited methods. Restoring the structural walk preserves that
+   floor. The walk is now documented as a transitional fallback
+   pending the graph-walking pillar; build-time edges remain the
+   primary path.
+
+   Cross-file plugin-namespace bridges (#3 of the structural walk —
+   `for_each_entity_bridged_to`) also stayed for a different reason:
+   pre-emitting `MethodOnClass(bridged_class, helper_name) →
+   Edge(...)` for every helper in every other file is N×N in the
+   worst case. The lazy `for_each_entity_bridged_to` walk is
+   strictly more efficient. The directive's "extend the writeback to
+   cover cross-file bridges" is feasible but unnecessary while the
+   walk is integrated with the registry (not a parallel system).
+
+2. **`SubReturnReducer`'s `arity_hint.is_some()` short-circuit
+   stayed.** D2 was supposed to move every branch_arm witness off
+   `Symbol(_)` so the source-tag filter could collapse, but the
+   materializer's `Symbol(_) + InferredType` synthetic witnesses
+   (one per arm, source preserved) still land on Symbol after edge
+   chase — `SymbolReturnArmFold` claims them via its `branch_arm`
+   filter. SubReturnReducer's matching exclusion is the floor that
+   keeps disagreement signals propagating. Same for the arity_hint
+   guard: removing it lets the per-getter-Symbol query at arity=1
+   wrong-answer with the getter's stored String instead of routing
+   to the writer's per-class arm. The `arity_hint=Some` →
+   `MethodOnClass{class, name}` escalation in `query_sub_return_type`
+   is what handles the cross-symbol dispatch.
+
+   Net effect: source-tag claims in `SubReturnReducer` collapsed
+   from four entries to one (`branch_arm` only). Same for
+   `FrameworkAwareTypeFold` and `ExprReturn`. Full collapse waits
+   on a follow-up that moves materialized branch_arm witnesses to a
+   dedicated attachment shape.
+
+### Validation
+
+After this directive: 507 unit tests + 93 e2e tests green. The
+unit count went up by 1 (rewrote
+`plugin_override_reducer_yields_when_only_builder_witnesses_present`
+to assert the post-D3 behavior; deleted two tests of the now-dead
+imported-returns parameter; rewrote
+`test_phase5_consumer_side_cross_file_resolves_via_enrichment` to
+build a real `ModuleIndex` stub instead of passing
+`imported_returns` as a parameter).
+
+Cache `EXTRACT_VERSION` bumped 19 → 20 (bag shape changed; cached
+blobs from older builds are re-resolved with priority).
 
 ---
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -7,7 +6,7 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::lsp_types::{notification, request};
 use tower_lsp::{Client, LanguageServer};
 
-use crate::file_analysis::{FileAnalysis, InferredType};
+use crate::file_analysis::FileAnalysis;
 use crate::file_store::{FileKey, FileStore};
 use crate::module_index::ModuleIndex;
 use crate::symbols;
@@ -48,13 +47,7 @@ impl Backend {
                 // across the await — publishing is async and could deadlock.
                 let mut pending: Vec<(Url, Vec<Diagnostic>)> = Vec::new();
                 files.for_each_open_mut(|uri, doc| {
-                    let (imported_returns, imported_keys) =
-                        build_imported_return_types(&doc.analysis, module_index);
-                    doc.analysis.enrich_imported_types_with_keys(
-                        imported_returns,
-                        imported_keys,
-                        Some(module_index),
-                    );
+                    doc.analysis.enrich_imported_types_with_keys(Some(module_index));
                     let diagnostics = symbols::collect_diagnostics(&doc.analysis, module_index);
                     pending.push((uri.clone(), diagnostics));
                 });
@@ -76,13 +69,7 @@ impl Backend {
 
     fn enrich_analysis(&self, uri: &Url) {
         if let Some(mut doc) = self.files.get_open_mut(uri) {
-            let (imported_returns, imported_keys) =
-                build_imported_return_types(&doc.analysis, &self.module_index);
-            doc.analysis.enrich_imported_types_with_keys(
-                imported_returns,
-                imported_keys,
-                Some(&self.module_index),
-            );
+            doc.analysis.enrich_imported_types_with_keys(Some(&self.module_index));
         }
     }
 
@@ -121,53 +108,6 @@ fn refs_to_locations(results: Vec<crate::resolve::RefLocation>) -> Option<Vec<Lo
     });
     locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
     Some(locations)
-}
-
-#[cfg(test)]
-pub fn build_imported_return_types_for_test(
-    analysis: &crate::file_analysis::FileAnalysis,
-    module_index: &ModuleIndex,
-) -> (HashMap<String, InferredType>, HashMap<String, Vec<String>>) {
-    build_imported_return_types(analysis, module_index)
-}
-
-pub(crate) fn build_imported_return_types(
-    analysis: &crate::file_analysis::FileAnalysis,
-    module_index: &ModuleIndex,
-) -> (HashMap<String, InferredType>, HashMap<String, Vec<String>>) {
-    use crate::file_analysis::{SymKind, SymbolDetail};
-
-    let mut type_map = HashMap::new();
-    let mut keys_map = HashMap::new();
-    for import in &analysis.imports {
-        let cached = match module_index.get_cached(&import.module_name) {
-            Some(c) => c,
-            None => continue,
-        };
-        for sym in &cached.analysis.symbols {
-            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
-                continue;
-            }
-            // Limit to exported names for parity with prior ExportedSub behavior.
-            if !cached.analysis.export.iter().any(|n| n == &sym.name)
-                && !cached.analysis.export_ok.iter().any(|n| n == &sym.name)
-            {
-                continue;
-            }
-            if matches!(sym.detail, SymbolDetail::Sub { .. }) {
-                if let Some(ty) = cached.analysis.symbol_return_type_via_bag(sym.id, None) {
-                    type_map.insert(sym.name.clone(), ty);
-                }
-            }
-            if let Some(sub_info) = cached.sub_info(&sym.name) {
-                let hk = sub_info.hash_keys();
-                if !hk.is_empty() {
-                    keys_map.insert(sym.name.clone(), hk.to_vec());
-                }
-            }
-        }
-    }
-    (type_map, keys_map)
 }
 
 #[tower_lsp::async_trait]
@@ -625,7 +565,8 @@ impl LanguageServer for Backend {
                     _ => unreachable!(),
                 };
 
-                let mut all_changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+                let mut all_changes: std::collections::HashMap<Url, Vec<TextEdit>> =
+                    std::collections::HashMap::new();
 
                 let mut collect = |uri: Url, analysis: &FileAnalysis| {
                     let edits = rename_fn(analysis, &name, new_name);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -351,14 +351,13 @@ impl<'a> Builder<'a> {
     ///   - one `InferredType` payload + (optional) class-assertion
     ///     observation per `TypeConstraint`,
     ///   - `HashRefAccess` observations per `$v->{k}` ref,
-    ///   - `Edge(NamedSub(method))` payloads per method-call ref so
-    ///     the fluent-chain Expression-attached fold sees the chased
-    ///     return type as a plain `InferredType` after registry
-    ///     materialization (replaces the closure-driven
-    ///     `TypeObservation::ReturnOfName` path),
     ///   - `mutation` facts on each Class/Sub-owned hash-key write,
     ///   - everything `pending_witnesses` collected during the walk
     ///     (branch arms, arity gating).
+    ///
+    /// Method-call return edges (`Expression(refidx) → Edge(MethodOnClass{class, method})`)
+    /// are emitted later — by `emit_method_call_return_edges` from
+    /// inside the worklist, once `invocant_class` is filled.
     ///
     /// After this point the bag is the source of truth. Subsequent
     /// passes that introduce new facts (call-binding propagation in
@@ -702,7 +701,7 @@ fn raw_mid_op(node: tree_sitter::Node, source: &[u8]) -> String {
 /// Structural index of one return-expression in a sub body. Type
 /// information lives in the bag: the body expression carries its own
 /// `Expr(body_span)` witnesses (literal types, Edges to Variable /
-/// NamedSub / Expression / nested Expr), and `Symbol(sub_id)` collects
+/// Symbol / Expression / nested Expr), and `Symbol(sub_id)` collects
 /// per-arm `branch_arm`-source `Edge(Expr(...))` witnesses. What's
 /// left in this struct is what consumers still need at a glance:
 /// which sub the return belongs to, where it is, the arity bucket it
@@ -903,10 +902,15 @@ struct Builder<'a> {
     /// (deleted in D1 of the bag-residual refactor). Walk-time synthesis
     /// (Mojo/Moo/DBIC accessors) writes here; worklist's `return_types`
     /// fold writes here; the final writeback iterates this map to push
-    /// `Symbol(sid)` / `NamedSub(name)` / `MethodOnClass{class, name}`
+    /// `Symbol(sid)` and (for first-seen `(class, name)`) `MethodOnClass`
     /// witnesses into the bag. Lives only inside the builder — never
     /// makes it into `FileAnalysis`. The bag is the single durable
     /// authority on return types post-build.
+    ///
+    /// Scheduled for deletion: see `docs/prompt-cleanups.md` #1. Direct
+    /// emit at synthesis time would remove this sidecar; what blocks it
+    /// is `MethodOnClass` primary-dedup, which currently needs the full
+    /// symbol list visible at writeback.
     resolved_returns: std::collections::HashMap<SymbolId, InferredType>,
     /// Framework mode per package (Moo, Moose, MojoBase) for accessor synthesis.
     framework_modes: std::collections::HashMap<String, FrameworkMode>,
@@ -1327,7 +1331,7 @@ impl<'a> Builder<'a> {
     ///   - bareword `Foo` (sub with ClassName return)          → that class
     ///   - bareword `Foo` (no such sub)                        → ClassName(Foo)
     ///   - `shift` / `$_[0]` in method body                    → ClassName(current_package)
-    ///   - `get_foo()->bar()` outer's invocant                 → bag query NamedSub(get_foo, arity)
+    ///   - `get_foo()->bar()` outer's invocant                 → bag query Symbol(get_foo, arity)
     /// `@`/`%` containers and unrecognized kinds return `None`.
     fn invocant_type_at_node(&self, node: Node<'a>) -> Option<InferredType> {
         match node.kind() {
@@ -1345,11 +1349,12 @@ impl<'a> Builder<'a> {
                 // Arity from the method-call node disambiguates fluent
                 // accessors (Mojo::Base `has 'title' => 'default'`
                 // synthesizes a 0-arg getter returning String AND a
-                // 1-arg writer returning $self). Without it the Edge
-                // chase to NamedSub(method) falls through
-                // FluentArityDispatch (no matching arm without a hint)
-                // to NamedSubReturn — latest-wins picks the writer's
-                // ClassName instead of the getter's String.
+                // 1-arg writer returning $self). Without it the
+                // MethodOnClass chase falls through FluentArityDispatch
+                // (no matching arm without a hint) and the primary
+                // (first-seen sym for the (class, name) pair) wins —
+                // which can be the writer's ClassName instead of the
+                // getter's String depending on declaration order.
                 let arity = self.extract_call_args(node).len() as u32;
                 self.bag_query_expression(crate::witnesses::RefIdx(idx as u32), Some(arity))
             }
@@ -1464,8 +1469,8 @@ impl<'a> Builder<'a> {
     /// Thin wrapper over `invocant_type_at_node`. Same node-kind
     /// dispatch the post-walk chain typer uses — variable arms read
     /// TCs (canonical at walk time, mirrored to the bag post-walk),
-    /// bareword arms query NamedSub, method-call arms query
-    /// Expression(refidx), shift / `$_[0]` / `__PACKAGE__` use
+    /// bareword arms query the local Symbol's return, method-call arms
+    /// query Expression(refidx), shift / `$_[0]` / `__PACKAGE__` use
     /// current_package. One function, one dispatch.
     fn receiver_type_for(&self, invocant_node: Option<Node<'a>>) -> Option<InferredType> {
         self.invocant_type_at_node(invocant_node?)
@@ -3560,8 +3565,9 @@ impl<'a> Builder<'a> {
             // Method call — constructor pattern is closed under
             // syntax (`Foo->new` → `ClassName("Foo")`), bake. Otherwise
             // Edge to the call's `Expression(refidx)` attachment;
-            // populate_witness_bag has pushed `Edge(NamedSub(method))`
-            // there, so the chase resolves through.
+            // `emit_method_call_return_edges` re-emits
+            // `Edge(MethodOnClass{class, method})` there once
+            // `invocant_class` is filled, so the chase resolves through.
             "method_call_expression" => {
                 if let Some(class) = self.extract_constructor_class(node) {
                     return Some(WitnessPayload::InferredType(InferredType::ClassName(class)));
@@ -3619,7 +3625,7 @@ impl<'a> Builder<'a> {
     /// Emit the `Expr(span)` witnesses for `node` and (recursively)
     /// its sub-arms. For a non-ternary node: one witness on
     /// `Expr(span)` with the node's `expr_payload` (literal type, or
-    /// Edge to Variable/NamedSub/Expression). For a ternary: two
+    /// Edge to Variable/Symbol/Expression). For a ternary: two
     /// `branch_arm`-source `Edge(Expr(arm_span))` witnesses on
     /// `Expr(span)`, plus a recursive call per arm so each arm's own
     /// `Expr(span)` is populated. Idempotent on span — multiple
@@ -6410,8 +6416,9 @@ impl<'a> Builder<'a> {
     }
 
     /// Bag-routed lookup for a sub's return type by name. Goes through
-    /// `query_sub_return_type` so arity dispatch / NamedSubReturn /
-    /// imported-return all compose. `arity_hint` is `None` for the
+    /// `query_sub_return_type` so arity dispatch (FluentArityDispatch),
+    /// the per-Symbol stored return (SubReturnReducer), and cross-file
+    /// imports (recurse into the cached module's bag) all compose. `arity_hint` is `None` for the
     /// chain-typer's invocant resolution since chain typing wants
     /// "what does this sub return when called as I see it being
     /// called" — for invocant resolution that's typically the
@@ -6876,27 +6883,40 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Step 7: writeback. Set `return_type` on matching Sub/Method
-    /// symbols, push a `NamedSub(name) → InferredType(t)` witness for
-    /// each resolved return so the bag publishes the answer to every
-    /// consumer (chain typer's `Edge(NamedSub(_))` chase, cross-file
-    /// callers via `query_sub_return_type`'s NamedSub branch — same
-    /// shape `enrich_imported_types_with_keys` uses for imports), and
-    /// record `return_self_method` for subs whose return type couldn't
+    /// Step 7: writeback. Iterate `resolved_returns` and publish each
+    /// resolved per-symbol return type to the bag on two attachments:
+    ///
+    ///   - `Symbol(sym_id)` — id-keyed answer, claimed by
+    ///     `SubReturnReducer`. Used by per-symbol queries that already
+    ///     know which sym they're asking about (cross-file imports
+    ///     recursing into a cached bag, dump-package iteration).
+    ///   - `MethodOnClass{class, name}` — class-keyed answer, claimed
+    ///     by `MethodOnClassReducer`. Only the FIRST sym for a given
+    ///     `(class, name)` pair publishes here (the "primary"); later
+    ///     syms participate via `ArityReturn` observations only. This
+    ///     is what `find_method_return_type` queries for the no-arity
+    ///     fallback.
+    ///
+    /// Cross-file imports do not get a writeback push here — they
+    /// resolve lazily via `query_sub_return_type` walking
+    /// `module_index.find_exporters` and recursing into the cached
+    /// module's `Symbol(cached_sid)`. Same registry, same rules; no
+    /// local mirror needed.
+    ///
+    /// `return_self_method` is set for subs whose return couldn't
     /// be collapsed in-file. Plugin overrides flow through
     /// `return_types` via the bag-priority seeding step, with
     /// `return_provenance` cleared so we don't clobber the existing
     /// `PluginOverride` entry written by `apply_type_overrides`. No
     /// special-case skip needed — overrides win because they're
-    /// higher-priority bag witnesses, not because the writeback knows
-    /// about them.
+    /// higher-priority bag witnesses.
     ///
     /// Idempotent across re-runs: `bag.remove_by_source_tag("local_return")`
-    /// at the start of every call drops the prior pass's NamedSub
-    /// witnesses before re-emitting. The worklist driver calls
-    /// `resolve_return_types` repeatedly until fixed point; without
-    /// this clear-and-emit, each iteration would duplicate every
-    /// sub's NamedSub witness.
+    /// (and `"plugin_bridge"` / `"inheritance"`) at the start of every
+    /// call drops the prior pass's witnesses before re-emitting. The
+    /// worklist driver calls `resolve_return_types` repeatedly until
+    /// fixed point; without this clear-and-emit, each iteration would
+    /// duplicate every sub's writeback witnesses.
     fn write_back_sub_return_types(
         &mut self,
         return_types: &std::collections::HashMap<String, InferredType>,
@@ -6975,17 +6995,14 @@ impl<'a> Builder<'a> {
         }
 
         // Publish every Sub/Method's resolved return type to the bag
-        // on THREE attachments:
-        //   - `NamedSub(name)` — name-keyed lookup. Cross-file imports
-        //     ride the same shape via `enrich_imported_types_with_keys`.
-        //     Used by chain typing's `Edge(NamedSub(_))` chases. This
-        //     attachment is going away in D3 (collapsed into
-        //     `MethodOnClass`); writes here will move with it.
+        // on TWO attachments:
         //   - `Symbol(sym_id)` — id-keyed lookup. The Symbol attachment
         //     carries every per-symbol fact in the bag (arity arms,
         //     plugin overrides). Writeback's value here is the
         //     "if you ask THIS sym what it returns, ignoring class
-        //     context, here's the inferred answer."
+        //     context, here's the inferred answer." Cross-file imports
+        //     reach this same shape by recursing into the cached
+        //     module's bag with `Symbol(cached_sid)`.
         //   - `MethodOnClass{class, name}` — class-keyed lookup. The
         //     authoritative class-scoped answer that
         //     `find_method_return_type` queries through. Multiple
@@ -6998,8 +7015,8 @@ impl<'a> Builder<'a> {
         //     `emit_arity_return_witnesses`'s mirror below).
         // Catches both worklist-resolved returns (set above) and
         // framework-pinned ones (Mojo::Base accessors, Moo `has`,
-        // DBIC column accessors — these set `return_type` in the
-        // SymbolDetail constructor at walk-time synthesis, never flow
+        // DBIC column accessors — these write directly into
+        // `resolved_returns` at walk-time synthesis, never flow
         // through `return_types`).
         let mut writeback_witnesses: Vec<Witness> = Vec::new();
         // Track primary for each (class, method_name) — the first

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -414,21 +414,18 @@ impl<'a> Builder<'a> {
             }
         }
 
-        // Rep observations + Expression-attached method-call returns
-        // from refs.
+        // Rep observations from `$v->{k}` access. Method-call return
+        // edges on `Expression(refidx)` are emitted later — by the
+        // chain-typing PostFold pass once `invocant_class` is filled —
+        // as `Edge(MethodOnClass{class, method})`. Without a known
+        // class there's no class-keyed answer to chase to, so the
+        // emission is gated by chain-typing's own progress.
         let mut hash_obs: Vec<(String, ScopeId, Span)> = Vec::new();
-        let mut method_exprs: Vec<(usize, String, Span)> = Vec::new();
-        for (i, r) in self.refs.iter().enumerate() {
-            match &r.kind {
-                RefKind::HashKeyAccess { var_text, .. } => {
-                    if var_text.starts_with('$') {
-                        hash_obs.push((var_text.clone(), r.scope, r.span));
-                    }
+        for r in self.refs.iter() {
+            if let RefKind::HashKeyAccess { var_text, .. } = &r.kind {
+                if var_text.starts_with('$') {
+                    hash_obs.push((var_text.clone(), r.scope, r.span));
                 }
-                RefKind::MethodCall { .. } => {
-                    method_exprs.push((i, r.target_name.clone(), r.span));
-                }
-                _ => {}
             }
         }
         for (var, scope, span) in hash_obs {
@@ -436,14 +433,6 @@ impl<'a> Builder<'a> {
                 attachment: WitnessAttachment::Variable { name: var, scope },
                 source: WitnessSource::Builder("hash_ref_access".into()),
                 payload: WitnessPayload::Observation(TypeObservation::HashRefAccess),
-                span,
-            });
-        }
-        for (idx, method, span) in method_exprs {
-            self.bag.push(Witness {
-                attachment: WitnessAttachment::Expression(crate::witnesses::RefIdx(idx as u32)),
-                source: WitnessSource::Builder("method_call_return".into()),
-                payload: WitnessPayload::Edge(WitnessAttachment::NamedSub(method)),
                 span,
             });
         }
@@ -1637,7 +1626,6 @@ impl<'a> Builder<'a> {
                 outline_label,
             } => {
                 let return_type_for_bag = return_type.clone();
-                let name_for_bag = name.clone();
                 let is_class_scoped = on_class.is_some();
                 let detail = SymbolDetail::Sub {
                     params: params.into_iter().map(Into::into).collect(),
@@ -1679,60 +1667,27 @@ impl<'a> Builder<'a> {
                 // Mirror the return type into the bag so walk-time and
                 // post-walk consumers see the plugin-synthesized sub
                 // through the same bag-query path locals + imports
-                // already use. Symbol(sid) always; NamedSub(name) only
-                // for free-function-style synth (`on_class.is_none()`).
-                // Class-scoped methods MUST stay class-scoped: pushing
-                // them on NamedSub would conflate same-named methods
-                // across classes (e.g. helper `users` namespace method
-                // on Mojolicious::Controller emitted by multiple
-                // unrelated `helper('users.X' => ...)` calls would
-                // collapse via NamedSubReturn-latest-wins, breaking
-                // class-scoped completion / hover).
+                // already use. Free-function synth gets `Symbol(sid)`;
+                // class-scoped synth (`on_class: Some(_)`) skips the
+                // bag push — `MethodOnClass{class, name}` is published
+                // later by the writeback from `resolved_returns`,
+                // keeping same-named methods across unrelated namespaces
+                // addressable per-class. Bridges remain the dispatch
+                // mechanism for class-scoped plugin synth (CLAUDE.md
+                // rule #8).
                 if let Some(rt) = return_type_for_bag {
                     use crate::witnesses::{
                         Witness, WitnessAttachment, WitnessPayload, WitnessSource,
                     };
-                    // Track the resolved return so the writeback's
-                    // `MethodOnClass` primary push picks this sym up.
                     self.resolved_returns.insert(sid, rt.clone());
                     if !is_class_scoped {
-                        // Top-level (free-function-style) plugin
-                        // synth: push Symbol + NamedSub. The bareword
-                        // invocant resolver in
-                        // `resolve_invocant_class_tree` queries
-                        // `NamedSub(name)` to type `app->routes` etc.,
-                        // so the push is required for that path.
                         self.bag.push(Witness {
                             attachment: WitnessAttachment::Symbol(sid),
-                            source: WitnessSource::Plugin(plugin_id.clone()),
-                            payload: WitnessPayload::InferredType(rt.clone()),
-                            span,
-                        });
-                        self.bag.push(Witness {
-                            attachment: WitnessAttachment::NamedSub(name_for_bag),
                             source: WitnessSource::Plugin(plugin_id),
                             payload: WitnessPayload::InferredType(rt),
                             span,
                         });
                     }
-                    // Class-scoped plugin synth (`on_class: Some(_)`):
-                    // skip the bag push entirely. Same-named methods
-                    // across unrelated namespaces (mojo-helpers
-                    // emits a `users` proxy on Controller AND inside
-                    // `admin`'s nested namespace, both sharing the
-                    // method name) are dispatched through plugin
-                    // namespace bridges via
-                    // `resolve_method_in_ancestors`, not the bag.
-                    // Bridges remain the dispatch mechanism for
-                    // class-scoped plugin synth (per CLAUDE.md rule
-                    // #8). The writeback that runs later iterates
-                    // `resolved_returns` and publishes
-                    // `MethodOnClass{class, name}` keyed by sym.package
-                    // (set by `add_symbol_ns` above) — class-scoped
-                    // synth gets its return type addressable through
-                    // the class-keyed bag attachment, where bridges
-                    // can find it without the cross-class
-                    // `NamedSub` collision risk.
                 }
             }
             plugin::EmitAction::HashKeyDef { name, owner, span, selection_span } => {
@@ -1824,13 +1779,10 @@ impl<'a> Builder<'a> {
                 // bag the same way the `Method` variant does, so the
                 // chain typer's bag-routed queries see
                 // plugin-synthesized callables (e.g. Mojolicious::Lite's
-                // `app` → ClassName(Mojolicious)). Only `SymKind::Sub`
-                // (free-function-style) gets the NamedSub push;
-                // methods stay class-scoped via Symbol(sid) +
-                // MethodOnClass{class, name} (published from
-                // `resolved_returns` by the writeback pass).
-                let push_named_sub = matches!(kind, SymKind::Sub);
-                let name_for_bag = name.clone();
+                // `app` → ClassName(Mojolicious)). One Symbol(sid)
+                // push covers every callable kind; the writeback's
+                // `MethodOnClass{class, name}` emission picks up
+                // class-scoped synths via `resolved_returns`.
                 let sid = self.add_symbol_ns(name, kind, span, selection_span, detail, ns);
                 if let Some(rt) = return_type {
                     use crate::witnesses::{
@@ -1839,18 +1791,10 @@ impl<'a> Builder<'a> {
                     self.resolved_returns.insert(sid, rt.clone());
                     self.bag.push(Witness {
                         attachment: WitnessAttachment::Symbol(sid),
-                        source: WitnessSource::Plugin(plugin_id.clone()),
-                        payload: WitnessPayload::InferredType(rt.clone()),
+                        source: WitnessSource::Plugin(plugin_id),
+                        payload: WitnessPayload::InferredType(rt),
                         span,
                     });
-                    if push_named_sub {
-                        self.bag.push(Witness {
-                            attachment: WitnessAttachment::NamedSub(name_for_bag),
-                            source: WitnessSource::Plugin(plugin_id),
-                            payload: WitnessPayload::InferredType(rt),
-                            span,
-                        });
-                    }
                 }
             }
             plugin::EmitAction::PackageParent { package, parent } => {
@@ -3631,24 +3575,34 @@ impl<'a> Builder<'a> {
                 ))))
             }
 
-            // Function call — Edge to NamedSub(name). Materialize
-            // chases NamedSub which carries InferredType from
-            // writeback (locals) or enrichment (imports).
+            // Function call — Edge to the matching local
+            // `Symbol(sid)`. For names that resolve to a local sub
+            // (or to a plugin-synthesized sub, since plugin synths
+            // also push into `self.symbols` before walk-time use),
+            // the chase resolves through. Cross-file imports without
+            // a local sym don't pin the Expr(span); chain typing's
+            // own resolvers cover the chain-receiver case.
             "function_call_expression" | "ambiguous_function_call_expression" => {
                 let func = node.child_by_field_name("function")?;
                 let name = func.utf8_text(self.source).ok()?;
-                Some(WitnessPayload::Edge(WitnessAttachment::NamedSub(
-                    name.to_string(),
-                )))
+                let bare = name.rsplit("::").next().unwrap_or(name);
+                let sid = self.symbols.iter().find(|s| {
+                    s.name == bare
+                        && matches!(s.kind, SymKind::Sub | SymKind::Method)
+                })?.id;
+                Some(WitnessPayload::Edge(WitnessAttachment::Symbol(sid)))
             }
 
             // Bareword / scoped-identifier as expression — same as
             // function call (calling a sub by name without parens).
             "bareword" | "scoped_identifier" => {
                 let name = node.utf8_text(self.source).ok()?;
-                Some(WitnessPayload::Edge(WitnessAttachment::NamedSub(
-                    name.to_string(),
-                )))
+                let bare = name.rsplit("::").next().unwrap_or(name);
+                let sid = self.symbols.iter().find(|s| {
+                    s.name == bare
+                        && matches!(s.kind, SymKind::Sub | SymKind::Method)
+                })?.id;
+                Some(WitnessPayload::Edge(WitnessAttachment::Symbol(sid)))
             }
 
             // Ternary — Edge to its own Expr(span). The per-arm
@@ -4411,15 +4365,17 @@ impl<'a> Builder<'a> {
     ///      of the invocant's `Mojo::Log`.
     ///
     /// This helper publishes both witnesses and the per-symbol
-    /// provenance entry. The two attachments cover the two query
-    /// shapes:
-    ///   - `Symbol(sym_id)` — bumps the symbol's witness count and
-    ///     handles per-symbol queries with an arity hint (e.g. the
-    ///     dump-package iteration).
-    ///   - `NamedSub(name)` — handles cross-symbol arity dispatch via
-    ///     `FluentArityDispatch`. The writer's `Some(1)` and the
-    ///     getter's `Some(0)` both attach here, and the reducer picks
-    ///     by `arity_hint` regardless of which sister `find()` returned.
+    /// provenance entry. Two attachment shapes cover the query
+    /// surface:
+    ///   - `Symbol(sym_id)` — per-symbol queries with an arity hint
+    ///     (e.g. the dump-package iteration); also bumps the
+    ///     symbol's witness count.
+    ///   - `MethodOnClass{class, name}` — cross-symbol arity dispatch
+    ///     scoped to the declaring class. The writer's `Some(1)` and
+    ///     the getter's `Some(0)` both attach here, and the reducer
+    ///     picks by `arity_hint` regardless of which sister `find()`
+    ///     returned. Class-keyed so `Sweet::flavor` and
+    ///     `Sour::flavor` stay addressable independently.
     ///
     /// Source is `Builder("framework_accessor")` — core synthesis,
     /// not a Plugin override. Provenance is `FrameworkSynthesis`
@@ -4451,7 +4407,7 @@ impl<'a> Builder<'a> {
         };
         let observation = TypeObservation::ArityReturn {
             arg_count: arity,
-            return_type: rt.clone(),
+            return_type: rt,
         };
         self.bag.push(Witness {
             attachment: WitnessAttachment::Symbol(sym_id),
@@ -4459,18 +4415,6 @@ impl<'a> Builder<'a> {
             payload: WitnessPayload::Observation(observation.clone()),
             span: zero,
         });
-        self.bag.push(Witness {
-            attachment: WitnessAttachment::NamedSub(name.to_string()),
-            source: WitnessSource::Builder("framework_accessor".to_string()),
-            payload: WitnessPayload::Observation(observation.clone()),
-            span: zero,
-        });
-        // Class-keyed mirror so `MethodOnClass{C, m}` queries pick up
-        // per-arity facts. NamedSub conflates classes that share a
-        // method name (Sweet::flavor vs Sour::flavor — both publish on
-        // `NamedSub("flavor")` and the latter overwrites the former
-        // in latest-wins semantics). MethodOnClass keys by class so
-        // each class's accessor stays addressable.
         if let Some(class) = self.current_package.clone() {
             self.bag.push(Witness {
                 attachment: WitnessAttachment::MethodOnClass {
@@ -6050,6 +5994,16 @@ impl<'a> Builder<'a> {
         match mode {
             ChainPassMode::PreFold => {
                 self.apply_chain_typing_assignments(idx);
+                // Refresh `invocant_class` each iteration too.
+                // Variable invocants whose TC just landed in the
+                // worklist's previous iteration become resolvable
+                // here — earlier this only ran in PostFold, which
+                // meant the bag's `method_call_return` edges
+                // (re-emitted from filled invocant_class) couldn't
+                // see them until the loop already terminated.
+                // `apply_chain_typing_invocants` is idempotent (skips
+                // refs whose class is already pinned).
+                self.apply_chain_typing_invocants(idx);
             }
             ChainPassMode::PostFold => {
                 self.apply_chain_typing_invocants(idx);
@@ -6118,7 +6072,7 @@ impl<'a> Builder<'a> {
     /// clear-and-emit, so their bag contribution is stable across
     /// iterations. The only monotonic-grower is chain typing's TCs,
     /// which the `type_constraints.len()` term captures.
-    fn fold_state_snapshot(&self) -> (Vec<(SymbolId, Option<InferredType>, Option<String>)>, usize) {
+    fn fold_state_snapshot(&self) -> (Vec<(SymbolId, Option<InferredType>, Option<String>)>, usize, usize) {
         let mut answers: Vec<(SymbolId, Option<InferredType>, Option<String>)> = self
             .symbols
             .iter()
@@ -6133,7 +6087,19 @@ impl<'a> Builder<'a> {
             })
             .collect();
         answers.sort_by_key(|(id, _, _)| id.0);
-        (answers, self.type_constraints.len())
+        // Count refs with filled `invocant_class` so progressive
+        // chain-typing inside the loop registers as movement —
+        // without this, an iteration that only newly fills
+        // `invocant_class` (driving the next iteration's
+        // `emit_method_call_return_edges` to publish a new edge)
+        // would produce the same answers/TCs snapshot and the loop
+        // would terminate prematurely.
+        let invocant_filled = self
+            .refs
+            .iter()
+            .filter(|r| matches!(&r.kind, RefKind::MethodCall { invocant_class: Some(_), .. }))
+            .count();
+        (answers, self.type_constraints.len(), invocant_filled)
     }
 
     /// Symbolically execute the rhs of every `my $X = <expr>` and
@@ -6347,11 +6313,48 @@ impl<'a> Builder<'a> {
     fn resolve_return_types(&mut self) {
         self.emit_arity_return_witnesses();
         self.emit_delegation_edges();
+        self.emit_method_call_return_edges();
         let (mut return_types, mut return_provenance) = self.fold_per_sub_return_arms();
         self.seed_plugin_overrides_into_return_types(&mut return_types, &mut return_provenance);
         self.write_back_sub_return_types(&return_types, &return_provenance);
         self.propagate_call_bindings_to_constraints(&return_types);
         self.fixup_call_bound_hash_key_owners(&return_types);
+    }
+
+    /// Re-emittable: for every `MethodCall` ref whose
+    /// `invocant_class` is filled (walk-time syntax-known invocants
+    /// like `Foo->m`, plus PostFold-resolved variable invocants),
+    /// publish `Expression(refidx) → Edge(MethodOnClass{class, method})`
+    /// so the chain typer's `bag_query_expression` chases the
+    /// receiver-and-method-resolved type through the class-keyed
+    /// attachment. Refs without a filled class skip emission —
+    /// without a known class there's no class-keyed slot to target.
+    ///
+    /// Clear-and-emit on tag `method_call_return` so repeat calls
+    /// inside the worklist driver stay idempotent.
+    fn emit_method_call_return_edges(&mut self) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+
+        self.bag.remove_by_source_tag("method_call_return");
+
+        let mut edges: Vec<Witness> = Vec::new();
+        for (i, r) in self.refs.iter().enumerate() {
+            let RefKind::MethodCall { invocant_class: Some(class), .. } = &r.kind else {
+                continue;
+            };
+            edges.push(Witness {
+                attachment: WitnessAttachment::Expression(crate::witnesses::RefIdx(i as u32)),
+                source: WitnessSource::Builder("method_call_return".into()),
+                payload: WitnessPayload::Edge(WitnessAttachment::MethodOnClass {
+                    class: class.clone(),
+                    name: r.target_name.clone(),
+                }),
+                span: r.span,
+            });
+        }
+        for w in edges {
+            self.bag.push(w);
+        }
     }
 
     /// Single-attachment registry query for `Expr(span)`. Used by
@@ -6737,24 +6740,24 @@ impl<'a> Builder<'a> {
 
     /// Re-emittable: push edge facts for every recorded sub-return
     /// delegation (`return other()` shape) and every self-method-tail
-    /// (`sub get { shift->method(...) }` shape) into the bag. Each
-    /// becomes `NamedSub(delegator) → Edge(NamedSub(delegate))`,
-    /// tagged so provenance attribution can later distinguish the two.
+    /// (`sub get { shift->method(...) }` shape) into the bag.
+    /// Edges live on `Symbol(delegator_sid)` (id-keyed) and
+    /// `MethodOnClass{class, delegator}` (class-keyed). The registry's
+    /// edge-chase resolves transitively, so multi-hop chains converge
+    /// as fast as the worklist's outer fold runs — no inner iter cap
+    /// to maintain.
     ///
     /// Replaces the old hand-rolled fixed-point loops
     /// (`propagate_via_delegation` / `propagate_via_self_method_tails`).
-    /// The registry's edge-chase resolves transitively, so multi-hop
-    /// chains converge as fast as the worklist's outer fold runs —
-    /// no inner iter cap to maintain.
     ///
     /// Clear-and-emit on tags `delegation` and `self_method_tail` so
     /// repeat calls inside the worklist driver stay idempotent (no
     /// duplicate edges accumulate).
     ///
     /// Self-recursion (a sub whose tail is its own name) is skipped —
-    /// can't infer your own return from yourself, and emitting the
-    /// edge would only contribute a `NamedSub(name) → Edge(NamedSub(name))`
-    /// that the registry's cycle guard would short-circuit on anyway.
+    /// can't infer your own return from yourself, and the registry's
+    /// cycle guard would short-circuit on the resulting self-edge
+    /// anyway.
     fn emit_delegation_edges(&mut self) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
 
@@ -6771,20 +6774,14 @@ impl<'a> Builder<'a> {
             if delegator == delegate {
                 continue;
             }
-            delegation_edges.push(Witness {
-                attachment: WitnessAttachment::NamedSub(delegator.clone()),
-                source: WitnessSource::Builder("delegation".into()),
-                payload: WitnessPayload::Edge(WitnessAttachment::NamedSub(delegate.clone())),
-                span: zero,
-            });
-            // Mirror onto MethodOnClass and Symbol for each sym that
-            // matches the delegator name. Class-keyed dispatch
-            // (`find_method_return_type`) and id-keyed Symbol
-            // queries both resolve through delegation chains via
-            // the registry's edge chase — replaces the
-            // `fill_returns_via_bag_chase` build-time pass that used
-            // to read the chain answer and write it back as a
-            // `Symbol.return_type` field.
+            // Resolve the delegate's first matching local sym for the
+            // id-keyed Edge target. `MethodOnClass` keeps the
+            // class-keyed edge name-based since class+name uniquely
+            // addresses the per-class dispatch slot.
+            let delegate_sid = self.symbols.iter().find(|s| {
+                s.name == *delegate
+                    && matches!(s.kind, SymKind::Sub | SymKind::Method)
+            }).map(|s| s.id);
             for sym in &self.symbols {
                 if sym.name != *delegator {
                     continue;
@@ -6792,12 +6789,14 @@ impl<'a> Builder<'a> {
                 if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                     continue;
                 }
-                delegation_edges.push(Witness {
-                    attachment: WitnessAttachment::Symbol(sym.id),
-                    source: WitnessSource::Builder("delegation".into()),
-                    payload: WitnessPayload::Edge(WitnessAttachment::NamedSub(delegate.clone())),
-                    span: zero,
-                });
+                if let Some(target_sid) = delegate_sid {
+                    delegation_edges.push(Witness {
+                        attachment: WitnessAttachment::Symbol(sym.id),
+                        source: WitnessSource::Builder("delegation".into()),
+                        payload: WitnessPayload::Edge(WitnessAttachment::Symbol(target_sid)),
+                        span: zero,
+                    });
+                }
                 let Some(class) = sym.package.as_ref() else { continue };
                 delegation_edges.push(Witness {
                     attachment: WitnessAttachment::MethodOnClass {
@@ -6833,17 +6832,9 @@ impl<'a> Builder<'a> {
             if sub_name == tail_method {
                 continue;
             }
-            tail_edges.push(Witness {
-                attachment: WitnessAttachment::NamedSub(sub_name.clone()),
-                source: WitnessSource::Builder("self_method_tail".into()),
-                payload: WitnessPayload::Edge(WitnessAttachment::NamedSub(tail_method.clone())),
-                span: zero,
-            });
-            // Mirror onto MethodOnClass and Symbol so class-keyed
-            // and id-keyed queries both chase through tail-call
-            // chains. Self-method-tails are class-scoped (`shift->M`
-            // calls M on the same class), so the chained edge
-            // stays inside the class's MethodOnClass attachment.
+            // Self-method-tails are class-scoped (`shift->M` calls M
+            // on the same class), so both the id-keyed and class-keyed
+            // edges stay inside the declaring class's namespace.
             for sym in &self.symbols {
                 if sym.name != *sub_name {
                     continue;
@@ -6851,15 +6842,21 @@ impl<'a> Builder<'a> {
                 if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                     continue;
                 }
-                tail_edges.push(Witness {
-                    attachment: WitnessAttachment::Symbol(sym.id),
-                    source: WitnessSource::Builder("self_method_tail".into()),
-                    payload: WitnessPayload::Edge(WitnessAttachment::NamedSub(
-                        tail_method.clone(),
-                    )),
-                    span: zero,
-                });
                 let Some(class) = sym.package.as_ref() else { continue };
+                // Resolve the tail-target sym in the same class.
+                let target_sid = self.symbols.iter().find(|s| {
+                    s.name == *tail_method
+                        && matches!(s.kind, SymKind::Sub | SymKind::Method)
+                        && s.package.as_deref() == Some(class.as_str())
+                }).map(|s| s.id);
+                if let Some(tsid) = target_sid {
+                    tail_edges.push(Witness {
+                        attachment: WitnessAttachment::Symbol(sym.id),
+                        source: WitnessSource::Builder("self_method_tail".into()),
+                        payload: WitnessPayload::Edge(WitnessAttachment::Symbol(tsid)),
+                        span: zero,
+                    });
+                }
                 tail_edges.push(Witness {
                     attachment: WitnessAttachment::MethodOnClass {
                         class: class.clone(),
@@ -6912,6 +6909,7 @@ impl<'a> Builder<'a> {
 
         self.bag.remove_by_source_tag("local_return");
         self.bag.remove_by_source_tag("plugin_bridge");
+        self.bag.remove_by_source_tag("inheritance");
 
         // First pass: update `resolved_returns` from worklist's
         // per-name folds and (when no fold answer exists) `return_self_method`
@@ -7028,19 +7026,11 @@ impl<'a> Builder<'a> {
             } else {
                 false
             };
-            // Symbol / NamedSub writeback: only when this sym has a
-            // resolved return type. Per-id (Symbol) and per-name
-            // (NamedSub) attachments answer their own queries. The
-            // single source of truth post-field-deletion is
+            // Symbol writeback: only when this sym has a resolved
+            // return type. The single source of truth is
             // `resolved_returns` — walk-time synthesis writes there,
             // worklist's first pass above updates it.
             let Some(rt) = self.resolved_returns.get(&sym.id).cloned() else { continue };
-            writeback_witnesses.push(Witness {
-                attachment: WitnessAttachment::NamedSub(sym.name.clone()),
-                source: WitnessSource::Builder("local_return".into()),
-                payload: WitnessPayload::InferredType(rt.clone()),
-                span: sym.span,
-            });
             writeback_witnesses.push(Witness {
                 attachment: WitnessAttachment::Symbol(sym.id),
                 source: WitnessSource::Builder("local_return".into()),
@@ -7094,6 +7084,69 @@ impl<'a> Builder<'a> {
                         },
                         source: WitnessSource::Builder("plugin_bridge".into()),
                         payload: WitnessPayload::Edge(WitnessAttachment::Symbol(*sym_id)),
+                        span: zero,
+                    });
+                }
+            }
+        }
+        // Inheritance edges: for every (child, parent) entry in
+        // `package_parents`, emit `MethodOnClass(child, m) →
+        // Edge(MethodOnClass(parent, m))` for each method `m` known
+        // on the parent (locally-declared or framework-synthesized).
+        // The registry's edge-chase walks these the same way it
+        // walks any other Edge — no procedural ancestor walker
+        // needed in `query_rec`. Cross-file parents inherit via
+        // the registry's existing cached-bag recursion in
+        // `query_rec`'s `MethodOnClass` arm: an edge into
+        // `MethodOnClass(P_cross, m)` re-enters `query` with the
+        // same attachment shape, and the shared visited set closes
+        // any mutual loops.
+        //
+        // Methods on the parent are enumerated locally — for parents
+        // that are themselves cross-file the recursion delivers
+        // their methods via the cached bag. Each local method-name
+        // emission is enough: when child's `MethodOnClass(C, m)`
+        // bag has no local witness, the inheritance Edge points at
+        // `MethodOnClass(P, m)` and the registry follows it.
+        let parents_snapshot: Vec<(String, Vec<String>)> = self
+            .package_parents
+            .iter()
+            .map(|(c, ps)| (c.clone(), ps.clone()))
+            .collect();
+        for (child, parents) in &parents_snapshot {
+            // Per-child: track which methods already got an
+            // inheritance edge, so the FIRST parent in `@ISA` order
+            // wins (Perl's default DFS-MRO is left-to-right). Without
+            // this dedup, two parents both defining `m` would push
+            // two edges on `MethodOnClass(child, m)` and the
+            // materializer's latest-wins reducer would silently pick
+            // the second-emitted parent.
+            let mut emitted_for_child: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for parent in parents {
+                if parent == child {
+                    continue;
+                }
+                for sym in &self.symbols {
+                    if sym.package.as_deref() != Some(parent.as_str()) {
+                        continue;
+                    }
+                    if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                        continue;
+                    }
+                    if !emitted_for_child.insert(sym.name.clone()) {
+                        continue;
+                    }
+                    writeback_witnesses.push(Witness {
+                        attachment: WitnessAttachment::MethodOnClass {
+                            class: child.clone(),
+                            name: sym.name.clone(),
+                        },
+                        source: WitnessSource::Builder("inheritance".into()),
+                        payload: WitnessPayload::Edge(WitnessAttachment::MethodOnClass {
+                            class: parent.clone(),
+                            name: sym.name.clone(),
+                        }),
                         span: zero,
                     });
                 }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -3247,12 +3247,12 @@ has 'name';
 /// `$ua->ca($f)->cert(...)` chain lost its receiver type at the second
 /// hop.
 ///
-/// Fix: framework synthesis now publishes per-arity `ArityReturn`
-/// observations on `NamedSub(name)`, and `FluentArityDispatch` claims
-/// `NamedSub` so the right arm wins regardless of which sister
-/// `find()` returned. Also publishes the same observations on
-/// `Symbol(id)` so per-symbol introspection (`witness_count`,
-/// arity-aware queries on a specific id) works.
+/// Fix: framework synthesis publishes per-arity `ArityReturn`
+/// observations on both `Symbol(sym_id)` (per-symbol introspection)
+/// and `MethodOnClass{class, name}` (cross-symbol arity dispatch
+/// scoped to the declaring class), and `FluentArityDispatch` claims
+/// either attachment so the right arm wins regardless of which
+/// sister sym `find()` returned.
 #[test]
 fn test_mojo_base_writer_returns_invocant_via_bag() {
     use crate::file_analysis::TypeProvenance;
@@ -3691,10 +3691,10 @@ has 'name' => (is => 'rw', isa => 'Str');
 /// Two unrelated classes (`Sweet`, `Sour`) ship a method `flavor` via
 /// Mojo::Base `has`, with different defaults. Class-keyed dispatch is
 /// required to disambiguate them — any code path that resolves
-/// methods by name alone (`return_types: HashMap<String, _>`,
-/// `WitnessAttachment::NamedSub(name)`, etc.) will silently shadow
-/// one class's getter with the other's whenever the second
-/// declaration overwrites the first.
+/// methods by name alone (a `return_types: HashMap<String, _>` mirror,
+/// or the now-deleted `WitnessAttachment::NamedSub(name)` shape)
+/// will silently shadow one class's getter with the other's whenever
+/// the second declaration overwrites the first.
 ///
 /// The arity=1 (fluent writer) assertions extend the same guarantee
 /// to overload dispatch: `Sweet`'s writer returns `Sweet`, `Sour`'s

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -6656,19 +6656,11 @@ sub to  { my $self = shift; return $self; }
     let mut fa = build_fa(app_src);
     // First enrichment — simulates publish_diagnostics after module
     // resolution. Populates type_constraints + type_constraints_by_var.
-    fa.enrich_imported_types_with_keys(
-        std::collections::HashMap::new(),
-        std::collections::HashMap::new(),
-        Some(&idx),
-    );
+    fa.enrich_imported_types_with_keys(Some(&idx));
     // Second enrichment — simulates a subsequent change or refresh.
     // Before the fix, the stale type_constraints_by_var indices
     // panicked `inferred_type` during resolve_method_call_types.
-    fa.enrich_imported_types_with_keys(
-        std::collections::HashMap::new(),
-        std::collections::HashMap::new(),
-        Some(&idx),
-    );
+    fa.enrich_imported_types_with_keys(Some(&idx));
 
     // Sanity: `$r` is still typed after the second run (not just
     // "didn't crash" — the state is actually usable).
@@ -6786,11 +6778,7 @@ sub to { my $self = shift; return $self; }
     // Mojolicious.pm's `routes` accessor) don't land in
     // `type_constraints`, and `$r` stays untyped.
     let mut fa = fa;
-    fa.enrich_imported_types_with_keys(
-        std::collections::HashMap::new(),
-        std::collections::HashMap::new(),
-        Some(&idx),
-    );
+    fa.enrich_imported_types_with_keys(Some(&idx));
     let fa = fa;
 
     // Locate the two target lines by content — decoupled from

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1107,21 +1107,18 @@ impl FileAnalysis {
 
     /// Mirror every existing `TypeConstraint` into the witness bag as
     /// a `Variable` witness (with class-assertion / FirstParam
-    /// observations for class-identity types), and every Sub/Method
-    /// symbol with a stored `return_type` as a `NamedSub` witness.
+    /// observations for class-identity types).
     ///
-    /// The Builder runs equivalent passes (`populate_witness_bag` for
-    /// constraints, `write_back_sub_return_types`'s NamedSub publish
-    /// for return types). This method is the fa-construction-time
+    /// Per-symbol return types are NOT seeded here — `Symbol.return_type`
+    /// was deleted in D1, and the bag carries those facts directly
+    /// (`Symbol(sym_id)` / `MethodOnClass{class, name}`) via the
+    /// builder's `write_back_sub_return_types` and round-trip through
+    /// the bincode blob. This method is the fa-construction-time
     /// counterpart for code that builds a FileAnalysis without going
     /// through `builder::build` — hand-crafted FAs in tests, ad-hoc
     /// FA assembly. Called from `FileAnalysis::new` and
-    /// `after_deserialize` to keep the invariant: bag and the
-    /// `Symbol.return_type` / `type_constraints` fields are always in
-    /// sync after a constructor returns. Without this, the bag's
-    /// canonical query path (`query_sub_return_type` etc.) silently
-    /// returns `None` for symbols whose return_type is set on the
-    /// field but never reached the bag.
+    /// `after_deserialize` to keep the invariant: bag and
+    /// `type_constraints` are in sync after a constructor returns.
     pub(crate) fn seed_bag_from_constraints(&mut self) {
         use crate::witnesses::{
             TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
@@ -1164,17 +1161,6 @@ impl FileAnalysis {
                 _ => {}
             }
         }
-        // Mirror every Sub/Method with a stored `return_type` as a
-        // `NamedSub(name) → InferredType(t)` witness — same shape
-        // `write_back_sub_return_types` publishes at the end of the
-        // worklist. The builder transfers its already-populated bag
-        // into `fa.witnesses` AFTER `FileAnalysis::new` returns, so on
-        // the build path these pushes are redundant duplicates of the
-        // builder's emissions; that's fine because `NamedSubReturn`
-        // takes the latest. On the non-build paths (hand-crafted FAs,
-        // bincode-deserialized blobs without a populated bag) this is
-        // the only seeding step that closes the "field set, bag empty"
-        // gap.
         // Sub/Method return-type seeding from `Symbol.return_type` is
         // gone: the field was deleted in D1 of the bag-residual
         // refactor. The bag is the single durable carrier of
@@ -1189,12 +1175,12 @@ impl FileAnalysis {
     /// bag has been moved in. Keeps the bag canonical: every new
     /// `TypeConstraint` pushed here lands as a `Witness` too.
     ///
-    /// `NamedSub(name) → InferredType(t)` witnesses for every local
-    /// Sub/Method are already in the bag — published by
-    /// `Builder::write_back_sub_return_types` at the end of the
-    /// worklist (single emission point for "this sub's return type
-    /// is known," same shape `enrich_imported_types_with_keys` uses
-    /// for imports).
+    /// `Symbol(sym_id)` and `MethodOnClass{class, name}` return-type
+    /// witnesses for every local Sub/Method are already in the bag —
+    /// published by `Builder::write_back_sub_return_types` at the
+    /// end of the worklist (single emission point for "this sub's
+    /// return type is known"). Cross-file imports do not get a local
+    /// mirror; they resolve lazily through `query_sub_return_type`.
     pub(crate) fn finalize_post_walk(&mut self) {
         self.resolve_method_call_types(None);
         self.base_type_constraint_count = self.type_constraints.len();
@@ -1571,9 +1557,10 @@ impl FileAnalysis {
     }
 
     /// Get the return type of a named sub/method. Local definitions
-    /// first (via the bag), then imported sub returns (also via the
-    /// bag's `NamedSub` attachment, which `enrich_imported_types_with_keys`
-    /// populates from module_index).
+    /// first (via the bag's `Symbol(sym_id)` writeback), then imported
+    /// sub returns (resolved lazily through `query_sub_return_type`'s
+    /// walk of `module_index.find_exporters` into the cached module's
+    /// own `Symbol(_)` witnesses).
     #[allow(dead_code)] // public type-query API; used by tooling/tests
     pub fn sub_return_type(&self, name: &str) -> Option<InferredType> {
         self.sub_return_type_at_arity(name, None)

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1591,31 +1591,64 @@ impl FileAnalysis {
             .unwrap_or(TypeProvenance::Inferred)
     }
 
-    /// Convenience wrapper: enrich with return types only (no hash keys).
-    #[cfg(test)]
-    pub fn enrich_imported_types(&mut self, imported_returns: HashMap<String, InferredType>) {
-        self.enrich_imported_types_with_keys(imported_returns, HashMap::new(), None);
-    }
-
-    /// Resolve call bindings for imported functions and inject hash key defs.
-    /// Call after building, when module index data is available.
+    /// Resolve call bindings for imported functions and inject
+    /// synthetic HashKeyDef symbols. Walks `self.imports` against
+    /// `module_index` to derive each imported sub's return type and
+    /// hash-key set inline — `build_imported_return_types` and the
+    /// `imported_returns` / `imported_hash_keys` parameters were
+    /// killed in D3 since the bag now reaches cross-file `Symbol(_)`
+    /// witnesses through `BagContext.module_index` directly. Call
+    /// after building, when the module index is available.
     pub fn enrich_imported_types_with_keys(
         &mut self,
-        imported_returns: HashMap<String, InferredType>,
-        imported_hash_keys: HashMap<String, Vec<String>>,
         module_index: Option<&ModuleIndex>,
     ) {
-        // Truncate back to baseline so repeated enrichment doesn't accumulate duplicates.
-        // Same idea applies to the bag — enrichment pushes new
-        // witnesses via `push_type_constraint`, so we truncate back
-        // to the build-time baseline witness count first.
+        // Truncate back to baseline so repeated enrichment doesn't
+        // accumulate duplicates. The bag is also truncated; enrichment
+        // pushes Variable witnesses via `push_type_constraint`.
         self.type_constraints.truncate(self.base_type_constraint_count);
         self.symbols.truncate(self.base_symbol_count);
         self.witnesses.truncate(self.base_witness_count);
 
+        // Build the import → exported-name map inline from
+        // `self.imports` + `module_index`. `imported_hash_keys` is
+        // the only piece still needed by enrichment; imported return
+        // types are reached lazily by `query_sub_return_type` walking
+        // `module_index.find_exporters(name)`.
+        let mut imported_hash_keys: HashMap<String, Vec<String>> = HashMap::new();
+        let mut imported_returns: HashMap<String, InferredType> = HashMap::new();
+        if let Some(idx) = module_index {
+            for import in &self.imports {
+                let Some(cached) = idx.get_cached(&import.module_name) else { continue };
+                for sym in &cached.analysis.symbols {
+                    if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                        continue;
+                    }
+                    if !cached.analysis.export.iter().any(|n| n == &sym.name)
+                        && !cached.analysis.export_ok.iter().any(|n| n == &sym.name)
+                    {
+                        continue;
+                    }
+                    if matches!(sym.detail, SymbolDetail::Sub { .. }) {
+                        if let Some(ty) = cached.analysis.symbol_return_type_via_bag(sym.id, None) {
+                            imported_returns.insert(sym.name.clone(), ty);
+                        }
+                    }
+                    if let Some(sub_info) = cached.sub_info(&sym.name) {
+                        let hk = sub_info.hash_keys();
+                        if !hk.is_empty() {
+                            imported_hash_keys.insert(sym.name.clone(), hk.to_vec());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Push call-binding TCs for imports whose return type the
+        // cross-file scan resolved. Same shape the local-sub path
+        // produces (`propagate_call_bindings_to_constraints`).
         let mut to_push: Vec<TypeConstraint> = Vec::new();
         for binding in &self.call_bindings {
-            // Skip if already resolved (local sub or builtin)
             if self.sub_return_type_local(&binding.func_name).is_some()
                 || builtin_return_type(&binding.func_name).is_some()
             {
@@ -1633,36 +1666,14 @@ impl FileAnalysis {
         for tc in to_push {
             self.push_type_constraint(tc);
         }
-        // Mirror every imported return type into the bag as a
-        // `NamedSub` witness so `query_sub_return_type` resolves
-        // imports through the same path it uses for locals. The
-        // bag is the only durable carrier of imported return types
-        // post-D1; the legacy `imported_return_types` map went away
-        // with the field-deletion pass.
-        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        for (name, ty) in &imported_returns {
-            self.witnesses.push(Witness {
-                attachment: WitnessAttachment::NamedSub(name.clone()),
-                source: WitnessSource::Enrichment("imported_return".to_string()),
-                payload: WitnessPayload::InferredType(ty.clone()),
-                span: Span {
-                    start: Point { row: 0, column: 0 },
-                    end: Point { row: 0, column: 0 },
-                },
-            });
-        }
-        let _ = imported_returns;
 
         // Inject synthetic HashKeyDef symbols for imported functions' hash keys.
         // Imported subs have no local package — package=None mirrors the
-        // HashKeyAccess fixup's default for imported bindings, so the pair
-        // match each other without bleeding into other workspace files'
-        // locally-packaged `sub get_config` hash keys.
+        // HashKeyAccess fixup's default for imported bindings.
         for (func_name, keys) in &imported_hash_keys {
             let owner = HashKeyOwner::Sub { package: None, name: func_name.clone() };
             for key_name in keys {
                 let id = SymbolId(self.symbols.len() as u32);
-                // Use a zero-size span at file start for synthetic symbols
                 let zero_span = Span {
                     start: Point { row: 0, column: 0 },
                     end: Point { row: 0, column: 0 },
@@ -1678,7 +1689,6 @@ impl FileAnalysis {
                     detail: SymbolDetail::HashKeyDef {
                         owner: owner.clone(),
                         is_dynamic: false,
-
                     },
                     namespace: Namespace::Language,
                     outline_label: None,
@@ -1686,14 +1696,12 @@ impl FileAnalysis {
             }
         }
 
-        // Phase 5 follow-up: the builder's HashKeyAccess owner fixup only runs
-        // for bindings where the func's return type is known at build time.
-        // Imported funcs aren't in that map; their return types come in via
-        // `imported_returns` here. Retry the fixup now so the consumer-side
-        // `$cfg = Lib::get_config(); $cfg->{host}` access gets its owner set
-        // to Sub{None, "get_config"}, matching the synthetic HashKeyDef we
-        // just injected. Without this, cross-file hash-key references
-        // would silently miss every consumer access.
+        // HashKeyAccess owner fixup for imports: the builder's pass
+        // only ran for bindings where the func's return type was
+        // known at build time. Cross-file return types come in here,
+        // so the consumer-side `$cfg = Lib::get_config(); $cfg->{host}`
+        // access gets its owner set to Sub{None, "get_config"},
+        // matching the synthetic HashKeyDef we just injected.
         let imported_keyed_subs: std::collections::HashSet<String> = imported_hash_keys
             .keys()
             .cloned()
@@ -1712,22 +1720,15 @@ impl FileAnalysis {
             for r in &mut self.refs {
                 if let RefKind::HashKeyAccess { ref var_text, ref mut owner } = r.kind {
                     if owner.is_some() && !matches!(owner, Some(HashKeyOwner::Variable { .. })) {
-                        // Already linked to a real owner by the builder — don't overwrite.
                         continue;
                     }
                     if let Some(func_name) = binding_by_var.get(var_text.as_str()) {
-                        // Only set if the specific key is actually in the
-                        // imported hash_keys for this func — avoids linking
-                        // unrelated `$cfg->{random}` to the imported def.
                         if let Some(keys) = imported_hash_keys.get(func_name) {
                             if keys.iter().any(|k| k == &r.target_name) {
                                 *owner = Some(HashKeyOwner::Sub {
                                     package: None,
                                     name: func_name.clone(),
                                 });
-                                // Clear resolves_to so the index linker in
-                                // rebuild_enrichment_indices picks it up
-                                // against the newly-injected synthetic def.
                                 r.resolves_to = None;
                             }
                         }
@@ -1736,9 +1737,67 @@ impl FileAnalysis {
             }
         }
 
-        // Cross-file method call return type resolution
-        self.resolve_method_call_types(module_index);
+        // Cross-file inheritance edges. Local writeback emits
+        // `MethodOnClass(child, m) → Edge(MethodOnClass(parent, m))`
+        // for every method `m` declared on a *local* parent. When
+        // the parent class lives in another file (or its methods
+        // do, via further parent chaining), we read the cached
+        // analysis here and project the same edge shape into the
+        // local bag. The registry's edge-chase then follows
+        // `MethodOnClass(child, m) → MethodOnClass(parent_cross, m)`
+        // and re-enters the cached parent's bag via the existing
+        // cross-file primary lookup in `query_rec`.
+        if let Some(idx) = module_index {
+            use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+            let zero = Span {
+                start: Point { row: 0, column: 0 },
+                end: Point { row: 0, column: 0 },
+            };
+            // Snapshot to avoid double-mutable-borrow when pushing.
+            let parents_snapshot: Vec<(String, Vec<String>)> = self
+                .package_parents
+                .iter()
+                .map(|(c, ps)| (c.clone(), ps.clone()))
+                .collect();
+            for (child, parents) in &parents_snapshot {
+                // First-parent-wins per method, mirroring Perl's
+                // default DFS-MRO. Aligned with the local-parent
+                // edge emission in `write_back_sub_return_types`.
+                let mut emitted_for_child: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for parent in parents {
+                    if parent == child {
+                        continue;
+                    }
+                    let Some(cached) = idx.get_cached(parent) else { continue };
+                    for sym in &cached.analysis.symbols {
+                        if sym.package.as_deref() != Some(parent.as_str()) {
+                            continue;
+                        }
+                        if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                            continue;
+                        }
+                        if !emitted_for_child.insert(sym.name.clone()) {
+                            continue;
+                        }
+                        self.witnesses.push(Witness {
+                            attachment: WitnessAttachment::MethodOnClass {
+                                class: child.clone(),
+                                name: sym.name.clone(),
+                            },
+                            source: WitnessSource::Enrichment("inheritance_cross".to_string()),
+                            payload: WitnessPayload::Edge(WitnessAttachment::MethodOnClass {
+                                class: parent.clone(),
+                                name: sym.name.clone(),
+                            }),
+                            span: zero,
+                        });
+                    }
+                }
+            }
+        }
 
+        self.resolve_method_call_types(module_index);
         self.rebuild_enrichment_indices();
     }
 

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -120,9 +120,8 @@ fn test_resolve_reassignment_changes_type() {
 fn test_resolve_sub_return_type() {
     use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
     // Hand-craft a FileAnalysis with a sub that has a return type.
-    // Post-D1, return types live in the bag — seed `Symbol(0)` and
-    // `NamedSub("get_config")` directly so the bag-routed query
-    // picks them up.
+    // Post-D3, return types live on `Symbol(_)` only — seed
+    // `Symbol(0)` directly so the bag-routed query picks it up.
     let mut fa = FileAnalysis::new(
         vec![Scope {
             id: ScopeId(0),
@@ -181,12 +180,6 @@ fn test_resolve_sub_return_type() {
     };
     fa.witnesses.push(Witness {
         attachment: WitnessAttachment::Symbol(SymbolId(0)),
-        source: WitnessSource::Builder("local_return".into()),
-        payload: WitnessPayload::InferredType(InferredType::HashRef),
-        span: zero_span,
-    });
-    fa.witnesses.push(Witness {
-        attachment: WitnessAttachment::NamedSub("get_config".to_string()),
         source: WitnessSource::Builder("local_return".into()),
         payload: WitnessPayload::InferredType(InferredType::HashRef),
         span: zero_span,
@@ -276,75 +269,16 @@ fn test_class_name_helper() {
     assert_eq!(InferredType::String.class_name(), None);
 }
 
-// ---- sub_return_type fallback tests ----
-
-#[test]
-fn test_sub_return_type_imported_fallback() {
-    let mut fa = fa_with_constraints(vec![]);
-    let mut imported = HashMap::new();
-    imported.insert("get_config".to_string(), InferredType::HashRef);
-    fa.enrich_imported_types(imported);
-
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_config", None),
-        Some(InferredType::HashRef)
-    );
-    // Local subs should still return None
-    assert_eq!(fa.sub_return_type_at_arity("nonexistent", None), None);
-}
-
-// ---- enrich_imported_types tests ----
-
-#[test]
-fn test_enrich_imported_types_pushes_constraints() {
-    let mut fa = FileAnalysis::new(
-        vec![Scope {
-            id: ScopeId(0),
-            parent: None,
-            kind: ScopeKind::File,
-            span: Span {
-                start: Point::new(0, 0),
-                end: Point::new(10, 0),
-            },
-            package: None,
-        }],
-        vec![],
-        vec![],
-        vec![],
-        vec![],
-        vec![],
-        // A call binding: my $cfg = get_config()
-        vec![CallBinding {
-            variable: "$cfg".to_string(),
-            func_name: "get_config".to_string(),
-            scope: ScopeId(0),
-            span: Span {
-                start: Point::new(2, 0),
-                end: Point::new(2, 30),
-            },
-        }],
-        HashMap::new(),
-        vec![],
-        HashSet::new(),
-        vec![],
-        vec![],
-        vec![],
-        HashMap::new(),
-        HashMap::new(),
-        vec![],
-    );
-
-    let mut imported = HashMap::new();
-    imported.insert("get_config".to_string(), InferredType::HashRef);
-    fa.enrich_imported_types(imported);
-
-    // Should have pushed a type constraint for $cfg
-    assert_eq!(
-        fa.inferred_type_via_bag("$cfg", Point::new(3, 0)),
-        Some(InferredType::HashRef),
-        "Enrichment should propagate imported return type to call binding variable"
-    );
-}
+// `test_sub_return_type_imported_fallback` and
+// `test_enrich_imported_types_pushes_constraints` were removed in
+// D3: the imported-returns path no longer rides a name-keyed bag
+// attachment. Cross-file imports resolve through
+// `query_sub_return_type` walking `module_index.find_exporters` and
+// recursing into the cached module's `Symbol(_)` witness; the
+// integration tests under `symbols_tests.rs` (e.g.
+// `test_demo_chain_empirical_truth_table`) and
+// `builder_tests.rs::enrichment_twice_does_not_crash_on_stale_indices`
+// exercise the new path end-to-end against a real `ModuleIndex`.
 
 // ---- Phase 5: refs_by_target index + eager HashKeyAccess resolution ----
 
@@ -403,6 +337,9 @@ fn test_phase5_dynamic_method_call_via_constant_folding() {
 /// synthetic def, so rename / references / refs_by_target all work.
 #[test]
 fn test_phase5_consumer_side_cross_file_resolves_via_enrichment() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+
     let mut fa = build_fa_from_source(
         r#"
             use TestExporter qw(get_config);
@@ -423,17 +360,23 @@ fn test_phase5_consumer_side_cross_file_resolves_via_enrichment() {
         "pre-enrichment, access should not be resolved"
     );
 
-    // Simulate what the Backend's enrich_analysis does after the
-    // module index resolves TestExporter::get_config returning HashRef
-    // with keys { host, port, name }.
-    let mut imported_returns = HashMap::new();
-    imported_returns.insert("get_config".to_string(), InferredType::HashRef);
-    let mut imported_hash_keys = HashMap::new();
-    imported_hash_keys.insert(
-        "get_config".to_string(),
-        vec!["host".to_string(), "port".to_string(), "name".to_string()],
+    // Stub `TestExporter` with `get_config` returning a hashref whose
+    // keys (host, port, name) the builder synthesizes as HashKeyDefs.
+    // Enrichment reads these via `cached.sub_info("get_config").hash_keys()`
+    // and injects synthetic local HashKeyDefs against the consumer.
+    let test_exporter_pm = r#"
+package TestExporter;
+use Exporter 'import';
+our @EXPORT_OK = qw(get_config);
+sub get_config { return { host => 'h', port => 1, name => 'n' }; }
+1;
+"#;
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(
+        std::path::PathBuf::from("/tmp/TestExporter.pm"),
+        Arc::new(build_fa_from_source(test_exporter_pm)),
     );
-    fa.enrich_imported_types_with_keys(imported_returns, imported_hash_keys, None);
+    fa.enrich_imported_types_with_keys(Some(&idx));
 
     // The synthetic HashKeyDef `host` owned by Sub{None, "get_config"}
     // must now have the access indexed under it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,13 +701,7 @@ fn cli_dump_package(root: &str, package_name: &str) {
     // are visible — same pass the LSP runs in publish_diagnostics.
     let bin = bincode::serialize(&*analysis_ro).expect("bincode FileAnalysis");
     let mut analysis: FileAnalysis = bincode::deserialize(&bin).expect("bincode FileAnalysis roundtrip");
-    let (imported_returns, imported_keys) =
-        backend::build_imported_return_types(&analysis, &module_index);
-    analysis.enrich_imported_types_with_keys(
-        imported_returns,
-        imported_keys,
-        Some(&module_index),
-    );
+    analysis.enrich_imported_types_with_keys(Some(&module_index));
 
     // Collect subs/methods declared inside this package.
     let mut subs: Vec<&file_analysis::Symbol> = analysis

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 19;
+pub const EXTRACT_VERSION: i64 = 20;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -1643,9 +1643,7 @@ fn test_demo_file_chain_to_resolves_on_line_71() {
     // `my $r = $app->routes;` becomes a TypeConstraint. Without
     // this, the backend's `enrich_analysis(uri)` hasn't fired
     // yet and the whole chain is un-typed.
-    let (imported_returns, imported_keys) =
-        crate::backend::build_imported_return_types_for_test(&analysis, &idx);
-    analysis.enrich_imported_types_with_keys(imported_returns, imported_keys, Some(&idx));
+    analysis.enrich_imported_types_with_keys(Some(&idx));
 
     // Find line 71 ($r->get('/users')->to('Users#list');).
     let (line_idx, chain_line) = demo_source
@@ -2073,8 +2071,7 @@ fn test_demo_chain_empirical_truth_table() {
         .unwrap();
     let tree = parser.parse(&demo_source, None).unwrap();
     let mut analysis = crate::builder::build(&tree, demo_source.as_bytes());
-    let (ir, ik) = crate::backend::build_imported_return_types_for_test(&analysis, &idx);
-    analysis.enrich_imported_types_with_keys(ir, ik, Some(&idx));
+    analysis.enrich_imported_types_with_keys(Some(&idx));
 
     let (line_idx, chain_line) = demo_source
         .lines()

--- a/src/type_inference_invariants_tests.rs
+++ b/src/type_inference_invariants_tests.rs
@@ -13,7 +13,7 @@
 //! `apply_type_overrides` step, etc.) and re-passes once it's restored.
 
 use super::*;
-use crate::file_analysis::{InferredType, SymKind, SymbolDetail, TypeProvenance};
+use crate::file_analysis::{InferredType, SymKind, TypeProvenance};
 use crate::plugin::{
     CompletionQueryContext, FrameworkPlugin, OverrideTarget, PluginCompletionAnswer,
     PluginRegistry, PluginSigHelpAnswer, SigHelpQueryContext, Trigger, TypeOverride,

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -63,7 +63,7 @@ pub enum WitnessAttachment {
     /// statements. Witnesses on an `Expr` are either a direct
     /// `InferredType(t)` (literals, constructors, builtin returns) or
     /// an `Edge` to the resolution target (`Variable{name, scope}` for
-    /// `$foo`, `NamedSub(name)` for a function call,
+    /// `$foo`, `Symbol(sym_id)` for a resolved local sub call,
     /// `Expression(refidx)` for a method call's
     /// receiver-and-method-resolved type, or another `Expr(inner_span)`
     /// for compound expressions). Replaces both the old
@@ -72,8 +72,8 @@ pub enum WitnessAttachment {
     /// per-sub fold reads `Edge(Expr(span))` arms via Symbol(sub_id).
     Expr(Span),
     /// Class-keyed method dispatch: "what does method `name` return on
-    /// class `class`?" — the cross-class disambiguation `NamedSub(name)`
-    /// can't carry. Inheritance composes through `Edge(MethodOnClass(parent, name))`
+    /// class `class`?" — the cross-class disambiguation a name-keyed
+    /// attachment can't carry. Inheritance composes through `Edge(MethodOnClass(parent, name))`
     /// witnesses emitted by the builder for each `package_parents[C] = [P, ...]`,
     /// so the registry's cycle-guarded edge chase walks the MRO without
     /// any procedural ancestor walker. Cross-file resolution: when the
@@ -797,9 +797,9 @@ impl WitnessReducer for FluentArityDispatch {
 // expression-result attachment that every rvalue node publishes
 // through. The walker pushes either `Type(t)` directly (literals,
 // constructors, builtin-determined returns) or `Edge(target)` for
-// name-keyed resolution (Variable lookups, NamedSub for plain-named
-// calls, Expression for method-call receivers, or recursive Expr edges
-// for compound expressions). Edge witnesses get materialized by the
+// resolution (Variable lookups for `$x`, Symbol(sym_id) for resolved
+// local sub calls, Expression for method-call receivers, or recursive
+// Expr edges for compound expressions). Edge witnesses get materialized by the
 // registry into synthetic `Type` witnesses before any reducer claims,
 // so this reducer always sees plain types. Latest-wins:
 // `emit_expr_witness` is called from multiple walk sites (return
@@ -837,19 +837,16 @@ impl WitnessReducer for ExprReturn {
 // ---- Symbol return reducer ----
 //
 // Claims plain `InferredType` payloads on `Symbol(_)` attachments —
-// the per-symbol equivalent of `NamedSubReturn`. Pushed by writeback
-// (local subs/methods) and `seed_bag_from_constraints` (hand-crafted
-// FAs / cache-loaded blobs) so any caller asking "what does THIS
-// specific sym return?" routes through the bag instead of reading
-// `Symbol.return_type` directly. Class-scoped multi-overload
-// dispatch (e.g. `find_method_return_type_raw`'s arity-bound lookup
-// against a candidate set) uses this — the dispatch pre-resolves to
-// a sym_id, then the bag answers what that sym's stored return type
-// is.
+// the id-keyed answer for "what does THIS specific sym return?".
+// Pushed by writeback (local subs/methods) and
+// `seed_bag_from_constraints` (hand-crafted FAs / cache-loaded blobs).
+// Class-scoped multi-overload dispatch goes through
+// `MethodOnClass{class, name}` instead — see `MethodOnClassReducer`
+// and the `arity_hint` short-circuit in `reduce` below.
 //
 // Latest wins so a later writeback re-publish (the worklist clears
 // `local_return` on every iteration and re-pushes from
-// `Symbol.return_type`) dominates an older value. Registered AFTER
+// `resolved_returns`) dominates an older value. Registered AFTER
 // every more-precise reducer (Plugin override, branch-arm fold,
 // arity dispatch) so those still get to claim first.
 
@@ -905,10 +902,10 @@ impl WitnessReducer for SubReturnReducer {
 // ---- Class-keyed method-on-class reducer ----
 //
 // Claims `MethodOnClass{class, name}` attachments carrying a plain
-// `InferredType` payload — the class-scoped equivalent of
-// `NamedSubReturn`. Pushed by `Builder::emit_method_on_class_facts`
-// for the primary symbol of each `(class, method)` pair: that's the
-// "default" return type when the caller doesn't constrain by arity.
+// `InferredType` payload — the class-scoped, name-keyed answer.
+// Pushed by `write_back_sub_return_types` for the primary symbol of
+// each `(class, method)` pair: that's the "default" return type when
+// the caller doesn't constrain by arity.
 // `FluentArityDispatch` runs first and handles per-arity dispatch
 // from `ArityReturn` observations; this reducer only fires when no
 // arity-specific fact answers (no arity hint, or no observation
@@ -1502,11 +1499,9 @@ pub fn query_sub_return_type(
     }
     // Cross-file imports: walk the module_index for exporters of
     // `sub_name` and recurse into each cached module's bag for the
-    // matching `Symbol(cached_sid)`. Replaces the legacy
-    // `NamedSub` attachment that enrichment used to mirror imports
-    // onto. The recursion shares the registry — same arity dispatch,
-    // same plugin overrides, same fold rules — only the bag and
-    // symbols change.
+    // matching `Symbol(cached_sid)`. The recursion shares the
+    // registry — same arity dispatch, same plugin overrides, same
+    // fold rules — only the bag and symbols change.
     if let Some(ctx) = context {
         if let Some(idx) = ctx.module_index {
             for module_name in idx.find_exporters(sub_name) {

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -50,13 +50,6 @@ pub enum WitnessAttachment {
     Expression(RefIdx),
     /// A symbol property ("this sub is a dispatcher").
     Symbol(SymbolId),
-    /// A symbol referenced by name without a local `SymbolId` — i.e.
-    /// imported from another module. The bag carries the imported
-    /// return type here so the bag-query path is uniform across
-    /// local and cross-file callees. Without this attachment kind
-    /// imported subs would need a separate lookup (the old
-    /// `imported_return_types` map), reintroducing parallel paths.
-    NamedSub(String),
     /// A specific call site — property of the call, not of its result
     /// or its receiver.
     CallSite(RefIdx),
@@ -739,25 +732,19 @@ impl WitnessReducer for FluentArityDispatch {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        // Three attachment shapes carry `ArityReturn` observations:
+        // Two attachment shapes carry `ArityReturn` observations:
         //   - `Symbol(_)` — single sub with internal arity branches
         //     (`return X unless @_; return Y;`), one Symbol id, one
         //     witness per arm.
-        //   - `NamedSub(_)` — multiple Symbol ids share a logical name
+        //   - `MethodOnClass{...}` — class-scoped multi-symbol dispatch
         //     (Mojo::Base / Moo `has` synthesizes a getter and writer
-        //     under the same method name). Per-Symbol witnesses can't
-        //     dispatch across distinct symbols, so the framework
-        //     synthesis publishes name-keyed observations and this
-        //     reducer folds them at query time.
-        //   - `MethodOnClass{...}` — class-scoped variant of NamedSub
-        //     for cross-class dispatch (`Sweet::flavor` vs `Sour::flavor`
-        //     can't share the same NamedSub bucket without
-        //     last-write-wins clobbering).
+        //     under the same method name; the per-class bucket carries
+        //     both arms). Cross-class same-name methods stay
+        //     addressable per `MethodOnClass{class, _}` — they can't
+        //     share a bucket and clobber each other.
         matches!(
             w.attachment,
-            WitnessAttachment::Symbol(_)
-                | WitnessAttachment::NamedSub(_)
-                | WitnessAttachment::MethodOnClass { .. }
+            WitnessAttachment::Symbol(_) | WitnessAttachment::MethodOnClass { .. }
         ) && matches!(
             w.payload,
             WitnessPayload::Observation(TypeObservation::ArityReturn { .. })
@@ -795,51 +782,14 @@ impl WitnessReducer for FluentArityDispatch {
 }
 
 // Sub-return delegation chains (`return other()`,
-// `shift->method(...)`) used to be represented as
-// `ReturnDelegation(name)` / `SelfMethodTail(name)` observations
-// chased via `ReducerQuery::return_of`. After the edge-fact
-// migration (May 2026) the bag-side representation is
-// `Edge(NamedSub(name))` — registry materialization handles the
-// chase transparently, so dedicated reducers are no longer
-// needed. The procedural fixed-point loops in
-// `Builder::propagate_via_delegation` /
+// `shift->method(...)`) are represented as `Edge(Symbol(...))` /
+// `Edge(MethodOnClass{...})` payloads. Registry materialization
+// handles the chase transparently. The procedural fixed-point loops
+// in `Builder::propagate_via_delegation` /
 // `Builder::propagate_via_self_method_tails` continue to own
 // build-time delegation propagation (they read the
 // `sub_return_delegations` / `self_method_tails` maps directly,
 // not the bag).
-
-// ---- Named-sub return reducer ----
-//
-// Claims plain `InferredType` payloads on `NamedSub` attachments —
-// the import-side equivalent of `Symbol.return_type` for local subs.
-// Produced by `FileAnalysis::enrich_imported_types_with_keys` so
-// imports flow through the SAME bag-query path as locals; no
-// separate `imported_return_types` lookup at consumer sites.
-
-pub struct NamedSubReturn;
-
-impl WitnessReducer for NamedSubReturn {
-    fn name(&self) -> &str {
-        "named_sub_return"
-    }
-
-    fn claims(&self, w: &Witness) -> bool {
-        matches!(w.attachment, WitnessAttachment::NamedSub(_))
-            && matches!(w.payload, WitnessPayload::InferredType(_))
-    }
-
-    fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
-        // One witness per import — the latest one wins (enrichment
-        // truncates back to baseline before re-deriving, so there's
-        // never accumulated stale state).
-        for w in ws.iter().rev() {
-            if let WitnessPayload::InferredType(t) = &w.payload {
-                return ReducedValue::Type(t.clone());
-            }
-        }
-        ReducedValue::None
-    }
-}
 
 // ---- Expression reducer ----
 //
@@ -911,46 +861,35 @@ impl WitnessReducer for SubReturnReducer {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        // Source-tag claim — only the writeback-pushed (`local_return`)
-        // and enrichment-pushed (`imported_return`) sources fire here.
-        // Excludes:
-        //   - branch_arm-source InferredType witnesses (materialized
-        //     by the registry from per-arm Edge facts) — those are
-        //     `BranchArmFold`'s, and its agreement / disagreement
-        //     result must propagate (single-arm or disagreeing arms
-        //     yield None on purpose; SubReturnReducer mustn't paper
-        //     over that with an arbitrary latest pick).
-        //   - framework_accessor-source ArityReturn observations
-        //     (different payload shape; FluentArityDispatch claims).
-        //   - any other Builder-source InferredType — Symbol attachment
-        //     should only carry our two flavors of "this sym's
-        //     stored return type" facts.
+        // Excludes `branch_arm`-source witnesses — those are
+        // `SymbolReturnArmFold`'s, and its agreement / disagreement
+        // result must propagate (single-arm ambiguity or disagreeing
+        // arms yield None on purpose; this reducer mustn't paper
+        // over that with a latest-wins pick on the same materialized
+        // arm types). Without the filter, materialize's synthetic
+        // `Symbol(_) + InferredType` witnesses (one per arm, with
+        // `branch_arm` source preserved) would all be claimed here
+        // too, and the disagreement signal disappears.
         if !matches!(w.attachment, WitnessAttachment::Symbol(_)) {
             return false;
         }
         if !matches!(w.payload, WitnessPayload::InferredType(_)) {
             return false;
         }
-        match &w.source {
-            WitnessSource::Builder(s) if s == "local_return" => true,
-            WitnessSource::Builder(s) if s == "delegation" => true,
-            WitnessSource::Builder(s) if s == "self_method_tail" => true,
-            WitnessSource::Enrichment(s) if s == "imported_return" => true,
-            _ => false,
-        }
+        !matches!(&w.source, WitnessSource::Builder(s) if s == "branch_arm")
     }
 
     fn reduce(&self, ws: &[&Witness], q: &ReducerQuery) -> ReducedValue {
-        // Only fire when the caller has no arity preference. With an
-        // arity hint, an arity-aware reducer (FluentArityDispatch)
-        // gets the first chance — and if its answer is None for the
-        // requested arity, that's a "this symbol doesn't dispatch
-        // here" signal that the caller will resolve via a different
-        // attachment (`NamedSub` lookup in `query_sub_return_type`,
-        // for instance). Falling through to a plain stored-return
-        // read in that case would silently wrong-answer Mojo::Base
-        // writer-vs-getter dispatch (`level(1)` on the getter sym
-        // would pretend to return the getter's String value).
+        // With an arity hint, an arity-aware reducer
+        // (`FluentArityDispatch`) gets the first chance — and if it
+        // returns None for the requested arity on this single sym,
+        // that's a "this symbol doesn't dispatch here" signal: the
+        // caller should be answering through `MethodOnClass{class,
+        // name}` (cross-symbol dispatch within the class). Falling
+        // through to a plain stored-return read on the wrong sym
+        // would silently wrong-answer Mojo::Base writer-vs-getter
+        // (`level(1)` on the getter sym would surface the getter's
+        // String value instead of routing to the writer).
         if q.arity_hint.is_some() {
             return ReducedValue::None;
         }
@@ -1116,7 +1055,6 @@ impl ReducerRegistry {
         r.register(Box::new(BranchArmFold));
         r.register(Box::new(FrameworkAwareTypeFold));
         r.register(Box::new(FluentArityDispatch));
-        r.register(Box::new(NamedSubReturn));
         r.register(Box::new(ExprReturn));
         // MethodOnClass primary-fallback runs after the arity-aware
         // dispatch (FluentArityDispatch claims MethodOnClass +
@@ -1218,39 +1156,48 @@ impl ReducerRegistry {
             }
         }
 
-        // Inheritance walk for `MethodOnClass{C, m}` queries the local
-        // bag couldn't answer. Two structural facts compose:
+        // Inheritance + bridge fallback for `MethodOnClass{C, m}`
+        // queries that the local bag couldn't answer.
+        //
+        // D3 added build-time and enrichment-time edge emission for
+        // the common cases: local writeback emits
+        // `MethodOnClass(child, m) → Edge(MethodOnClass(parent, m))`
+        // for every method `m` on a *local* parent;
+        // `enrich_imported_types_with_keys` projects the same shape
+        // for *cross-file* parents. When edges are present, the
+        // generic edge-chase machinery resolves inheritance without
+        // touching this fallback.
+        //
+        // The fallback covers the residual: callers that build a
+        // FileAnalysis without going through `build()` +
+        // enrichment (hand-crafted FAs, isolated tests), and
+        // cross-file plugin-namespace bridges declared in *other*
+        // files whose entities would otherwise need an N×N
+        // pre-emission to reach. Three structural facts compose:
         //
         //   1. `module_index.get_cached(C)` — when `C` lives in
-        //      another file, its cached `FileAnalysis` carries the
-        //      direct facts for C (its synthesized accessors, its own
-        //      writeback witnesses). Recurse with C's cached bag.
+        //      another file, recurse into its cached bag for the
+        //      direct facts on C.
         //   2. `package_parents[C]` (local) ∪
         //      `module_index.parents_cached(C)` (cross-file) — the
-        //      inheritance chain in Perl-default DFS-MRO order
-        //      (left-to-right `@ISA`). Recurse on
-        //      `MethodOnClass{P, m}` for each parent until one
-        //      answers. Cross-file P resolves through (1) on the
-        //      recursive call.
+        //      Perl DFS-MRO chain. Recurse on `MethodOnClass{P, m}`
+        //      for each parent. Cross-file P resolves through (1)
+        //      on the recursive call.
+        //   3. `module_index.for_each_entity_bridged_to(class, ...)`
+        //      — entities in *other* files' plugin namespaces
+        //      bridged to `class`. Each match feeds the cached bag
+        //      a `Symbol(sym.id)` query, since per-FA SymbolIds
+        //      can't be portably edge-encoded.
         //
-        // The shared `(bag, attachment)`-keyed visited set breaks both
+        // The shared `(bag, attachment)`-keyed visited set breaks
         // local cycles (`class :isa Self`) and cross-file loops
-        // (`A use parent B; B use parent A`) — see the doc on `query`.
+        // (`A use parent B; B use parent A`).
         if let WitnessAttachment::MethodOnClass { class, name } = q.attachment {
             if let Some(ctx) = q.context {
-                // (1) Cross-file primary: cached module for class C.
-                // Skip when the current bag IS already the cached
-                // module's bag — `query_rec`'s entry guard would
-                // bounce us anyway, but the explicit check avoids
-                // even building `cached_ctx` and `sub_q`.
+                // (1) Cross-file primary lookup.
                 if let Some(idx) = ctx.module_index {
                     if let Some(cached) = idx.get_cached(class) {
                         if !std::ptr::eq(bag, &cached.analysis.witnesses) {
-                            // Reuse cached's own package_parents /
-                            // scopes / package_framework so further
-                            // parent walks and Variable edge chases
-                            // happen in the cached file's context,
-                            // not ours.
                             let cached_ctx = BagContext {
                                 scopes: &cached.analysis.scopes,
                                 package_framework: &cached.analysis.package_framework,
@@ -1303,26 +1250,16 @@ impl ReducerRegistry {
                     }
                 }
                 // (3) Cross-file plugin-namespace bridges. Plugin
-                // namespaces in OTHER files may bridge entities to
-                // `class` (mojo-helpers emits `helper` Methods with
-                // a `Bridge::Class("Mojolicious::Controller")` so
-                // any controller's method dispatch picks them up).
-                // The local file's `plugin_namespaces` already gets
-                // edges emitted at build time
-                // (`Builder::write_back_sub_return_types`'s bridge
-                // pass); cross-file ones need module_index walking.
-                //
-                // For each matching entity, query the cached
-                // module's bag for `Symbol(sym.id)` at arity=None.
-                // Plugin-emitted Methods aren't arity-discriminated
-                // (each helper has one signature), so the writeback's
-                // plain `InferredType` answer is the right one
-                // regardless of how many args the caller passed.
-                // SubReturnReducer's `arity_hint=Some` short-circuit
-                // would silently zero this out — the arity-aware
-                // gate exists for Mojo accessor getter/writer
-                // dispatch, where multiple syms share a name and
-                // arity disambiguates; it doesn't apply here.
+                // entities declared in OTHER files (mojo-helpers'
+                // helpers, etc.) bridged to `class` aren't
+                // reachable via the local bag's edges nor the
+                // cross-file primary (`get_cached(class)` returns
+                // the canonical class file, not the file with the
+                // bridging plugin). Walk the index for matching
+                // entities and ask each cached module for
+                // `Symbol(sym.id)` at arity=None — bridged Methods
+                // aren't arity-discriminated, so the writeback's
+                // plain `InferredType` answer is correct.
                 if let Some(idx) = ctx.module_index {
                     let mut found: Option<InferredType> = None;
                     idx.for_each_entity_bridged_to(class, |cached, sym| {
@@ -1508,10 +1445,10 @@ fn scope_point(scopes: &[Scope], scope: ScopeId) -> tree_sitter::Point {
 
 /// Single canonical query for "what does this sub return?". Handles
 /// both local subs (resolved via the `symbols` table to a `Symbol`
-/// attachment) and imported / cross-file subs (`NamedSub` attachment,
-/// pushed by enrichment) through one path. Callers don't need to
-/// branch on "is this local"; the bag has the right witnesses either
-/// way and the reducer registry produces an answer if one exists.
+/// attachment) and imported / cross-file subs (resolved through
+/// `BagContext.module_index`'s exporter index → recurse into the
+/// cached module's bag with `Symbol(cached_sid)`). Callers don't
+/// need to branch on "is this local"; one path covers both.
 pub fn query_sub_return_type(
     bag: &WitnessBag,
     symbols: &[crate::file_analysis::Symbol],
@@ -1519,9 +1456,9 @@ pub fn query_sub_return_type(
     arity_hint: Option<u32>,
     context: Option<&BagContext>,
 ) -> Option<InferredType> {
-    // Local-symbol bag query first — picks up arity-discriminated
-    // dispatch via FluentArityDispatch.
     let reg = ReducerRegistry::with_defaults();
+    // Local-symbol bag query first — picks up arity-discriminated
+    // dispatch via FluentArityDispatch on the matching sym.
     let local_sym = symbols.iter().find(|s| {
         s.name == sub_name
             && matches!(
@@ -1541,33 +1478,68 @@ pub fn query_sub_return_type(
         if let ReducedValue::Type(t) = reg.query(bag, &q) {
             return Some(t);
         }
+        // Cross-symbol dispatch within the sym's class (Mojo::Base
+        // getter+writer share a name; `find()` returns the getter
+        // first but at `arity=1` the writer's answer is required).
+        // `MethodOnClass{class, name}` carries every per-arity arm
+        // that synthesis published.
+        if let Some(class) = sym.package.as_ref() {
+            let att = WitnessAttachment::MethodOnClass {
+                class: class.clone(),
+                name: sub_name.to_string(),
+            };
+            let q = ReducerQuery {
+                attachment: &att,
+                point: None,
+                framework: FrameworkFact::Plain,
+                arity_hint,
+                context,
+            };
+            if let ReducedValue::Type(t) = reg.query(bag, &q) {
+                return Some(t);
+            }
+        }
     }
-    // Name-keyed multi-dispatch and cross-file imports both ride
-    // `NamedSub` — frameworks like Mojo::Base publish per-arity
-    // observations on the logical name (one getter + one writer share
-    // it), `write_back_sub_return_types` mirrors every local sub's
-    // resolved return type here, and `enrich_imported_types_with_keys`
-    // does the same for cross-file imports. After the writeback runs
-    // there is no plain sub whose answer is reachable only through
-    // `Symbol.return_type`; the field is a cache, not a parallel
-    // truth. (Mid-build callers don't exist — every consumer reaches
-    // this function through `FileAnalysis::sub_return_type_at_arity`,
-    // which only runs post-build.)
-    //
-    // `local_sym` is still used above for the `Symbol(_)` query branch
-    // — arity-discriminated single-symbol dispatch (`return X if @_ == N`)
-    // attaches to the symbol id, not the name.
-    let _ = local_sym;
-    let att = WitnessAttachment::NamedSub(sub_name.to_string());
-    let q = ReducerQuery {
-        attachment: &att,
-        point: None,
-        framework: FrameworkFact::Plain,
-        arity_hint,
-        context,
-    };
-    if let ReducedValue::Type(t) = reg.query(bag, &q) {
-        return Some(t);
+    // Cross-file imports: walk the module_index for exporters of
+    // `sub_name` and recurse into each cached module's bag for the
+    // matching `Symbol(cached_sid)`. Replaces the legacy
+    // `NamedSub` attachment that enrichment used to mirror imports
+    // onto. The recursion shares the registry — same arity dispatch,
+    // same plugin overrides, same fold rules — only the bag and
+    // symbols change.
+    if let Some(ctx) = context {
+        if let Some(idx) = ctx.module_index {
+            for module_name in idx.find_exporters(sub_name) {
+                let Some(cached) = idx.get_cached(&module_name) else { continue };
+                let Some(sym) = cached.analysis.symbols.iter().find(|s| {
+                    s.name == sub_name
+                        && matches!(
+                            s.kind,
+                            crate::file_analysis::SymKind::Sub
+                                | crate::file_analysis::SymKind::Method
+                        )
+                }) else {
+                    continue;
+                };
+                let cached_ctx = BagContext {
+                    scopes: &cached.analysis.scopes,
+                    package_framework: &cached.analysis.package_framework,
+                    module_index: Some(idx),
+                    package_parents: &cached.analysis.package_parents,
+                };
+                let att = WitnessAttachment::Symbol(sym.id);
+                let q = ReducerQuery {
+                    attachment: &att,
+                    point: None,
+                    framework: FrameworkFact::Plain,
+                    arity_hint,
+                    context: Some(&cached_ctx),
+                };
+                if let ReducedValue::Type(t) = reg.query(&cached.analysis.witnesses, &q) {
+                    return Some(t);
+                }
+            }
+        }
     }
     None
 }

--- a/src/witnesses_tests.rs
+++ b/src/witnesses_tests.rs
@@ -210,22 +210,21 @@ fn core_class_still_holds_class_against_hashref_access() {
 #[test]
 fn fluent_chain_get_to_resolves_via_edge_chase() {
     // `$r->get('/x')->to('Y#z')` — the RefIdx for `->get(...)`'s
-    // result carries `Edge(NamedSub("get"))`. Registry materialization
-    // chases the edge through `NamedSub("get")` (where the resolved
-    // return type lives, mirrored from local subs by
-    // `mirror_local_returns_to_named_sub` and from imports by
-    // `enrich_imported_types_with_keys`), finds Route, and the chain
-    // hop sees a plain `InferredType::ClassName`.
+    // result carries `Edge(Symbol(get_sid))`. Registry materialization
+    // chases the edge through `Symbol(get_sid)` (where the resolved
+    // return type lives, published by writeback), finds Route, and
+    // the chain hop sees a plain `InferredType::ClassName`.
     let mut bag = WitnessBag::new();
     let get_ref = RefIdx(42);
+    let get_sid = SymbolId(7);
     bag.push(Witness {
         attachment: WitnessAttachment::Expression(get_ref),
         source: WitnessSource::Builder("chain".into()),
-        payload: WitnessPayload::Edge(WitnessAttachment::NamedSub("get".into())),
+        payload: WitnessPayload::Edge(WitnessAttachment::Symbol(get_sid)),
         span: span(0, 0, 0, 0),
     });
     bag.push(Witness {
-        attachment: WitnessAttachment::NamedSub("get".into()),
+        attachment: WitnessAttachment::Symbol(get_sid),
         source: WitnessSource::Builder("local_return".into()),
         payload: WitnessPayload::InferredType(InferredType::ClassName(
             "Mojolicious::Routes::Route".into(),
@@ -255,7 +254,7 @@ fn edge_with_unresolved_target_yields_none() {
     bag.push(Witness {
         attachment: WitnessAttachment::Expression(RefIdx(7)),
         source: WitnessSource::Builder("chain".into()),
-        payload: WitnessPayload::Edge(WitnessAttachment::NamedSub("nowhere".into())),
+        payload: WitnessPayload::Edge(WitnessAttachment::Symbol(SymbolId(99))),
         span: span(0, 0, 0, 0),
     });
     let reg = ReducerRegistry::with_defaults();
@@ -274,8 +273,8 @@ fn edge_with_unresolved_target_yields_none() {
 #[test]
 fn edge_chase_terminates_on_cycle() {
     let mut bag = WitnessBag::new();
-    let a = WitnessAttachment::NamedSub("a".into());
-    let b = WitnessAttachment::NamedSub("b".into());
+    let a = WitnessAttachment::Symbol(SymbolId(1));
+    let b = WitnessAttachment::Symbol(SymbolId(2));
     bag.push(Witness {
         attachment: a.clone(),
         source: WitnessSource::Builder("test".into()),
@@ -302,8 +301,8 @@ fn edge_chase_terminates_on_cycle() {
 #[test]
 fn edge_chase_resolves_transitively() {
     let mut bag = WitnessBag::new();
-    let a = WitnessAttachment::NamedSub("a".into());
-    let b = WitnessAttachment::NamedSub("b".into());
+    let a = WitnessAttachment::Symbol(SymbolId(1));
+    let b = WitnessAttachment::Symbol(SymbolId(2));
     bag.push(Witness {
         attachment: a.clone(),
         source: WitnessSource::Builder("test".into()),
@@ -669,10 +668,13 @@ fn plugin_override_priority_dominates_builder_inferred_type() {
 // for the new contract.)
 
 #[test]
-fn plugin_override_reducer_yields_when_only_builder_witnesses_present() {
-    // Plugin-priority short-circuit must not claim Builder-only
-    // Symbol+InferredType witnesses — those are Phase 4+ inferred
-    // facts. Returning None here lets later reducers handle them.
+fn plugin_override_reducer_declines_builder_priority_witnesses() {
+    // Plugin-priority short-circuit must not fire on Builder-only
+    // Symbol+InferredType witnesses (priority == 10). Post-D3,
+    // `SubReturnReducer` claims those instead and produces the
+    // stored-return answer; what we're asserting here is that the
+    // claim is NOT routed through `PluginOverrideReducer`'s
+    // priority short-circuit.
     let sym_id = SymbolId(7);
     let mut bag = WitnessBag::new();
     bag.push(Witness {
@@ -689,8 +691,10 @@ fn plugin_override_reducer_yields_when_only_builder_witnesses_present() {
         framework: FrameworkFact::Plain,
         arity_hint: None, context: None,
     };
-    // PluginOverrideReducer declines (priority == 10), no other
-    // reducer claims Symbol+InferredType in Phase 3, so the
-    // registry returns None.
-    assert_eq!(reg.query(&bag, &q), ReducedValue::None);
+    // SubReturnReducer (registered last) returns the stored type.
+    // PluginOverrideReducer's short-circuit didn't fire — if it had,
+    // the answer would still be `Type(String)` but this test is
+    // mostly a smoke check that the registry resolves through the
+    // expected reducer chain.
+    assert_eq!(reg.query(&bag, &q), ReducedValue::Type(InferredType::String));
 }


### PR DESCRIPTION
## Summary

D3 of the bag-residual directive arc. Subtractive deletion of the
`WitnessAttachment::NamedSub` variant and the dual storage it caused.
`cargo build` enumerated 17 consumer sites; each migrated to
`Symbol(sym_id)` (id-keyed), `MethodOnClass{class, name}` (class-keyed),
or removed outright.

The bag is now closer to "the only truth": one attachment shape per
query family, cross-file imports flow through the same registry as
local subs (`query_sub_return_type` walks `find_exporters` and
recurses into the cached bag's `Symbol(cached_sid)`), inheritance is
expressed as `Edge(MethodOnClass(parent, m))` witnesses (writeback
local, enrichment cross-file).

### What landed

- **`WitnessAttachment::NamedSub` deleted.** Writeback collapses to
  `Symbol(sym_id)` + `MethodOnClass{class, name}`. Plugin synth drops
  the free-function `NamedSub` push.
- **Cross-file imports stop riding `NamedSub`.**
  `query_sub_return_type` walks `idx.find_exporters(name)` and recurses
  into the cached module's bag with `Symbol(cached_sid)`. Same registry,
  same arity dispatch, same plugin overrides.
- **`build_imported_return_types` deleted.**
  `enrich_imported_types_with_keys` derives `imported_hash_keys` inline
  from `self.imports` + `module_index`; imported return types are
  reached lazily.
- **Build-time `Edge(MethodOnClass(parent, name))` inheritance
  witnesses.** First-parent-wins DFS-MRO dedup. Local writeback
  (tag `inheritance`) + cross-file enrichment projection
  (tag `inheritance_cross`).
- **Method-call expression edges keyed on class.** Re-emittable
  `emit_method_call_return_edges` publishes
  `Expression(refidx) → Edge(MethodOnClass{class, method})` once
  `invocant_class` is filled. `apply_chain_typing_invocants` now runs
  in PreFold too so variable-typed receivers' classes land while the
  worklist iterates.
- **Source-tag claim filters collapsed** from 4 to 1 in
  `SubReturnReducer` (the `branch_arm` exclusion stays — see residue).
- **Cache `EXTRACT_VERSION` bumped 19 → 20.**

### Documented residue

Two pieces shipped differently than the original plan; both are
explicit in `docs/working-bag-residual.md`:

1. **`query_rec`'s structural inheritance + bridge fallback retained.**
   Build-time edges optimize the common path. The fallback covers
   (a) tests/tools that build a `FileAnalysis` without going through
   enrichment, and (b) cross-file plugin-namespace bridges (mojo
   helpers) where pre-emission would be N×N. The bridge case is
   already reverse-indexed via `bridges_index`, so it's a bounded
   reverse-index lookup, not a global walk. Slated for the
   graph-walking pillar.

2. **`SubReturnReducer`'s `arity_hint.is_some()` short-circuit
   stayed,** along with the `branch_arm`-source exclusion. They're
   the last source-tag filter in the registry. Now an explicit D4
   action item with the real fix named: move per-arm branch
   witnesses + arity dispatch off `Symbol(_)` so the reducer can
   claim unconditionally.

### Comment / doc cleanup (this PR's second commit)

Post-D3 sweep of stale `NamedSub` references in code comments
(builder.rs, witnesses.rs, file_analysis.rs, builder_tests.rs).
Most consequential: `write_back_sub_return_types`' head comment was
claiming "publish on THREE attachments" while the code did two.

Also refreshed `docs/prompt-cleanups.md`:
- #1 (delete `Builder.resolved_returns`) names `MethodOnClass`
  primary-dedup as the explicit blocker.
- #2 — `--dump-package` instruction no longer references deleted
  `Edge(NamedSub(_))`.
- New #5 — replace `fold_state_snapshot`'s ad-hoc tuple with a
  `bag_generation` counter so future re-emittable passes don't have
  to be manually wired into convergence detection (D3 had to add
  `invocant_filled` for exactly this reason).

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — 507 / 507 unit tests green
- [ ] `./run_e2e.sh` — needs nvim + release build (was 93 / 93 green at D3 head)
- [x] `--dump-package` against test fixtures: type provenance still
      attributes per-arity dispatch correctly
- [x] Mojo getter-vs-writer disambiguation
      (`builder_tests.rs::test_mojo_arity_resolution`,
      `method_on_class_disambiguates_same_name_across_classes`) green
- [x] `for_each_ancestor_class_walks_left_to_right_isa_order` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)