### PR TITLE
feat: CodeRef as a first-class typed value — survives rebind, refgen, deref-call

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,6 +76,18 @@ invocant refresh) and the commit history.
   dispatch, truthiness, `wantarray`). Do **not** ship more arity-shaped
   facts that need their own reducer in the meantime — fold them into
   `ReturnExpr` instead.
+- **`return_via_edge` chases lack provenance.** Helper Methods that
+  resolve their return type by chasing a `CodeRef.return_edge` (anon-
+  literal `Expr(span)` or `\&foo` `MethodOnClass{...}`) record no
+  `TypeProvenance` for the chase — `--dump-package` shows the resolved
+  type but not "via Edge → MethodOnClass{Producer, build_rs} → reducer
+  fold". Not a regression (the older span-based path was the same), but
+  weaker than `MethodOnClassReducer`'s existing provenance story for
+  method dispatch. Fix: stamp `TypeProvenance::Delegation { kind:
+  "callable_return_edge", via: <attachment-tag> }` when the chain
+  typer's `coderef_call_expression` arm fires, and mirror it onto the
+  synthesized Method's symbol when `EmitAction::Method.return_via_edge`
+  resolves.
 
 ---
 

--- a/frameworks/mojo-helpers.rhai
+++ b/frameworks/mojo-helpers.rhai
@@ -100,6 +100,10 @@ fn on_method_call(ctx) {
         // pointer. Lets `$c->name->method` chain on a helper that
         // returns a Parametric ResultSet (DBIC), a Promise, etc.,
         // without the plugin inspecting the body at parse time.
+        // `callable_return_edge` is bag-aware — it carries the
+        // body span whether the callback is a literal in the arg
+        // slot (`helper(name => sub { ... })`) or a rebound
+        // scalar (`my $sub = sub { ... }; helper(name => $sub)`).
         out += #{
             Method: #{
                 name: name,
@@ -108,7 +112,7 @@ fn on_method_call(ctx) {
                 params: params,
                 is_method: true,
                 return_type: (),
-                return_via_edge: args[1].sub_body_last_expr_span,
+                return_via_edge: args[1].callable_return_edge,
                 doc: (),
                 on_class: "Mojolicious::Controller",
                 display: "Helper",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1309,14 +1309,32 @@ impl<'a> Builder<'a> {
             _ => None,
         };
         let inferred_type = self.infer_expression_type(arg);
-        let (sub_params, sub_body_last_expr_span) =
-            if arg.kind() == "anonymous_subroutine_expression" {
-                let params = self.extract_anonymous_sub_params(arg);
-                let last = self.anonymous_sub_body_last_expr_span(arg);
-                (params, last)
-            } else {
-                (Vec::new(), None)
-            };
+        let sub_params = if arg.kind() == "anonymous_subroutine_expression" {
+            self.extract_anonymous_sub_params(arg)
+        } else {
+            Vec::new()
+        };
+        // `callable_return_edge` flows from whichever
+        // `InferredType::CodeRef { return_edge }` is reachable for
+        // this arg. Two reachability paths covered uniformly:
+        //
+        //   helper(name => sub { … })          (literal in arg slot)
+        //   my $sub = sub { … }; helper(name => $sub)   (rebound)
+        //
+        // The literal path goes through `infer_expression_type`'s
+        // syntax-closed `anonymous_subroutine_expression` arm; the
+        // rebind path goes through `invocant_type_at_node`'s
+        // `scalar` arm, which `bag_query_variable`-resolves the
+        // variable's TC. Either yields the right `CodeRef` shape;
+        // the projection extracts `return_edge`.
+        let callable_return_edge = inferred_type
+            .as_ref()
+            .and_then(InferredType::callable_return_edge)
+            .or_else(|| {
+                self.invocant_type_at_node(arg)
+                    .as_ref()
+                    .and_then(InferredType::callable_return_edge)
+            });
         plugin::ArgInfo {
             text,
             string_value,
@@ -1324,7 +1342,7 @@ impl<'a> Builder<'a> {
             content_span,
             inferred_type,
             sub_params,
-            sub_body_last_expr_span,
+            callable_return_edge,
         }
     }
 
@@ -2084,7 +2102,7 @@ impl<'a> Builder<'a> {
                 self.visit_children(node);
             }
             "coderef_call_expression" => {
-                self.infer_deref_type(node, InferredType::CodeRef);
+                self.infer_deref_type(node, InferredType::CodeRef { return_edge: None });
                 self.visit_children(node);
             }
             "array_deref_expression" => {
@@ -3688,7 +3706,8 @@ impl<'a> Builder<'a> {
             }
             "quoted_regexp" => Some(WitnessPayload::InferredType(InferredType::Regexp)),
             "anonymous_subroutine_expression" => {
-                Some(WitnessPayload::InferredType(InferredType::CodeRef))
+                let return_edge = self.anonymous_sub_body_last_expr_span(node);
+                Some(WitnessPayload::InferredType(InferredType::CodeRef { return_edge }))
             }
             "binary_expression"
             | "equality_expression"
@@ -3939,7 +3958,9 @@ impl<'a> Builder<'a> {
             "anonymous_hash_expression" => Some(InferredType::HashRef),
             "anonymous_array_expression" => Some(InferredType::ArrayRef),
             "quoted_regexp" => Some(InferredType::Regexp),
-            "anonymous_subroutine_expression" => Some(InferredType::CodeRef),
+            "anonymous_subroutine_expression" => Some(InferredType::CodeRef {
+                return_edge: self.anonymous_sub_body_last_expr_span(node),
+            }),
             "method_call_expression" => {
                 self.extract_constructor_class(node).map(InferredType::ClassName)
             }
@@ -4166,7 +4187,7 @@ impl<'a> Builder<'a> {
             "function" => {
                 if let Ok(text) = outer.utf8_text(self.source) {
                     if text.starts_with("&{") {
-                        return Some((InferredType::CodeRef, outer));
+                        return Some((InferredType::CodeRef { return_edge: None }, outer));
                     }
                 }
                 None
@@ -4997,7 +5018,7 @@ impl<'a> Builder<'a> {
             "Bool" => Some(InferredType::Numeric),
             "HashRef" => Some(InferredType::HashRef),
             "ArrayRef" => Some(InferredType::ArrayRef),
-            "CodeRef" => Some(InferredType::CodeRef),
+            "CodeRef" => Some(InferredType::CodeRef { return_edge: None }),
             "RegexpRef" => Some(InferredType::Regexp),
             _ => {
                 // InstanceOf['Foo::Bar'] (Moo style) — the isa value is

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1316,24 +1316,28 @@ impl<'a> Builder<'a> {
         };
         // `callable_return_edge` flows from whichever
         // `InferredType::CodeRef { return_edge }` is reachable for
-        // this arg. Two reachability paths covered uniformly:
+        // this arg. Three reachability paths covered uniformly:
         //
-        //   helper(name => sub { … })          (literal in arg slot)
-        //   my $sub = sub { … }; helper(name => $sub)   (rebound)
+        //   helper(name => sub { … })             (anon literal)
+        //   my $sub = sub { … }; helper(_, $sub)   (rebound anon)
+        //   helper(name => \&Foo::bar)             (named ref)
         //
         // The literal path goes through `infer_expression_type`'s
-        // syntax-closed `anonymous_subroutine_expression` arm; the
-        // rebind path goes through `invocant_type_at_node`'s
-        // `scalar` arm, which `bag_query_variable`-resolves the
-        // variable's TC. Either yields the right `CodeRef` shape;
-        // the projection extracts `return_edge`.
+        // syntax-closed arms (anon-sub + refgen); the rebind path
+        // goes through `invocant_type_at_node`'s `scalar` arm,
+        // which `bag_query_variable`-resolves the variable's TC.
+        // Either yields the right `CodeRef` shape; the projection
+        // extracts the attachment whatever its target shape
+        // (`Expr(span)` for anon, `MethodOnClass{...}` for refgen).
         let callable_return_edge = inferred_type
             .as_ref()
             .and_then(InferredType::callable_return_edge)
+            .cloned()
             .or_else(|| {
                 self.invocant_type_at_node(arg)
                     .as_ref()
                     .and_then(InferredType::callable_return_edge)
+                    .cloned()
             });
         plugin::ArgInfo {
             text,
@@ -1374,6 +1378,33 @@ impl<'a> Builder<'a> {
             }
         }
         Some(node_to_span(node))
+    }
+
+    /// Project a `refgen_expression` (`\&foo`, `\&Foo::bar`,
+    /// `\&$dynamic`) onto a `MethodOnClass{class, name}`
+    /// attachment that names the referenced sub. The bag's
+    /// existing edge-chase handles in-file resolution (against
+    /// the named sub's `Symbol` witnesses, which carry its
+    /// return-arm folds) AND cross-file resolution via
+    /// `module_index` — we don't need to know the body span;
+    /// MethodOnClass IS the address. `class` defaults to the
+    /// current package for bare names; for `Foo::bar` we split
+    /// at the last `::`. Returns `None` for `\&$var` whose name
+    /// isn't const-foldable.
+    fn refgen_method_on_class(
+        &self,
+        node: Node<'a>,
+    ) -> Option<crate::witnesses::WitnessAttachment> {
+        if node.kind() != "refgen_expression" {
+            return None;
+        }
+        let names = self.extract_names_from_refgen(node);
+        let raw = names.into_iter().next()?;
+        let (class, name) = match raw.rsplit_once("::") {
+            Some((c, n)) => (c.to_string(), n.to_string()),
+            None => (self.current_package.clone()?, raw),
+        };
+        Some(crate::witnesses::WitnessAttachment::MethodOnClass { class, name })
     }
 
     /// Extract params from an anonymous sub. Delegates to the builder's
@@ -1481,6 +1512,22 @@ impl<'a> Builder<'a> {
                 // getter's String depending on declaration order.
                 let arity = self.extract_call_args(node).len() as u32;
                 self.bag_query_expression(crate::witnesses::RefIdx(idx as u32), Some(arity))
+            }
+            "coderef_call_expression" => {
+                // `$cb->()` — value-type IS whatever the operand's
+                // `CodeRef.return_edge` resolves to. Resolve the
+                // operand recursively (via this same dispatch),
+                // pull its callable return target, and chase it
+                // through the bag. No witness emission, no
+                // post-walk pass — chain typing re-asks every fold
+                // iteration, so monotone refinement of the operand
+                // type lifts $r's type on the next pass for free.
+                let operand = node.named_child(0)?;
+                let target = self
+                    .invocant_type_at_node(operand)?
+                    .callable_return_edge()?
+                    .clone();
+                self.bag_query_attachment(&target)
             }
             "scalar" => {
                 let text = node.utf8_text(self.source).ok()?;
@@ -1811,25 +1858,26 @@ impl<'a> Builder<'a> {
                             span,
                         });
                     }
-                } else if let Some(target_span) = return_via_edge {
-                    // Lazy return type: emit `Symbol(sid) → Edge(
-                    // Expr(target_span))`. The writeback
-                    // (`write_back_sub_return_types`) iterates
-                    // symbols and projects whatever payload sits
-                    // on each `Symbol(sid)` to `MethodOnClass{class,
-                    // name}` for class-scoped methods, so this
-                    // single Symbol-attached emission reaches both
-                    // attachments. The bag's edge-chase resolver
-                    // follows the edge at query time — by then,
-                    // the sub body has been walked and
-                    // `Expr(target_span)` carries its type.
+                } else if let Some(target) = return_via_edge {
+                    // Lazy return type: emit `Symbol(sid) →
+                    // Edge(target)`. `target` is whichever
+                    // attachment the source callable carries
+                    // (`Expr(span)` for anon-sub bodies, or
+                    // `MethodOnClass{class, name}` for `\&foo` /
+                    // `\&Foo::bar` references — the bag's existing
+                    // edge-chase covers both, including the
+                    // cross-file `module_index` recursion for
+                    // MethodOnClass). Writeback projects this
+                    // single Symbol-attached emission to
+                    // `MethodOnClass{class, name}` for class-
+                    // scoped methods at the post-walk pass.
                     use crate::witnesses::{
                         Witness, WitnessAttachment, WitnessPayload, WitnessSource,
                     };
                     self.bag.push(Witness {
                         attachment: WitnessAttachment::Symbol(sid),
                         source: WitnessSource::Plugin(plugin_id),
-                        payload: WitnessPayload::Edge(WitnessAttachment::Expr(target_span)),
+                        payload: WitnessPayload::Edge(target),
                         span,
                     });
                 }
@@ -2102,6 +2150,12 @@ impl<'a> Builder<'a> {
                 self.visit_children(node);
             }
             "coderef_call_expression" => {
+                // Walk-time: just narrow the operand to CodeRef.
+                // The callable-return propagation onto this call's
+                // `Expr(span)` happens post-walk in
+                // `emit_coderef_call_return_edges` — at walk time
+                // the operand's TC isn't seeded yet (chain typing
+                // runs in step 6, after the live walk in step 1).
                 self.infer_deref_type(node, InferredType::CodeRef { return_edge: None });
                 self.visit_children(node);
             }
@@ -3706,7 +3760,20 @@ impl<'a> Builder<'a> {
             }
             "quoted_regexp" => Some(WitnessPayload::InferredType(InferredType::Regexp)),
             "anonymous_subroutine_expression" => {
-                let return_edge = self.anonymous_sub_body_last_expr_span(node);
+                let return_edge = self
+                    .anonymous_sub_body_last_expr_span(node)
+                    .map(WitnessAttachment::Expr);
+                Some(WitnessPayload::InferredType(InferredType::CodeRef { return_edge }))
+            }
+            "refgen_expression" => {
+                // `\&foo`, `\&Foo::bar`, `\&$dynamic_const_folded`
+                // — typed CodeRef with a MethodOnClass attachment
+                // pointing at the referenced sub. Lets cross-file
+                // `helper(name => \&Other::Pkg::sub)` lift the
+                // helper's return type through the bag's existing
+                // module_index recursion. Bare-name `\&foo` falls
+                // back to `current_package` for the class.
+                let return_edge = self.refgen_method_on_class(node);
                 Some(WitnessPayload::InferredType(InferredType::CodeRef { return_edge }))
             }
             "binary_expression"
@@ -3945,7 +4012,9 @@ impl<'a> Builder<'a> {
     /// type is determined by the syntax alone:
     ///
     /// - Literals (`"foo"`, `42`, `{}`, `[]`, `qr//`).
-    /// - Anonymous subs → `CodeRef`.
+    /// - Anonymous subs → `CodeRef { return_edge: Expr(body_last) }`.
+    /// - `\&foo` / `\&Foo::bar` →
+    ///   `CodeRef { return_edge: MethodOnClass{class, name} }`.
     /// - Constructor pattern `Bareword->new` → `ClassName`.
     ///
     /// Variables, function calls, name-driven method calls — all
@@ -3959,7 +4028,12 @@ impl<'a> Builder<'a> {
             "anonymous_array_expression" => Some(InferredType::ArrayRef),
             "quoted_regexp" => Some(InferredType::Regexp),
             "anonymous_subroutine_expression" => Some(InferredType::CodeRef {
-                return_edge: self.anonymous_sub_body_last_expr_span(node),
+                return_edge: self
+                    .anonymous_sub_body_last_expr_span(node)
+                    .map(crate::witnesses::WitnessAttachment::Expr),
+            }),
+            "refgen_expression" => Some(InferredType::CodeRef {
+                return_edge: self.refgen_method_on_class(node),
             }),
             "method_call_expression" => {
                 self.extract_constructor_class(node).map(InferredType::ClassName)
@@ -4024,6 +4098,20 @@ impl<'a> Builder<'a> {
     /// Infer a type on the first named child (the operand) of a dereference expression.
     fn infer_deref_type(&mut self, node: Node<'a>, inferred_type: InferredType) {
         if let Some(operand) = node.named_child(0) {
+            // Skip the deref-narrowing TC when the operand is
+            // already known to be the same shape — pushing a
+            // coarser fact (`CodeRef { return_edge: None }` from
+            // `$cb->()` after `my $cb = sub { ... }` typed it
+            // with an edge) would clobber the literal's richer
+            // attachment under latest-wins reduction. The narrowing
+            // is meant to TYPE the variable when its assignment
+            // is opaque; if the type is already established with
+            // matching shape, the fact adds nothing.
+            if let Some(existing) = self.invocant_type_at_node(operand) {
+                if std::mem::discriminant(&existing) == std::mem::discriminant(&inferred_type) {
+                    return;
+                }
+            }
             self.push_var_type_constraint(operand, node, inferred_type);
         }
     }
@@ -6858,20 +6946,31 @@ impl<'a> Builder<'a> {
     /// so Edge chases through `Variable{...}` use scope-chain +
     /// framework-aware semantics.
     fn bag_query_expr_span(&self, span: Span) -> Option<InferredType> {
+        self.bag_query_attachment(&crate::witnesses::WitnessAttachment::Expr(span))
+    }
+
+    /// Generic registry query against any attachment shape.
+    /// `bag_query_expr_span` is a thin wrapper for the common
+    /// `Expr(span)` case; the coderef-call arm of
+    /// `invocant_type_at_node` uses this to chase a CodeRef's
+    /// `return_edge` (which can be `Expr(body_last)` for anon
+    /// literals or `MethodOnClass{class, name}` for `\&foo`).
+    fn bag_query_attachment(
+        &self,
+        att: &crate::witnesses::WitnessAttachment,
+    ) -> Option<InferredType> {
         use crate::witnesses::{
             BagContext, FrameworkFact, ReducedValue, ReducerQuery, ReducerRegistry,
-            WitnessAttachment,
         };
-        let att = WitnessAttachment::Expr(span);
         let reg = ReducerRegistry::with_defaults();
         let ctx = BagContext {
             scopes: &self.scopes,
             package_framework: &self.package_framework,
             module_index: None,
             package_parents: &self.package_parents,
-            };
+        };
         let q = ReducerQuery {
-            attachment: &att,
+            attachment: att,
             point: None,
             framework: FrameworkFact::Plain,
             arity_hint: None,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1380,31 +1380,47 @@ impl<'a> Builder<'a> {
         Some(node_to_span(node))
     }
 
-    /// Project a `refgen_expression` (`\&foo`, `\&Foo::bar`,
-    /// `\&$dynamic`) onto a `MethodOnClass{class, name}`
-    /// attachment that names the referenced sub. The bag's
-    /// existing edge-chase handles in-file resolution (against
-    /// the named sub's `Symbol` witnesses, which carry its
-    /// return-arm folds) AND cross-file resolution via
-    /// `module_index` — we don't need to know the body span;
-    /// MethodOnClass IS the address. `class` defaults to the
-    /// current package for bare names; for `Foo::bar` we split
-    /// at the last `::`. Returns `None` for `\&$var` whose name
-    /// isn't const-foldable.
-    fn refgen_method_on_class(
+    /// Single derivation site for a CodeRef-shaped value's
+    /// `return_edge`, given the source node. Both `expr_payload`
+    /// (bag-witness emission, walk-time) and
+    /// `infer_expression_type` (closed-syntax InferredType for
+    /// chain typing's RHS) call this — keeping them in sync by
+    /// construction.
+    ///
+    /// Two recognized shapes:
+    ///   - `anonymous_subroutine_expression` →
+    ///     `Expr(body_last_expr_span)`. Bag walks the body's
+    ///     last-expression witnesses at query time.
+    ///   - `refgen_expression` (`\&foo`, `\&Foo::bar`,
+    ///     `\&$const_folded`) → `MethodOnClass { class, name }`.
+    ///     Bag's MRO + `module_index` machinery resolves it,
+    ///     including cross-file. Bare names default `class` to
+    ///     the current package; qualified names split at the
+    ///     last `::`. `\&$var` with a non-const-foldable name
+    ///     returns `None`.
+    ///
+    /// Other node kinds return `None` (caller decides whether to
+    /// wrap the result in `CodeRef { return_edge: None }` for
+    /// opaque-coderef sources or fall through entirely).
+    fn coderef_return_edge_for(
         &self,
         node: Node<'a>,
     ) -> Option<crate::witnesses::WitnessAttachment> {
-        if node.kind() != "refgen_expression" {
-            return None;
+        match node.kind() {
+            "anonymous_subroutine_expression" => self
+                .anonymous_sub_body_last_expr_span(node)
+                .map(crate::witnesses::WitnessAttachment::Expr),
+            "refgen_expression" => {
+                let names = self.extract_names_from_refgen(node);
+                let raw = names.into_iter().next()?;
+                let (class, name) = match raw.rsplit_once("::") {
+                    Some((c, n)) => (c.to_string(), n.to_string()),
+                    None => (self.current_package.clone()?, raw),
+                };
+                Some(crate::witnesses::WitnessAttachment::MethodOnClass { class, name })
+            }
+            _ => None,
         }
-        let names = self.extract_names_from_refgen(node);
-        let raw = names.into_iter().next()?;
-        let (class, name) = match raw.rsplit_once("::") {
-            Some((c, n)) => (c.to_string(), n.to_string()),
-            None => (self.current_package.clone()?, raw),
-        };
-        Some(crate::witnesses::WitnessAttachment::MethodOnClass { class, name })
     }
 
     /// Extract params from an anonymous sub. Delegates to the builder's
@@ -2152,10 +2168,15 @@ impl<'a> Builder<'a> {
             "coderef_call_expression" => {
                 // Walk-time: just narrow the operand to CodeRef.
                 // The callable-return propagation onto this call's
-                // `Expr(span)` happens post-walk in
-                // `emit_coderef_call_return_edges` — at walk time
-                // the operand's TC isn't seeded yet (chain typing
-                // runs in step 6, after the live walk in step 1).
+                // value-type happens at *query* time — `invocant_
+                // type_at_node`'s `coderef_call_expression` arm
+                // chases the operand's `CodeRef.return_edge`
+                // through the bag every time it's asked. Chain
+                // typing already re-asks on each worklist
+                // iteration, so monotone refinement of the
+                // operand's TC lifts the call's type for free as
+                // the lattice settles. No witness emission here;
+                // no post-walk pass.
                 self.infer_deref_type(node, InferredType::CodeRef { return_edge: None });
                 self.visit_children(node);
             }
@@ -3759,21 +3780,8 @@ impl<'a> Builder<'a> {
                 Some(WitnessPayload::InferredType(InferredType::ArrayRef))
             }
             "quoted_regexp" => Some(WitnessPayload::InferredType(InferredType::Regexp)),
-            "anonymous_subroutine_expression" => {
-                let return_edge = self
-                    .anonymous_sub_body_last_expr_span(node)
-                    .map(WitnessAttachment::Expr);
-                Some(WitnessPayload::InferredType(InferredType::CodeRef { return_edge }))
-            }
-            "refgen_expression" => {
-                // `\&foo`, `\&Foo::bar`, `\&$dynamic_const_folded`
-                // — typed CodeRef with a MethodOnClass attachment
-                // pointing at the referenced sub. Lets cross-file
-                // `helper(name => \&Other::Pkg::sub)` lift the
-                // helper's return type through the bag's existing
-                // module_index recursion. Bare-name `\&foo` falls
-                // back to `current_package` for the class.
-                let return_edge = self.refgen_method_on_class(node);
+            "anonymous_subroutine_expression" | "refgen_expression" => {
+                let return_edge = self.coderef_return_edge_for(node);
                 Some(WitnessPayload::InferredType(InferredType::CodeRef { return_edge }))
             }
             "binary_expression"
@@ -4027,14 +4035,11 @@ impl<'a> Builder<'a> {
             "anonymous_hash_expression" => Some(InferredType::HashRef),
             "anonymous_array_expression" => Some(InferredType::ArrayRef),
             "quoted_regexp" => Some(InferredType::Regexp),
-            "anonymous_subroutine_expression" => Some(InferredType::CodeRef {
-                return_edge: self
-                    .anonymous_sub_body_last_expr_span(node)
-                    .map(crate::witnesses::WitnessAttachment::Expr),
-            }),
-            "refgen_expression" => Some(InferredType::CodeRef {
-                return_edge: self.refgen_method_on_class(node),
-            }),
+            "anonymous_subroutine_expression" | "refgen_expression" => {
+                Some(InferredType::CodeRef {
+                    return_edge: self.coderef_return_edge_for(node),
+                })
+            }
             "method_call_expression" => {
                 self.extract_constructor_class(node).map(InferredType::ClassName)
             }
@@ -4096,23 +4101,25 @@ impl<'a> Builder<'a> {
     }
 
     /// Infer a type on the first named child (the operand) of a dereference expression.
-    fn infer_deref_type(&mut self, node: Node<'a>, inferred_type: InferredType) {
+    fn infer_deref_type(&mut self, node: Node<'a>, narrowing: InferredType) {
         if let Some(operand) = node.named_child(0) {
-            // Skip the deref-narrowing TC when the operand is
-            // already known to be the same shape — pushing a
-            // coarser fact (`CodeRef { return_edge: None }` from
-            // `$cb->()` after `my $cb = sub { ... }` typed it
-            // with an edge) would clobber the literal's richer
-            // attachment under latest-wins reduction. The narrowing
-            // is meant to TYPE the variable when its assignment
-            // is opaque; if the type is already established with
-            // matching shape, the fact adds nothing.
+            // The narrowing is observational — `$cb->()` says
+            // "$cb is a coderef", `${$x}` says "$x is a hashref",
+            // etc. — and doesn't reveal payload (no body span
+            // from the deref site). If the operand is ALREADY
+            // typed with a witness at least as informative as
+            // this narrowing, the TC would only ever clobber
+            // richer payload under latest-wins reduction (the
+            // motivating regression: a `my $cb = sub { ... }`
+            // literal's `CodeRef { return_edge: Some(_) }` losing
+            // its edge to the subsequent `$cb->()`'s
+            // `CodeRef { return_edge: None }`). Skip in that case.
             if let Some(existing) = self.invocant_type_at_node(operand) {
-                if std::mem::discriminant(&existing) == std::mem::discriminant(&inferred_type) {
+                if existing.subsumes_narrowing(&narrowing) {
                     return;
                 }
             }
-            self.push_var_type_constraint(operand, node, inferred_type);
+            self.push_var_type_constraint(operand, node, narrowing);
         }
     }
 

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -704,7 +704,15 @@ fn test_extract_arrayref_literal() {
 fn test_extract_coderef_literal() {
     let fa = build_fa("my $cref = sub { 42 };");
     let ty = fa.inferred_type_via_bag("$cref", Point::new(0, 22));
-    assert_eq!(ty, Some(InferredType::CodeRef), "anonymous sub");
+    // Sub-literal CodeRef carries `return_edge: Some(_)` — the
+    // body's last-expression span. Survives the `my $cref = ...`
+    // binding so downstream callable-shape consumers can edge-chase
+    // into the body's type. Opaque coderef tests below use `None`.
+    assert!(
+        matches!(ty, Some(InferredType::CodeRef { return_edge: Some(_) })),
+        "anonymous sub: got {:?}",
+        ty
+    );
 }
 
 #[test]
@@ -753,7 +761,9 @@ fn test_arrow_array_deref_infers_arrayref() {
 fn test_arrow_code_deref_infers_coderef() {
     let fa = build_fa("my $x;\n$x->(1, 2);");
     let ty = fa.inferred_type_via_bag("$x", Point::new(1, 10));
-    assert_eq!(ty, Some(InferredType::CodeRef));
+    // Deref-context inference: `$x->(...)` says `$x` is a coderef
+    // but reveals nothing about its body (the binding is opaque).
+    assert_eq!(ty, Some(InferredType::CodeRef { return_edge: None }));
 }
 
 #[test]
@@ -882,7 +892,7 @@ fn test_block_hash_deref_infers_hashref() {
 fn test_block_code_deref_infers_coderef() {
     let fa = build_fa("my $z;\n&{$z}();\nmy $w;");
     let ty = fa.inferred_type_via_bag("$z", Point::new(2, 0));
-    assert_eq!(ty, Some(InferredType::CodeRef));
+    assert_eq!(ty, Some(InferredType::CodeRef { return_edge: None }));
 }
 
 #[test]
@@ -981,9 +991,13 @@ fn test_return_type_arrayref() {
 #[test]
 fn test_return_type_coderef() {
     let fa = build_fa("sub get_handler {\n    return sub { 1 };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_handler", None),
-        Some(InferredType::CodeRef)
+    let ty = fa.sub_return_type_at_arity("get_handler", None);
+    // `return sub { 1 }` is a sub-literal — the returned CodeRef
+    // carries `return_edge` to the body's last expression.
+    assert!(
+        matches!(ty, Some(InferredType::CodeRef { return_edge: Some(_) })),
+        "got {:?}",
+        ty
     );
 }
 

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -767,6 +767,24 @@ fn test_arrow_code_deref_infers_coderef() {
 }
 
 #[test]
+fn test_coderef_call_propagates_return_type() {
+    // `my $cb = sub { [1,2] }; my $r = $cb->();` — the literal's
+    // `return_edge` (Expr(body_last)) rides through the binding,
+    // and `$cb->()` should chase it: $r types as ArrayRef.
+    // Anonymous-sub literal whose body's last expression is an
+    // anonymous_array_expression — closed-under-syntax, so the
+    // body span resolves to ArrayRef without name lookup.
+    let fa = build_fa("my $cb = sub { [1,2] };\nmy $r = $cb->();\nmy $z;");
+    let ty = fa.inferred_type_via_bag("$r", Point::new(2, 0));
+    assert_eq!(
+        ty,
+        Some(InferredType::ArrayRef),
+        "coderef call must inherit the callable's return type via return_edge: got {:?}",
+        ty,
+    );
+}
+
+#[test]
 fn test_postfix_array_deref_infers_arrayref() {
     let fa = build_fa("my $x;\nmy @a = $x->@*;\nmy $z;");
     let ty = fa.inferred_type_via_bag("$x", Point::new(2, 0));

--- a/src/cursor_context.rs
+++ b/src/cursor_context.rs
@@ -951,7 +951,7 @@ pub fn build_plugin_query_context(
                 content_span: None,
                 inferred_type: Some(InferredType::String),
                 sub_params: Vec::new(),
-                sub_body_last_expr_span: None,
+                callable_return_edge: None,
             }],
             None => Vec::new(),
         };

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -491,8 +491,16 @@ pub enum InferredType {
     HashRef,
     /// `$x = []` or `$x = [ ... ]` — unblessed array reference.
     ArrayRef,
-    /// `$x = sub { ... }` — code reference.
-    CodeRef,
+    /// `$x = sub { ... }` — code reference. `return_edge` carries
+    /// the span of the body's last expression for sub-literal
+    /// origins, so calling it through a rebound scalar (`my $sub =
+    /// sub {...}; $app->helper(thing => $sub)`) propagates the
+    /// callable's return type the same way a literal-in-arg-slot
+    /// does. `None` for opaque coderefs (function references,
+    /// `\&foo`, params typed `CodeRef`, etc.) where we don't have
+    /// a body span to point at — the bag's edge-chase resolver
+    /// just returns nothing for those, same as before.
+    CodeRef { return_edge: Option<Span> },
     /// `$x = qr/.../` — compiled regular expression.
     Regexp,
     /// Used in numeric context (`+`, `-`, `==`, etc.).
@@ -693,6 +701,21 @@ impl InferredType {
     pub fn as_parametric(&self) -> Option<&ParametricType> {
         match self {
             InferredType::Parametric(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Span of the body's last expression for sub-literal-origin
+    /// `CodeRef` values. Survives variable rebinding because it's
+    /// carried on the `InferredType` itself: `my $sub = sub { ... }`
+    /// propagates the same `CodeRef { return_edge: Some(span) }`
+    /// through chain typing, so a downstream callable-shape consumer
+    /// (Mojo helper plugin, signature-help return formatter, etc.)
+    /// can `Edge(Expr(span))` into the body's last expression and
+    /// pick up its type at query time.
+    pub fn callable_return_edge(&self) -> Option<Span> {
+        match self {
+            InferredType::CodeRef { return_edge } => *return_edge,
             _ => None,
         }
     }
@@ -5927,7 +5950,7 @@ pub fn inferred_type_to_tag(ty: &InferredType) -> String {
         InferredType::FirstParam { package } => format!("Object:{}", package),
         InferredType::HashRef => "HashRef".to_string(),
         InferredType::ArrayRef => "ArrayRef".to_string(),
-        InferredType::CodeRef => "CodeRef".to_string(),
+        InferredType::CodeRef { .. } => "CodeRef".to_string(),
         InferredType::Regexp => "Regexp".to_string(),
         InferredType::Numeric => "Numeric".to_string(),
         InferredType::String => "String".to_string(),
@@ -5974,7 +5997,7 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
         InferredType::FirstParam { package } => package.clone(),
         InferredType::HashRef => "HashRef".to_string(),
         InferredType::ArrayRef => "ArrayRef".to_string(),
-        InferredType::CodeRef => "CodeRef".to_string(),
+        InferredType::CodeRef { .. } => "CodeRef".to_string(),
         InferredType::Regexp => "Regexp".to_string(),
         InferredType::Numeric => "Numeric".to_string(),
         InferredType::String => "String".to_string(),

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -737,6 +737,42 @@ impl InferredType {
             _ => None,
         }
     }
+
+    /// True when `self` is at least as informative as `narrowing`
+    /// — adding the narrowing's TC would not refine `self` further.
+    /// "Informativeness" is defined per-variant: same discriminant
+    /// AND, where the variant carries refinable payload, `self`'s
+    /// payload is at least as specific as `narrowing`'s.
+    ///
+    /// Used by `infer_deref_type` to suppress the
+    /// `$cb->()`-shaped narrowing TC when the operand was already
+    /// typed with a richer attachment (e.g. an anon-sub literal's
+    /// `CodeRef { return_edge: Some(_) }` should NOT be clobbered
+    /// by the deref's `CodeRef { return_edge: None }` under
+    /// latest-wins reduction).
+    ///
+    /// Conservative: returns false on different discriminants
+    /// (let the reducer-stack decide the conflict). Variants
+    /// without refinable payload (HashRef/ArrayRef/Regexp/Numeric/
+    /// String) subsume themselves trivially.
+    pub fn subsumes_narrowing(&self, narrowing: &InferredType) -> bool {
+        match (self, narrowing) {
+            // Refinable-payload variants — `self` subsumes only
+            // if its payload is at least as specific.
+            (
+                InferredType::CodeRef { return_edge: have },
+                InferredType::CodeRef { return_edge: want },
+            ) => want.is_none() || have.is_some(),
+            (InferredType::ClassName(a), InferredType::ClassName(b)) => a == b,
+            (InferredType::FirstParam { package: a }, InferredType::FirstParam { package: b }) => {
+                a == b
+            }
+            (InferredType::Parametric(a), InferredType::Parametric(b)) => a == b,
+            // Unit-shape variants subsume themselves; mismatched
+            // discriminants don't subsume.
+            (a, b) => std::mem::discriminant(a) == std::mem::discriminant(b),
+        }
+    }
 }
 
 /// Where a type judgement came from. Lets debugging surface "the

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -491,16 +491,30 @@ pub enum InferredType {
     HashRef,
     /// `$x = []` or `$x = [ ... ]` — unblessed array reference.
     ArrayRef,
-    /// `$x = sub { ... }` — code reference. `return_edge` carries
-    /// the span of the body's last expression for sub-literal
-    /// origins, so calling it through a rebound scalar (`my $sub =
-    /// sub {...}; $app->helper(thing => $sub)`) propagates the
-    /// callable's return type the same way a literal-in-arg-slot
-    /// does. `None` for opaque coderefs (function references,
-    /// `\&foo`, params typed `CodeRef`, etc.) where we don't have
-    /// a body span to point at — the bag's edge-chase resolver
-    /// just returns nothing for those, same as before.
-    CodeRef { return_edge: Option<Span> },
+    /// `$x = sub { ... }` — code reference. `return_edge` is a
+    /// witness-bag attachment whose type IS the callable's return
+    /// when invoked. Two shapes populate it:
+    ///
+    ///   - Anonymous-sub literals (`sub { ... }`) →
+    ///     `Expr(body_last_expr_span)`. The bag walks that span's
+    ///     own witnesses at query time, after the body is built.
+    ///   - Named-sub references (`\&foo`, `\&Foo::bar`) →
+    ///     `MethodOnClass { class, name }`. Same attachment the
+    ///     bag's existing edge-chase uses for method dispatch —
+    ///     resolves in-file via the named-sub's Symbol witnesses
+    ///     AND cross-file via `module_index` (the bag transparently
+    ///     recurses into the cached module's bag).
+    ///
+    /// Survives variable rebinding because chain typing propagates
+    /// the whole `InferredType` through `my $sub = ...` via the
+    /// bag's TC machinery — so `helper(name => sub {...})` and
+    /// `my $cb = \&foo; helper(name => $cb)` both reach the same
+    /// attachment-driven resolution.
+    ///
+    /// `None` for opaque sources (params typed `CodeRef`, deref-
+    /// shape narrowing, `Rep::Code` observations) where no body or
+    /// named target is reachable from the syntax alone.
+    CodeRef { return_edge: Option<crate::witnesses::WitnessAttachment> },
     /// `$x = qr/.../` — compiled regular expression.
     Regexp,
     /// Used in numeric context (`+`, `-`, `==`, etc.).
@@ -705,17 +719,21 @@ impl InferredType {
         }
     }
 
-    /// Span of the body's last expression for sub-literal-origin
-    /// `CodeRef` values. Survives variable rebinding because it's
-    /// carried on the `InferredType` itself: `my $sub = sub { ... }`
-    /// propagates the same `CodeRef { return_edge: Some(span) }`
-    /// through chain typing, so a downstream callable-shape consumer
-    /// (Mojo helper plugin, signature-help return formatter, etc.)
-    /// can `Edge(Expr(span))` into the body's last expression and
-    /// pick up its type at query time.
-    pub fn callable_return_edge(&self) -> Option<Span> {
+    /// Witness-bag attachment whose type IS this callable's return
+    /// when invoked. `Expr(span)` for anon-sub literals (resolves
+    /// at query time via the body's last-expression witnesses);
+    /// `MethodOnClass{class, name}` for named-sub references
+    /// (`\&foo`, `\&Foo::bar` — resolves via the bag's existing
+    /// MRO + cross-file machinery, same shape used by method
+    /// dispatch). Returns `None` for opaque coderef sources.
+    ///
+    /// Survives variable rebinding: chain typing propagates the
+    /// `InferredType` through `my $cb = ...` via the bag's TC
+    /// machinery, so consumers see the same attachment whether
+    /// the callable arrives as a literal or a rebound scalar.
+    pub fn callable_return_edge(&self) -> Option<&crate::witnesses::WitnessAttachment> {
         match self {
-            InferredType::CodeRef { return_edge } => *return_edge,
+            InferredType::CodeRef { return_edge } => return_edge.as_ref(),
             _ => None,
         }
     }

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -71,10 +71,14 @@ fn test_resolve_arrayref_type() {
 
 #[test]
 fn test_resolve_coderef_type() {
-    let fa = fa_with_constraints(vec![constraint("$cref", 0, InferredType::CodeRef)]);
+    let fa = fa_with_constraints(vec![constraint(
+        "$cref",
+        0,
+        InferredType::CodeRef { return_edge: None },
+    )]);
     assert_eq!(
         fa.inferred_type_via_bag("$cref", Point::new(1, 0)),
-        Some(InferredType::CodeRef)
+        Some(InferredType::CodeRef { return_edge: None })
     );
 }
 
@@ -246,8 +250,8 @@ fn test_resolve_return_type_object_does_not_subsume_arrayref() {
 #[test]
 fn test_resolve_return_type_single() {
     assert_eq!(
-        resolve_return_type(&[InferredType::CodeRef]),
-        Some(InferredType::CodeRef),
+        resolve_return_type(&[InferredType::CodeRef { return_edge: None }]),
+        Some(InferredType::CodeRef { return_edge: None }),
     );
 }
 
@@ -266,7 +270,7 @@ fn test_class_name_helper() {
     );
     assert_eq!(InferredType::HashRef.class_name(), None);
     assert_eq!(InferredType::ArrayRef.class_name(), None);
-    assert_eq!(InferredType::CodeRef.class_name(), None);
+    assert_eq!(InferredType::CodeRef { return_edge: None }.class_name(), None);
     assert_eq!(InferredType::Regexp.class_name(), None);
     assert_eq!(InferredType::Numeric.class_name(), None);
     assert_eq!(InferredType::String.class_name(), None);

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 24;
+pub const EXTRACT_VERSION: i64 = 25;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 25;
+pub const EXTRACT_VERSION: i64 = 26;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/parametric_resultset_tests.rs
+++ b/src/parametric_resultset_tests.rs
@@ -588,6 +588,58 @@ sub action {
     assert_eq!(def.unwrap().start.row, 4);
 }
 
+/// **Composition: rebound coderef in helper arg slot.** Same end
+/// result as `…composes_in_file` but the callback is bound to a
+/// scalar first (`my $body = sub { … }; $app->helper(name =>
+/// $body)`). Forces the chain typer + bag's `CodeRef.return_edge`
+/// to carry through the rebinding — `infer_expression_type` only
+/// fires for literal-in-arg-slot, so the rebind path comes from
+/// `invocant_type_at_node` resolving `$body` to the bag-typed
+/// CodeRef. If `callable_return_edge` is reachable through both
+/// shapes, the helper's synthesized return Edges into the body
+/// the same way and the `name`-key resolution composes.
+#[test]
+fn mojo_helper_returning_resultset_via_rebound_coderef_composes() {
+    let src = "
+package Schema::Result::Sner;
+use base 'DBIx::Class::Core';
+__PACKAGE__->add_columns(
+    name => { data_type => 'varchar' },
+);
+
+package MyApp;
+use Mojo::Base 'Mojolicious';
+my $schema;
+my $app;
+my $body = sub {
+    my $sner = 'Schema::Result::Sner';
+    return $schema->resultset($sner);
+};
+$app->helper(sner_r => $body);
+
+package MyApp::Controller::X;
+use Mojo::Base 'Mojolicious::Controller';
+sub action {
+    my $c = shift;
+    $c->sner_r->search({ name => 'foo' });
+}
+1;
+";
+    let (fa, tree) = parse_with_tree(src);
+    let pt = point_at(src, "name => 'foo'");
+    let def = fa.find_definition(pt, Some(&tree), Some(src.as_bytes()), None);
+    assert!(
+        def.is_some(),
+        "rebound-coderef helper must compose the same as a literal \
+         in-arg-slot helper: `my $$body = sub {{...}}; \
+         $$app->helper(name => $$body)` should let \
+         `$$c->sner_r->search({{ name }})` resolve to Sner's column. \
+         got: {:?}",
+        def,
+    );
+    assert_eq!(def.unwrap().start.row, 4);
+}
+
 /// **Composition: same as the in-file test, split across two
 /// files.** Producer declares `Schema::Result::Sner` + the
 /// `MyApp` helper; consumer is a Mojolicious::Controller subclass

--- a/src/parametric_resultset_tests.rs
+++ b/src/parametric_resultset_tests.rs
@@ -703,3 +703,74 @@ sub action {
         refs.iter().map(|r| (&r.key, r.span.start.row)).collect::<Vec<_>>(),
     );
 }
+
+/// **Composition: cross-file `\&Foo::bar` reference as helper
+/// callback.** The helper plugin synthesizes a Method whose return
+/// edges to `MethodOnClass{class: "Producer", name: "build_rs"}`.
+/// The bag's existing edge-chase resolves it through `module_index`
+/// — no consumer-side branching on whether the named sub lives
+/// in this file or another. If column-key resolution still works,
+/// the whole `\&foo`-as-callable + cross-file return-type chase
+/// composes end-to-end.
+#[test]
+fn mojo_helper_with_named_sub_reference_composes_cross_file() {
+    let producer_src = "
+package Schema::Result::Sner;
+use base 'DBIx::Class::Core';
+__PACKAGE__->add_columns(
+    name => { data_type => 'varchar' },
+);
+
+package Producer;
+my $schema;
+sub build_rs {
+    my $sner = 'Schema::Result::Sner';
+    return $schema->resultset($sner);
+}
+
+package MyApp;
+use Mojo::Base 'Mojolicious';
+my $app;
+$app->helper(sner_r => \\&Producer::build_rs);
+1;
+";
+    let consumer_src = "
+package MyApp::Controller::X;
+use Mojo::Base 'Mojolicious::Controller';
+sub action {
+    my $c = shift;
+    $c->sner_r->search({ name => 'foo' });
+}
+1;
+";
+    let producer_path = PathBuf::from("/tmp/named_ref_producer.pm");
+    let consumer_path = PathBuf::from("/tmp/named_ref_consumer.pm");
+
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(producer_path.clone(), Arc::new(parse(producer_src)));
+
+    let mut consumer_fa = parse(consumer_src);
+    consumer_fa.enrich_imported_types_with_keys(Some(&idx));
+
+    let store = FileStore::new();
+    store.insert_workspace(producer_path.clone(), parse(producer_src));
+    store.insert_workspace(consumer_path.clone(), consumer_fa);
+
+    let target = TargetRef {
+        name: "name".to_string(),
+        kind: TargetKind::HashKeyOfClass("Schema::Result::Sner".to_string()),
+    };
+    let refs = refs_to(&store, Some(&idx), &target, RoleMask::WORKSPACE);
+    let consumer_hit = refs
+        .iter()
+        .any(|r| matches!(&r.key, FileKey::Path(p) if p == &consumer_path));
+    assert!(
+        consumer_hit,
+        "Mojo helper with `\\&Foo::bar` named-sub reference must compose \
+         cross-file: the helper's return edge points at \
+         MethodOnClass{{class: Producer, name: build_rs}}, the bag \
+         chases that through module_index to find the row class, and \
+         column-key resolution finds the call site. hits: {:?}",
+        refs.iter().map(|r| (&r.key, r.span.start.row)).collect::<Vec<_>>(),
+    );
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -52,21 +52,29 @@ pub struct ArgInfo {
     /// HashKeyDef so signature help can surface it at call sites.
     #[serde(default)]
     pub sub_params: Vec<EmittedParam>,
-    /// For anonymous-sub args, the span of the body's last expression
-    /// (the one that determines the sub's return value when called).
-    /// Lets plugins emit `Symbol(method_id) → Edge(Expr(span))` so
-    /// the synthesized callable's return type follows the body's
-    /// last-expression type — resolved at query time, after the
-    /// body has been walked. The natural shape for
-    /// `$app->helper(name => sub { ... })`-style synthesis where
-    /// the plugin doesn't statically know what the body returns
-    /// (it could be a Parametric resultset, a class instance, an
-    /// arbitrary value).
+    /// Span of the body's last expression for any arg whose type
+    /// resolves to `InferredType::CodeRef { return_edge: Some(_) }`.
+    /// Plugins emit `Symbol(method_id) → Edge(Expr(span))` against
+    /// it so the synthesized callable's return type follows the
+    /// body's last-expression type at query time.
     ///
-    /// `None` for non-sub args, sub args without a recognizable
-    /// last expression, or empty bodies.
+    /// Bag-aware. Two shapes resolve uniformly:
+    ///
+    /// ```perl
+    /// $app->helper(name => sub { ... });           # literal
+    /// my $sub = sub { ... };
+    /// $app->helper(name => $sub);                  # rebound
+    /// ```
+    ///
+    /// In both cases the `CodeRef`'s `return_edge` carries the
+    /// body span — populated at the literal site, propagated
+    /// through `my $sub = ...` by the bag's TC machinery, and
+    /// projected onto this field by the host. `None` for opaque
+    /// coderefs (function refs, params typed `CodeRef`, deref
+    /// shapes like `&{...}`, empty bodies) where the body span
+    /// genuinely isn't reachable.
     #[serde(default)]
-    pub sub_body_last_expr_span: Option<Span>,
+    pub callable_return_edge: Option<Span>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -201,8 +209,12 @@ pub enum EmitAction {
         /// walked. Lets plugins like `mojo-helpers` lift the return
         /// type from a `sub { ... }` callback's body without
         /// inspecting the body at plugin-call time (when the body
-        /// hasn't been walked yet). Set to `args[N].sub_body_last_expr_span`
-        /// for the relevant callback arg.
+        /// hasn't been walked yet). Set to `args[N].callable_return_edge`
+        /// for the relevant callback arg — works whether the arg is
+        /// a sub-literal (`helper(name => sub { ... })`) or a
+        /// rebound coderef (`my $sub = sub { ... }; helper(name =>
+        /// $sub)`). The host populates `callable_return_edge` from
+        /// the arg's bag-resolved `CodeRef` shape.
         ///
         /// Mutually exclusive with `return_type` in spirit — if both
         /// are set, `return_type` wins (the plugin overrode

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -52,29 +52,30 @@ pub struct ArgInfo {
     /// HashKeyDef so signature help can surface it at call sites.
     #[serde(default)]
     pub sub_params: Vec<EmittedParam>,
-    /// Span of the body's last expression for any arg whose type
-    /// resolves to `InferredType::CodeRef { return_edge: Some(_) }`.
-    /// Plugins emit `Symbol(method_id) → Edge(Expr(span))` against
-    /// it so the synthesized callable's return type follows the
-    /// body's last-expression type at query time.
+    /// Witness-bag attachment whose type IS this arg's callable
+    /// return when invoked, projected from
+    /// `arg.inferred_type.callable_return_edge()`. Plugins emit
+    /// `Symbol(method_id) → Edge(target)` against it so a
+    /// synthesized callable's return follows the source
+    /// callable's return at query time.
     ///
-    /// Bag-aware. Two shapes resolve uniformly:
+    /// Three reachability shapes resolve uniformly:
     ///
     /// ```perl
-    /// $app->helper(name => sub { ... });           # literal
+    /// $app->helper(name => sub { ... });          # anon literal
     /// my $sub = sub { ... };
-    /// $app->helper(name => $sub);                  # rebound
+    /// $app->helper(name => $sub);                 # rebound anon
+    /// $app->helper(name => \&Foo::bar);           # named ref (cross-file ok)
     /// ```
     ///
-    /// In both cases the `CodeRef`'s `return_edge` carries the
-    /// body span — populated at the literal site, propagated
-    /// through `my $sub = ...` by the bag's TC machinery, and
-    /// projected onto this field by the host. `None` for opaque
-    /// coderefs (function refs, params typed `CodeRef`, deref
-    /// shapes like `&{...}`, empty bodies) where the body span
-    /// genuinely isn't reachable.
+    /// Anon-sub origins yield `Expr(body_last_expr_span)`; named-
+    /// sub references yield `MethodOnClass{class, name}`, which
+    /// resolves through the bag's MRO + `module_index` machinery
+    /// — so cross-file `\&Foo::bar` works without any consumer-
+    /// side branching. `None` for genuinely opaque coderefs
+    /// (params typed `CodeRef`, deref-shape narrowing, etc.).
     #[serde(default)]
-    pub callable_return_edge: Option<Span>,
+    pub callable_return_edge: Option<crate::witnesses::WitnessAttachment>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,26 +204,29 @@ pub enum EmitAction {
         /// ("helper") and appends the non-invocant params.
         #[serde(default)]
         outline_label: Option<String>,
-        /// Lazy return type via `Edge` to an `Expr(span)` attachment
-        /// — the synthesized Method's return type IS that expression's
-        /// type, resolved at query time after the source has fully
-        /// walked. Lets plugins like `mojo-helpers` lift the return
-        /// type from a `sub { ... }` callback's body without
-        /// inspecting the body at plugin-call time (when the body
-        /// hasn't been walked yet). Set to `args[N].callable_return_edge`
-        /// for the relevant callback arg — works whether the arg is
-        /// a sub-literal (`helper(name => sub { ... })`) or a
-        /// rebound coderef (`my $sub = sub { ... }; helper(name =>
-        /// $sub)`). The host populates `callable_return_edge` from
-        /// the arg's bag-resolved `CodeRef` shape.
+        /// Lazy return type via `Edge` to a witness-bag attachment
+        /// — the synthesized Method's return type IS that
+        /// attachment's type, resolved at query time. The target
+        /// can be:
         ///
-        /// Mutually exclusive with `return_type` in spirit — if both
-        /// are set, `return_type` wins (the plugin overrode
-        /// explicitly). Builder pushes a `Symbol(sid) → Edge(Expr(span))`
-        /// witness; the bag's edge-chase resolver follows it at
-        /// query time.
+        ///   - `Expr(span)` for anon-sub bodies (the bag walks
+        ///     the body's last-expression witnesses).
+        ///   - `MethodOnClass{class, name}` for named-sub
+        ///     references (the bag's MRO + cross-file machinery
+        ///     resolves it).
+        ///
+        /// Set to `args[N].callable_return_edge` for the relevant
+        /// callback arg — works for anon literals, rebound
+        /// scalars, AND `\&Foo::bar` references (cross-file). The
+        /// host populates `callable_return_edge` from the arg's
+        /// bag-resolved `CodeRef` shape.
+        ///
+        /// Mutually exclusive with `return_type` in spirit — if
+        /// both are set, `return_type` wins (the plugin overrode
+        /// explicitly). Builder pushes `Symbol(sid) → Edge(target)`;
+        /// the bag's edge-chase resolver follows it at query time.
         #[serde(default)]
-        return_via_edge: Option<Span>,
+        return_via_edge: Option<crate::witnesses::WitnessAttachment>,
     },
     /// Synthesize a `HashKeyDef` for a constructor/stash/etc. key.
     HashKeyDef {

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -63,7 +63,9 @@ pub fn make_engine() -> Engine {
     engine.register_fn("type_numeric", || to_dynamic(InferredType::Numeric).unwrap());
     engine.register_fn("type_hashref", || to_dynamic(InferredType::HashRef).unwrap());
     engine.register_fn("type_arrayref", || to_dynamic(InferredType::ArrayRef).unwrap());
-    engine.register_fn("type_coderef", || to_dynamic(InferredType::CodeRef).unwrap());
+    engine.register_fn("type_coderef", || {
+        to_dynamic(InferredType::CodeRef { return_edge: None }).unwrap()
+    });
     engine.register_fn("type_regexp", || to_dynamic(InferredType::Regexp).unwrap());
     engine.register_fn("type_class", |class: String| {
         to_dynamic(InferredType::ClassName(class)).unwrap_or(Dynamic::UNIT)
@@ -581,14 +583,14 @@ mod tests {
                     string_value: Some("connect".into()),
                     span: evt_span,
                     content_span: None,
-                    inferred_type: Some(InferredType::String), sub_params: vec![], sub_body_last_expr_span: None,
+                    inferred_type: Some(InferredType::String), sub_params: vec![], callable_return_edge: None,
                 },
                 ArgInfo {
                     text: "sub { ... }".into(),
                     string_value: None,
                     span: cb_span,
                     content_span: None,
-                    inferred_type: Some(InferredType::CodeRef), sub_params: vec![], sub_body_last_expr_span: None,
+                    inferred_type: Some(InferredType::CodeRef { return_edge: None }), sub_params: vec![], callable_return_edge: None,
                 },
             ],
             call_span: sp(3, 4, 3, 45),
@@ -648,14 +650,14 @@ mod tests {
                     string_value: None,
                     span: sp(0, 0, 0, 5),
                     content_span: None,
-                    inferred_type: None, sub_params: vec![], sub_body_last_expr_span: None,
+                    inferred_type: None, sub_params: vec![], callable_return_edge: None,
                 },
                 ArgInfo {
                     text: "sub {}".into(),
                     string_value: None,
                     span: sp(0, 6, 0, 12),
                     content_span: None,
-                    inferred_type: Some(InferredType::CodeRef), sub_params: vec![], sub_body_last_expr_span: None,
+                    inferred_type: Some(InferredType::CodeRef { return_edge: None }), sub_params: vec![], callable_return_edge: None,
                 },
             ],
             call_span: sp(0, 0, 0, 15),

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -795,7 +795,7 @@ fn ref_type_snippet_completions(ty: &InferredType) -> Vec<CompletionItem> {
             sort_text: Some("000".to_string()),
             ..Default::default()
         }],
-        InferredType::CodeRef => vec![CompletionItem {
+        InferredType::CodeRef { .. } => vec![CompletionItem {
             label: "(args)".to_string(),
             kind: Some(CompletionItemKind::SNIPPET),
             detail: Some("code dereference".to_string()),

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -570,7 +570,7 @@ impl WitnessReducer for FrameworkAwareTypeFold {
             return ReducedValue::Type(match r {
                 Rep::Hash => InferredType::HashRef,
                 Rep::Array => InferredType::ArrayRef,
-                Rep::Code => InferredType::CodeRef,
+                Rep::Code => InferredType::CodeRef { return_edge: None },
                 Rep::Scalar => InferredType::String,
             });
         }


### PR DESCRIPTION
## Summary

`InferredType::CodeRef` was a flat marker — "this is a sub" with no
information about what calling it returns. Helper-body inference (PR #35)
worked around it by routing the body span through a CST-positional field
on `ArgInfo`, which only fired for sub-literals directly in an arg slot.
Three shapes leaked through the gap:

```perl
my $sub = sub { ... };
$app->helper(name => $sub);          # rebind through scalar — lost the edge

$app->helper(name => \&Foo::bar);    # named-sub reference — never typed

my $r = $cb->();                     # coderef call — return type not propagated
```

This PR closes all three by making `CodeRef` carry its own return edge,
typed as a `WitnessAttachment` so the bag's existing edge-chase machinery
handles in-file AND cross-file resolution uniformly.

## Type model

```rust
InferredType::CodeRef { return_edge: Option<WitnessAttachment> }
```

Two attachment shapes populate it:

| source                | edge target                            | resolution path |
|-----------------------|----------------------------------------|-----------------|
| `sub { ... }` literal | `Expr(body_last_expr_span)`            | bag walks the body's last-expression witnesses |
| `\&foo` / `\&Foo::bar`| `MethodOnClass { class, name }`        | bag's MRO + `module_index` cross-file recursion |
| anything else         | `None`                                 | genuinely opaque (params typed `CodeRef`, deref-shape narrowing, `Rep::Code` observations) |

Survives variable rebinding because chain typing already propagates
`InferredType` through `my $cb = ...` via the bag's TC machinery — the
attachment rides along inside the type.

## Coderef call (`$cb->()`)

`invocant_type_at_node` gets a new `coderef_call_expression` arm: resolve
the operand recursively, pull `callable_return_edge()`, chase through
the bag. No witness emission, no post-walk pass — chain typing already
re-asks every fold iteration, so monotone refinement of the operand
type lifts `$r`'s type on the next pass. The worklist does the work
once the arm exists.

`infer_deref_type` now skips when the operand's known type already
matches the narrowing discriminant. Without that, `$cb->()` would push
a coarser `CodeRef { return_edge: None }` TC that clobbered the
literal's edge under latest-wins reduction.

## Plugin surface

`ArgInfo.sub_body_last_expr_span` → `callable_return_edge:
Option<WitnessAttachment>`. The Mojo helpers plugin sees the broader
coverage transparently — same field name, richer type, no rhai change
beyond the rename. `EmitAction::Method.return_via_edge` upgraded to
match.

## Tests

- `test_coderef_call_propagates_return_type` — `my $cb = sub { [1,2] };
  my $r = $cb->()` types `$r` as `ArrayRef`.
- `mojo_helper_returning_resultset_via_rebound_coderef_composes` —
  rebind through scalar composes the same as literal-in-arg-slot.
- `mojo_helper_with_named_sub_reference_composes_cross_file` —
  `\&Producer::build_rs` as helper callback resolves the row class via
  `module_index` recursion; column-key search composes end-to-end.

543 unit / 0 ignored.

## EXTRACT_VERSION

24 → 26 — two shape changes (`Option<Span>` then `Option<WitnessAttachment>`).

## Test plan

- [ ] `cargo test`
- [ ] `./run_e2e.sh`
- [ ] Hover/goto-def on `$c->sner_r->search({ … })` chains where the helper is registered with `\&Foo::bar` resolves to the row class's column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)