### PR TITLE
fix: forward-reference resolution + --clear-cache CLI

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ Four docs, one engine:
 |---|---|---|
 | `prompt-type-inference-unification.md` | **HOW** — collapse walker + bag into one path | **Steps 1–4 landed (PR #27)** — historical |
 | `working-bag-residual.md` | **FINISH THE COLLAPSE** — four directives for "bag is the only truth" | **D1–D4 landed (PR #31).** D4-G follow-up open |
-| `prompt-forward-reference-resolution.md` | **REGRESSION** — walk-time sym lookups miss forward-defined callees | **Top of queue.** Red-pinned |
+| `prompt-forward-reference-resolution.md` | **REGRESSION** — walk-time sym lookups miss forward-defined callees | **LANDED** — post-walk resolver |
 | `prompt-cross-file-invocant-refresh.md` | **REGRESSION** — `invocant_class` cache stale after enrichment, cross-file refs under-match | **Top of queue.** Red-pinned |
 | `prompt-type-inference-residual.md` | **WHAT'S MISSING** — Parts 1–5 fact classes | each is a reducer+emitter pair |
 | `prompt-sequence-types.md` | **FIRST BIG CONSUMER** — sequence type lattice | 5 phases; ~half the spike's diff on a clean foundation |
@@ -40,7 +40,7 @@ staircase 1–4 (LANDED, PR #27) ─┐
                                  ├─▶ bag-residual D4 + follow-up (LANDED, PR #31 —
                                  │       FA.type_constraints gone, EXTRACT_VERSION 21)
                                  │       │
-                                 │       ├─▶ ★ forward-reference resolution (red-pinned)
+                                 │       ├─▶ forward-reference resolution (LANDED)
                                  │       ├─▶ ★ cross-file invocant refresh (red-pinned)
                                  │       │
                                  │       └─▶ sequence-types phases 1-3
@@ -52,8 +52,10 @@ staircase 1–4 (LANDED, PR #27) ─┐
 ```
 
 ★ = known regression with a pinned `#[ignore]` test that fails until
-fixed. Both block downstream type-intelligence quality but don't block
-sequence-types architecturally — sequence types can land in parallel.
+fixed. Forward-reference resolution landed; cross-file invocant
+refresh is the only ★ left. Both block downstream type-intelligence
+quality but don't block sequence-types architecturally — sequence
+types can land in parallel.
 
 - **Unification staircase** is done. PR #27 subsumed Steps 1–4: the walker only
   observes, edge-payload witnesses replace closure-driven chase, deferred-var /
@@ -131,17 +133,22 @@ sequence-types architecturally — sequence types can land in parallel.
    bumped 20 → 21), migrated `--dump-package vars_in_scope` and the
    plugin sandbox diff to bag reads, and pushed two known regressions
    into red-pinned tests rather than leaving them undocumented:
-   - **★ forward-reference resolution.** D4-E's bag-routed `Symbol ←
-     branch_arm Edge → Expr(body) → Edge(call_target)` chain assumes
-     `expr_payload` can resolve `call_target` at walk time, but
-     `function_call_expression`'s arm does walk-time
-     `self.symbols.iter().find(name)` — silently emits nothing for
-     forward-defined callees. Real-world hit: Carp's `longmess` →
-     `longmess_heavy`. Fix surface = a single post-walk
-     "compile-esque" pass that performs all definedness-dependent
-     lookups against the final symbol table; spec in
-     `docs/prompt-forward-reference-resolution.md`. Pinned by
-     `forward_reference_call_in_sub_return_resolves`.
+   - **forward-reference resolution.** **LANDED.** Walk queues every
+     name-driven `expr_payload` arm (`function_call_expression` /
+     `ambiguous_function_call_expression` / `bareword` /
+     `scoped_identifier`) whose symbol-table lookup came up empty as
+     `(name, expr_span)` in `Builder.unresolved_call_targets`. New
+     post-walk pass `resolve_forward_call_targets` runs between
+     `populate_witness_bag` and `fold_to_fixed_point` and pushes the
+     missing `Expr(span) → Edge(Symbol(sid))` witness for every entry
+     that resolves against the now-final symbol table. Same source
+     tag (`expression`) and span as the walk-time path so reducers
+     can't tell the two emission sites apart. Tests: 512 unit + 93
+     e2e green; coverage expanded beyond the Carp shape to ternary
+     arms, scoped-identifier calls, implicit returns, and
+     self-method tails (see `forward_reference_*` in
+     `builder_tests.rs`). Spec:
+     `docs/prompt-forward-reference-resolution.md`.
    - **★ cross-file `invocant_class` refresh.** `Ref::MethodCall.invocant_class`
      is set once at build time and never refreshed; when a consumer's
      invocant only becomes typeable post-enrichment (cross-file
@@ -151,11 +158,8 @@ sequence-types architecturally — sequence types can land in parallel.
      `docs/prompt-cross-file-invocant-refresh.md`. Pinned by
      `references_cross_file_invocant_resolved_post_enrichment`.
 
-   Both regressions are next on the queue before sequence-types
-   phases. They're independent of each other (different attachment
-   shapes, different fix surfaces) — order by which hurts user
-   workflows more. The forward-ref one is the higher-frequency hit
-   in real Perl code (Carp pattern is everywhere).
+   Forward-ref landed first (higher-frequency hit; Carp pattern is
+   everywhere). Cross-file invocant refresh remains queued.
 
 5. **Sequence-types phases 1-3** on the clean foundation. Can land in
    parallel with the regression fixes above; not architecturally

--- a/docs/prompt-cleanups.md
+++ b/docs/prompt-cleanups.md
@@ -183,6 +183,105 @@ strictly grows when work happens. The convergence rule is unchanged.
 
 ---
 
+## 6. Unify name resolution via a name-keyed witness attachment
+
+**Where:** `src/builder.rs` — `expr_payload`'s
+`function_call_expression` / `ambiguous_function_call_expression` /
+`bareword` / `scoped_identifier` arm,
+`Builder::find_callee_symbol`, `Builder::forward_callee_name`,
+`Builder::resolve_forward_call_targets`, and the
+`unresolved_call_targets: Vec<UnresolvedCallTarget>` field on
+`Builder`. Witness attachment enum in `src/witnesses.rs`.
+
+**Why:** the forward-reference fix (PR landed alongside this entry,
+see `prompt-forward-reference-resolution.md`) is a two-phase
+recovery: walk-time `find_callee_symbol` for the fast path, plus a
+queue + post-walk retry for misses. The structure works but
+*duplicates the lookup rule* (`s.kind ∈ {Sub, Method}` and
+`s.name == bare`) across two sites. If the rule ever has to grow —
+package-aware lookup, plugin-synthesized callees, private/anonymous
+exclusions — both sites have to change in lockstep, and the
+`find_callee_symbol` helper hides but doesn't eliminate the
+duplication (the retry path still has to know *when* to call it).
+
+The principled shape is to push the lookup off the walk entirely:
+emit a name-keyed witness at walk time (no symbol-table consult), and
+let a single post-walk reducer or pass resolve all such witnesses
+against the final symbol table.
+
+**How to apply:** add a `WitnessAttachment::CalleeByName { name:
+String }` variant (or a `WitnessPayload::CalleeByName` payload —
+attachment-vs-payload depends on whether other reducers want to
+chase into "the sub named X" abstractly, or only at the Expr-arm
+level). `expr_payload`'s call arm becomes:
+
+```rust
+"function_call_expression"
+| "ambiguous_function_call_expression"
+| "bareword"
+| "scoped_identifier" => Some(WitnessPayload::Edge(
+    WitnessAttachment::CalleeByName {
+        name: self.forward_callee_name(node)?,
+    },
+)),
+```
+
+A single post-walk pass (`resolve_callee_by_name_witnesses`, replacing
+`resolve_forward_call_targets`) walks the bag for
+`Edge(CalleeByName{..})` payloads and rewrites each to
+`Edge(Symbol(sid))` once `find_callee_symbol` resolves — or drops
+the rewrite if it doesn't (still monotone; consumers see no Edge,
+which is the same as today's "name didn't resolve" semantics).
+
+After this lands, `unresolved_call_targets`, `forward_callee_name`'s
+.to_string() owned-name return, and the post-walk recovery queue all
+collapse — the attachment IS the queue. `find_callee_symbol` survives
+as the single lookup helper, called only from the resolver pass.
+
+**Watch out for:**
+
+1. **Bag generation.** Pushing a name-keyed attachment that gets
+   *rewritten* in place is a bag mutation, which violates monotonicity.
+   Two viable shapes: (a) the resolver pass pushes a *new*
+   `Edge(Symbol(sid))` witness alongside the original (the
+   `CalleeByName` one becomes a non-resolving dead end the registry
+   ignores once a `Symbol`-keyed sibling exists) — strictly monotone,
+   matches today's pattern; or (b) the registry resolves
+   `CalleeByName` lazily at query time via a reducer that does the
+   lookup itself. (b) is simpler in code but pushes I/O-shaped work
+   into the query path, which the rest of the registry takes pains to
+   avoid. (a) is the right shape for this repo.
+
+2. **Cross-file imports.** Today, `find_callee_symbol` returns `None`
+   for cross-file imports (the local symbol table doesn't carry
+   imported subs as own-Symbol entries). The `CalleeByName` resolver
+   should preserve that — the chain-receiver path through enrichment
+   covers cross-file return types via `MethodOnClass` / `NamedSub`
+   reducers, not via the `Expr(span)` Edge. Verify by removing the
+   recovery queue and confirming the cross-file enrichment tests
+   (`test_cross_file_*` in `builder_tests.rs`) still pass.
+
+3. **Span equality of synthetic witnesses.** The current path uses the
+   call's `expr_span` for both the Expr attachment and the Witness
+   span; the rewrite must keep that exact span so
+   `FrameworkAwareTypeFold`'s point-contains filter behaves
+   identically. Hand-test against `forward_reference_in_ternary_arms_resolves`
+   (the trickiest of the four sibling tests — recursion into ternary arms
+   means the same span is referenced from multiple Edge witnesses).
+
+4. **Cache version.** Adding a `WitnessAttachment` variant changes the
+   bincode shape. Bump `EXTRACT_VERSION` in `module_cache.rs` so
+   stale cache blobs are re-resolved.
+
+**Shipping check:** the four `forward_reference_*` sibling tests in
+`builder_tests.rs` should pass byte-for-byte (same return types) before
+and after this refactor — that's the regression bar. The diff should
+be net-negative LOC: the `unresolved_call_targets` field, the
+`UnresolvedCallTarget` struct, and the pre-walk-vs-post-walk split in
+`emit_expr_witness` all collapse.
+
+---
+
 ## Notes on what's NOT in this list
 
 - **Two D1 bullets that didn't land as written** (inheritance via

--- a/docs/prompt-forward-reference-resolution.md
+++ b/docs/prompt-forward-reference-resolution.md
@@ -1,8 +1,12 @@
 # Forward-reference resolution
 
-**Status:** known regression introduced by D4-E (commit 80b2b88). Pinned by
-`forward_reference_call_in_sub_return_resolves` in `builder_tests.rs`
-(`#[ignore]` until this lands).
+**Status:** **LANDED.** Pinned test
+`forward_reference_call_in_sub_return_resolves` (and four siblings —
+implicit return, ternary arms, scoped-identifier call, self-method
+tail) green in `builder_tests.rs`. Implemented as
+`Builder::resolve_forward_call_targets`, called between
+`populate_witness_bag` and `fold_to_fixed_point`. The remaining
+sections below are kept as historical context for the diagnosis.
 
 ## The bug
 

--- a/docs/prompt-forward-reference-resolution.md
+++ b/docs/prompt-forward-reference-resolution.md
@@ -8,6 +8,15 @@ tail) green in `builder_tests.rs`. Implemented as
 `populate_witness_bag` and `fold_to_fixed_point`. The remaining
 sections below are kept as historical context for the diagnosis.
 
+**Follow-up filed:** the landed shape is a two-phase recovery
+(walk-time `find_callee_symbol` + post-walk retry queue) which still
+duplicates the "is this a callee symbol?" rule across two sites. The
+deeper unification — pushing the lookup off the walk entirely via a
+`WitnessAttachment::CalleeByName` and a single post-walk resolver —
+is filed as `prompt-cleanups.md` **§6**. Independent, self-contained,
+and the regression bar is "the four `forward_reference_*` sibling
+tests pass byte-for-byte." Pick it up when convenient.
+
 ## The bug
 
 ```perl

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -186,6 +186,7 @@ fn build_with_plugins_inner(
         plugin_namespaces: Vec::new(),
         type_provenance: std::collections::HashMap::new(),
         bag: crate::witnesses::WitnessBag::new(),
+        unresolved_call_targets: Vec::new(),
         package_framework: std::collections::HashMap::new(),
         scope_stack: Vec::new(),
         current_package: None,
@@ -259,6 +260,17 @@ fn build_with_plugins_inner(
     // (branch arms, arity gating) are already in `b.bag` — pushed
     // live during the walk.
     b.populate_witness_bag();
+
+    // Forward-reference resolution: walk-time `expr_payload` arms for
+    // `function_call_expression` / `bareword` / `scoped_identifier` did
+    // a `self.symbols.iter().find` against a partial symbol table.
+    // Forward-defined callees (Perl's `sub a { b() } sub b {…}` pattern,
+    // canonically Carp's `longmess` → `longmess_heavy`) silently
+    // produced no witness. The walk queued each missing lookup; resolve
+    // them now against the final symbol table and push the
+    // `Expr(span) → Edge(Symbol(sid))` witness the walk would have.
+    // See `docs/prompt-forward-reference-resolution.md`.
+    b.resolve_forward_call_targets();
 
     // Phase 6: worklist driver. Replaces the manually-ordered
     // `fold → chain → fold → chain` sequence with one fixed-point
@@ -909,6 +921,15 @@ struct Builder<'a> {
     /// push directly here. Moved into `FileAnalysis.witnesses` when
     /// the analysis is constructed — no second seeding pass.
     bag: crate::witnesses::WitnessBag,
+    /// Walk-time symbol-table lookups that came up empty for a name
+    /// resolvable to a local sub. Perl's name resolution for subs is
+    /// forward-tolerant (`sub a { b() } sub b {…}` is legal), but the
+    /// walk emits witnesses live, so a forward-defined callee silently
+    /// produces no witness in `expr_payload`'s call arms. Re-resolved
+    /// against the final symbol table by `resolve_forward_call_targets`
+    /// between `populate_witness_bag` and `fold_to_fixed_point`. See
+    /// `docs/prompt-forward-reference-resolution.md`.
+    unresolved_call_targets: Vec<UnresolvedCallTarget>,
     /// Per-package framework fact, computed from `framework_modes` once
     /// the walk finishes. Available before `resolve_return_types` so
     /// the bag-aware return-arm fold can ask the framework-aware
@@ -943,6 +964,18 @@ enum FrameworkMode {
     Moo,
     Moose,
     MojoBase,
+}
+
+/// Queued by `emit_expr_witness` whenever a name-driven call kind
+/// (`function_call_expression`, `bareword`, `scoped_identifier`) couldn't
+/// emit its `Edge(Symbol(_))` witness because the callee wasn't in the
+/// symbol table yet. Re-resolved post-walk against the final symbols.
+#[derive(Debug, Clone)]
+struct UnresolvedCallTarget {
+    /// Bare sub name (e.g. `longmess_heavy`, stripped of any `Pkg::` prefix).
+    name: String,
+    /// `Expr(span)` attachment that the missing witness should land on.
+    expr_span: Span,
 }
 
 impl<'a> Builder<'a> {
@@ -3608,6 +3641,62 @@ impl<'a> Builder<'a> {
                 source: WitnessSource::Builder("expression".into()),
                 payload,
                 span,
+            });
+        } else if let Some(name) = self.forward_call_name(node) {
+            // Sub call by bare name whose target wasn't in the symbol
+            // table yet — Perl resolves these at symbol-table time, not
+            // parse time, so the lookup is legitimately deferred. Queue
+            // for `resolve_forward_call_targets` to retry post-walk.
+            self.unresolved_call_targets.push(UnresolvedCallTarget {
+                name,
+                expr_span: span,
+            });
+        }
+    }
+
+    /// Return the bare-name of the sub the expression node *would* have
+    /// been resolved to, for the kinds whose `expr_payload` arm produces
+    /// `Edge(Symbol(sid))`. `None` for any other kind. Mirrors the
+    /// extraction logic in `expr_payload` exactly so a lookup that
+    /// failed there with `?` is rephrased as a queue entry here.
+    fn forward_call_name(&self, node: Node<'a>) -> Option<String> {
+        match node.kind() {
+            "function_call_expression" | "ambiguous_function_call_expression" => {
+                let func = node.child_by_field_name("function")?;
+                let name = func.utf8_text(self.source).ok()?;
+                Some(name.rsplit("::").next().unwrap_or(name).to_string())
+            }
+            "bareword" | "scoped_identifier" => {
+                let name = node.utf8_text(self.source).ok()?;
+                Some(name.rsplit("::").next().unwrap_or(name).to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// Post-walk: re-resolve every queued `(name, expr_span)` pair
+    /// against the now-final symbol table and push the
+    /// `Expr(span) → Edge(Symbol(sid))` witness that
+    /// `emit_expr_witness` would have pushed live if the target had
+    /// existed. Same source tag (`expression`) and span as the
+    /// walk-time path so reducers can't tell the two emission sites
+    /// apart. Names that still don't resolve (cross-file imports
+    /// without a local sym, typos) are silently dropped — the bag is
+    /// monotone, no negative witnesses.
+    fn resolve_forward_call_targets(&mut self) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        let queued = std::mem::take(&mut self.unresolved_call_targets);
+        for entry in queued {
+            let Some(sid) = self.symbols.iter().find(|s| {
+                s.name == entry.name && matches!(s.kind, SymKind::Sub | SymKind::Method)
+            }).map(|s| s.id) else {
+                continue;
+            };
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::Expr(entry.expr_span),
+                source: WitnessSource::Builder("expression".into()),
+                payload: WitnessPayload::Edge(WitnessAttachment::Symbol(sid)),
+                span: entry.expr_span,
             });
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -716,6 +716,13 @@ struct ReturnInfo {
     body_span: Option<Span>,
 }
 
+/// Strip a `Pkg::Sub::` prefix from a sub-name identifier, returning the bare
+/// trailing component. `"Foo::Bar::baz"` → `"baz"`; `"baz"` → `"baz"`. Pure
+/// string op — does not consult the symbol table or package state.
+fn bare_name(s: &str) -> &str {
+    s.rsplit("::").next().unwrap_or(s)
+}
+
 /// If `return_node` is `return CALL`, where CALL is a simple named function
 /// call or method call, return the bare called name. Otherwise None. Used to
 /// collect hash-key ownership delegation chains for post-pass resolution.
@@ -733,7 +740,7 @@ fn extract_delegated_call_name<'a>(return_node: Node<'a>, source: &'a [u8]) -> O
     };
     // Strip package prefix — delegation is stored by bare sub name to match
     // the return_types lookup convention.
-    Some(call_name.rsplit("::").next().unwrap_or(call_name).to_string())
+    Some(bare_name(call_name).to_string())
 }
 
 /// Find the `varname` child of a variable node (`scalar`/`array`/`hash`/etc.).
@@ -1383,7 +1390,7 @@ impl<'a> Builder<'a> {
                 if text == "__PACKAGE__" {
                     return self.package_for_node(node).map(InferredType::ClassName);
                 }
-                let bare = text.rsplit("::").next().unwrap_or(text);
+                let bare = bare_name(text);
                 // Bareword invocant is ambiguous: class-name reference
                 // OR zero-arg function call whose return type seeds
                 // the chain (`app->routes` where `sub app :: Mojolicious`).
@@ -1416,7 +1423,7 @@ impl<'a> Builder<'a> {
                 }
                 let func = node.child_by_field_name("function")?;
                 let name = func.utf8_text(self.source).ok()?;
-                let bare = name.rsplit("::").next().unwrap_or(name);
+                let bare = bare_name(name);
                 let arg_count = self.extract_call_args(node).len() as u32;
                 self.bag_query_named_sub(bare, Some(arg_count))
             }
@@ -3431,6 +3438,18 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Find a local Sub or Method symbol by bare name. Used by
+    /// `expr_payload`'s function/bareword arms (walk-time) and
+    /// `resolve_forward_call_targets` (post-walk) — both want the same
+    /// "is there a local sub I could route a call edge to" answer, so
+    /// they share this lookup.
+    fn find_callee_symbol(&self, bare: &str) -> Option<SymbolId> {
+        self.symbols
+            .iter()
+            .find(|s| s.name == bare && matches!(s.kind, SymKind::Sub | SymKind::Method))
+            .map(|s| s.id)
+    }
+
     /// Locate the SymbolId for a Sub/Method named `name` whose body's
     /// inner scope is (an ancestor of) `body_scope`. Scans
     /// `self.symbols` for a matching Sub symbol.
@@ -3567,26 +3586,18 @@ impl<'a> Builder<'a> {
             // the chase resolves through. Cross-file imports without
             // a local sym don't pin the Expr(span); chain typing's
             // own resolvers cover the chain-receiver case.
-            "function_call_expression" | "ambiguous_function_call_expression" => {
-                let func = node.child_by_field_name("function")?;
-                let name = func.utf8_text(self.source).ok()?;
-                let bare = name.rsplit("::").next().unwrap_or(name);
-                let sid = self.symbols.iter().find(|s| {
-                    s.name == bare
-                        && matches!(s.kind, SymKind::Sub | SymKind::Method)
-                })?.id;
-                Some(WitnessPayload::Edge(WitnessAttachment::Symbol(sid)))
-            }
-
-            // Bareword / scoped-identifier as expression — same as
-            // function call (calling a sub by name without parens).
-            "bareword" | "scoped_identifier" => {
-                let name = node.utf8_text(self.source).ok()?;
-                let bare = name.rsplit("::").next().unwrap_or(name);
-                let sid = self.symbols.iter().find(|s| {
-                    s.name == bare
-                        && matches!(s.kind, SymKind::Sub | SymKind::Method)
-                })?.id;
+            // Function / bareword / scoped-identifier call — extract the
+            // callee's bare name and Edge to its `Symbol(sid)`. Failures
+            // (target not yet in symbol table) are recovered post-walk by
+            // `resolve_forward_call_targets`; same `forward_callee_name`
+            // helper is the source of truth for "what name does this node
+            // refer to" so the live and recovery paths can't diverge.
+            "function_call_expression"
+            | "ambiguous_function_call_expression"
+            | "bareword"
+            | "scoped_identifier" => {
+                let bare = self.forward_callee_name(node)?;
+                let sid = self.find_callee_symbol(&bare)?;
                 Some(WitnessPayload::Edge(WitnessAttachment::Symbol(sid)))
             }
 
@@ -3642,7 +3653,7 @@ impl<'a> Builder<'a> {
                 payload,
                 span,
             });
-        } else if let Some(name) = self.forward_call_name(node) {
+        } else if let Some(name) = self.forward_callee_name(node) {
             // Sub call by bare name whose target wasn't in the symbol
             // table yet — Perl resolves these at symbol-table time, not
             // parse time, so the lookup is legitimately deferred. Queue
@@ -3654,24 +3665,22 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Return the bare-name of the sub the expression node *would* have
-    /// been resolved to, for the kinds whose `expr_payload` arm produces
-    /// `Edge(Symbol(sid))`. `None` for any other kind. Mirrors the
-    /// extraction logic in `expr_payload` exactly so a lookup that
-    /// failed there with `?` is rephrased as a queue entry here.
-    fn forward_call_name(&self, node: Node<'a>) -> Option<String> {
-        match node.kind() {
+    /// Bare callee name for an expression node whose `expr_payload` arm
+    /// resolves to `Edge(Symbol(sid))`. `None` for any other kind. Sole
+    /// source of truth for "what sub-name does this node reference" —
+    /// `expr_payload`'s call arm calls this for the live lookup, and
+    /// `emit_expr_witness` calls it again to queue forward-ref retries
+    /// when the live lookup misses. Keeping a single extractor is what
+    /// makes the live and post-walk paths impossible to diverge.
+    fn forward_callee_name(&self, node: Node<'a>) -> Option<String> {
+        let raw = match node.kind() {
             "function_call_expression" | "ambiguous_function_call_expression" => {
-                let func = node.child_by_field_name("function")?;
-                let name = func.utf8_text(self.source).ok()?;
-                Some(name.rsplit("::").next().unwrap_or(name).to_string())
+                node.child_by_field_name("function")?.utf8_text(self.source).ok()?
             }
-            "bareword" | "scoped_identifier" => {
-                let name = node.utf8_text(self.source).ok()?;
-                Some(name.rsplit("::").next().unwrap_or(name).to_string())
-            }
-            _ => None,
-        }
+            "bareword" | "scoped_identifier" => node.utf8_text(self.source).ok()?,
+            _ => return None,
+        };
+        Some(bare_name(raw).to_string())
     }
 
     /// Post-walk: re-resolve every queued `(name, expr_span)` pair
@@ -3687,9 +3696,7 @@ impl<'a> Builder<'a> {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
         let queued = std::mem::take(&mut self.unresolved_call_targets);
         for entry in queued {
-            let Some(sid) = self.symbols.iter().find(|s| {
-                s.name == entry.name && matches!(s.kind, SymKind::Sub | SymKind::Method)
-            }).map(|s| s.id) else {
+            let Some(sid) = self.find_callee_symbol(&entry.name) else {
                 continue;
             };
             self.bag.push(Witness {
@@ -7007,18 +7014,15 @@ impl<'a> Builder<'a> {
         &mut self,
         return_types: &std::collections::HashMap<String, InferredType>,
     ) {
-        let bare = |s: &str| -> String { s.rsplit("::").next().unwrap_or(s).to_string() };
-
         let binding_map: std::collections::HashMap<&str, String> = self
             .call_bindings
             .iter()
             .filter(|b| {
-                let name = bare(&b.func_name);
                 return_types
-                    .get(&name)
+                    .get(bare_name(&b.func_name))
                     .map_or(false, |t| *t == InferredType::HashRef)
             })
-            .map(|b| (b.variable.as_str(), bare(&b.func_name)))
+            .map(|b| (b.variable.as_str(), bare_name(&b.func_name).to_string()))
             .collect();
 
         let sub_package: std::collections::HashMap<&str, Option<String>> = self

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -8647,21 +8647,14 @@ my $m = MooApp->new('a', 1, 'b', 2);
     );
 }
 
-/// Red-pin: known regression introduced by D4-E (commit 80b2b88).
-/// `longmess` calls `longmess_heavy` which is defined later in the
-/// source. Both arms of the if/else return that call, so the chain
-/// should fold to String. It currently folds to None because
-/// `expr_payload`'s `function_call_expression` arm does a walk-time
-/// `self.symbols.iter().find(name)` that misses forward references —
-/// the post-walk `emit_delegation_edges` pass that used to cover this
-/// case in D3 was removed without an equivalent.
-///
-/// Spec: docs/prompt-forward-reference-resolution.md.
-/// Reverse the order of the two subs in the source and the test
-/// passes. When the spec lands, drop `#[ignore]` and add coverage for
-/// method calls + scoped-identifier calls.
+/// Carp's canonical shape: `longmess` (caller) is defined before
+/// `longmess_heavy` (callee). Both arms of the if/else return the
+/// forward-defined call, so the per-sub fold should agree on `String`
+/// — but only if the walk-time symbol-table miss for `longmess_heavy`
+/// is recovered post-walk. `resolve_forward_call_targets` is what
+/// makes this work; without it the bag has no `Expr(call_span)`
+/// witness at all and `longmess` returns `None`.
 #[test]
-#[ignore = "forward-reference regression — see docs/prompt-forward-reference-resolution.md"]
 fn forward_reference_call_in_sub_return_resolves() {
     let src = r#"
 package main;
@@ -8686,5 +8679,102 @@ sub longmess_heavy { return "ouch"; }
          got {:?}. Walk-order regression: longmess_heavy is \
          defined after longmess.",
         rt,
+    );
+}
+
+/// Single-arm forward call: implicit `return forward()` should fold
+/// to whatever `forward()` returns. No branch arms — exercises the
+/// `Symbol ← branch_arm Edge → Expr(body) → Edge(Symbol(callee))`
+/// chain at minimum width.
+#[test]
+fn forward_reference_implicit_return_resolves() {
+    let src = r#"
+package main;
+
+sub caller_sub { forward_sub() }
+
+sub forward_sub { return "ok"; }
+"#;
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.sub_return_type_at_arity("caller_sub", None),
+        Some(InferredType::String),
+    );
+}
+
+/// Forward reference inside a ternary return. Each arm calls a
+/// different forward-defined sub; both must resolve so the ternary's
+/// `BranchArmFold` agrees on `String`. Mixes the forward-ref fix with
+/// the existing ternary path (`emit_expr_witness` recursion + arm
+/// witnesses on the ternary span).
+#[test]
+fn forward_reference_in_ternary_arms_resolves() {
+    let src = r#"
+package main;
+
+sub dispatch {
+    return $_[0] ? handle_a() : handle_b();
+}
+
+sub handle_a { return "a"; }
+sub handle_b { return "b"; }
+"#;
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.sub_return_type_at_arity("dispatch", None),
+        Some(InferredType::String),
+    );
+}
+
+/// Scoped-identifier call: `Pkg::name()` form. `expr_payload`'s
+/// `bareword`/`scoped_identifier` arm does the same walk-time lookup
+/// as `function_call_expression`; the queue + post-walk resolve must
+/// cover it too.
+#[test]
+fn forward_reference_scoped_identifier_call_resolves() {
+    let src = r#"
+package main;
+
+sub bridge { return Helper::canon(); }
+
+package Helper;
+
+sub canon { return "yes"; }
+"#;
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.sub_return_type_at_arity("bridge", None),
+        Some(InferredType::String),
+    );
+}
+
+/// Self-method tail with a forward-defined target. `$self->later()`
+/// where `later` is declared after the caller. The MethodOnClass
+/// chase needs the callee's `Symbol(sid)` writeback, which only fires
+/// once the callee's own `Expr(body)` is populated — exercising the
+/// forward-ref fix on the inner sub's body, not the call site itself.
+#[test]
+fn forward_reference_self_method_call_resolves() {
+    let src = r#"
+package Box;
+
+sub new { my $class = shift; return bless {}, $class; }
+
+sub head {
+    my ($self) = @_;
+    return $self->tail();
+}
+
+sub tail {
+    my ($self) = @_;
+    return helper();
+}
+
+sub helper { return "fin"; }
+"#;
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.sub_return_type_at_arity("tail", None),
+        Some(InferredType::String),
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,22 @@ fn index_workspace(root: &str) -> file_store::FileStore {
     store
 }
 
+/// Canonicalize `root` and produce the matching `file://...` URI.
+/// Returns both because callers usually want the path (for `@INC`
+/// project-lib discovery, file walking) AND the URI (the cache hash
+/// key, since the LSP server's `cache_dir_for_workspace` is fed the
+/// initialize request's `root_uri` string verbatim — `file://...`).
+/// Falls back to the raw input if `canonicalize` fails (path doesn't
+/// exist, permissions): same string lands in both halves so the
+/// caller's downstream "does this dir exist?" check still fires.
+fn canonical_root_and_uri(root: &str) -> (std::path::PathBuf, String) {
+    let path = std::path::Path::new(root)
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from(root));
+    let uri = format!("file://{}", path.display());
+    (path, uri)
+}
+
 /// Full CLI workspace setup: index the workspace, open the SQLite cache,
 /// warm cached modules, resolve missing imports + ancestors via @INC,
 /// save fresh entries back to disk. Mirrors the LSP server's startup
