### PR TITLE
fix: cross-file invocant refresh — drop the cache, single bag-routed resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ categories = ["development-tools", "text-editors"]
 name = "perl-lsp"
 path = "src/main.rs"
 
+[features]
+default = []
+# Compile the workspace-scale `refs_to` perf bench
+# (`bench_refs_to_invocant_resolution`). Off by default so the
+# regular `cargo test` doesn't carry a long-running synthetic
+# workload — and so we never ship `#[ignore]`d tests as
+# perpetual yellow output. Run with:
+#   cargo test --release --features perf_bench bench_refs_to
+perf_bench = []
+
 [dependencies]
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ Four docs, one engine:
 | `prompt-type-inference-unification.md` | **HOW** — collapse walker + bag into one path | **Steps 1–4 landed (PR #27)** — historical |
 | `working-bag-residual.md` | **FINISH THE COLLAPSE** — four directives for "bag is the only truth" | **D1–D4 landed (PR #31).** D4-G follow-up open |
 | `prompt-forward-reference-resolution.md` | **REGRESSION** — walk-time sym lookups miss forward-defined callees | **LANDED** — post-walk resolver |
-| `prompt-cross-file-invocant-refresh.md` | **REGRESSION** — `invocant_class` cache stale after enrichment, cross-file refs under-match | **Top of queue.** Red-pinned |
+| `prompt-cross-file-invocant-refresh.md` | **REGRESSION** — `invocant_class` cache stale after enrichment, cross-file refs under-match | **LANDED (PR #34)** — bag-only resolver |
 | `prompt-type-inference-residual.md` | **WHAT'S MISSING** — Parts 1–5 fact classes | each is a reducer+emitter pair |
 | `prompt-sequence-types.md` | **FIRST BIG CONSUMER** — sequence type lattice | 5 phases; ~half the spike's diff on a clean foundation |
 
@@ -41,7 +41,7 @@ staircase 1–4 (LANDED, PR #27) ─┐
                                  │       FA.type_constraints gone, EXTRACT_VERSION 21)
                                  │       │
                                  │       ├─▶ forward-reference resolution (LANDED)
-                                 │       ├─▶ ★ cross-file invocant refresh (red-pinned)
+                                 │       ├─▶ cross-file invocant refresh (LANDED, PR #34)
                                  │       │
                                  │       └─▶ sequence-types phases 1-3
                                  │
@@ -52,10 +52,11 @@ staircase 1–4 (LANDED, PR #27) ─┐
 ```
 
 ★ = known regression with a pinned `#[ignore]` test that fails until
-fixed. Forward-reference resolution landed; cross-file invocant
-refresh is the only ★ left. Both block downstream type-intelligence
-quality but don't block sequence-types architecturally — sequence
-types can land in parallel.
+fixed. Both ★ regressions have landed (forward-reference resolution
++ cross-file invocant refresh). The bag is now canonical at every
+phase: no cached projections, no parallel paths. Sequence types and
+the residual Parts build directly on top with no remaining
+regression backlog gating them.
 
 - **Unification staircase** is done. PR #27 subsumed Steps 1–4: the walker only
   observes, edge-payload witnesses replace closure-driven chase, deferred-var /
@@ -149,17 +150,33 @@ types can land in parallel.
      self-method tails (see `forward_reference_*` in
      `builder_tests.rs`). Spec:
      `docs/prompt-forward-reference-resolution.md`.
-   - **★ cross-file `invocant_class` refresh.** `Ref::MethodCall.invocant_class`
-     is set once at build time and never refreshed; when a consumer's
-     invocant only becomes typeable post-enrichment (cross-file
-     return type), `refs_to`'s `cn == pkg` filter excludes it. Fix
-     surface (recommended): hybrid cache + bag fallback — readers
-     consult the bag when `invocant_class` is `None`; spec in
-     `docs/prompt-cross-file-invocant-refresh.md`. Pinned by
-     `references_cross_file_invocant_resolved_post_enrichment`.
+   - **cross-file `invocant_class` refresh.** **LANDED in PR #34.**
+     The hybrid (option 3) recommended in the original spec was
+     superseded by option 2 (drop the cached field outright). The
+     decisive factor: chain hops where the inner receiver's class
+     is only known via cross-file enrichment
+     (`$x->makeFoo()->ping()` where `makeFoo` returns a cross-file
+     class). Option 3's bag fallback hits a string-based resolver
+     that doesn't walk a chain at read time; option 2's helper
+     recurses on the inner receiver via `call_ref_by_start` and
+     re-resolves fresh, so cross-file enrichment composes through
+     every chain hop without any read-time refresh logic. Single
+     dispatcher: `FileAnalysis::method_call_invocant_class(ref,
+     module_index)` — invocant shape (variable / chain / function-
+     call receiver / bareword / `__PACKAGE__` / `shift` / `$_[0]`)
+     dispatches into bag queries. `Builder.method_call_invocant`
+     remains as build-only worklist state, never copied into FA.
+     Bonus collapses: 7-arg `resolve_method_invocant_public` →
+     2-arg helper; `module_index` threaded uniformly through every
+     in-file reader (was index-blind); `_with_index` API
+     duplicates removed; perf bench gated on `--features
+     perf_bench` (~11.5ms per `refs_to` over 200 files × 50
+     calls). Tiebreak invariants on `call_ref_by_start` pinned by
+     8 targeted tests in `src/call_ref_index_tests.rs`. Tests:
+     525 unit + 20 e2e green.
 
    Forward-ref landed first (higher-frequency hit; Carp pattern is
-   everywhere). Cross-file invocant refresh remains queued.
+   everywhere). Cross-file invocant refresh now also landed.
 
 5. **Sequence-types phases 1-3** on the clean foundation. Can land in
    parallel with the regression fixes above; not architecturally
@@ -218,15 +235,17 @@ already exists; just the eager-target invariant is missing.
 
 ### Why this matters
 
-The bag-residual directives are done — the bag is canonical. The two
-red-pinned regressions are the immediate priority because they're the
-only places where "more type intelligence" *doesn't* automatically
-flow through to user-visible features. Both are bag-canonical
-violations of different flavors: forward-ref is *emit-side* (witness
-never gets pushed for forward-defined callees), invocant-refresh is
-*cache-side* (witness exists, the cached projection on refs is stale).
-Fixing them keeps the audited claim — "all type intelligence routes
-through the bag" — actually true at every phase.
+The bag-residual directives are done — the bag is canonical. Both
+red-pinned regressions have landed: forward-ref was *emit-side* (the
+witness never got pushed for forward-defined callees, fixed by the
+post-walk resolver), invocant-refresh was *cache-side* (the cached
+projection on refs went stale; fixed by deleting the cache outright
+and routing every reader through one bag-routed dispatcher). The
+audited claim — "all type intelligence routes through the bag" —
+now holds at every phase, with no parallel cache paths and no
+shape-specific resolvers per reader. New type intelligence (residual
+fact classes, sequence types) is now purely additive: emit a witness,
+write a reducer, no parallel path to keep in sync.
 
 Graph rework is what unblocks Phase 6 (Openness diagnostic), multi-app
 Mojo support, and the eventual `Symbol.home_scope` move (was: phase

--- a/docs/prompt-cross-file-invocant-refresh.md
+++ b/docs/prompt-cross-file-invocant-refresh.md
@@ -1,8 +1,56 @@
 # Cross-file invocant_class refresh
 
-**Status:** known regression. Pinned by
-`references_cross_file_invocant_resolved_post_enrichment` in
-`resolve_tests.rs` (`#[ignore]` until this lands).
+**Status:** **LANDED in PR #34.** Implemented as **option 2** (drop
+the cached field), not option 3 (hybrid cache + bag fallback) which
+this spec originally recommended. Decisive factor against option 3:
+chain hops where the inner receiver's class is only known via
+cross-file enrichment (`$x->makeFoo()->ping()` — `makeFoo` returns
+a cross-file class) — option 3's bag fallback hits a string-based
+resolver that doesn't walk a chain at read time, so the chain hop
+keeps `invocant_class: None` and class-keyed ref filters silently
+miss it. Option 2's helper recurses on the inner receiver via
+`call_ref_by_start` and re-resolves fresh; cross-file enrichment
+composes through every chain hop without any read-time refresh
+logic. Pinned by `refs_to_cross_file_chain_hop_post_enrichment` and
+`find_highlights_cross_file_chain_hop_post_enrichment`.
+
+The single dispatcher is `FileAnalysis::method_call_invocant_class
+(ref, module_index)` — invocant shape (variable / chain receiver /
+function-call receiver / bareword / `__PACKAGE__` / `shift` /
+`$_[0]`) dispatches into bag queries; build-time chain typing
+publishes the witnesses the helper reads.
+`Builder.method_call_invocant: HashMap<usize, String>` survives as
+build-only worklist state (movement counter + post-walk arg-key
+emission gating) but is never copied into `FileAnalysis`.
+
+Bonus collapses landed in the same PR:
+  * 7-arg `resolve_method_invocant_public(invocant, span, scope,
+    point, tree, source, module_index)` → 2-arg `method_call_
+    invocant_class(ref, module_index)`.
+  * `_with_index` API duplicates removed; one signature with
+    `Option<&ModuleIndex>`.
+  * `module_index` threaded uniformly through the in-file readers
+    (`find_references` / `find_highlights` / `collect_refs_for_target`
+    / `rename_kind_at` / `rename_callable_in_scope` /
+    `rename_sub_in_package` / `rename_method_in_class`) — was
+    index-blind before.
+  * Perf bench gated on `--features perf_bench` (~11.5ms per
+    `refs_to` over 200 files × 50 calls; comfortably inside an LSP
+    interactive budget).
+  * 8 targeted tests pinning the `call_ref_by_start` tiebreak
+    invariants (smallest-span wins, equal-span first-write-wins,
+    only-call-kinds-indexed, `is_self` recursion guard) in
+    `src/call_ref_index_tests.rs`.
+
+Tests: 525 unit + 20 e2e green; the original red-pin
+`references_cross_file_invocant_resolved_post_enrichment` is
+un-ignored, plus `find_highlights_cross_file_invocant_resolved_post_enrichment`,
+`refs_to_cross_file_invocant_inherited_method` (multi-hop `use
+parent` chain), and the two chain-hop discriminators above.
+
+Original spec preserved below for context.
+
+---
 
 ## The bug
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -541,12 +541,14 @@ impl LanguageServer for Backend {
                     crate::file_analysis::RenameKind::Method { name, class } => {
                         // Walk MyWorker → ... → BaseWorker (the actual
                         // defining class). Each link is needed: the
-                        // call-site invocant_class on `$worker->process`
-                        // is "MyWorker" (the static type), while the
-                        // `sub process` definition lives in BaseWorker.
+                        // call-site invocant class on `$worker->process`
+                        // (resolved via the bag-routed
+                        // `method_call_invocant_class`) is "MyWorker"
+                        // (the static type), while the `sub process`
+                        // definition lives in BaseWorker.
                         // `rename_method_in_class` matches strict
-                        // `invocant_class == scope`, so without the
-                        // chain we'd pick up only one of the two ends.
+                        // class == scope, so without the chain we'd
+                        // pick up only one of the two ends.
                         let chain = doc.analysis.method_rename_chain(
                             class,
                             name,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -378,7 +378,7 @@ impl LanguageServer for Backend {
         use crate::resolve::{refs_to, RoleMask, TargetKind, TargetRef};
 
         let point = symbols::position_to_point(pos);
-        let target = match doc.analysis.rename_kind_at(point) {
+        let target = match doc.analysis.rename_kind_at(point, Some(&self.module_index)) {
             Some(RenameKind::Function { name, package }) => TargetRef {
                 name,
                 kind: TargetKind::Sub { package },
@@ -448,7 +448,7 @@ impl LanguageServer for Backend {
                         // Fall back to single-file (e.g. keys owned by a lexical
                         // variable — scope-local by definition).
                         let refs = symbols::find_references(
-                            &doc.analysis, pos, uri, &doc.tree, &doc.text,
+                            &doc.analysis, pos, uri, &doc.tree, &doc.text, Some(&self.module_index),
                         );
                         return Ok(if refs.is_empty() { None } else { Some(refs) });
                     }
@@ -457,7 +457,7 @@ impl LanguageServer for Backend {
             Some(RenameKind::Variable) | None => {
                 // Variables are lexical — single-file only.
                 let refs = symbols::find_references(
-                    &doc.analysis, pos, uri, &doc.tree, &doc.text,
+                    &doc.analysis, pos, uri, &doc.tree, &doc.text, Some(&self.module_index),
                 );
                 return Ok(if refs.is_empty() { None } else { Some(refs) });
             }
@@ -512,7 +512,7 @@ impl LanguageServer for Backend {
         };
 
         let point = symbols::position_to_point(pos);
-        let rename_kind = doc.analysis.rename_kind_at(point);
+        let rename_kind = doc.analysis.rename_kind_at(point, Some(&self.module_index));
 
         match rename_kind {
             Some(crate::file_analysis::RenameKind::Variable) => {
@@ -536,7 +536,10 @@ impl LanguageServer for Backend {
                 let (name, rename_fn): (String, Box<dyn Fn(&FileAnalysis, &str, &str) -> Vec<(crate::file_analysis::Span, String)>>) = match rename_kind.as_ref().unwrap() {
                     crate::file_analysis::RenameKind::Function { name, package } => {
                         let p = package.clone();
-                        (name.clone(), Box::new(move |fa, old, new| fa.rename_sub_in_package(old, &p, new)))
+                        let mi = Arc::clone(&self.module_index);
+                        (name.clone(), Box::new(move |fa, old, new| {
+                            fa.rename_sub_in_package(old, &p, new, Some(&mi))
+                        }))
                     }
                     crate::file_analysis::RenameKind::Method { name, class } => {
                         // Walk MyWorker → ... → BaseWorker (the actual
@@ -554,10 +557,11 @@ impl LanguageServer for Backend {
                             name,
                             Some(&self.module_index),
                         );
+                        let mi = Arc::clone(&self.module_index);
                         (name.clone(), Box::new(move |fa, old, new| {
                             let mut all = Vec::new();
                             for c in &chain {
-                                all.extend(fa.rename_method_in_class(old, c, new));
+                                all.extend(fa.rename_method_in_class(old, c, new, Some(&mi)));
                             }
                             all
                         }))
@@ -690,7 +694,7 @@ impl LanguageServer for Backend {
             Some(doc) => doc,
             None => return Ok(None),
         };
-        let highlights = symbols::document_highlights(&doc.analysis, pos, &doc.tree, &doc.text);
+        let highlights = symbols::document_highlights(&doc.analysis, pos, &doc.tree, &doc.text, Some(&self.module_index));
         if highlights.is_empty() {
             Ok(None)
         } else {
@@ -996,7 +1000,7 @@ impl LanguageServer for Backend {
         };
 
         let point = symbols::position_to_point(pos);
-        let refs = doc.analysis.find_references(point, None, None);
+        let refs = doc.analysis.find_references(point, None, None, Some(&self.module_index));
         if refs.len() < 2 {
             return Ok(None);
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -195,6 +195,7 @@ fn build_with_plugins_inner(
         package_ranges: Vec::new(),
         open_statement_package: None,
         plugins,
+        method_call_invocant: std::collections::HashMap::new(),
     };
 
     // Create file-level scope and walk
@@ -964,6 +965,20 @@ struct Builder<'a> {
     /// Framework plugin registry. Shared Arc so multiple builders in one
     /// process avoid re-compiling the same Rhai scripts.
     plugins: Arc<PluginRegistry>,
+
+    /// Build-time chain-typing cache for MethodCall ref invocants.
+    /// Keyed by `refs[idx]`. Walk-time fills it for syntactic cases
+    /// (constructor pattern `Foo->new`, `__PACKAGE__->m`); PostFold's
+    /// `apply_chain_typing_invocants` fills it for variable invocants
+    /// whose TC has crystallized. Build-time consumers
+    /// (`emit_method_call_arg_keys`, `emit_method_call_return_edges`,
+    /// fixed-point movement counter) read it.
+    ///
+    /// **Build-only.** Never copied into `FileAnalysis`. The reader-
+    /// side counterpart is `FileAnalysis::method_call_invocant_class`,
+    /// which queries the bag at read time and so picks up cross-file
+    /// enrichment automatically.
+    method_call_invocant: std::collections::HashMap<usize, String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1744,12 +1759,12 @@ impl<'a> Builder<'a> {
                 } else {
                     Some(invocant.clone())
                 };
+                let ref_idx = self.refs.len();
                 self.refs.push(Ref {
                     kind: RefKind::MethodCall {
                         invocant,
                         invocant_span,
                         method_name_span: span,
-                        invocant_class,
                     },
                     span,
                     scope: self.current_scope(),
@@ -1757,6 +1772,9 @@ impl<'a> Builder<'a> {
                     access: AccessKind::Read,
                     resolves_to: None,
                 });
+                if let Some(c) = invocant_class {
+                    self.method_call_invocant.insert(ref_idx, c);
+                }
             }
             plugin::EmitAction::DispatchCall { name, dispatcher, owner, span, var_text } => {
                 // Same pattern as HashKeyAccess: record the owner so
@@ -4950,31 +4968,37 @@ impl<'a> Builder<'a> {
             if name.starts_with('$') {
                 if let Some(resolved) = self.resolve_constant_strings(name, 0) {
                     for rname in resolved {
+                        let idx = self.refs.len();
                         self.add_ref(
                             RefKind::MethodCall {
                                 invocant: invocant.clone().unwrap_or_default(),
                                 invocant_span,
                                 method_name_span,
-                                invocant_class: invocant_class.clone(),
                             },
                             node_to_span(node),
                             rname,
                             AccessKind::Read,
                         );
+                        if let Some(c) = invocant_class.clone() {
+                            self.method_call_invocant.insert(idx, c);
+                        }
                     }
                 }
             } else {
+                let idx = self.refs.len();
                 self.add_ref(
                     RefKind::MethodCall {
                         invocant: invocant.clone().unwrap_or_default(),
                         invocant_span,
                         method_name_span,
-                        invocant_class: invocant_class.clone(),
                     },
                     node_to_span(node),
                     name.clone(),
                     AccessKind::Read,
                 );
+                if let Some(c) = invocant_class.clone() {
+                    self.method_call_invocant.insert(idx, c);
+                }
             }
         }
 
@@ -6074,18 +6098,14 @@ impl<'a> Builder<'a> {
             .map(|s| (s.id, self.resolved_returns.get(&s.id).cloned()))
             .collect();
         answers.sort_by_key(|(id, _)| id.0);
-        // Count refs with filled `invocant_class` so progressive
-        // chain-typing inside the loop registers as movement —
-        // without this, an iteration that only newly fills
-        // `invocant_class` (driving the next iteration's
+        // Count entries in the build-time invocant cache so
+        // progressive chain-typing inside the loop registers as
+        // movement — without this, an iteration that only newly
+        // fills the invocant cache (driving the next iteration's
         // `emit_method_call_return_edges` to publish a new edge)
         // would produce the same answers/bag snapshot and the loop
         // would terminate prematurely.
-        let invocant_filled = self
-            .refs
-            .iter()
-            .filter(|r| matches!(&r.kind, RefKind::MethodCall { invocant_class: Some(_), .. }))
-            .count();
+        let invocant_filled = self.method_call_invocant.len();
         (answers, self.bag.len(), invocant_filled)
     }
 
@@ -6204,12 +6224,11 @@ impl<'a> Builder<'a> {
         let mut pending: Vec<(usize, Node<'a>)> = Vec::new();
         for (i, r) in self.refs.iter().enumerate() {
             if let RefKind::MethodCall {
-                invocant_class,
                 invocant_span: Some(sp),
                 ..
             } = &r.kind
             {
-                if invocant_class.is_some() {
+                if self.method_call_invocant.contains_key(&i) {
                     continue;
                 }
                 if let Some(n) = idx.invocant_nodes.get(&(sp.start, sp.end)).copied() {
@@ -6219,9 +6238,7 @@ impl<'a> Builder<'a> {
         }
         for (i, node) in pending {
             if let Some(class) = self.resolve_invocant_class_tree(node) {
-                if let RefKind::MethodCall { invocant_class, .. } = &mut self.refs[i].kind {
-                    *invocant_class = Some(class);
-                }
+                self.method_call_invocant.insert(i, class);
             }
         }
     }
@@ -6242,8 +6259,11 @@ impl<'a> Builder<'a> {
     fn emit_method_call_arg_keys(&mut self, idx: &ChainTypingIndex<'a>) {
         // Snapshot first so we can `&mut self` the emit loop below.
         let mut pending: Vec<(HashKeyOwner, Node<'a>)> = Vec::new();
-        for r in &self.refs {
-            let RefKind::MethodCall { invocant_class: Some(cls), .. } = &r.kind else {
+        for (i, r) in self.refs.iter().enumerate() {
+            if !matches!(r.kind, RefKind::MethodCall { .. }) {
+                continue;
+            }
+            let Some(cls) = self.method_call_invocant.get(&i) else {
                 continue;
             };
             let Some(args) = idx
@@ -6301,7 +6321,10 @@ impl<'a> Builder<'a> {
 
         let mut edges: Vec<Witness> = Vec::new();
         for (i, r) in self.refs.iter().enumerate() {
-            let RefKind::MethodCall { invocant_class: Some(class), .. } = &r.kind else {
+            if !matches!(r.kind, RefKind::MethodCall { .. }) {
+                continue;
+            }
+            let Some(class) = self.method_call_invocant.get(&i) else {
                 continue;
             };
             edges.push(Witness {

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -6539,7 +6539,8 @@ sub _generate_route {
         })
         .expect("MethodCall ref for `_generate_route`");
 
-    if let RefKind::MethodCall { invocant_class, .. } = &gr_ref.kind {
+    if matches!(gr_ref.kind, RefKind::MethodCall { .. }) {
+        let invocant_class = fa.method_call_invocant_class(gr_ref);
         assert_eq!(
             invocant_class.as_deref(),
             Some("Mojolicious::Routes::Route"),
@@ -6577,7 +6578,8 @@ sub inline {
         .find(|r| matches!(r.kind, RefKind::MethodCall { .. }) && r.target_name == "inline")
         .expect("MethodCall ref for `inline`");
 
-    if let RefKind::MethodCall { invocant_class, .. } = &inline_ref.kind {
+    if matches!(inline_ref.kind, RefKind::MethodCall { .. }) {
+        let invocant_class = fa.method_call_invocant_class(inline_ref);
         assert_eq!(
             invocant_class.as_deref(),
             Some("Mojolicious::Routes::Route"),

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1370,7 +1370,7 @@ fn test_find_references_variable() {
     let src = "my $x = 1;\nprint $x;\n$x = 2;";
     let fa = build_fa(src);
     // Cursor on the declaration of $x
-    let refs = fa.find_references(Point::new(0, 4), None, None);
+    let refs = fa.find_references(Point::new(0, 4), None, None, None);
     assert!(
         refs.len() >= 2,
         "should find at least declaration + usage, got {}",
@@ -1428,7 +1428,7 @@ fn test_find_references_sub() {
     let src = "sub greet { }\ngreet();\ngreet();";
     let fa = build_fa(src);
     // Cursor on the sub name
-    let refs = fa.find_references(Point::new(0, 5), None, None);
+    let refs = fa.find_references(Point::new(0, 5), None, None, None);
     assert!(
         refs.len() >= 2,
         "should find definition + calls, got {}",
@@ -1451,7 +1451,7 @@ get_foo()->bar();
     let tree = parse(src);
     let fa = build(&tree, src.as_bytes());
     // Cursor on bar definition (line 2, col 4)
-    let refs = fa.find_references(Point::new(2, 5), Some(&tree), Some(src.as_bytes()));
+    let refs = fa.find_references(Point::new(2, 5), Some(&tree), Some(src.as_bytes()), None);
     // Should find: $f->bar() + get_foo()->bar() (definition may or may not be included)
     let ref_lines: Vec<usize> = refs.iter().map(|s| s.start.row).collect();
     assert!(
@@ -1517,7 +1517,7 @@ fn test_hash_key_def_in_return_gets_sub_owner() {
 
     // Verify go-to-references from the def finds the usage
     let host_def_point = host_defs[0].selection_span.start;
-    let refs = fa.find_references(host_def_point, Some(&tree), Some(src.as_bytes()));
+    let refs = fa.find_references(host_def_point, Some(&tree), Some(src.as_bytes()), None);
     // symbol_at returns include_decl=false, so only usages are returned
     assert!(
         refs.len() >= 1,
@@ -1527,7 +1527,7 @@ fn test_hash_key_def_in_return_gets_sub_owner() {
 
     // Verify go-to-references from the usage finds back to the def
     let host_ref_point = host_refs[0].span.start;
-    let refs_from_usage = fa.find_references(host_ref_point, Some(&tree), Some(src.as_bytes()));
+    let refs_from_usage = fa.find_references(host_ref_point, Some(&tree), Some(src.as_bytes()), None);
     // ref resolves to def → include_decl=true, so def + usage
     assert!(
         refs_from_usage.len() >= 2,
@@ -1577,7 +1577,7 @@ $calc->get_self->get_config->{host};
 
     // find_references from the def should find the chained usage via tree fallback
     let host_def_point = host_defs[0].selection_span.start;
-    let refs = fa.find_references(host_def_point, Some(&tree), Some(src.as_bytes()));
+    let refs = fa.find_references(host_def_point, Some(&tree), Some(src.as_bytes()), None);
     assert!(
         refs.len() >= 1,
         "should find chained usage via tree fallback, got {} refs",
@@ -1589,7 +1589,7 @@ $calc->get_self->get_config->{host};
 fn test_highlights_read_write() {
     let src = "my $x = 1;\nprint $x;\n$x = 2;";
     let fa = build_fa(src);
-    let highlights = fa.find_highlights(Point::new(0, 4), None, None);
+    let highlights = fa.find_highlights(Point::new(0, 4), None, None, None);
     assert!(!highlights.is_empty(), "should have highlights");
     // Check that we have both read and write accesses
     let has_write = highlights
@@ -1730,7 +1730,7 @@ sub test {
     // package=Foo catches the decl, the FunctionCall `emit()`,
     // AND the MethodCall `$self->emit()` — two shapes of the
     // same callable.
-    let edits = fa.rename_sub_in_package("emit", &Some("Foo".to_string()), "fire");
+    let edits = fa.rename_sub_in_package("emit", &Some("Foo".to_string()), "fire", None);
     assert!(
         edits.len() >= 3,
         "rename_sub_in_package should find def + function call + method call, got {} edits",
@@ -6298,7 +6298,7 @@ sub run {
     let col = src.lines().nth(row).unwrap().find("do_thing").unwrap();
     let point = tree_sitter::Point::new(row, col + 1);
 
-    let hits = fa.find_highlights(point, None, None);
+    let hits = fa.find_highlights(point, None, None, None);
     assert!(!hits.is_empty(), "should highlight at least one occurrence");
 
     for (span, _access) in &hits {
@@ -6540,7 +6540,7 @@ sub _generate_route {
         .expect("MethodCall ref for `_generate_route`");
 
     if matches!(gr_ref.kind, RefKind::MethodCall { .. }) {
-        let invocant_class = fa.method_call_invocant_class(gr_ref);
+        let invocant_class = fa.method_call_invocant_class(gr_ref, None);
         assert_eq!(
             invocant_class.as_deref(),
             Some("Mojolicious::Routes::Route"),
@@ -6579,7 +6579,7 @@ sub inline {
         .expect("MethodCall ref for `inline`");
 
     if matches!(inline_ref.kind, RefKind::MethodCall { .. }) {
-        let invocant_class = fa.method_call_invocant_class(inline_ref);
+        let invocant_class = fa.method_call_invocant_class(inline_ref, None);
         assert_eq!(
             invocant_class.as_deref(),
             Some("Mojolicious::Routes::Route"),

--- a/src/call_ref_index_tests.rs
+++ b/src/call_ref_index_tests.rs
@@ -1,0 +1,437 @@
+//! Tiebreak / shape pins for `FileAnalysis::call_ref_by_start` —
+//! the start-point → call-shaped-ref index that powers chain
+//! receiver dispatch in `method_call_invocant_class`.
+//!
+//! The index is small but its rules are subtle: only MethodCall +
+//! FunctionCall refs go in; identical-start collisions are won by
+//! smallest span; equal spans first-write-wins; recursion needs the
+//! `is_self` pointer guard so a ref doesn't chase itself. This file
+//! pins each rule with a targeted test so future refactors of the
+//! invocant resolver can't silently break one without lighting up
+//! a specific failure.
+
+use super::*;
+use tree_sitter::{Parser, Point};
+
+fn parse(source: &str) -> FileAnalysis {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&ts_parser_perl::LANGUAGE.into())
+        .unwrap();
+    let tree = parser.parse(source, None).unwrap();
+    crate::builder::build(&tree, source.as_bytes())
+}
+
+/// Find the index of the (last) ref whose `target_name` matches and
+/// whose kind matches the predicate. Test helper — multiple refs may
+/// share a name across a chain (e.g. `Foo->new->new` would have two
+/// `new` MethodCalls), but our fixtures keep names unique.
+fn ref_idx<F: Fn(&RefKind) -> bool>(fa: &FileAnalysis, name: &str, kind_pred: F) -> usize {
+    fa.refs
+        .iter()
+        .enumerate()
+        .find(|(_, r)| r.target_name == name && kind_pred(&r.kind))
+        .map(|(i, _)| i)
+        .unwrap_or_else(|| {
+            panic!(
+                "no ref with target_name={:?} matching predicate; refs: {:?}",
+                name,
+                fa.refs.iter().map(|r| (&r.target_name, &r.kind)).collect::<Vec<_>>(),
+            )
+        })
+}
+
+fn is_method_call(k: &RefKind) -> bool {
+    matches!(k, RefKind::MethodCall { .. })
+}
+
+fn is_function_call(k: &RefKind) -> bool {
+    matches!(k, RefKind::FunctionCall { .. })
+}
+
+/// `Foo->new->bar()`: outer `bar`'s `invocant_span` starts at the
+/// same point as the inner `Foo->new` call's start. The index must
+/// resolve that start point to the **inner** `new` ref, not the
+/// outer `bar` (smallest-span wins). This is the rule that makes
+/// chain dispatch in `method_call_invocant_class` recurse onto the
+/// genuine receiver instead of looping back on itself.
+#[test]
+fn smallest_span_wins_method_chain() {
+    let fa = parse(
+        r#"
+package Foo;
+sub new { bless {}, shift }
+sub bar { 1 }
+package main;
+Foo->new->bar();
+"#,
+    );
+
+    let bar_idx = ref_idx(&fa, "bar", is_method_call);
+    let new_idx = ref_idx(&fa, "new", is_method_call);
+
+    let bar = &fa.refs[bar_idx];
+    let RefKind::MethodCall { invocant_span: Some(bar_invocant_span), .. } = &bar.kind else {
+        panic!("bar is a MethodCall");
+    };
+
+    // Both `bar` (outer) and `new` (inner) have call-spans starting
+    // at the same point as the chain's leftmost token (`Foo`'s
+    // start, which is also `bar.invocant_span.start`).
+    let key = bar_invocant_span.start;
+    let resolved = fa.call_ref_by_start.get(&key).copied();
+
+    assert_eq!(
+        resolved,
+        Some(new_idx),
+        "lookup at the chain's leftmost point must return the \
+         inner `new` MethodCall (smaller span), not the outer `bar`. \
+         got: {:?} (bar={}, new={})",
+        resolved, bar_idx, new_idx,
+    );
+
+    // And critically: not the outer ref itself. If this fires, the
+    // `is_self` guard in `method_call_invocant_class` is the only
+    // thing protecting against an infinite recursion.
+    assert_ne!(resolved, Some(bar_idx));
+}
+
+/// `make_b()->touch()`: outer `touch`'s `invocant_span` starts at
+/// the same point as the `make_b` FunctionCall ref's span. The
+/// `FunctionCall` ref's span covers just the function-name node
+/// (`make_b`), which is strictly contained in the outer
+/// MethodCall's span — so smallest-span wins picks the
+/// FunctionCall.
+///
+/// This is what lets `method_call_invocant_class` chase
+/// `make_b()->touch()` back to `make_b`'s zero-arg return type
+/// without depending on any cached field.
+#[test]
+fn smallest_span_wins_function_call_inner() {
+    let fa = parse(
+        r#"
+sub make_b { bless {}, 'B' }
+make_b()->touch();
+"#,
+    );
+
+    let touch_idx = ref_idx(&fa, "touch", is_method_call);
+    let make_b_idx = ref_idx(&fa, "make_b", is_function_call);
+
+    let touch = &fa.refs[touch_idx];
+    let RefKind::MethodCall { invocant_span: Some(touch_invocant_span), .. } = &touch.kind else {
+        panic!("touch is a MethodCall");
+    };
+
+    let resolved = fa.call_ref_by_start.get(&touch_invocant_span.start).copied();
+    assert_eq!(
+        resolved,
+        Some(make_b_idx),
+        "lookup at touch's invocant_span.start must return the \
+         `make_b` FunctionCall ref (narrower span). got: {:?}",
+        resolved,
+    );
+}
+
+/// Only call-shaped refs (MethodCall, FunctionCall) enter the
+/// index. Variable / HashKeyAccess / ContainerAccess refs sharing
+/// the same start point don't.
+///
+/// `$x->m(); $x->{k}`: the `$x->{k}` access produces a
+/// HashKeyAccess + ContainerAccess pair at `$x`'s start, neither
+/// of which is call-shaped. Chain dispatch must never hand off to
+/// a non-call kind, so we cross-check every entry the parser
+/// produces against the kind invariant. (PackageRef shape — the
+/// other natural source of "non-call ref at chain start" — turns
+/// out not to be emitted by tree-sitter-perl for the bareword in
+/// `Foo->m()`; the outer MethodCall already covers that span. The
+/// invariant still holds, just with one less natural collider.)
+#[test]
+fn non_call_kinds_at_call_start_dont_enter_index() {
+    let fa = parse(
+        r#"
+package Foo;
+sub new { bless {}, shift }
+sub m { 1 }
+package main;
+my $x = Foo->new;
+$x->m();
+my $k = $x->{key};
+"#,
+    );
+
+    // Cross-check: nothing in the index points at a non-call kind.
+    for (&_pt, &idx) in fa.call_ref_by_start.iter() {
+        let kind = &fa.refs[idx].kind;
+        assert!(
+            matches!(kind, RefKind::MethodCall { .. } | RefKind::FunctionCall { .. }),
+            "non-call kind in call_ref_by_start: {:?}",
+            kind,
+        );
+    }
+
+    // And specifically: any HashKeyAccess / ContainerAccess /
+    // Variable ref starting at the same point as `$x` is excluded.
+    let m_idx = ref_idx(&fa, "m", is_method_call);
+    let m = &fa.refs[m_idx];
+    let RefKind::MethodCall { invocant_span: Some(m_invocant_span), .. } = &m.kind else {
+        panic!("m is a MethodCall");
+    };
+    let key_point = m_invocant_span.start;
+    let resolved = fa.call_ref_by_start.get(&key_point).copied();
+
+    // The only call-shaped ref starting at `$x`'s point is the
+    // outer `m` itself — the index must point there. (Recursion's
+    // `is_self` guard takes care of the rest; see
+    // `is_self_guard_falls_through_to_variable_branch`.)
+    assert_eq!(
+        resolved,
+        Some(m_idx),
+        "only call ref at $$x's start is `m` itself",
+    );
+
+    // Sanity: at least one non-call ref *does* start at that
+    // point (otherwise the test asserts nothing).
+    let non_call_at_same_start = fa
+        .refs
+        .iter()
+        .any(|r| {
+            r.span.start == key_point
+                && !matches!(r.kind, RefKind::MethodCall { .. } | RefKind::FunctionCall { .. })
+        });
+    assert!(
+        non_call_at_same_start,
+        "fixture should produce at least one non-call ref starting at $$x's point; \
+         refs: {:?}",
+        fa.refs
+            .iter()
+            .map(|r| (r.span.start, &r.target_name, &r.kind))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// `is_self` guard: when `Foo->m()` is the only call-shaped ref at
+/// the chain's leftmost point, the index lookup from `m`'s
+/// `invocant_span` returns `m` itself. The recursion in
+/// `method_call_invocant_class` must detect that (pointer compare
+/// against the input ref) and bail out, so the bareword invocant
+/// branch can resolve `Foo` → "Foo" at the bottom of the function.
+///
+/// Without the guard: infinite recursion (or loops back through
+/// the same call edge).
+#[test]
+fn is_self_guard_resolves_bareword_invocant() {
+    let fa = parse(
+        r#"
+package Foo;
+sub m { 1 }
+package main;
+Foo->m();
+"#,
+    );
+    let m = &fa.refs[ref_idx(&fa, "m", is_method_call)];
+
+    // Sanity: index lookup at m's invocant_span DOES point at `m`
+    // itself (no smaller call ref to displace it).
+    let RefKind::MethodCall { invocant_span: Some(span), .. } = &m.kind else {
+        panic!("m is a MethodCall");
+    };
+    let resolved = fa.call_ref_by_start.get(&span.start).copied();
+    let m_idx = ref_idx(&fa, "m", is_method_call);
+    assert_eq!(resolved, Some(m_idx));
+
+    // The functional consequence of the guard: resolution returns
+    // "Foo" (the bareword invocant), not None or a hang.
+    let class = fa.method_call_invocant_class(m, None);
+    assert_eq!(class.as_deref(), Some("Foo"));
+}
+
+/// Same guard, variable invocant: `$x->m()` — the only call ref at
+/// `$x`'s start is the outer `m` itself (a Variable ref isn't
+/// call-shaped, so it's not in the index). Recursion detects self,
+/// bails, falls through to the bag query for `$x`.
+///
+/// This test pins the interaction: the variable branch is reached
+/// even when the chain branch would otherwise loop on itself.
+#[test]
+fn is_self_guard_falls_through_to_variable_branch() {
+    let fa = parse(
+        r#"
+package Bar;
+sub new { bless {}, shift }
+sub m { 1 }
+package main;
+my $x = Bar->new;
+$x->m();
+"#,
+    );
+    let m = &fa.refs[ref_idx(&fa, "m", is_method_call)];
+
+    let RefKind::MethodCall { invocant_span: Some(span), .. } = &m.kind else {
+        panic!("m is a MethodCall");
+    };
+    // The outer `m` is the only call-shaped ref starting at `$x`'s
+    // point — `$x` itself is a Variable ref, not indexed.
+    let resolved = fa.call_ref_by_start.get(&span.start).copied();
+    let m_idx = ref_idx(&fa, "m", is_method_call);
+    assert_eq!(
+        resolved,
+        Some(m_idx),
+        "with no inner call receiver, the index points at the outer \
+         method call itself; the `is_self` guard must keep us from \
+         recursing on it",
+    );
+
+    // Functional consequence: `$x` is typed as `Bar` via the
+    // build-time TC; the variable branch in
+    // `method_call_invocant_class` reads that from the bag.
+    assert_eq!(fa.method_call_invocant_class(m, None).as_deref(), Some("Bar"));
+}
+
+/// Equal spans: when two MethodCall refs occupy the exact same
+/// span (a synthesized / plugin-emitted shape that the parser
+/// can't naturally produce), the index keeps the **first** insert
+/// — smallest-span comparison uses strict `<`, so neither ref
+/// displaces the other.
+///
+/// Pin this with a hand-built FileAnalysis. Documents the
+/// resolved tie behavior so a future refactor that loosens the
+/// comparison to `<=` (which would silently flip the winner)
+/// trips this assertion.
+#[test]
+fn equal_span_first_write_wins() {
+    let span = Span {
+        start: Point::new(0, 0),
+        end: Point::new(0, 10),
+    };
+    // Two MethodCall refs at the exact same span. Order matters
+    // because we're pinning "first wins".
+    let refs = vec![
+        Ref {
+            kind: RefKind::MethodCall {
+                invocant: "$a".into(),
+                invocant_span: Some(Span {
+                    start: Point::new(0, 0),
+                    end: Point::new(0, 2),
+                }),
+                method_name_span: Span {
+                    start: Point::new(0, 4),
+                    end: Point::new(0, 5),
+                },
+            },
+            span,
+            scope: ScopeId(0),
+            target_name: "first".into(),
+            access: AccessKind::Read,
+            resolves_to: None,
+        },
+        Ref {
+            kind: RefKind::MethodCall {
+                invocant: "$b".into(),
+                invocant_span: Some(Span {
+                    start: Point::new(0, 0),
+                    end: Point::new(0, 2),
+                }),
+                method_name_span: Span {
+                    start: Point::new(0, 6),
+                    end: Point::new(0, 7),
+                },
+            },
+            span,
+            scope: ScopeId(0),
+            target_name: "second".into(),
+            access: AccessKind::Read,
+            resolves_to: None,
+        },
+    ];
+
+    let fa = FileAnalysis::new(
+        vec![Scope {
+            id: ScopeId(0),
+            parent: None,
+            kind: ScopeKind::File,
+            span: Span {
+                start: Point::new(0, 0),
+                end: Point::new(10, 0),
+            },
+            package: None,
+        }],
+        vec![],
+        refs,
+        vec![],
+        vec![],
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashSet::new(),
+        vec![],
+        vec![],
+        vec![],
+        HashMap::new(),
+        HashMap::new(),
+        vec![],
+    );
+
+    let resolved = fa.call_ref_by_start.get(&span.start).copied();
+    assert_eq!(
+        resolved,
+        Some(0),
+        "first insert wins on equal spans; got idx {:?}",
+        resolved,
+    );
+}
+
+/// Stress: a deep chain `a()->b()->c()->d()->e()->f()` resolves
+/// without recursion blow-up. Each hop's index lookup lands on the
+/// next-inner call ref (smallest-span wins), so recursion strictly
+/// narrows; total depth is bounded by chain length.
+///
+/// Concrete pin: top-level `f`'s invocant_class resolves through
+/// every hop. We don't define typed bodies — the resolver should
+/// return `None` (no class info), but it must do so in finite time
+/// without panicking.
+#[test]
+fn deep_chain_terminates() {
+    let fa = parse(
+        r#"
+sub a { 1 }
+a()->b()->c()->d()->e()->f();
+"#,
+    );
+
+    let f_idx = ref_idx(&fa, "f", is_method_call);
+    let f = &fa.refs[f_idx];
+
+    // No panic, no hang. Return value can be None (no return-type
+    // info available); the point is termination.
+    let _ = fa.method_call_invocant_class(f, None);
+}
+
+/// Cross-check: every ref in `call_ref_by_start` is actually a
+/// MethodCall or FunctionCall. Guards against a future code
+/// addition that puts another kind in.
+#[test]
+fn index_only_holds_call_shaped_kinds() {
+    let fa = parse(
+        r#"
+package Foo;
+sub new { bless {}, shift }
+sub bar { 1 }
+package main;
+my $x = Foo->new;
+$x->bar();
+make_b()->touch();
+sub make_b { 1 }
+sub touch { 1 }
+"#,
+    );
+
+    for (&_pt, &idx) in fa.call_ref_by_start.iter() {
+        let kind = &fa.refs[idx].kind;
+        assert!(
+            matches!(kind, RefKind::MethodCall { .. } | RefKind::FunctionCall { .. }),
+            "call_ref_by_start contains non-call kind: {:?}",
+            kind,
+        );
+    }
+}

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -420,9 +420,26 @@ pub enum RefKind {
         #[serde(default)]
         resolved_package: Option<String>,
     },
+    /// Method call site `$obj->m(...)` / `Class->m(...)` /
+    /// `chain()->m(...)`. **Invocant class is NOT cached on the
+    /// variant** — it's resolved on demand via
+    /// `FileAnalysis::method_call_invocant_class(ref, module_index)`,
+    /// which dispatches by invocant shape (variable / chain receiver /
+    /// function-call receiver / bareword / `__PACKAGE__` / `shift` /
+    /// `$_[0]`) and queries the witness bag. This is intentional:
+    /// a cached field would silently miss invocants that get typed
+    /// only by post-build cross-file enrichment, and chain hops
+    /// can't be cached without invalidation. The bag-routed helper
+    /// composes through cross-file enrichment automatically.
+    ///
+    /// Build-time chain typing still runs in the builder — it
+    /// publishes Variable witnesses + chain-receiver `Expression`
+    /// edge witnesses; the helper reads those at query time.
     MethodCall {
         invocant: String,
-        /// Span of the invocant node (for complex expressions needing tree resolution).
+        /// Span of the invocant node. Used by
+        /// `method_call_invocant_class` to find an inner-receiver
+        /// ref via `call_ref_by_start` (chain dispatch).
         invocant_span: Option<Span>,
         /// Span of just the method name (for rename — r.span covers the whole expression).
         method_name_span: Span,
@@ -5599,3 +5616,7 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
 #[cfg(test)]
 #[path = "file_analysis_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "call_ref_index_tests.rs"]
+mod call_ref_index_tests;

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -426,17 +426,6 @@ pub enum RefKind {
         invocant_span: Option<Span>,
         /// Span of just the method name (for rename — r.span covers the whole expression).
         method_name_span: Span,
-        /// Resolved class of the invocant at build time, when derivable
-        /// from the tree. Populated for:
-        ///   - `$self`/`__PACKAGE__` → current package
-        ///   - bareword `Foo` → `Foo`
-        ///   - typed `$var` → constraint's ClassName
-        ///   - `Foo->new` chain invocant → `Foo` (via extract_constructor_class)
-        /// `None` means "couldn't pin a class at build time" — refs_to
-        /// treats that as no-match (safe default, avoids cross-linking
-        /// unrelated classes that share a method name).
-        #[serde(default)]
-        invocant_class: Option<String>,
     },
     PackageRef,
     HashKeyAccess {
@@ -1016,6 +1005,15 @@ pub struct FileAnalysis {
     /// Every query for "refs to symbol X" collapses to an O(1) lookup here.
     #[serde(skip, default)]
     refs_by_target: HashMap<SymbolId, Vec<usize>>,
+    /// Start-point → call-shaped ref index. Used by
+    /// `method_call_invocant_class` to chase a chain receiver:
+    /// `Foo->new->m`'s outer `->m` `invocant_span` starts at the
+    /// inner `Foo->new` call's start; `make_b()->touch()`'s outer
+    /// `invocant_span` starts at `make_b`'s start. Only MethodCall
+    /// and FunctionCall refs go in here — the receiver dispatch is
+    /// keyed on those two kinds.
+    #[serde(skip, default)]
+    call_ref_by_start: HashMap<Point, usize>,
 }
 
 impl FileAnalysis {
@@ -1062,6 +1060,7 @@ impl FileAnalysis {
             symbols_by_scope: HashMap::new(),
             refs_by_name: HashMap::new(),
             refs_by_target: HashMap::new(),
+            call_ref_by_start: HashMap::new(),
         };
         fa.build_indices();
         // The builder path overwrites `witnesses` with its already-populated
@@ -1099,6 +1098,7 @@ impl FileAnalysis {
         self.symbols_by_scope.clear();
         self.refs_by_name.clear();
         self.refs_by_target.clear();
+        self.call_ref_by_start.clear();
         self.build_indices();
     }
 
@@ -1188,6 +1188,12 @@ impl FileAnalysis {
         }
 
         // Refs by target name, and refs by resolved target SymbolId (phase 5).
+        // Same loop populates the start-point → call-ref-idx index
+        // used by `method_call_invocant_class` to chase chain
+        // receivers. Only MethodCall (whose span covers the whole
+        // call expression) and FunctionCall (whose span covers just
+        // the function-name node, but whose start point still
+        // matches the outer call's invocant_span.start) refs go in.
         for (i, r) in self.refs.iter().enumerate() {
             self.refs_by_name
                 .entry(r.target_name.clone())
@@ -1195,6 +1201,37 @@ impl FileAnalysis {
                 .push(i);
             if let Some(sym_id) = r.resolves_to {
                 self.refs_by_target.entry(sym_id).or_default().push(i);
+            }
+            if matches!(r.kind, RefKind::MethodCall { .. } | RefKind::FunctionCall { .. }) {
+                // First write wins. Method-call refs are visited
+                // outer-first by the walker (the outer call site is
+                // emitted before recursing into its receiver), so
+                // for a chain like `Foo->new->m` the outer `m` ref
+                // would land at start point of `Foo`. Insert with
+                // `or_insert(i)` and rely on the inner receiver
+                // being visited later — but for FunctionCall there
+                // is no outer clash because chains-of-function-calls
+                // don't have the same shape. To keep the inner
+                // receiver as the lookup target, prefer overwriting
+                // when the new ref has a *smaller* span (closer to
+                // the actual receiver).
+                let cur = self.call_ref_by_start.get(&r.span.start).copied();
+                let take = match cur {
+                    None => true,
+                    Some(prev) => {
+                        let prev_span = self.refs[prev].span;
+                        // Smaller span (closer to the receiver) wins.
+                        // Tie-breaker: prefer FunctionCall over MethodCall
+                        // when at the same start, since FunctionCall is
+                        // narrower (just the function-name span).
+                        let new_smaller = (r.span.end.row, r.span.end.column)
+                            < (prev_span.end.row, prev_span.end.column);
+                        new_smaller
+                    }
+                };
+                if take {
+                    self.call_ref_by_start.insert(r.span.start, i);
+                }
             }
         }
     }
@@ -1352,6 +1389,18 @@ impl FileAnalysis {
     /// across chain hops without needing an intermediate variable.
     #[allow(dead_code)] // documented type-query entry point; CLAUDE.md
     pub fn method_call_return_type_via_bag(&self, ref_idx: usize) -> Option<InferredType> {
+        self.method_call_return_type_via_bag_with_index(ref_idx, None)
+    }
+
+    /// Like `method_call_return_type_via_bag` but threads a
+    /// `ModuleIndex` so cross-file MethodOnClass edges (e.g.
+    /// `$r->get(...)`'s return type when `get` is defined in
+    /// `Mojolicious::Routes`) can resolve.
+    pub fn method_call_return_type_via_bag_with_index(
+        &self,
+        ref_idx: usize,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<InferredType> {
         use crate::witnesses::{
             BagContext, FrameworkFact, ReducedValue, ReducerQuery, ReducerRegistry,
             WitnessAttachment,
@@ -1362,7 +1411,7 @@ impl FileAnalysis {
         let ctx = BagContext {
             scopes: &self.scopes,
             package_framework: &self.package_framework,
-            module_index: None,
+            module_index,
             package_parents: &self.package_parents,
             };
         let q = ReducerQuery {
@@ -2592,16 +2641,8 @@ impl FileAnalysis {
                     // Nothing local; leave cross-file resolution to
                     // the LSP adapter (symbols::find_definition).
                 }
-                RefKind::MethodCall { ref invocant, ref invocant_span, ref invocant_class, .. } => {
-                    // Prefer the build-time `invocant_class` (pre-computed
-                    // by `resolve_invocant_class_tree`, handles chains
-                    // like `Foo->new->m`). Fall back to the runtime
-                    // resolver for refs where the builder couldn't pin
-                    // a class (rare — plugin-emitted refs from older
-                    // code paths, ERROR-recovered invocants).
-                    let class_name = invocant_class.clone().or_else(|| self.resolve_method_invocant(
-                        invocant, invocant_span, r.scope, point, tree, source_bytes, module_index,
-                    ));
+                RefKind::MethodCall { .. } => {
+                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
 
                     // Check if cursor is on a named arg key in the call args,
                     // not on the method name itself. Resolve to hash key def or :param field.
@@ -2743,16 +2784,21 @@ impl FileAnalysis {
         if let Some(r) = self.ref_at(point) {
             let mut results: Vec<(Span, AccessKind)> = Vec::new();
             match &r.kind {
-                RefKind::MethodCall { invocant_class: Some(cn), method_name_span, .. } => {
-                    let wanted_class = cn.clone();
+                RefKind::MethodCall { method_name_span, .. } => {
+                    // Single bag-routed invocant resolver — same call
+                    // for the cursor's ref and every candidate.
+                    let Some(wanted_class) = self.method_call_invocant_class(r) else {
+                        return Vec::new();
+                    };
                     results.push((*method_name_span, r.access));
                     for other in &self.refs {
                         if std::ptr::eq(other, r) { continue; }
                         if other.target_name != r.target_name { continue; }
-                        if let RefKind::MethodCall { invocant_class: Some(ocn), method_name_span: ms, .. } = &other.kind {
-                            if ocn == &wanted_class {
-                                results.push((*ms, other.access));
-                            }
+                        if !matches!(other.kind, RefKind::MethodCall { .. }) { continue; }
+                        let Some(ocn) = self.method_call_invocant_class(other) else { continue };
+                        if ocn != wanted_class { continue; }
+                        if let RefKind::MethodCall { method_name_span: ms, .. } = &other.kind {
+                            results.push((*ms, other.access));
                         }
                     }
                 }
@@ -2820,7 +2866,7 @@ impl FileAnalysis {
                                 results.push((r.span, r.access));
                             }
                         }
-                        (RefKind::MethodCall { method_name_span, invocant_class, .. },
+                        (RefKind::MethodCall { method_name_span, .. },
                          SymKind::Sub | SymKind::Method) => {
                             // Same-class match only; unresolved or
                             // different-class invocants are excluded.
@@ -2828,8 +2874,8 @@ impl FileAnalysis {
                             // `$obj->foo(...)` expression so we use
                             // `method_name_span` to highlight just
                             // the identifier.
-                            match (invocant_class, &sym_package) {
-                                (Some(cn), Some(pkg)) if cn == pkg => {
+                            match (self.method_call_invocant_class(r), &sym_package) {
+                                (Some(cn), Some(pkg)) if cn == *pkg => {
                                     results.push((*method_name_span, r.access));
                                 }
                                 _ => {}
@@ -2872,7 +2918,7 @@ impl FileAnalysis {
     }
 
     /// Hover info: return display text for the symbol at cursor.
-    pub fn hover_info(&self, point: Point, source: &str, tree: Option<&tree_sitter::Tree>, module_index: Option<&ModuleIndex>) -> Option<String> {
+    pub fn hover_info(&self, point: Point, source: &str, _tree: Option<&tree_sitter::Tree>, module_index: Option<&ModuleIndex>) -> Option<String> {
         // Check refs first
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
@@ -2884,10 +2930,8 @@ impl FileAnalysis {
                             && contains_point(&mr.span, point)
                             && mr.target_name != r.target_name);
                     if let Some(mr) = method_hover {
-                        if let RefKind::MethodCall { ref invocant, ref invocant_span, ref invocant_class, .. } = mr.kind {
-                            let class_name = invocant_class.clone().or_else(|| self.resolve_method_invocant(
-                                invocant, invocant_span, mr.scope, point, tree, Some(source.as_bytes()), module_index,
-                            ));
+                        if matches!(mr.kind, RefKind::MethodCall { .. }) {
+                            let class_name = self.method_call_invocant_class_with_index(mr, module_index);
                             if let Some(ref cn) = class_name {
                                 match self.resolve_method_in_ancestors(cn, &mr.target_name, module_index) {
                                     Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -2991,13 +3035,8 @@ impl FileAnalysis {
                         }
                     }
                 }
-                RefKind::MethodCall { ref invocant, ref invocant_span, ref invocant_class, .. } => {
-                    // Prefer the build-time `invocant_class` field
-                    // (handles chains); fall back to the runtime
-                    // tree-based resolver.
-                    let class_name = invocant_class.clone().or_else(|| self.resolve_method_invocant(
-                        invocant, invocant_span, r.scope, point, tree, Some(source.as_bytes()), module_index,
-                    ));
+                RefKind::MethodCall { .. } => {
+                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
                     if let Some(ref cn) = class_name {
                         match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
                             Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -3151,15 +3190,8 @@ impl FileAnalysis {
                         package: resolved_package.clone(),
                     });
                 }
-                RefKind::MethodCall { invocant, invocant_span, invocant_class, .. } => {
-                    // Prefer build-time class (chain-resolved);
-                    // fall back to text-based resolution.
-                    let class = invocant_class.clone()
-                        .or_else(|| {
-                            let resolve_point = invocant_span.map(|s| s.start).unwrap_or(point);
-                            self.invocant_text_to_class(Some(invocant), resolve_point)
-                        });
-                    if let Some(class) = class {
+                RefKind::MethodCall { .. } => {
+                    if let Some(class) = self.method_call_invocant_class(r) {
                         return Some(RenameKind::Method {
                             name: r.target_name.clone(),
                             class,
@@ -3246,11 +3278,13 @@ impl FileAnalysis {
                         edits.push((r.span, new_name.to_string()));
                     }
                 }
-                RefKind::MethodCall { invocant_class, method_name_span, .. } => {
+                RefKind::MethodCall { method_name_span, .. } => {
                     // MethodCall refs target a class — `None` scope
                     // doesn't reach methods.
-                    if let (Some(cls), Some(wanted)) = (invocant_class, scope.as_ref()) {
-                        if cls == wanted {
+                    if let (Some(cls), Some(wanted)) =
+                        (self.method_call_invocant_class(r), scope.as_ref())
+                    {
+                        if &cls == wanted {
                             edits.push((*method_name_span, new_name.to_string()));
                         }
                     }
@@ -3319,10 +3353,8 @@ impl FileAnalysis {
                         }
                     }
                 }
-                RefKind::MethodCall { ref invocant, ref invocant_span, ref invocant_class, .. } => {
-                    let class_name = invocant_class.clone().or_else(|| self.resolve_method_invocant(
-                        invocant, invocant_span, r.scope, point, tree, source_bytes, module_index,
-                    ));
+                RefKind::MethodCall { .. } => {
+                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
                     // Try inheritance-aware resolution first
                     if let Some(ref cn) = class_name {
                         match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
@@ -3419,46 +3451,186 @@ impl FileAnalysis {
         None
     }
 
-    /// Resolve a method call's invocant to a class name (public API for cross-file goto-def).
-    pub fn resolve_method_invocant_public(
-        &self,
-        invocant: &str,
-        invocant_span: &Option<Span>,
-        scope: ScopeId,
-        point: Point,
-        tree: Option<&tree_sitter::Tree>,
-        source_bytes: Option<&[u8]>,
-        module_index: Option<&ModuleIndex>,
-    ) -> Option<String> {
-        self.resolve_method_invocant(invocant, invocant_span, scope, point, tree, source_bytes, module_index)
+    /// Resolve a `MethodCall` ref's invocant class via the witness
+    /// bag — **the** invocant resolver. No tree, no text fallback,
+    /// no per-reader parallel paths. Every reader (refs_to,
+    /// find_highlights, collect_refs_for_target, rename_callable_in_scope,
+    /// hover, find-def, rename_kind_at, resolve_target_at, the
+    /// completion path) routes through here.
+    ///
+    /// Dispatch by invocant shape:
+    ///   * `$var` / `@var` / `%var` → `inferred_type_via_bag` (so
+    ///     cross-file enrichment's variable types compose
+    ///     automatically — the bug that prompted this rewrite).
+    ///   * `$self` (untyped) → enclosing class fallback.
+    ///   * `__PACKAGE__` → enclosing class.
+    ///   * Chain or function-call receiver (invocant_span points at
+    ///     another ref) → that ref's bag answer
+    ///     (`method_call_return_type_via_bag` for MethodCall;
+    ///     `sub_return_type_at_arity` for FunctionCall). Receiver
+    ///     ref is found via `ref_idx_by_exact_span` (O(1)).
+    ///   * Bareword → `Foo` if a zero-arg sub by that name returns
+    ///     ClassName, else the bareword itself.
+    ///
+    /// Build-time chain typing still runs in the builder — its
+    /// product lands in the bag (Variable witnesses, `Expression`
+    /// edge witnesses on chain receivers). This helper just queries
+    /// the bag, never re-derives.
+    ///
+    /// Threadless variant — equivalent to
+    /// `method_call_invocant_class_with_index(r, None)`. Use this
+    /// for callers that don't have a `ModuleIndex` (CLI debug,
+    /// tests). Cross-file MethodOnClass edges won't chase without
+    /// an index.
+    pub fn method_call_invocant_class(&self, r: &Ref) -> Option<String> {
+        self.method_call_invocant_class_with_index(r, None)
     }
 
-    /// Resolve a method call's invocant to a class name, using tree-based resolution
-    /// for complex expressions when available.
-    fn resolve_method_invocant(
+    /// `method_call_invocant_class` with a `ModuleIndex` so chain
+    /// receivers whose return type lives in another package can be
+    /// resolved (e.g. `$r->get('/x')->to(...)` where `Routes::get`
+    /// returns `Routes::Route`).
+    pub fn method_call_invocant_class_with_index(
         &self,
-        invocant: &str,
-        invocant_span: &Option<Span>,
-        scope: ScopeId,
-        point: Point,
-        tree: Option<&tree_sitter::Tree>,
-        source_bytes: Option<&[u8]>,
+        r: &Ref,
         module_index: Option<&ModuleIndex>,
     ) -> Option<String> {
-        // Try tree-based resolution for complex invocants, fall through on failure
-        if let (Some(span), Some(tree), Some(src)) = (invocant_span, tree, source_bytes) {
-            if let Some(node) = tree.root_node()
-                .descendant_for_point_range(span.start, span.end)
-            {
-                if let Some(ty) = self.resolve_expression_type(node, src, module_index) {
-                    if let Some(cn) = ty.class_name() {
-                        return Some(cn.to_string());
+        let RefKind::MethodCall { invocant, invocant_span, .. } = &r.kind else {
+            return None;
+        };
+        if invocant.is_empty() {
+            return None;
+        }
+        let point = invocant_span.map(|s| s.start).unwrap_or(r.span.start);
+
+        // Pseudo-invocants for "$self at the method's first arg":
+        // `shift` (no args; `sub m { my $self = shift; ... }`),
+        // `$_[0]` / `@_[0]` (positional). Tree-aware build-time
+        // resolver treats these as enclosing-class identity. The
+        // bag has no Variable witness for them — they aren't real
+        // variables — so we resolve here directly.
+        if invocant == "shift" || invocant == "$_[0]" || invocant == "@_[0]" {
+            return self.enclosing_class_for_scope(r.scope);
+        }
+
+        // `__PACKAGE__` is rewritten to the enclosing package at
+        // walk time, but synthesized refs may still carry it raw.
+        if invocant == "__PACKAGE__" {
+            return self.enclosing_class_for_scope(r.scope);
+        }
+
+        // Chain / function-call receiver — checked BEFORE the
+        // simple-variable path because complex invocants like
+        // `$r->get('/x')` lead with `$` but aren't a variable
+        // lookup; they're a sub-expression whose type lives in
+        // another ref's bag answer. Index `call_ref_by_start`
+        // returns the *innermost* call-shaped ref starting at
+        // `invocant_span.start` (smallest-span tie-break in
+        // `build_indices`); we additionally require that ref's
+        // span be contained in `invocant_span` so we don't loop
+        // back on the outer ref itself for `Foo->m` where there's
+        // no real inner receiver.
+        if let Some(span) = invocant_span {
+            if let Some(&recv_idx) = self.call_ref_by_start.get(&span.start) {
+                let recv_span = self.refs[recv_idx].span;
+                let contained = recv_span.start == span.start
+                    && (recv_span.end.row, recv_span.end.column)
+                        <= (span.end.row, span.end.column);
+                // Guard against the lookup returning the outer ref
+                // itself (no genuine inner receiver). Compare by
+                // pointer to handle the equal-span case.
+                let is_self = std::ptr::eq(&self.refs[recv_idx], r);
+                if contained && !is_self {
+                    match &self.refs[recv_idx].kind {
+                    RefKind::MethodCall { .. } => {
+                        // Recursive: resolve the receiver's own
+                        // invocant class fresh (so cross-file
+                        // enrichment-typed variables compose
+                        // through chain hops without depending on
+                        // a build-time-published Expression edge),
+                        // then chase MethodOnClass{class, method}
+                        // through `find_method_return_type` — the
+                        // single class-keyed entry point that walks
+                        // ancestors + cross-file bridges via the
+                        // registry's `query_rec`.
+                        let recv = &self.refs[recv_idx];
+                        if let Some(recv_class) =
+                            self.method_call_invocant_class_with_index(recv, module_index)
+                        {
+                            if recv.target_name == "new" {
+                                return Some(recv_class);
+                            }
+                            if let Some(t) = self.find_method_return_type(
+                                &recv_class,
+                                &recv.target_name,
+                                module_index,
+                                None,
+                            ) {
+                                if let Some(cn) = t.class_name() {
+                                    return Some(cn.to_string());
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                    RefKind::FunctionCall { .. } => {
+                        let recv = &self.refs[recv_idx];
+                        if let Some(InferredType::ClassName(c)) =
+                            self.sub_return_type_at_arity(&recv.target_name, Some(0))
+                        {
+                            return Some(c);
+                        }
+                        return None;
+                    }
+                    _ => {}
                     }
                 }
             }
         }
-        // Fall back to string-based resolution
-        self.resolve_invocant_class(invocant, scope, point)
+
+        // Variable invocant — bag query handles every typed shape
+        // (TC, FrameworkAware, BranchArm, ArityReturn, cross-file
+        // Variable witnesses pushed by enrichment).
+        let first = invocant.as_bytes()[0];
+        if first == b'$' || first == b'@' || first == b'%' {
+            if let Some(t) = self.inferred_type_via_bag(invocant, point) {
+                if let Some(cn) = t.class_name() {
+                    return Some(cn.to_string());
+                }
+            }
+            // `$self` enclosing-class fallback. Other untyped
+            // variable invocants stay None — better than poisoning
+            // them with the surrounding package and pretending
+            // method calls land on it.
+            if invocant == "$self" {
+                return self.enclosing_class_for_scope(r.scope);
+            }
+            return None;
+        }
+
+        // Bareword invocant. Could be a zero-arg sub returning
+        // ClassName (`app->routes` where `app` is plugin-emitted) —
+        // promote that case. Otherwise the bareword *is* the class
+        // name (`Foo->method`).
+        let bare = invocant.rsplit("::").next().unwrap_or(invocant);
+        if let Some(InferredType::ClassName(c)) = self.sub_return_type_at_arity(bare, Some(0)) {
+            return Some(c);
+        }
+        Some(invocant.to_string())
+    }
+
+    /// Walk the scope chain to find the enclosing class or package.
+    fn enclosing_class_for_scope(&self, scope: ScopeId) -> Option<String> {
+        for sid in self.scope_chain(scope).iter() {
+            let s = self.scope(*sid);
+            if let ScopeKind::Class { ref name } = s.kind {
+                return Some(name.clone());
+            }
+            if let Some(ref pkg) = s.package {
+                return Some(pkg.clone());
+            }
+        }
+        None
     }
 
     /// Test-only wrapper over the private `resolve_invocant_class`.
@@ -3472,7 +3644,11 @@ impl FileAnalysis {
         self.resolve_invocant_class(invocant, scope, point)
     }
 
-    /// Resolve an invocant string to a class name.
+    /// Resolve an invocant string to a class name. Internal helper
+    /// used by string-based completion / hover-context paths that
+    /// don't have a `Ref` in hand. The ref-aware
+    /// `method_call_invocant_class` is preferred everywhere a
+    /// `&Ref` is available.
     fn resolve_invocant_class(&self, invocant: &str, scope: ScopeId, point: Point) -> Option<String> {
         if invocant.starts_with('$') || invocant.starts_with('@') || invocant.starts_with('%') {
             // Variable invocant → infer type via the witness bag so

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1387,16 +1387,14 @@ impl FileAnalysis {
     ///
     /// This is the piece that makes `$r->get('/x')->to(...)` fold
     /// across chain hops without needing an intermediate variable.
+    /// Resolve the inferred return type of a method call by its
+    /// ref index. Reads `Expression(refidx)` witnesses seeded by
+    /// the builder; `module_index` lets cross-file MethodOnClass
+    /// edges (e.g. `$r->get(...)` where `get` lives in
+    /// `Mojolicious::Routes`) chase through the registry's
+    /// recursive walker.
     #[allow(dead_code)] // documented type-query entry point; CLAUDE.md
-    pub fn method_call_return_type_via_bag(&self, ref_idx: usize) -> Option<InferredType> {
-        self.method_call_return_type_via_bag_with_index(ref_idx, None)
-    }
-
-    /// Like `method_call_return_type_via_bag` but threads a
-    /// `ModuleIndex` so cross-file MethodOnClass edges (e.g.
-    /// `$r->get(...)`'s return type when `get` is defined in
-    /// `Mojolicious::Routes`) can resolve.
-    pub fn method_call_return_type_via_bag_with_index(
+    pub fn method_call_return_type_via_bag(
         &self,
         ref_idx: usize,
         module_index: Option<&ModuleIndex>,
@@ -2642,7 +2640,7 @@ impl FileAnalysis {
                     // the LSP adapter (symbols::find_definition).
                 }
                 RefKind::MethodCall { .. } => {
-                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
+                    let class_name = self.method_call_invocant_class(r, module_index);
 
                     // Check if cursor is on a named arg key in the call args,
                     // not on the method name itself. Resolve to hash key def or :param field.
@@ -2756,9 +2754,15 @@ impl FileAnalysis {
     }
 
     /// Find all references to the symbol at cursor.
-    pub fn find_references(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Vec<Span> {
-        if let Some((target_id, include_decl)) = self.resolve_target_at(point, tree, source_bytes, None) {
-            let mut results = self.collect_refs_for_target(target_id, include_decl, tree, source_bytes);
+    pub fn find_references(
+        &self,
+        point: Point,
+        tree: Option<&tree_sitter::Tree>,
+        source_bytes: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
+    ) -> Vec<Span> {
+        if let Some((target_id, include_decl)) = self.resolve_target_at(point, tree, source_bytes, module_index) {
+            let mut results = self.collect_refs_for_target(target_id, include_decl, tree, source_bytes, module_index);
             results.sort_by_key(|(s, _)| (s.start.row, s.start.column));
             results.dedup_by(|a, b| a.0.start == b.0.start && a.0.end == b.0.end);
             results.into_iter().map(|(span, _)| span).collect()
@@ -2768,9 +2772,15 @@ impl FileAnalysis {
     }
 
     /// Document highlights: like references but with read/write annotation.
-    pub fn find_highlights(&self, point: Point, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Vec<(Span, AccessKind)> {
-        if let Some((target_id, _)) = self.resolve_target_at(point, tree, source_bytes, None) {
-            let mut results = self.collect_refs_for_target(target_id, true, tree, source_bytes);
+    pub fn find_highlights(
+        &self,
+        point: Point,
+        tree: Option<&tree_sitter::Tree>,
+        source_bytes: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
+    ) -> Vec<(Span, AccessKind)> {
+        if let Some((target_id, _)) = self.resolve_target_at(point, tree, source_bytes, module_index) {
+            let mut results = self.collect_refs_for_target(target_id, true, tree, source_bytes, module_index);
             results.sort_by_key(|(s, _)| (s.start.row, s.start.column));
             results.dedup_by(|a, b| a.0.start == b.0.start && a.0.end == b.0.end);
             return results;
@@ -2787,7 +2797,7 @@ impl FileAnalysis {
                 RefKind::MethodCall { method_name_span, .. } => {
                     // Single bag-routed invocant resolver — same call
                     // for the cursor's ref and every candidate.
-                    let Some(wanted_class) = self.method_call_invocant_class(r) else {
+                    let Some(wanted_class) = self.method_call_invocant_class(r, module_index) else {
                         return Vec::new();
                     };
                     results.push((*method_name_span, r.access));
@@ -2795,7 +2805,7 @@ impl FileAnalysis {
                         if std::ptr::eq(other, r) { continue; }
                         if other.target_name != r.target_name { continue; }
                         if !matches!(other.kind, RefKind::MethodCall { .. }) { continue; }
-                        let Some(ocn) = self.method_call_invocant_class(other) else { continue };
+                        let Some(ocn) = self.method_call_invocant_class(other, module_index) else { continue };
                         if ocn != wanted_class { continue; }
                         if let RefKind::MethodCall { method_name_span: ms, .. } = &other.kind {
                             results.push((*ms, other.access));
@@ -2831,6 +2841,7 @@ impl FileAnalysis {
         include_decl: bool,
         tree: Option<&tree_sitter::Tree>,
         source_bytes: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
     ) -> Vec<(Span, AccessKind)> {
         let sym = self.symbol(target_id);
         let mut results: Vec<(Span, AccessKind)> = Vec::new();
@@ -2874,7 +2885,7 @@ impl FileAnalysis {
                             // `$obj->foo(...)` expression so we use
                             // `method_name_span` to highlight just
                             // the identifier.
-                            match (self.method_call_invocant_class(r), &sym_package) {
+                            match (self.method_call_invocant_class(r, module_index), &sym_package) {
                                 (Some(cn), Some(pkg)) if cn == *pkg => {
                                     results.push((*method_name_span, r.access));
                                 }
@@ -2931,7 +2942,7 @@ impl FileAnalysis {
                             && mr.target_name != r.target_name);
                     if let Some(mr) = method_hover {
                         if matches!(mr.kind, RefKind::MethodCall { .. }) {
-                            let class_name = self.method_call_invocant_class_with_index(mr, module_index);
+                            let class_name = self.method_call_invocant_class(mr, module_index);
                             if let Some(ref cn) = class_name {
                                 match self.resolve_method_in_ancestors(cn, &mr.target_name, module_index) {
                                     Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -3036,7 +3047,7 @@ impl FileAnalysis {
                     }
                 }
                 RefKind::MethodCall { .. } => {
-                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
+                    let class_name = self.method_call_invocant_class(r, module_index);
                     if let Some(ref cn) = class_name {
                         match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
                             Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -3139,7 +3150,7 @@ impl FileAnalysis {
 
     /// Rename: return all spans + new text for renaming the symbol at cursor.
     pub fn rename_at(&self, point: Point, new_name: &str, tree: Option<&tree_sitter::Tree>, source_bytes: Option<&[u8]>) -> Option<Vec<(Span, String)>> {
-        let refs = self.find_references(point, tree, source_bytes);
+        let refs = self.find_references(point, tree, source_bytes, None);
         if refs.is_empty() {
             return None;
         }
@@ -3180,7 +3191,7 @@ impl FileAnalysis {
     /// falls through to symbol-at resolution; if that also has no
     /// class context (orphan Sub), returns `None` — the cursor isn't
     /// on something we can safely rename.
-    pub fn rename_kind_at(&self, point: Point) -> Option<RenameKind> {
+    pub fn rename_kind_at(&self, point: Point, module_index: Option<&ModuleIndex>) -> Option<RenameKind> {
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
                 RefKind::Variable | RefKind::ContainerAccess => return Some(RenameKind::Variable),
@@ -3191,7 +3202,7 @@ impl FileAnalysis {
                     });
                 }
                 RefKind::MethodCall { .. } => {
-                    if let Some(class) = self.method_call_invocant_class(r) {
+                    if let Some(class) = self.method_call_invocant_class(r, module_index) {
                         return Some(RenameKind::Method {
                             name: r.target_name.clone(),
                             class,
@@ -3262,6 +3273,7 @@ impl FileAnalysis {
         old_name: &str,
         scope: &Option<String>,
         new_name: &str,
+        module_index: Option<&ModuleIndex>,
     ) -> Vec<(Span, String)> {
         let mut edits = Vec::new();
         for sym in &self.symbols {
@@ -3282,7 +3294,7 @@ impl FileAnalysis {
                     // MethodCall refs target a class — `None` scope
                     // doesn't reach methods.
                     if let (Some(cls), Some(wanted)) =
-                        (self.method_call_invocant_class(r), scope.as_ref())
+                        (self.method_call_invocant_class(r, module_index), scope.as_ref())
                     {
                         if &cls == wanted {
                             edits.push((*method_name_span, new_name.to_string()));
@@ -3299,8 +3311,14 @@ impl FileAnalysis {
     /// Function rename path. Delegates to the unified
     /// `rename_callable_in_scope`; the distinction between "function"
     /// and "method" in Perl is just call shape, not identity.
-    pub fn rename_sub_in_package(&self, old_name: &str, package: &Option<String>, new_name: &str) -> Vec<(Span, String)> {
-        self.rename_callable_in_scope(old_name, package, new_name)
+    pub fn rename_sub_in_package(
+        &self,
+        old_name: &str,
+        package: &Option<String>,
+        new_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Vec<(Span, String)> {
+        self.rename_callable_in_scope(old_name, package, new_name, module_index)
     }
 
     /// Class-scoped method rename — public-API name used by the
@@ -3308,8 +3326,14 @@ impl FileAnalysis {
     /// `rename_sub_in_package(old, &Some(class), new)`: function and
     /// method calls into the same package are two shapes of the same
     /// callable.
-    pub fn rename_method_in_class(&self, old_name: &str, class: &str, new_name: &str) -> Vec<(Span, String)> {
-        self.rename_callable_in_scope(old_name, &Some(class.to_string()), new_name)
+    pub fn rename_method_in_class(
+        &self,
+        old_name: &str,
+        class: &str,
+        new_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Vec<(Span, String)> {
+        self.rename_callable_in_scope(old_name, &Some(class.to_string()), new_name, module_index)
     }
 
     /// Find all occurrences of a package name (def + refs + use statements) for cross-file rename.
@@ -3354,7 +3378,7 @@ impl FileAnalysis {
                     }
                 }
                 RefKind::MethodCall { .. } => {
-                    let class_name = self.method_call_invocant_class_with_index(r, module_index);
+                    let class_name = self.method_call_invocant_class(r, module_index);
                     // Try inheritance-aware resolution first
                     if let Some(ref cn) = class_name {
                         match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
@@ -3477,20 +3501,12 @@ impl FileAnalysis {
     /// edge witnesses on chain receivers). This helper just queries
     /// the bag, never re-derives.
     ///
-    /// Threadless variant — equivalent to
-    /// `method_call_invocant_class_with_index(r, None)`. Use this
-    /// for callers that don't have a `ModuleIndex` (CLI debug,
-    /// tests). Cross-file MethodOnClass edges won't chase without
-    /// an index.
-    pub fn method_call_invocant_class(&self, r: &Ref) -> Option<String> {
-        self.method_call_invocant_class_with_index(r, None)
-    }
-
-    /// `method_call_invocant_class` with a `ModuleIndex` so chain
-    /// receivers whose return type lives in another package can be
-    /// resolved (e.g. `$r->get('/x')->to(...)` where `Routes::get`
-    /// returns `Routes::Route`).
-    pub fn method_call_invocant_class_with_index(
+    /// `module_index` lets chain receivers whose return type lives
+    /// in another package resolve (e.g. `$r->get('/x')->to(...)`
+    /// where `Routes::get` returns `Routes::Route`). Pass `None`
+    /// only when no index is available (CLI debug, isolated tests);
+    /// every LSP-facing reader has one.
+    pub fn method_call_invocant_class(
         &self,
         r: &Ref,
         module_index: Option<&ModuleIndex>,
@@ -3555,7 +3571,7 @@ impl FileAnalysis {
                         // registry's `query_rec`.
                         let recv = &self.refs[recv_idx];
                         if let Some(recv_class) =
-                            self.method_call_invocant_class_with_index(recv, module_index)
+                            self.method_call_invocant_class(recv, module_index)
                         {
                             if recv.target_name == "new" {
                                 return Some(recv_class);

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -606,7 +606,7 @@ fn test_phase5_find_references_on_hash_key_def_without_tree() {
     // *usages*, not the def itself. Previously this returned 0 without a
     // tree; phase 5 returns the access sites via refs_by_target.
     let point = def_host.selection_span.start;
-    let refs = fa.find_references(point, None, None);
+    let refs = fa.find_references(point, None, None, None);
     assert!(
         !refs.is_empty(),
         "expected at least one access for 'host' via refs_by_target (no tree), got empty",
@@ -866,7 +866,7 @@ $r->get('/x')->to('Y#z');
     // Querying the bag for the get-call's return should yield
     // MyApp::Route (since its return is `return $self`, which is
     // FirstParam → ClassName projection).
-    let t = fa.method_call_return_type_via_bag(get_ref_idx);
+    let t = fa.method_call_return_type_via_bag(get_ref_idx, None);
     assert!(
         matches!(t, Some(InferredType::ClassName(ref n)) if n == "MyApp::Route"),
         "->get's return type via bag should be ClassName(MyApp::Route), got {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -554,8 +554,8 @@ fn cli_references(root: &str, file: &str, line_str: &str, col_str: &str) {
             let scope_from_ref = match &r.kind {
                 file_analysis::RefKind::FunctionCall { resolved_package } =>
                     Some(("sub", resolved_package.clone())),
-                file_analysis::RefKind::MethodCall { invocant_class, .. } =>
-                    invocant_class.as_ref().map(|c| ("method", Some(c.clone()))),
+                file_analysis::RefKind::MethodCall { .. } =>
+                    analysis.method_call_invocant_class(r).map(|c| ("method", Some(c))),
                 _ => None,
             };
             let scope_from_sym = analysis.symbol_at(point).and_then(|s| match s.kind {

--- a/src/main.rs
+++ b/src/main.rs
@@ -528,7 +528,7 @@ fn cli_references(root: &str, file: &str, line_str: &str, col_str: &str) {
         .unwrap_or_else(|_| std::path::PathBuf::from(file));
 
     // Local refs
-    let local_refs = analysis.find_references(point, Some(&tree), Some(source.as_bytes()));
+    let local_refs = analysis.find_references(point, Some(&tree), Some(source.as_bytes()), None);
     for span in &local_refs {
         results.push(serde_json::json!({
             "file": file_path.display().to_string(),
@@ -555,7 +555,7 @@ fn cli_references(root: &str, file: &str, line_str: &str, col_str: &str) {
                 file_analysis::RefKind::FunctionCall { resolved_package } =>
                     Some(("sub", resolved_package.clone())),
                 file_analysis::RefKind::MethodCall { .. } =>
-                    analysis.method_call_invocant_class(r).map(|c| ("method", Some(c))),
+                    analysis.method_call_invocant_class(r, None).map(|c| ("method", Some(c))),
                 _ => None,
             };
             let scope_from_sym = analysis.symbol_at(point).and_then(|s| match s.kind {
@@ -572,9 +572,9 @@ fn cli_references(root: &str, file: &str, line_str: &str, col_str: &str) {
                 } else {
                     match &scope {
                         Some(("sub", package)) =>
-                            entry.value().rename_sub_in_package(target, package, target),
+                            entry.value().rename_sub_in_package(target, package, target, None),
                         Some(("method", Some(class))) =>
-                            entry.value().rename_method_in_class(target, class, target),
+                            entry.value().rename_method_in_class(target, class, target, None),
                         // Unresolvable method scope — skip rather than
                         // cross-link. Matches refs_to / rename semantics.
                         _ => Vec::new(),
@@ -611,7 +611,7 @@ fn cli_rename(root: &str, file: &str, line_str: &str, col_str: &str, new_name: &
     }
     let analysis_ref = ws.get_workspace(&file_path).unwrap();
 
-    let rename_kind = match analysis_ref.rename_kind_at(point) {
+    let rename_kind = match analysis_ref.rename_kind_at(point, None) {
         Some(k) => k,
         None => {
             eprintln!("Nothing renameable at {}:{}", line_str, col_str);
@@ -641,9 +641,9 @@ fn cli_rename(root: &str, file: &str, line_str: &str, col_str: &str, new_name: &
             for entry in ws.workspace_raw().iter() {
                 let edits = match &rename_kind {
                     file_analysis::RenameKind::Function { name, package } =>
-                        entry.value().rename_sub_in_package(name, package, new_name),
+                        entry.value().rename_sub_in_package(name, package, new_name, None),
                     file_analysis::RenameKind::Method { name, class } =>
-                        entry.value().rename_method_in_class(name, class, new_name),
+                        entry.value().rename_method_in_class(name, class, new_name, None),
                     _ => unreachable!(),
                 };
                 if !edits.is_empty() {

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 21;
+pub const EXTRACT_VERSION: i64 = 22;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -110,7 +110,7 @@ pub fn refs_to(
             if let Ok(p) = url.to_file_path() {
                 covered_paths.insert(p);
             }
-            collect_from_analysis(&FileKey::Url(url), &doc.analysis, target, &mut out);
+            collect_from_analysis(&FileKey::Url(url), &doc.analysis, target, module_index, &mut out);
         });
     } else {
         // Even if open isn't in the mask, track the paths so a WORKSPACE walk
@@ -128,7 +128,7 @@ pub fn refs_to(
             if covered_paths.contains(entry.key()) {
                 continue;
             }
-            collect_from_analysis(&FileKey::Path(entry.key().clone()), entry.value(), target, &mut out);
+            collect_from_analysis(&FileKey::Path(entry.key().clone()), entry.value(), target, module_index, &mut out);
         }
     }
 
@@ -137,7 +137,7 @@ pub fn refs_to(
         if let Some(idx) = module_index {
             idx.for_each_cached(|_module_name, cached| {
                 let key = FileKey::Path(cached.path.clone());
-                collect_from_analysis(&key, &cached.analysis, target, &mut out);
+                collect_from_analysis(&key, &cached.analysis, target, module_index, &mut out);
             });
         }
     }
@@ -170,6 +170,7 @@ fn collect_from_analysis(
     key: &FileKey,
     analysis: &FileAnalysis,
     target: &TargetRef,
+    module_index: Option<&ModuleIndex>,
     out: &mut Vec<RefLocation>,
 ) {
     use crate::file_analysis::{HashKeyOwner, SymbolDetail};
@@ -246,16 +247,21 @@ fn collect_from_analysis(
                 resolved_package == scope
             }
             (TargetKind::Sub { .. } | TargetKind::Method { .. },
-             RefKind::MethodCall { invocant_class, .. }) => {
+             RefKind::MethodCall { .. }) => {
                 // Method-shaped call: match only when the ref's
-                // invocant resolved to the target scope. No text
-                // fallback — unresolved invocants are excluded rather
-                // than cross-linked. (Build-time
-                // `resolve_invocant_class_tree` handles chains.)
+                // invocant resolves to the target scope. The bag is
+                // the single resolver — `method_call_invocant_class`
+                // dispatches by invocant shape (variable / chain /
+                // bareword / `__PACKAGE__`) and queries the bag.
+                // Cross-file enrichment composes naturally because
+                // it pushes Variable witnesses the bag query reads.
+                // Class still has to be `Some` to match — package-
+                // less subs and genuinely unpinnable invocants stay
+                // out, no cross-linking.
                 let scope = callable_scope_for_refs.as_ref().unwrap();
-                match (invocant_class, scope) {
-                    (Some(cn), Some(pkg)) => cn == pkg,
-                    _ => false, // package-less sub or unpinned method
+                match (analysis.method_call_invocant_class_with_index(r, module_index), scope) {
+                    (Some(cn), Some(pkg)) => &cn == pkg,
+                    _ => false,
                 }
             }
             (TargetKind::Package, RefKind::PackageRef) => true,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -259,7 +259,7 @@ fn collect_from_analysis(
                 // less subs and genuinely unpinnable invocants stay
                 // out, no cross-linking.
                 let scope = callable_scope_for_refs.as_ref().unwrap();
-                match (analysis.method_call_invocant_class_with_index(r, module_index), scope) {
+                match (analysis.method_call_invocant_class(r, module_index), scope) {
                     (Some(cn), Some(pkg)) => &cn == pkg,
                     _ => false,
                 }

--- a/src/resolve_tests.rs
+++ b/src/resolve_tests.rs
@@ -1144,7 +1144,6 @@ fn test_refs_to_role_mask_excludes_workspace() {
 /// resolves invocant from the bag on every refs_to read would also
 /// work and avoids the cache-invalidation question.
 #[test]
-#[ignore = "cross-file invocant_class not refreshed by enrichment — see docs/prompt-cross-file-invocant-refresh.md"]
 fn references_cross_file_invocant_resolved_post_enrichment() {
     use crate::module_index::ModuleIndex;
     use std::sync::Arc;
@@ -1214,5 +1213,374 @@ $b->touch();
          consumer was built before B's return types were known, and \
          enrichment does not refresh ref fields. hits: {:?}",
         refs.iter().map(|r| (&r.key, r.span.start.row)).collect::<Vec<_>>(),
+    );
+}
+
+/// Companion: `find_highlights`'s cross-file fallback path
+/// must match both `$b->touch()` sites once enrichment has typed
+/// `$b: B`. Cursor on the first call; the second has the same None
+/// build-time-resolved invocant_class — both should highlight.
+#[test]
+fn find_highlights_cross_file_invocant_resolved_post_enrichment() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    let producer_src = r#"
+package B;
+use Exporter 'import';
+our @EXPORT_OK = qw(make_b);
+
+sub new    { return bless {}, shift }
+sub make_b { return B->new }
+sub touch  { 1 }
+1;
+"#;
+    let consumer_src = r#"
+use B qw(make_b);
+my $b = make_b();
+$b->touch();
+$b->touch();
+1;
+"#;
+
+    let producer_path = PathBuf::from("/tmp/highlights_xfile_b.pm");
+
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(producer_path, Arc::new(parse(producer_src)));
+
+    let mut consumer_fa = parse(consumer_src);
+    consumer_fa.enrich_imported_types_with_keys(Some(&idx));
+
+    // Cursor on the first $b->touch() — column 4 lands on `t` of touch.
+    let highlights = consumer_fa.find_highlights(
+        tree_sitter::Point { row: 3, column: 4 },
+        None,
+        None,
+    );
+
+    assert_eq!(
+        highlights.len(),
+        2,
+        "find_highlights should match both $$b->touch() sites once \
+         enrichment has typed $$b: B. got {:?}",
+        highlights,
+    );
+}
+
+/// Multi-hop: producer's exported sub returns a class that inherits
+/// from another. The consumer's `$x->ancestor_method()` call site
+/// resolves to the parent class only after enrichment + ancestor
+/// walk. Confirms the bag-only path composes with cross-file
+/// inheritance resolution.
+#[test]
+fn refs_to_cross_file_invocant_inherited_method() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    let parent_src = r#"
+package P;
+sub new { return bless {}, shift }
+sub ping { "pong" }
+1;
+"#;
+    let child_src = r#"
+package C;
+use parent 'P';
+use Exporter 'import';
+our @EXPORT_OK = qw(make_c);
+sub make_c { return C->new }
+1;
+"#;
+    let consumer_src = r#"
+use C qw(make_c);
+my $x = make_c();
+$x->ping();
+1;
+"#;
+
+    let parent_path = PathBuf::from("/tmp/multihop_p.pm");
+    let child_path = PathBuf::from("/tmp/multihop_c.pm");
+    let consumer_path = PathBuf::from("/tmp/multihop_consumer.pm");
+
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(parent_path.clone(), Arc::new(parse(parent_src)));
+    idx.register_workspace_module(child_path.clone(), Arc::new(parse(child_src)));
+
+    let mut consumer_fa = parse(consumer_src);
+    consumer_fa.enrich_imported_types_with_keys(Some(&idx));
+
+    // Sanity: enrichment typed $x as C.
+    let x_type = consumer_fa.inferred_type_via_bag(
+        "$x",
+        tree_sitter::Point { row: 4, column: 0 },
+    );
+    assert_eq!(
+        x_type.as_ref().and_then(|t| t.class_name()),
+        Some("C"),
+        "precondition: enrichment must type $$x as C; got {:?}",
+        x_type,
+    );
+
+    let store = FileStore::new();
+    store.insert_workspace(parent_path, parse(parent_src));
+    store.insert_workspace(child_path, parse(child_src));
+    store.insert_workspace(consumer_path.clone(), consumer_fa);
+
+    // Target the parent's `ping` — refs_to uses class-keyed Method
+    // matching, so `$x->ping()` (whose nearest invocant class is C)
+    // doesn't directly equal P. Targeting `C::ping` (the inherited
+    // shape) is what matches today.
+    let refs = refs_to(
+        &store,
+        Some(&idx),
+        &TargetRef {
+            name: "ping".to_string(),
+            kind: TargetKind::Method { class: "C".to_string() },
+        },
+        RoleMask::WORKSPACE,
+    );
+    assert!(
+        refs.iter().any(|r| matches!(&r.key, FileKey::Path(p) if p == &consumer_path)),
+        "refs_to(C::ping) missed consumer's $$x->ping() call site \
+         (multi-hop: $$x typed as C only post-enrichment). hits: {:?}",
+        refs.iter().map(|r| (&r.key, r.span.start.row)).collect::<Vec<_>>(),
+    );
+}
+
+/// Perf bench (gated `#[ignore]`). Generates a synthetic
+/// workspace with N files × M method-call sites and measures
+/// `refs_to` wall time. Useful when changing the invocant
+/// resolver — gut-check the cost. Run with
+///   `cargo test --release -- --nocapture --ignored \
+///    bench_refs_to_invocant_resolution`
+#[test]
+#[ignore]
+fn bench_refs_to_invocant_resolution() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    const N_FILES: usize = 200;
+    const M_CALLS: usize = 50;
+    const R_REPS: usize = 50;
+
+    // Producer: defines `B::touch` plus a constructor.
+    let producer_src = r#"
+package B;
+use Exporter 'import';
+our @EXPORT_OK = qw(make_b);
+
+sub new    { return bless {}, shift }
+sub make_b { return B->new }
+sub touch  { 1 }
+1;
+"#;
+
+    let store = FileStore::new();
+    let idx = ModuleIndex::new_for_test();
+    let producer_path = PathBuf::from("/tmp/bench_b.pm");
+    idx.register_workspace_module(producer_path.clone(), Arc::new(parse(producer_src)));
+    store.insert_workspace(producer_path, parse(producer_src));
+
+    // N consumer files, each with M method-call sites that mix:
+    //  - $b->touch() (var invocant, cross-file enrichment)
+    //  - B->touch() (bareword invocant)
+    //  - $self->touch() (enclosing-class invocant)
+    //  - $b->touch()->touch() (chain invocant)
+    //  - make_b()->touch() (function-call invocant)
+    for f in 0..N_FILES {
+        let mut src = String::from(
+            "package Consumer;\nuse B qw(make_b);\nsub run {\n  my $self = shift;\n  my $b = make_b();\n",
+        );
+        for c in 0..M_CALLS {
+            match c % 5 {
+                0 => src.push_str("  $b->touch();\n"),
+                1 => src.push_str("  B->touch();\n"),
+                2 => src.push_str("  $self->touch();\n"),
+                3 => src.push_str("  $b->touch()->touch();\n"),
+                _ => src.push_str("  make_b()->touch();\n"),
+            }
+        }
+        src.push_str("}\n1;\n");
+        let path = PathBuf::from(format!("/tmp/bench_consumer_{}.pm", f));
+        let mut fa = parse(&src);
+        fa.enrich_imported_types_with_keys(Some(&idx));
+        store.insert_workspace(path, fa);
+    }
+
+    let target = TargetRef {
+        name: "touch".to_string(),
+        kind: TargetKind::Method { class: "B".to_string() },
+    };
+
+    // Warm-up — JIT'd registry caches, lazy index allocs.
+    let _ = refs_to(&store, Some(&idx), &target, RoleMask::WORKSPACE);
+
+    let t0 = Instant::now();
+    let mut total_hits: usize = 0;
+    for _ in 0..R_REPS {
+        let refs = refs_to(&store, Some(&idx), &target, RoleMask::WORKSPACE);
+        total_hits += refs.len();
+    }
+    let elapsed = t0.elapsed();
+    let per_call = elapsed / (R_REPS as u32);
+    eprintln!(
+        "BENCH refs_to: {} files × {} calls × {} reps = {} hits in {:?} ({:?}/call avg)",
+        N_FILES, M_CALLS, R_REPS, total_hits, elapsed, per_call,
+    );
+}
+
+/// Discriminator: a chain hop where the inner receiver's class is
+/// only known via cross-file enrichment. Hybrid branch (cache + bag
+/// fallback inside `invocant_class_of_method_call`) handles VARIABLE
+/// invocants whose type comes from enrichment, but does NOT handle
+/// CHAIN invocants (`$x->makeFoo()->ping()`) when the inner
+/// `$x->makeFoo()` ref's invocant_class cache stayed None at build
+/// time — the hybrid's bag fallback hits `resolve_invocant_class`
+/// which doesn't know how to walk a chain at read time. Option 2's
+/// helper recurses on the inner receiver via `call_ref_by_start`,
+/// re-resolving fresh, so cross-file enrichment composes through
+/// every chain hop.
+///
+/// Expected:
+///   * Option 2 branch: passes (refs_to finds the consumer's chain hop).
+///   * Hybrid branch: fails (chain hop's class stays unknown).
+#[test]
+fn refs_to_cross_file_chain_hop_post_enrichment() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    // Producer P — defines a class returning itself (so makeFoo's return is P).
+    let producer_src = r#"
+package P;
+use Exporter 'import';
+our @EXPORT_OK = qw(makeP);
+
+sub new     { return bless {}, shift }
+sub makeP   { return P->new }
+sub makeFoo { return P->new }
+sub ping    { 1 }
+1;
+"#;
+    // Consumer A — uses P, builds a chain whose inner receiver
+    // ($x) is typed only by cross-file enrichment.
+    let consumer_src = r#"
+use P qw(makeP);
+my $x = makeP();
+$x->makeFoo()->ping();
+1;
+"#;
+
+    let producer_path = PathBuf::from("/tmp/chain_xfile_p.pm");
+    let consumer_path = PathBuf::from("/tmp/chain_xfile_consumer.pm");
+
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(producer_path.clone(), Arc::new(parse(producer_src)));
+
+    let mut consumer_fa = parse(consumer_src);
+    consumer_fa.enrich_imported_types_with_keys(Some(&idx));
+
+    // Sanity: $x types as P via enrichment.
+    let x_type = consumer_fa.inferred_type_via_bag(
+        "$x",
+        tree_sitter::Point { row: 4, column: 0 },
+    );
+    assert_eq!(
+        x_type.as_ref().and_then(|t| t.class_name()),
+        Some("P"),
+        "precondition: enrichment must type $$x as P; got {:?}",
+        x_type,
+    );
+
+    let store = FileStore::new();
+    store.insert_workspace(producer_path, parse(producer_src));
+    store.insert_workspace(consumer_path.clone(), consumer_fa);
+
+    // refs_to(P::ping) — the consumer's `->ping()` is reachable
+    // only by typing `$x->makeFoo()` (the chain hop's invocant)
+    // through the cross-file P::makeFoo return type. Only works
+    // if the helper resolves the chain hop fresh against the bag.
+    let refs = refs_to(
+        &store,
+        Some(&idx),
+        &TargetRef {
+            name: "ping".to_string(),
+            kind: TargetKind::Method { class: "P".to_string() },
+        },
+        RoleMask::WORKSPACE,
+    );
+    assert!(
+        refs.iter().any(|r| matches!(&r.key, FileKey::Path(p) if p == &consumer_path)),
+        "refs_to(P::ping) missed the chain hop $$x->makeFoo()->ping(). \
+         The inner $$x->makeFoo() invocant ($$x) was typed only by \
+         cross-file enrichment; chain typing must compose through the \
+         bag at read time. hits: {:?}",
+        refs.iter().map(|r| (&r.key, r.span.start.row)).collect::<Vec<_>>(),
+    );
+}
+
+/// **Red-pin** — `find_highlights` doesn't thread `module_index`
+/// down to `method_call_invocant_class`, so a chain hop whose
+/// receiver class is only known via cross-file `MethodOnClass`
+/// resolution (`$x->makeFoo()->ping()` — `makeFoo` returns a
+/// cross-file class) silently fails to highlight.
+///
+/// The threaded reader is `crate::resolve::refs_to`; it works
+/// (`refs_to_cross_file_chain_hop_post_enrichment` covers it).
+/// The same scenario via the in-file `find_highlights` path
+/// (used by `textDocument/documentHighlight`) currently doesn't.
+///
+/// Un-ignore when polish lands `module_index` through
+/// `find_highlights` / `collect_refs_for_target` /
+/// `find_references` / `rename_kind_at` / `rename_callable_in_scope`.
+#[test]
+#[ignore = "find_highlights doesn't thread module_index — polish commit un-ignores"]
+fn find_highlights_cross_file_chain_hop_post_enrichment() {
+    use crate::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    let producer_src = r#"
+package P;
+use Exporter 'import';
+our @EXPORT_OK = qw(makeP);
+
+sub new     { return bless {}, shift }
+sub makeP   { return P->new }
+sub makeFoo { return P->new }
+sub ping    { 1 }
+1;
+"#;
+    let consumer_src = r#"
+use P qw(makeP);
+my $x = makeP();
+$x->makeFoo()->ping();
+$x->makeFoo()->ping();
+1;
+"#;
+
+    let producer_path = PathBuf::from("/tmp/highlights_chain_p.pm");
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(producer_path, Arc::new(parse(producer_src)));
+
+    let mut consumer_fa = parse(consumer_src);
+    consumer_fa.enrich_imported_types_with_keys(Some(&idx));
+
+    // Cursor on the first `->ping()` — column 18 lands on `p` of ping.
+    let highlights = consumer_fa.find_highlights(
+        tree_sitter::Point { row: 3, column: 18 },
+        None,
+        None,
+    );
+
+    // Both call sites of `->ping()` share the same chain receiver
+    // shape; they must highlight together once chain typing
+    // composes through the bag at read time.
+    assert_eq!(
+        highlights.len(),
+        2,
+        "find_highlights should match both $$x->makeFoo()->ping() sites \
+         once chain typing through cross-file enrichment is threaded \
+         via module_index. got {:?}",
+        highlights,
     );
 }

--- a/src/resolve_tests.rs
+++ b/src/resolve_tests.rs
@@ -355,19 +355,19 @@ Bler->new->hi;
 }
 
 /// ALL FOUR LSP paths (hover, gd, gr, rename) must class-scope
-/// for two packages sharing a method name. Five different resolvers
-/// exist in the codebase:
+/// for two packages sharing a method name. Single resolver post
+/// option-2 — `FileAnalysis::method_call_invocant_class(ref, idx)`
+/// — but the four user-visible surfaces still each need their own
+/// integration coverage:
 ///
-///   1. `Builder::resolve_invocant_class_tree` — populates
-///      `RefKind::MethodCall.invocant_class` at build time.
-///   2. `FileAnalysis::resolve_method_invocant` — tree-based,
-///      used by `find_definition` and `hover_info`.
-///   3. `FileAnalysis::resolve_invocant_class` — text fallback
-///      used by resolve_method_invocant.
-///   4. `FileAnalysis::invocant_text_to_class` — used by
-///      `rename_kind_at` and `refs_to` fallback.
-///   5. `FileAnalysis::rename_method_in_class` — my new one;
-///      filters rename edits by class.
+///   1. find_definition (gd) — bag-routed via the helper, then
+///      walks ancestors for cross-class fallback.
+///   2. hover_info (K) — same helper; walks ancestors for the
+///      "*from BaseClass*" provenance.
+///   3. find_references / refs_to (gr) — iterates every MethodCall
+///      ref and filters by helper-resolved invocant class.
+///   4. rename_method_in_class — class-scopes edits to MethodCall
+///      refs whose helper answer matches.
 ///
 /// Classic copy-paste risk. This test drives all four LSP-visible
 /// surfaces with a single Foo/Bar fixture and proves every path

--- a/src/resolve_tests.rs
+++ b/src/resolve_tests.rs
@@ -462,7 +462,7 @@ $b->run;
     );
 
     // ---- (3) references — via rename_kind_at → TargetRef → refs_to.
-    let target_from_f = match fa.rename_kind_at(f_run_call) {
+    let target_from_f = match fa.rename_kind_at(f_run_call, None) {
         Some(RenameKind::Method { name, class }) => TargetRef {
             name,
             kind: TargetKind::Method { class },
@@ -484,7 +484,7 @@ $b->run;
     // ---- (4) rename — BEFORE moving `fa` into the store. Rename
     // Foo::run to renamed_run. Must edit Foo::run decl + $f->run
     // call, NOT Bar::run or $b->run.
-    let edits = fa.rename_method_in_class("run", "Foo", "renamed_run");
+    let edits = fa.rename_method_in_class("run", "Foo", "renamed_run", None);
     let edit_lines: Vec<usize> = edits.iter().map(|(span, _)| span.start.row).collect();
     assert!(
         edit_lines.contains(&2),
@@ -610,7 +610,7 @@ hi();
     //   row 15 — `hi()` call
     let hi_call = tree_sitter::Point { row: 15, column: 0 };
 
-    let kind = fa.rename_kind_at(hi_call);
+    let kind = fa.rename_kind_at(hi_call, None);
     let hover = fa.hover_info(hi_call, src, Some(&tree), None);
     let gd = fa.find_definition(hi_call, Some(&tree), Some(src.as_bytes()), None);
 
@@ -633,10 +633,10 @@ hi();
 
     let rename_edits = match &kind {
         Some(RenameKind::Function { name, package }) => {
-            fa.rename_sub_in_package(name, package, "renamed_hi")
+            fa.rename_sub_in_package(name, package, "renamed_hi", None)
         }
         Some(RenameKind::Method { name, class }) => {
-            fa.rename_method_in_class(name, class, "renamed_hi")
+            fa.rename_method_in_class(name, class, "renamed_hi", None)
         }
         _ => Vec::new(),
     };
@@ -783,7 +783,7 @@ $r->post('/users')->to(controller => 'Users', action => 'create');
         row: line_helper,
         column: helper_col + 2,
     };
-    let helper_highlights = fa.find_highlights(helper_pt, Some(&tree), Some(src.as_bytes()));
+    let helper_highlights = fa.find_highlights(helper_pt, Some(&tree), Some(src.as_bytes()), None);
     let helper_rows: Vec<usize> = helper_highlights.iter().map(|(s, _)| s.start.row).collect();
     assert!(
         helper_rows.contains(&line_helper),
@@ -803,7 +803,7 @@ $r->post('/users')->to(controller => 'Users', action => 'create');
         row: line_route,
         column: route_col + 2,
     };
-    let route_highlights = fa.find_highlights(route_pt, Some(&tree), Some(src.as_bytes()));
+    let route_highlights = fa.find_highlights(route_pt, Some(&tree), Some(src.as_bytes()), None);
     let route_rows: Vec<usize> = route_highlights.iter().map(|(s, _)| s.start.row).collect();
     assert!(
         route_rows.contains(&line_route),
@@ -890,7 +890,7 @@ $u->create(name => 'alice');
         column: create_col + 2,
     };
 
-    let kind = f1_fa.rename_kind_at(cursor);
+    let kind = f1_fa.rename_kind_at(cursor, None);
     let target = match kind {
         Some(RenameKind::Method { name, class }) => TargetRef {
             name,
@@ -1256,6 +1256,7 @@ $b->touch();
         tree_sitter::Point { row: 3, column: 4 },
         None,
         None,
+        Some(&idx),
     );
 
     assert_eq!(
@@ -1519,22 +1520,14 @@ $x->makeFoo()->ping();
     );
 }
 
-/// **Red-pin** — `find_highlights` doesn't thread `module_index`
-/// down to `method_call_invocant_class`, so a chain hop whose
-/// receiver class is only known via cross-file `MethodOnClass`
-/// resolution (`$x->makeFoo()->ping()` — `makeFoo` returns a
-/// cross-file class) silently fails to highlight.
-///
-/// The threaded reader is `crate::resolve::refs_to`; it works
-/// (`refs_to_cross_file_chain_hop_post_enrichment` covers it).
-/// The same scenario via the in-file `find_highlights` path
-/// (used by `textDocument/documentHighlight`) currently doesn't.
-///
-/// Un-ignore when polish lands `module_index` through
+/// `find_highlights` chain-hop case: receiver class only known
+/// via cross-file `MethodOnClass` resolution (`$x->makeFoo()->ping()`
+/// — `makeFoo` returns a cross-file class). Was a red-pin until
+/// the polish commit threaded `module_index` through
 /// `find_highlights` / `collect_refs_for_target` /
-/// `find_references` / `rename_kind_at` / `rename_callable_in_scope`.
+/// `find_references` / `rename_kind_at` / `rename_callable_in_scope`,
+/// matching `crate::resolve::refs_to`'s already-threaded shape.
 #[test]
-#[ignore = "find_highlights doesn't thread module_index — polish commit un-ignores"]
 fn find_highlights_cross_file_chain_hop_post_enrichment() {
     use crate::module_index::ModuleIndex;
     use std::sync::Arc;
@@ -1570,6 +1563,7 @@ $x->makeFoo()->ping();
         tree_sitter::Point { row: 3, column: 18 },
         None,
         None,
+        Some(&idx),
     );
 
     // Both call sites of `->ping()` share the same chain receiver

--- a/src/resolve_tests.rs
+++ b/src/resolve_tests.rs
@@ -1348,14 +1348,15 @@ $x->ping();
     );
 }
 
-/// Perf bench (gated `#[ignore]`). Generates a synthetic
-/// workspace with N files × M method-call sites and measures
-/// `refs_to` wall time. Useful when changing the invocant
-/// resolver — gut-check the cost. Run with
-///   `cargo test --release -- --nocapture --ignored \
-///    bench_refs_to_invocant_resolution`
+/// Perf bench, gated on `--features perf_bench` so the default
+/// `cargo test` never sees it (no `#[ignore]` count). Generates
+/// a synthetic workspace with N files × M method-call sites and
+/// measures `refs_to` wall time. Useful when changing the
+/// invocant resolver — gut-check the cost. Run with:
+///   cargo test --release --features perf_bench -- --nocapture \
+///     bench_refs_to_invocant_resolution
+#[cfg(feature = "perf_bench")]
 #[test]
-#[ignore]
 fn bench_refs_to_invocant_resolution() {
     use crate::module_index::ModuleIndex;
     use std::sync::Arc;

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -285,11 +285,9 @@ pub fn find_definition(
         }
 
         // Cross-file method goto-def: resolve inherited methods through module index
-        if let RefKind::MethodCall { ref invocant, ref invocant_span, .. } = r.kind {
+        if matches!(r.kind, RefKind::MethodCall { .. }) {
             use crate::file_analysis::MethodResolution;
-            let class_name = analysis.resolve_method_invocant_public(
-                invocant, invocant_span, r.scope, point, Some(tree), Some(source.as_bytes()), Some(module_index),
-            );
+            let class_name = analysis.method_call_invocant_class_with_index(r, Some(module_index));
             if let Some(ref cn) = class_name {
                 if let Some(MethodResolution::CrossFile { ref class }) = analysis.resolve_method_in_ancestors(cn, &r.target_name, Some(module_index)) {
                     if let Some(cached) = module_index.get_cached(class) {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -287,7 +287,7 @@ pub fn find_definition(
         // Cross-file method goto-def: resolve inherited methods through module index
         if matches!(r.kind, RefKind::MethodCall { .. }) {
             use crate::file_analysis::MethodResolution;
-            let class_name = analysis.method_call_invocant_class_with_index(r, Some(module_index));
+            let class_name = analysis.method_call_invocant_class(r, Some(module_index));
             if let Some(ref cn) = class_name {
                 if let Some(MethodResolution::CrossFile { ref class }) = analysis.resolve_method_in_ancestors(cn, &r.target_name, Some(module_index)) {
                     if let Some(cached) = module_index.get_cached(class) {
@@ -313,8 +313,8 @@ pub fn find_definition(
     None
 }
 
-pub fn find_references(analysis: &FileAnalysis, pos: Position, uri: &Url, tree: &Tree, source: &str) -> Vec<Location> {
-    analysis.find_references(position_to_point(pos), Some(tree), Some(source.as_bytes()))
+pub fn find_references(analysis: &FileAnalysis, pos: Position, uri: &Url, tree: &Tree, source: &str, module_index: Option<&ModuleIndex>) -> Vec<Location> {
+    analysis.find_references(position_to_point(pos), Some(tree), Some(source.as_bytes()), module_index)
         .into_iter()
         .map(|span| Location {
             uri: uri.clone(),
@@ -885,9 +885,9 @@ pub fn hover_info(
     None
 }
 
-pub fn document_highlights(analysis: &FileAnalysis, pos: Position, tree: &tree_sitter::Tree, source: &str) -> Vec<DocumentHighlight> {
+pub fn document_highlights(analysis: &FileAnalysis, pos: Position, tree: &tree_sitter::Tree, source: &str, module_index: Option<&ModuleIndex>) -> Vec<DocumentHighlight> {
     use crate::file_analysis::AccessKind;
-    analysis.find_highlights(position_to_point(pos), Some(tree), Some(source.as_bytes()))
+    analysis.find_highlights(position_to_point(pos), Some(tree), Some(source.as_bytes()), module_index)
         .into_iter()
         .map(|(span, access)| DocumentHighlight {
             range: span_to_range(span),

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -1579,8 +1579,9 @@ fn data_printer_use_line_options_completion() {
 /// (a) `$r` at line 71 resolves to a known class.
 /// (b) `->to` on line 71 is a MethodCall ref.
 /// (c) `->to`'s invocant resolves to a class via
-///     `resolve_method_invocant_public` (the path nvim hover/gd
-///     uses internally).
+///     `FileAnalysis::method_call_invocant_class` (the bag-routed
+///     resolver every reader — hover, gd, gr, rename — funnels
+///     through).
 ///
 /// Two possible failure modes the test distinguishes:
 ///   - `$r` is typed but `->to`'s invocant fails → crossfile

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -1713,21 +1713,9 @@ fn test_demo_file_chain_to_resolves_on_line_71() {
     // invocant is `$r`. Resolve it cross-file.
     let get_ref = analysis.ref_at(pt(get_col)).expect("ref at ->get");
     assert_eq!(get_ref.target_name, "get");
-    if let crate::file_analysis::RefKind::MethodCall {
-        invocant,
-        invocant_span,
-        ..
-    } = &get_ref.kind
-    {
-        let klass = analysis.resolve_method_invocant_public(
-            invocant,
-            invocant_span,
-            get_ref.scope,
-            pt(get_col),
-            Some(&tree),
-            Some(demo_source.as_bytes()),
-            Some(&idx),
-        );
+    if matches!(get_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
+        let _ = (&tree, demo_source.as_bytes(), &idx, get_col);
+        let klass = analysis.method_call_invocant_class_with_index(get_ref, Some(&idx));
         assert!(
             klass.is_some(),
             "`->get`'s invocant (= $r) should resolve to SOME class; got {:?}",
@@ -1755,21 +1743,9 @@ fn test_demo_file_chain_to_resolves_on_line_71() {
         ),
         "ref at ->to is a MethodCall"
     );
-    if let crate::file_analysis::RefKind::MethodCall {
-        invocant,
-        invocant_span,
-        ..
-    } = &to_ref.kind
-    {
-        let klass = analysis.resolve_method_invocant_public(
-            invocant,
-            invocant_span,
-            to_ref.scope,
-            pt(to_col),
-            Some(&tree),
-            Some(demo_source.as_bytes()),
-            Some(&idx),
-        );
+    if matches!(to_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
+        let _ = (&tree, demo_source.as_bytes(), &idx, to_col);
+        let klass = analysis.method_call_invocant_class_with_index(to_ref, Some(&idx));
         eprintln!(
             "DIAG: ->to invocant class (real Mojo): {:?} \
                  (None expected until deep chain through \
@@ -2089,21 +2065,8 @@ fn test_demo_chain_empirical_truth_table() {
 
     // --- Link 2: ->get's invocant class (= $r's class) ---
     let get_ref = analysis.ref_at(pt(get_col)).expect("ref at ->get");
-    let get_invocant_class = if let crate::file_analysis::RefKind::MethodCall {
-        invocant,
-        invocant_span,
-        ..
-    } = &get_ref.kind
-    {
-        analysis.resolve_method_invocant_public(
-            invocant,
-            invocant_span,
-            get_ref.scope,
-            pt(get_col),
-            Some(&tree),
-            Some(demo_source.as_bytes()),
-            Some(&idx),
-        )
+    let get_invocant_class = if matches!(get_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
+        analysis.method_call_invocant_class_with_index(get_ref, Some(&idx))
     } else {
         None
     };
@@ -2135,21 +2098,8 @@ fn test_demo_chain_empirical_truth_table() {
 
     // --- Link 4: ->to's invocant class (= ->get's return class) ---
     let to_ref = analysis.ref_at(pt(to_col)).expect("ref at ->to");
-    let to_invocant_class = if let crate::file_analysis::RefKind::MethodCall {
-        invocant,
-        invocant_span,
-        ..
-    } = &to_ref.kind
-    {
-        analysis.resolve_method_invocant_public(
-            invocant,
-            invocant_span,
-            to_ref.scope,
-            pt(to_col),
-            Some(&tree),
-            Some(demo_source.as_bytes()),
-            Some(&idx),
-        )
+    let to_invocant_class = if matches!(to_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
+        analysis.method_call_invocant_class_with_index(to_ref, Some(&idx))
     } else {
         None
     };

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -1715,7 +1715,7 @@ fn test_demo_file_chain_to_resolves_on_line_71() {
     assert_eq!(get_ref.target_name, "get");
     if matches!(get_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
         let _ = (&tree, demo_source.as_bytes(), &idx, get_col);
-        let klass = analysis.method_call_invocant_class_with_index(get_ref, Some(&idx));
+        let klass = analysis.method_call_invocant_class(get_ref, Some(&idx));
         assert!(
             klass.is_some(),
             "`->get`'s invocant (= $r) should resolve to SOME class; got {:?}",
@@ -1745,7 +1745,7 @@ fn test_demo_file_chain_to_resolves_on_line_71() {
     );
     if matches!(to_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
         let _ = (&tree, demo_source.as_bytes(), &idx, to_col);
-        let klass = analysis.method_call_invocant_class_with_index(to_ref, Some(&idx));
+        let klass = analysis.method_call_invocant_class(to_ref, Some(&idx));
         eprintln!(
             "DIAG: ->to invocant class (real Mojo): {:?} \
                  (None expected until deep chain through \
@@ -2066,7 +2066,7 @@ fn test_demo_chain_empirical_truth_table() {
     // --- Link 2: ->get's invocant class (= $r's class) ---
     let get_ref = analysis.ref_at(pt(get_col)).expect("ref at ->get");
     let get_invocant_class = if matches!(get_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
-        analysis.method_call_invocant_class_with_index(get_ref, Some(&idx))
+        analysis.method_call_invocant_class(get_ref, Some(&idx))
     } else {
         None
     };
@@ -2099,7 +2099,7 @@ fn test_demo_chain_empirical_truth_table() {
     // --- Link 4: ->to's invocant class (= ->get's return class) ---
     let to_ref = analysis.ref_at(pt(to_col)).expect("ref at ->to");
     let to_invocant_class = if matches!(to_ref.kind, crate::file_analysis::RefKind::MethodCall { .. }) {
-        analysis.method_call_invocant_class_with_index(to_ref, Some(&idx))
+        analysis.method_call_invocant_class(to_ref, Some(&idx))
     } else {
         None
     };


### PR DESCRIPTION
## Summary

- **Option 2 (bag-only) instead of option 3 (hybrid).** The earlier draft (#33) kept `Ref::MethodCall.invocant_class` as a build-time cache and added a bag fallback in readers. This PR drops the field outright and replaces it with `FileAnalysis::method_call_invocant_class(ref, module_index)` — a single dispatcher by invocant shape (variable / chain receiver / function-call receiver / bareword / `__PACKAGE__` / `shift` / `$_[0]`) that queries the witness bag. Build-time chain typing still runs, but its product lands in the bag (Variable witnesses, `Expression` edge witnesses on chain receivers); the helper just queries it.
- **Why option 2 won.** It composes through chain hops that option 3 silently misses. With a hybrid cache, an inner receiver typed only by post-build cross-file enrichment (`$x->makeFoo()->ping()` where `$x` types as `P` cross-file and `P::makeFoo` returns `P`) keeps `invocant_class: None` on the inner ref's cache; the bag fallback in option 3's helper hits a string-based resolver that doesn't walk a chain at read time. Pinned by `refs_to_cross_file_chain_hop_post_enrichment` and `find_highlights_cross_file_chain_hop_post_enrichment` — both fail on option 3, pass here.
- **API collapse.** The 7-arg `resolve_method_invocant_public(invocant, span, scope, point, tree, source, module_index)` is gone. `method_call_invocant_class(ref, module_index)` is the only entry point. `symbols_tests.rs` lost 56 lines of destructure-and-thread boilerplate. The transitional `_with_index` API duplicates from the WIP commit got collapsed into a single `module_index: Option<&ModuleIndex>` parameter in the polish commit.
- **`module_index` threaded uniformly.** `resolve::refs_to` was already index-aware; `find_references` / `find_highlights` / `collect_refs_for_target` / `rename_kind_at` / `rename_callable_in_scope` / `rename_sub_in_package` / `rename_method_in_class` were not. They now accept and thread `Option<&ModuleIndex>`. LSP backend passes `Some(&self.module_index)`; CLI passes `None` (file-local rename, existing semantics).
- **Build-only state stays build-only.** `Builder.method_call_invocant: HashMap<usize, String>` survives where it's actually needed (worklist movement counter + post-walk arg-key emission gating) but is never copied into `FileAnalysis`. The type system enforces no leak.

### Tiebreak invariants pinned

The chain dispatcher uses `FileAnalysis::call_ref_by_start: HashMap<Point, usize>` to find an inner receiver from an outer ref's `invocant_span.start`. Its rules are subtle: only MethodCall + FunctionCall enter; identical-start collisions resolve by smallest-span wins (strict `<`); equal spans first-write-wins; recursion needs an `is_self` pointer guard. None of this was directly tested before. New `src/call_ref_index_tests.rs` adds 8 targeted pins (one per rule), plus a "deep chain terminates" smoke test and an invariant cross-check that no non-call kind ever enters the index.

A test-discovered finding from this work: **tree-sitter-perl does not emit a separate `PackageRef` for the bareword in `Foo->m()`** — and rightly so, because at the parser level `Foo` is ambiguous between a class name and a zero-arg sub call. Disambiguating that needs file-level knowledge (does a `sub Foo { ... }` exist? returning what?), which is the LSP layer's job. The new resolver's bareword branch handles it: `if a zero-arg sub by that name returns ClassName, treat the bareword as that call; else the bareword IS the class name`. The non-call-kinds-don't-enter-index test pivoted to using `HashKeyAccess` / `ContainerAccess` from `$x->{key}` as the collider source.

### Perf

`bench_refs_to_invocant_resolution` (gated on `--features perf_bench` so default `cargo test` doesn't carry a long-running synthetic workload, and so we never ship perpetual `#[ignore]` yellow output): 200 files × 50 calls × 50 reps = 300k method-call invocant resolutions in 572ms (~11.5ms per `refs_to` query, ~38µs per ref). Comfortably inside an LSP interactive budget. The spec called out option 2's "walk every ref, per-ref bag query" as worth measuring before adopting; this is the measurement.

### Doc cleanup

- `RefKind::MethodCall` variant gained a doc comment pointing readers at the helper and explaining why there's no cached field.
- Stale doc-refs to the deleted `resolve_method_invocant{,_public}` and the pre-unification five-resolver list got rewritten to name the single helper (`resolve_tests.rs`, `symbols_tests.rs`).

## Test plan

- [x] Red-pin un-ignored: `references_cross_file_invocant_resolved_post_enrichment`
- [x] Discriminator tests added (these specifically distinguish option 2 from option 3): `refs_to_cross_file_chain_hop_post_enrichment`, `find_highlights_cross_file_chain_hop_post_enrichment`
- [x] Coverage tests: `find_highlights_cross_file_invocant_resolved_post_enrichment`, `refs_to_cross_file_invocant_inherited_method` (multi-hop `use parent`)
- [x] Tiebreak suite: 8 tests in `src/call_ref_index_tests.rs`
- [x] `cargo test` — 525 unit, 0 failed, 0 ignored (was 512 + 1 ignored)
- [x] `./run_e2e.sh` — 20/20 e2e green
- [x] `cargo test --release --features perf_bench bench_refs_to` — bench runs clean

Closes #33 (this PR supersedes it: same regression, better fix — the cache is gone instead of papered over, and chain hops compose through cross-file enrichment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)