@@ -180,9 +196,7 @@ fn cli_full_startup(root: &str) -> (file_store::FileStore, module_index::ModuleI
     let ws = index_workspace(root);
 
     let module_index = module_index::ModuleIndex::new_for_cli();
-    let root_path = std::path::Path::new(root).canonicalize()
-        .unwrap_or_else(|_| std::path::PathBuf::from(root));
-    let root_uri = format!("file://{}", root_path.display());
+    let (root_path, root_uri) = canonical_root_and_uri(root);
 
     let mut inc_paths = module_resolver::discover_inc_paths();
     module_resolver::add_project_lib_paths(&mut inc_paths, &root_path);
@@ -963,10 +977,7 @@ fn cli_workspace_symbol(root: &str, query: &str) {
 fn cli_clear_cache(root: Option<&str>) {
     let target = match root {
         Some(r) => {
-            let root_path = std::path::Path::new(r)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from(r));
-            let root_uri = format!("file://{}", root_path.display());
+            let (_, root_uri) = canonical_root_and_uri(r);
             module_cache::cache_dir_for_workspace(Some(&root_uri))
         }
         None => module_cache::cache_base_dir(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,10 @@ async fn main() {
             cli_dump_package(&args[2], &args[3]);
             return;
         }
+        Some("--clear-cache") => {
+            cli_clear_cache(args.get(2).map(|s| s.as_str()));
+            return;
+        }
         _ => {}
     }
 
@@ -122,6 +126,9 @@ fn print_usage() {
     eprintln!("DEBUG:");
     eprintln!("  perl-lsp --dump-package <root> <package>               Dump every sub in <package>");
     eprintln!("                                                         with derived type info");
+    eprintln!("  perl-lsp --clear-cache [<root>]                        Wipe the module cache for");
+    eprintln!("                                                         <root>, or every project if");
+    eprintln!("                                                         <root> is omitted");
     eprintln!();
     eprintln!("  perl-lsp --version                                     Print version");
 }
@@ -933,4 +940,50 @@ fn cli_workspace_symbol(root: &str, query: &str) {
 
     eprintln!("{} symbols matching '{}'", results.len(), query);
     println!("{}", serde_json::to_string_pretty(&results).unwrap());
+}
+
+/// --clear-cache [<root>] — Remove the SQLite module cache.
+///
+/// Without `<root>`: nuke the entire `~/.cache/perl-lsp` (or
+/// `$XDG_CACHE_HOME/perl-lsp`) tree — every project the user has
+/// touched. With `<root>`: only the per-project cache dir
+/// (`<base>/<workspace_hash>`) is removed; other projects keep theirs.
+///
+/// `<root>` is canonicalized and joined with `file://` to match the
+/// hash key the LSP server and `cli_full_startup` write under (the
+/// initialize request hands a `file://` URI; both CLI and server feed
+/// that string into `cache_dir_for_workspace`). Without canonicalizing
+/// here a relative path would hash to a different bucket and silently
+/// "clear" a non-existent dir.
+///
+/// On the next LSP start the cache is recreated from scratch — the
+/// resolver re-resolves modules lazily and the workspace indexer
+/// re-walks the tree. Pure side-effect command; prints what was
+/// removed so it's obvious whether anything happened.
+fn cli_clear_cache(root: Option<&str>) {
+    let target = match root {
+        Some(r) => {
+            let root_path = std::path::Path::new(r)
+                .canonicalize()
+                .unwrap_or_else(|_| std::path::PathBuf::from(r));
+            let root_uri = format!("file://{}", root_path.display());
+            module_cache::cache_dir_for_workspace(Some(&root_uri))
+        }
+        None => module_cache::cache_base_dir(),
+    };
+    let Some(path) = target else {
+        eprintln!("Cannot determine cache dir: $HOME and $XDG_CACHE_HOME are both unset");
+        std::process::exit(1);
+    };
+    if !path.exists() {
+        eprintln!("Cache already absent: {}", path.display());
+        return;
+    }
+    match std::fs::remove_dir_all(&path) {
+        Ok(()) => eprintln!("Cleared cache: {}", path.display()),
+        Err(e) => {
+            eprintln!("Failed to remove {}: {}", path.display(), e);
+            std::process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **Forward-reference resolution** — fixes the red-pinned regression where walk-time `expr_payload` arms (`function_call_expression` / `bareword` / `scoped_identifier`) silently emitted no witness when the callee was defined later in the source. Adds a queue + post-walk `resolve_forward_call_targets` pass that retries each missed lookup against the now-final symbol table and pushes the missing `Expr(span) → Edge(Symbol(sid))` witness. Same source tag and span as the walk-time path so reducers can't tell the two emission sites apart. Canonical real-world hit: Carp's `longmess` → `longmess_heavy`.
- **`--clear-cache` CLI** — adds `perl-lsp --clear-cache [<root>]`. With `<root>`: removes that project's per-workspace cache dir. Without: nukes the entire base cache dir. Canonicalizes `<root>` and prefixes `file://` to match the hash key the LSP server writes under.
- **Cleanup** — hoists `bare_name(s)` and `find_callee_symbol(bare)` as shared helpers; collapses `expr_payload`'s parallel call arms into one; factors `canonical_root_and_uri(root)` for both CLI callers. Filed `docs/prompt-cleanups.md` §6 for the deeper unification (a `WitnessAttachment::CalleeByName` would subsume the recovery queue).

Tests dropped `#[ignore]` from `forward_reference_call_in_sub_return_resolves` and added four sibling cases per the spec: implicit return, ternary arms, scoped-identifier call (`Pkg::name()`), and self-method tail with a forward-defined inner sub.

## Test plan

- [x] `cargo test` — 512 unit (was 508 + 1 ignored), 0 failed, 1 ignored (the *other* red pin)
- [x] `./run_e2e.sh` — 93 e2e green
- [x] QA harness (`./scripts/qa/run-all.sh`): cold 12.31s / warm 0.37s, no panics, coverage matches prior baselines (Mojo accessor residual is pre-existing, not introduced)
- [x] `--clear-cache <root>` smoke-tested end-to-end against this project's actual cache dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)