### PR TITLE
feat: SyntheticUse — plugin-emitted `use` statements for style kits

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -197,6 +197,7 @@ fn build_with_plugins_inner(
         pod_texts: Vec::new(),
         package_parents: std::collections::HashMap::new(),
         package_uses: std::collections::HashMap::new(),
+        use_dedup: std::collections::HashSet::new(),
         sub_return_delegations: std::collections::HashMap::new(),
         resolved_returns: std::collections::HashMap::new(),
         framework_modes: std::collections::HashMap::new(),
@@ -903,6 +904,14 @@ struct Builder<'a> {
     /// Modules the current package has `use`d, in source order. Used by
     /// `PluginRegistry::applicable` for `Trigger::UsesModule` matching.
     package_uses: std::collections::HashMap<String, Vec<String>>,
+    /// `(current_package, module, raw_args)` tuples already processed by
+    /// `process_use` in this build. Both real `use` statements (from
+    /// `visit_use`) and plugin-emitted `SyntheticUse` actions go through
+    /// the same gate, so a second `use Moo` — real or synthetic — is a
+    /// no-op. Cleared between files (lives on Builder, not FileAnalysis).
+    /// Also breaks cycles when a kit plugin's SyntheticUse re-triggers
+    /// the same kit plugin's `on_use`.
+    use_dedup: std::collections::HashSet<(Option<String>, String, Vec<String>)>,
     /// sub_name → delegated sub name, for bodies that are `return other()` or
     /// a bare trailing call. Used to propagate hash-key ownership through
     /// intermediate subs so `sub chain { return get_config() }` doesn't
@@ -2142,6 +2151,20 @@ impl<'a> Builder<'a> {
                     inferred_type,
                 });
             }
+            plugin::EmitAction::SyntheticUse { module, args, imports, span } => {
+                // Route through the same worker `visit_use` uses. Plugin
+                // dispatch re-fires inside; `use_dedup` breaks cycles.
+                // `node: None` skips source-positioned ref emission
+                // (parent PackageRefs, qw-import FunctionCalls) — there's
+                // no source span to attach those to. The Module symbol,
+                // framework mode flip, package_uses, package_parents, the
+                // `Import` entry, and the recursive `on_use` dispatch all
+                // run identically to a literal `use`. `plugin_id` is
+                // unused — the synthetic use isn't tagged with a plugin
+                // namespace; anything emitted DOWNSTREAM of it (the
+                // re-entered `on_use` hooks) gets its own emitter's id.
+                self.process_use(module, args, imports, span, span, None);
+            }
             plugin::EmitAction::PluginNamespace {
                 id,
                 kind,
@@ -3222,77 +3245,108 @@ impl<'a> Builder<'a> {
     }
 
     fn visit_use(&mut self, node: Node<'a>) {
-        if let Some(module_node) = node.child_by_field_name("module") {
-            if let Ok(module_name) = module_node.utf8_text(self.source) {
-                self.add_symbol(
-                    module_name.to_string(),
-                    SymKind::Module,
-                    node_to_span(node),
-                    node_to_span(module_node),
-                    SymbolDetail::None,
-                );
+        // Thin shim: pull the value triple off the CST node and hand it
+        // to the value-taking worker. `process_use` runs the actual
+        // framework-detection, package_uses tracking, import emission,
+        // and plugin dispatch — shared with `EmitAction::SyntheticUse`
+        // so kit plugins (`use Co::Base -Class` → SyntheticUse "Moo")
+        // hit the exact same code path the user's literal `use Moo`
+        // would.
+        let Some(module_node) = node.child_by_field_name("module") else { return };
+        let Ok(module_name) = module_node.utf8_text(self.source) else { return };
+        let raw_args = self.extract_mojo_base_args(node);
+        let (imports, _qw_close) = self.extract_use_import_list(node);
+        self.process_use(
+            module_name.to_string(),
+            raw_args,
+            imports,
+            node_to_span(node),
+            node_to_span(module_node),
+            Some(node),
+        );
+        // Don't recurse — use statements don't contain interesting sub-nodes
+    }
 
-                // Track uses per-package so `Trigger::UsesModule` matches.
-                // Populated before any plugin-dispatch site reads it.
-                if let Some(pkg) = self.current_package.as_ref().cloned() {
-                    self.package_uses
-                        .entry(pkg)
-                        .or_default()
-                        .push(module_name.to_string());
-                }
+    /// Value-taking core of `use` handling. Shared by real source uses
+    /// (`visit_use`) and plugin-emitted `EmitAction::SyntheticUse`. Both
+    /// callers route through here so framework mode, package_uses,
+    /// Import / Module symbol emission, and the on_use plugin re-dispatch
+    /// happen identically — there is no `synthetic: bool` branch inside.
+    ///
+    /// `node` is `Some` when the call originated from a real CST node and
+    /// `None` for synthetic. The only thing it gates is source-positioned
+    /// ref emission (parent `PackageRef`s, qw-import `FunctionCall`s,
+    /// `use constant` accumulation, the qw-close-paren completion anchor)
+    /// — there's no source span to attach those to when the use was
+    /// synthesized, so they're skipped. Everything else (the Module
+    /// symbol, package_uses, framework_modes, package_parents, the
+    /// `Import` entry, plugin dispatch) runs uniformly.
+    ///
+    /// Dedup gate: `(current_package, module, raw_args)` is the work
+    /// identity. A second real `use Moo;` after a synthetic one — or
+    /// vice versa, or two real ones, or a SyntheticUse cycle (kit
+    /// plugin reacting to its own emission) — short-circuits here.
+    fn process_use(
+        &mut self,
+        module_name: String,
+        raw_args: Vec<String>,
+        imports: Vec<String>,
+        span: Span,
+        module_name_span: Span,
+        node: Option<Node<'a>>,
+    ) {
+        let key = (self.current_package.clone(), module_name.clone(), raw_args.clone());
+        if !self.use_dedup.insert(key) { return; }
 
-                // Detect framework mode from use statements
-                if let Some(pkg) = self.current_package.as_ref().cloned() {
-                    match module_name {
-                        "Moo" | "Moo::Role" => {
-                            self.framework_modes.insert(pkg, FrameworkMode::Moo);
-                            for kw in &["has", "with", "extends", "around", "before", "after"] {
-                                self.framework_imports.insert(kw.to_string());
-                            }
-                        }
-                        "Moose" | "Moose::Role" => {
-                            self.framework_modes.insert(pkg, FrameworkMode::Moose);
-                            for kw in &["has", "with", "extends", "around", "before", "after",
-                                        "override", "super", "inner", "augment", "confess", "blessed"] {
-                                self.framework_imports.insert(kw.to_string());
-                            }
-                        }
-                        "Mojo::Base" => {
-                            // Check args: -strict means no accessors, -base or 'Parent' means MojoBase mode
-                            // Collect all args including barewords (which extract_use_import_list skips)
-                            let all_args = self.extract_mojo_base_args(node);
-                            let is_strict = all_args.iter().any(|a| a == "-strict");
-                            if !is_strict {
-                                self.framework_modes.insert(pkg.clone(), FrameworkMode::MojoBase);
-                                self.framework_imports.insert("has".to_string());
-                                // 'Parent' arg (not starting with -) is an inheritance declaration
-                                let parents: Vec<String> = all_args.into_iter()
-                                    .filter(|s| !s.starts_with('-'))
-                                    .collect();
-                                if !parents.is_empty() {
-                                    let parent_set: std::collections::HashSet<&str> = parents.iter().map(|s| s.as_str()).collect();
-                                    self.emit_refs_for_strings(node, &parent_set, RefKind::PackageRef);
-                                    self.package_parents
-                                        .entry(pkg)
-                                        .or_default()
-                                        .extend(parents);
-                                }
-                            }
-                        }
-                        _ => {}
+        self.add_symbol(
+            module_name.clone(),
+            SymKind::Module,
+            span,
+            module_name_span,
+            SymbolDetail::None,
+        );
+
+        // Track uses per-package so `Trigger::UsesModule` matches.
+        // Populated before any plugin-dispatch site reads it.
+        if let Some(pkg) = self.current_package.as_ref().cloned() {
+            self.package_uses
+                .entry(pkg)
+                .or_default()
+                .push(module_name.clone());
+        }
+
+        // Detect framework mode from use statements
+        if let Some(pkg) = self.current_package.as_ref().cloned() {
+            match module_name.as_str() {
+                "Moo" | "Moo::Role" => {
+                    self.framework_modes.insert(pkg, FrameworkMode::Moo);
+                    for kw in &["has", "with", "extends", "around", "before", "after"] {
+                        self.framework_imports.insert(kw.to_string());
                     }
                 }
-
-                // Extract parent classes from `use parent` / `use base`
-                if module_name == "parent" || module_name == "base" {
-                    if let Some(pkg) = self.current_package.clone() {
-                        let (parents, _) = self.extract_use_import_list(node);
-                        let parents: Vec<String> = parents.into_iter()
-                            .filter(|s| !s.starts_with('-')) // skip -norequire etc.
+                "Moose" | "Moose::Role" => {
+                    self.framework_modes.insert(pkg, FrameworkMode::Moose);
+                    for kw in &["has", "with", "extends", "around", "before", "after",
+                                "override", "super", "inner", "augment", "confess", "blessed"] {
+                        self.framework_imports.insert(kw.to_string());
+                    }
+                }
+                "Mojo::Base" => {
+                    // Check args: -strict means no accessors, -base or 'Parent' means MojoBase mode
+                    let is_strict = raw_args.iter().any(|a| a == "-strict");
+                    if !is_strict {
+                        self.framework_modes.insert(pkg.clone(), FrameworkMode::MojoBase);
+                        self.framework_imports.insert("has".to_string());
+                        // 'Parent' arg (not starting with -) is an inheritance declaration
+                        let parents: Vec<String> = raw_args.iter()
+                            .filter(|s| !s.starts_with('-'))
+                            .cloned()
                             .collect();
                         if !parents.is_empty() {
-                            let parent_set: std::collections::HashSet<&str> = parents.iter().map(|s| s.as_str()).collect();
-                            self.emit_refs_for_strings(node, &parent_set, RefKind::PackageRef);
+                            if let Some(node) = node {
+                                let parent_set: std::collections::HashSet<&str> = parents.iter().map(|s| s.as_str()).collect();
+                                self.emit_refs_for_strings(node, &parent_set, RefKind::PackageRef);
+                            }
                             self.package_parents
                                 .entry(pkg)
                                 .or_default()
@@ -3300,60 +3354,86 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
+                _ => {}
+            }
+        }
 
-                // Accumulate constant values: use constant NAME => 'val' / qw(a b)
-                if module_name == "constant" {
-                    self.accumulate_use_constant(node);
-                }
-
-                // Extract imported symbols from qw(...) or list
-                let (raw_names, qw_close_paren) = self.extract_use_import_list(node);
-                // Emit FunctionCall refs for imported symbol names (for goto-def on import args).
-                // These refs pin to the module being imported from — the
-                // qw list IS the authoritative source.
-                if module_name != "parent" && module_name != "base" {
-                    if !raw_names.is_empty() {
-                        let sym_set: std::collections::HashSet<&str> = raw_names.iter().map(|s| s.as_str()).collect();
-                        let kind = RefKind::FunctionCall {
-                            resolved_package: Some(module_name.to_string()),
-                        };
-                        self.emit_refs_for_strings(node, &sym_set, kind);
-                    }
-                }
-                // Tree-sitter parses `qw(a b)` as same-name imports — no
-                // syntactic support for `use Foo ( a => { -as => 'b' } )`
-                // yet, so this loop is pure `ImportedSymbol::same`. Plugin
-                // emissions (below) can produce renaming imports.
-                let imported_symbols: Vec<ImportedSymbol> = raw_names
-                    .iter()
-                    .map(|n| ImportedSymbol::same(n.clone()))
+        // Extract parent classes from `use parent` / `use base`
+        if module_name == "parent" || module_name == "base" {
+            if let Some(pkg) = self.current_package.clone() {
+                let parents: Vec<String> = imports.iter()
+                    .filter(|s| !s.starts_with('-')) // skip -norequire etc.
+                    .cloned()
                     .collect();
-                self.imports.push(Import {
-                    module_name: module_name.to_string(),
-                    imported_symbols,
-                    span: node_to_span(node),
-                    qw_close_paren,
-                });
-
-                // Plugin dispatch for use-statements. Mojolicious::Lite
-                // autoimports a verb set (`get`, `post`, `helper`, ...)
-                // — the plugin emits `Import` actions pointing at the
-                // real source module so hover/gd/sig-help flow through
-                // the existing imported-function resolution path.
-                if !self.plugins.is_empty() {
-                    let raw_args = self.extract_mojo_base_args(node);
-                    let ctx = plugin::UseContext {
-                        module_name: module_name.to_string(),
-                        imports: raw_names,
-                        raw_args,
-                        current_package: self.current_package.clone(),
-                        span: node_to_span(node),
-                    };
-                    self.dispatch_use_plugins(ctx);
+                if !parents.is_empty() {
+                    if let Some(node) = node {
+                        let parent_set: std::collections::HashSet<&str> = parents.iter().map(|s| s.as_str()).collect();
+                        self.emit_refs_for_strings(node, &parent_set, RefKind::PackageRef);
+                    }
+                    self.package_parents
+                        .entry(pkg)
+                        .or_default()
+                        .extend(parents);
                 }
             }
         }
-        // Don't recurse — use statements don't contain interesting sub-nodes
+
+        // Accumulate constant values: use constant NAME => 'val' / qw(a b)
+        if module_name == "constant" {
+            if let Some(node) = node {
+                self.accumulate_use_constant(node);
+            }
+        }
+
+        let qw_close_paren = node.and_then(|n| self.find_qw_close_position(n));
+
+        // Emit FunctionCall refs for imported symbol names (for goto-def on import args).
+        // These refs pin to the module being imported from — the qw list
+        // IS the authoritative source. Synthetic uses skip this — there's
+        // no source span for the imported names to live on.
+        if module_name != "parent" && module_name != "base" {
+            if !imports.is_empty() {
+                if let Some(node) = node {
+                    let sym_set: std::collections::HashSet<&str> = imports.iter().map(|s| s.as_str()).collect();
+                    let kind = RefKind::FunctionCall {
+                        resolved_package: Some(module_name.clone()),
+                    };
+                    self.emit_refs_for_strings(node, &sym_set, kind);
+                }
+            }
+        }
+        // Tree-sitter parses `qw(a b)` as same-name imports — no
+        // syntactic support for `use Foo ( a => { -as => 'b' } )`
+        // yet, so this loop is pure `ImportedSymbol::same`. Plugin
+        // emissions (below) can produce renaming imports.
+        let imported_symbols: Vec<ImportedSymbol> = imports
+            .iter()
+            .map(|n| ImportedSymbol::same(n.clone()))
+            .collect();
+        self.imports.push(Import {
+            module_name: module_name.clone(),
+            imported_symbols,
+            span,
+            qw_close_paren,
+        });
+
+        // Plugin dispatch for use-statements. Mojolicious::Lite
+        // autoimports a verb set (`get`, `post`, `helper`, ...) —
+        // the plugin emits `Import` actions pointing at the real
+        // source module so hover/gd/sig-help flow through the
+        // existing imported-function resolution path. Re-entered
+        // (without distinction) when a plugin emits SyntheticUse;
+        // `use_dedup` breaks any cycle.
+        if !self.plugins.is_empty() {
+            let ctx = plugin::UseContext {
+                module_name,
+                imports,
+                raw_args,
+                current_package: self.current_package.clone(),
+                span,
+            };
+            self.dispatch_use_plugins(ctx);
+        }
     }
 
     /// Check if we're at package scope (file scope or class block, not inside a sub).

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -904,14 +904,21 @@ struct Builder<'a> {
     /// Modules the current package has `use`d, in source order. Used by
     /// `PluginRegistry::applicable` for `Trigger::UsesModule` matching.
     package_uses: std::collections::HashMap<String, Vec<String>>,
-    /// `(current_package, module, raw_args)` tuples already processed by
-    /// `process_use` in this build. Both real `use` statements (from
-    /// `visit_use`) and plugin-emitted `SyntheticUse` actions go through
-    /// the same gate, so a second `use Moo` — real or synthetic — is a
-    /// no-op. Cleared between files (lives on Builder, not FileAnalysis).
-    /// Also breaks cycles when a kit plugin's SyntheticUse re-triggers
-    /// the same kit plugin's `on_use`.
-    use_dedup: std::collections::HashSet<(Option<String>, String, Vec<String>)>,
+    /// `(current_package, module, raw_args, imports)` tuples already
+    /// processed by `process_use` in this build. Both real `use`
+    /// statements (from `visit_use`) and plugin-emitted `SyntheticUse`
+    /// actions go through the same gate, so a second `use Moo` — real
+    /// or synthetic — is a no-op. Cleared between files (lives on
+    /// Builder, not FileAnalysis). Also breaks cycles when a kit
+    /// plugin's SyntheticUse re-triggers the same kit plugin's `on_use`.
+    ///
+    /// `imports` lives in the key because the synthetic shape carries
+    /// `args` and `imports` as separate fields, and real `use Foo qw(a)`
+    /// vs `use Foo qw(b)` is two distinct pieces of work. Without
+    /// `imports` here, `SyntheticUse { args: [], imports: ["a"] }` and
+    /// `SyntheticUse { args: [], imports: ["b"] }` would collide on the
+    /// args-only key and silently drop the second emission.
+    use_dedup: std::collections::HashSet<(Option<String>, String, Vec<String>, Vec<String>)>,
     /// sub_name → delegated sub name, for bodies that are `return other()` or
     /// a bare trailing call. Used to propagate hash-key ownership through
     /// intermediate subs so `sub chain { return get_config() }` doesn't
@@ -2159,11 +2166,16 @@ impl<'a> Builder<'a> {
                 // no source span to attach those to. The Module symbol,
                 // framework mode flip, package_uses, package_parents, the
                 // `Import` entry, and the recursive `on_use` dispatch all
-                // run identically to a literal `use`. `plugin_id` is
-                // unused — the synthetic use isn't tagged with a plugin
-                // namespace; anything emitted DOWNSTREAM of it (the
-                // re-entered `on_use` hooks) gets its own emitter's id.
-                self.process_use(module, args, imports, span, span, None);
+                // run identically to a literal `use`. `plugin_id` rides
+                // through as `synthesized_by` so the Module symbol carries
+                // the emitting plugin's `Namespace::Framework { id }` tag
+                // — `--dump-package` / outline filters can distinguish
+                // synthesized Module symbols from user-written ones.
+                // Anything DOWNSTREAM of the synthetic (re-entered
+                // `on_use` hooks, has-synthesizers, etc.) gets its own
+                // emitter's id through the regular `apply_emit_action`
+                // path; the namespace chain works out naturally.
+                self.process_use(module, args, imports, span, span, None, Some(plugin_id));
             }
             plugin::EmitAction::PluginNamespace {
                 id,
@@ -3263,6 +3275,7 @@ impl<'a> Builder<'a> {
             node_to_span(node),
             node_to_span(module_node),
             Some(node),
+            None, // real source — default `Namespace::Language` on the Module
         );
         // Don't recurse — use statements don't contain interesting sub-nodes
     }
@@ -3282,10 +3295,25 @@ impl<'a> Builder<'a> {
     /// symbol, package_uses, framework_modes, package_parents, the
     /// `Import` entry, plugin dispatch) runs uniformly.
     ///
-    /// Dedup gate: `(current_package, module, raw_args)` is the work
-    /// identity. A second real `use Moo;` after a synthetic one — or
-    /// vice versa, or two real ones, or a SyntheticUse cycle (kit
-    /// plugin reacting to its own emission) — short-circuits here.
+    /// `synthesized_by` is `Some(plugin_id)` for synthetic uses — the
+    /// emitting plugin's id rides through to the Module symbol's
+    /// `Namespace::Framework { id }` tag, so `--dump-package` / outline
+    /// / completion filters can distinguish "this `use Moo` came from
+    /// the user's source" from "this `use Moo` came from the
+    /// `co-base` kit plugin reacting to `use Co::Base -Class`". `None`
+    /// leaves the Module on the default `Namespace::Language`, matching
+    /// every literal `use` line's symbol tagging.
+    ///
+    /// When a kit chains (`co-base` plugin emits `SyntheticUse "Moo"`,
+    /// then the bundled `moo` plugin reacts to it via on_use), the
+    /// Module symbol carries the OUTER emitter's id (`co-base`). The
+    /// inner emissions get their own emitter's namespace through the
+    /// regular `apply_emit_action` path.
+    ///
+    /// Dedup gate: `(current_package, module, raw_args, imports)` is
+    /// the work identity. A second real `use Moo;` after a synthetic
+    /// one — or vice versa, or two real ones, or a SyntheticUse cycle
+    /// (kit plugin reacting to its own emission) — short-circuits here.
     fn process_use(
         &mut self,
         module_name: String,
@@ -3294,16 +3322,31 @@ impl<'a> Builder<'a> {
         span: Span,
         module_name_span: Span,
         node: Option<Node<'a>>,
+        synthesized_by: Option<String>,
     ) {
-        let key = (self.current_package.clone(), module_name.clone(), raw_args.clone());
+        let key = (
+            self.current_package.clone(),
+            module_name.clone(),
+            raw_args.clone(),
+            imports.clone(),
+        );
         if !self.use_dedup.insert(key) { return; }
 
-        self.add_symbol(
+        // Module symbol gets the synthesizing plugin's namespace tag
+        // when this is a SyntheticUse — that's the channel `--dump-package`
+        // / outline / completion already use to surface "this came from
+        // plugin X". For literal source `use`, default `Namespace::Language`.
+        let module_ns = match &synthesized_by {
+            Some(id) => Namespace::framework(id.clone()),
+            None => Namespace::Language,
+        };
+        self.add_symbol_ns(
             module_name.clone(),
             SymKind::Module,
             span,
             module_name_span,
             SymbolDetail::None,
+            module_ns,
         );
 
         // Track uses per-package so `Trigger::UsesModule` matches.
@@ -3378,7 +3421,16 @@ impl<'a> Builder<'a> {
             }
         }
 
-        // Accumulate constant values: use constant NAME => 'val' / qw(a b)
+        // Accumulate constant values: use constant NAME => 'val' / qw(a b).
+        // Gated on `Some(node)`: the accumulator scans the CST for the
+        // value side of the fat-comma pair, so a synthetic
+        // `SyntheticUse "constant"` can't populate `constant_strings`
+        // (there's no source to scan). This is the one observable
+        // axis where synthetic doesn't match a literal — kit plugins
+        // that need to inject constants should request a dedicated
+        // `EmitAction::ConstantString { name, values }` rather than
+        // routing it through SyntheticUse. See `EmitAction::SyntheticUse`
+        // doc for the limitation context.
         if module_name == "constant" {
             if let Some(node) = node {
                 self.accumulate_use_constant(node);

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -8826,6 +8826,7 @@ sub helper { return "fin"; }
 // literal build.
 mod synthetic_use {
     use super::*;
+    use crate::file_analysis::Namespace;
     use crate::plugin::{
         CompletionQueryContext, EmitAction, FrameworkPlugin, PluginCompletionAnswer,
         PluginRegistry, PluginSigHelpAnswer, SigHelpQueryContext, Trigger, UseContext,
@@ -8940,6 +8941,29 @@ has 'name' => (is => 'ro');
              SyntheticUse \"Moo\" as under literal `use Moo`",
         );
         assert_eq!(kit_methods.len(), 1, "ro getter is exactly one Method");
+
+        // Provenance: the synthesized `Moo` Module symbol in the kit
+        // build carries the emitting plugin's namespace tag; the
+        // literal build's `Moo` Module is plain `Language`. This is
+        // the one observable axis where the two builds are SUPPOSED
+        // to differ — it's what lets `--dump-package` / outline /
+        // completion filters surface "this came from co-base-test".
+        let kit_moo = kit.symbols.iter()
+            .find(|s| s.kind == SymKind::Module && s.name == "Moo")
+            .expect("kit build must have a Module symbol for synthesized `use Moo`");
+        assert_eq!(
+            kit_moo.namespace,
+            Namespace::framework("co-base-test"),
+            "synthesized Module must carry the emitting plugin's namespace tag"
+        );
+        let lit_moo = lit.symbols.iter()
+            .find(|s| s.kind == SymKind::Module && s.name == "Moo")
+            .expect("literal build must have a Module symbol for `use Moo`");
+        assert_eq!(
+            lit_moo.namespace,
+            Namespace::Language,
+            "literal-source Module must stay on Namespace::Language (no plugin tag)"
+        );
     }
 
     /// `use_dedup` short-circuits cycles. The stub plugin reacts to
@@ -8984,5 +9008,91 @@ has 'name' => (is => 'ro');
             .filter(|s| s.kind == SymKind::Module && s.name == "Co::Base")
             .count();
         assert_eq!(module_syms, 1, "self-cycle must emit one Module symbol");
+
+        // Belt-and-suspenders for the gate. The dedup short-circuits at
+        // the top of `process_use`, so every downstream effect is bounded
+        // by construction — but pinning each axis catches a future
+        // regression where the gate gets moved or `process_use` gets
+        // split. If any of these grow without the others, something's
+        // half-processing the cycle.
+        let co_base_uses = fa.symbols.iter()
+            .filter(|s| s.kind == SymKind::Module && s.name == "Co::Base")
+            .count();
+        assert_eq!(
+            co_base_uses, 1,
+            "package_uses-equivalent (Module symbol count) should match Import count"
+        );
+        // `framework_imports` for `use Co::Base` (not a built-in framework
+        // module): the bundled plugins shouldn't touch it. Cycle should
+        // leave this empty whether it loops once or a thousand times.
+        assert!(
+            fa.framework_imports.is_empty()
+                || fa.framework_imports.iter().all(|s| !s.starts_with("co_base_")),
+            "cycle on a non-framework module should not leak Co::Base-tagged keywords \
+             into framework_imports; got {:?}",
+            fa.framework_imports,
+        );
+    }
+
+    /// `imports` MUST be part of the dedup key. Real `use Foo qw(a)` and
+    /// `use Foo qw(b)` discriminate via `extract_mojo_base_args`'s
+    /// fallback to `extract_use_import_list` (the fallback fires when
+    /// no barewords / literals are present, putting qw imports in
+    /// `raw_args`). Synthetic emissions carry `args` and `imports` as
+    /// separate fields, so the equivalent two SyntheticUses with
+    /// different `imports` and empty `args` must NOT collide on the
+    /// dedup key. Pre-fix, both keyed on `(pkg, "Foo", [])` and the
+    /// second silently dropped.
+    #[test]
+    fn synthetic_use_distinct_imports_both_emit() {
+        struct ImportPlugin;
+        impl FrameworkPlugin for ImportPlugin {
+            fn id(&self) -> &str { "imports-test" }
+            fn triggers(&self) -> &[Trigger] {
+                static T: [Trigger; 1] = [Trigger::Always];
+                &T
+            }
+            fn on_use(&self, ctx: &UseContext) -> Vec<EmitAction> {
+                if ctx.module_name != "Trigger::Kit" { return Vec::new(); }
+                vec![
+                    EmitAction::SyntheticUse {
+                        module: "Foo".into(),
+                        args: vec![],
+                        imports: vec!["a".into()],
+                        span: ctx.span,
+                    },
+                    EmitAction::SyntheticUse {
+                        module: "Foo".into(),
+                        args: vec![],
+                        imports: vec!["b".into()],
+                        span: ctx.span,
+                    },
+                ]
+            }
+            fn on_signature_help(&self, _: &SigHelpQueryContext) -> Option<PluginSigHelpAnswer> { None }
+            fn on_completion(&self, _: &CompletionQueryContext) -> Option<PluginCompletionAnswer> { None }
+        }
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(ImportPlugin));
+        let fa = build_with("package Foo; use Trigger::Kit;\n", Arc::new(reg));
+
+        let foo_imports: Vec<&crate::file_analysis::Import> = fa.imports.iter()
+            .filter(|i| i.module_name == "Foo")
+            .collect();
+        assert_eq!(
+            foo_imports.len(), 2,
+            "two SyntheticUse \"Foo\" with distinct imports must both produce \
+             Import entries — dedup must NOT collide on the args-only key. \
+             Got imports: {:?}",
+            foo_imports.iter().map(|i| &i.imported_symbols).collect::<Vec<_>>(),
+        );
+
+        // Each Import entry must carry its own qw-style import name.
+        // Order-independent: we check the union covers both.
+        let all_names: std::collections::HashSet<&str> = foo_imports.iter()
+            .flat_map(|i| i.imported_symbols.iter().map(|s| s.local_name.as_str()))
+            .collect();
+        assert!(all_names.contains("a"), "missing import name 'a': {:?}", all_names);
+        assert!(all_names.contains("b"), "missing import name 'b': {:?}", all_names);
     }
 }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -8813,3 +8813,176 @@ sub helper { return "fin"; }
         Some(InferredType::String),
     );
 }
+
+// ---- SyntheticUse — plugin-emitted `use` statements ------------------------
+//
+// `EmitAction::SyntheticUse` lets a plugin react to a kit module's outer
+// use (e.g. `use Co::Base -Class`) by injecting the inner `use`s that the
+// kit performs at runtime (`Moo`, `parent`, etc.). The point is that the
+// downstream effect — framework detection, has-synthesis, parent
+// inheritance, plugin re-dispatch — is identical to what the user would
+// have gotten by writing those `use` lines literally. The test below
+// drives the kit path through a stub plugin and compares against a
+// literal build.
+mod synthetic_use {
+    use super::*;
+    use crate::plugin::{
+        CompletionQueryContext, EmitAction, FrameworkPlugin, PluginCompletionAnswer,
+        PluginRegistry, PluginSigHelpAnswer, SigHelpQueryContext, Trigger, UseContext,
+    };
+    use std::sync::Arc;
+
+    /// Catches `use Co::Base -Class` and emits a synthetic `use Moo`.
+    /// One trigger (`Always`), one hook (`on_use`), zero overrides.
+    /// Stripped to the minimum that exercises the path.
+    struct CoBasePlugin;
+
+    impl FrameworkPlugin for CoBasePlugin {
+        fn id(&self) -> &str { "co-base-test" }
+        fn triggers(&self) -> &[Trigger] {
+            // `on_use` bypasses the trigger filter (every plugin sees
+            // every use), so the trigger list here is incidental. Kept
+            // non-empty to mirror real plugins.
+            static T: [Trigger; 1] = [Trigger::Always];
+            &T
+        }
+        fn on_use(&self, ctx: &UseContext) -> Vec<EmitAction> {
+            if ctx.module_name != "Co::Base" { return Vec::new(); }
+            let is_class = ctx.raw_args.iter().any(|a| a == "-Class");
+            if !is_class { return Vec::new(); }
+            vec![EmitAction::SyntheticUse {
+                module: "Moo".into(),
+                args: vec![],
+                imports: vec![],
+                span: ctx.span,
+            }]
+        }
+        fn on_signature_help(&self, _: &SigHelpQueryContext) -> Option<PluginSigHelpAnswer> { None }
+        fn on_completion(&self, _: &CompletionQueryContext) -> Option<PluginCompletionAnswer> { None }
+    }
+
+    fn registry_with_co_base() -> Arc<PluginRegistry> {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(CoBasePlugin));
+        Arc::new(reg)
+    }
+
+    fn build_with(source: &str, plugins: Arc<PluginRegistry>) -> FileAnalysis {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        super::super::build_with_plugins(&tree, source.as_bytes(), plugins)
+    }
+
+    /// `use Co::Base -Class` (via the stub kit plugin) produces the same
+    /// observable downstream state as a literal `use Moo`:
+    ///
+    ///   * `package_framework` carries `Moo` for the package.
+    ///   * `framework_imports` covers Moo's keyword set.
+    ///   * `has 'name'` synthesizes the accessor Method.
+    ///
+    /// Anything that depends on those — has-synthesis, accessor symbols,
+    /// inheritance via `with`/`extends`, the constructor key, downstream
+    /// plugin chains — comes along for free because it reads the same
+    /// state. We pin only the load-bearing axes; broader Moo behavior
+    /// has its own dedicated tests.
+    #[test]
+    fn synthetic_use_moo_matches_literal_use_moo() {
+        let kit_src = r#"
+package Foo;
+use Co::Base -Class;
+has 'name' => (is => 'ro');
+"#;
+        let lit_src = r#"
+package Foo;
+use Moo;
+has 'name' => (is => 'ro');
+"#;
+        let kit = build_with(kit_src, registry_with_co_base());
+        let lit = build_with(lit_src, registry_with_co_base());
+
+        // Both should record Moo as the active framework for Foo.
+        assert_eq!(
+            kit.package_framework.get("Foo"),
+            lit.package_framework.get("Foo"),
+            "kit (`use Co::Base -Class`) and literal (`use Moo`) must agree on package_framework"
+        );
+        assert!(
+            kit.package_framework.contains_key("Foo"),
+            "Foo's framework should be set by SyntheticUse \"Moo\"; package_framework={:?}",
+            kit.package_framework,
+        );
+
+        // Both should have Moo's keyword set in framework_imports.
+        for kw in &["has", "with", "extends", "around", "before", "after"] {
+            assert!(
+                kit.framework_imports.contains(*kw),
+                "SyntheticUse \"Moo\" must populate framework_imports[{kw}]; got {:?}",
+                kit.framework_imports,
+            );
+        }
+
+        // The `has 'name'` accessor synthesis depends on framework_modes
+        // being set at the time `visit_has_call` fires. With SyntheticUse,
+        // the kit's `use Co::Base -Class` precedes `has`, so the plugin
+        // re-dispatch flips the mode before the has-call is walked.
+        let kit_methods: Vec<&str> = kit.symbols.iter()
+            .filter(|s| s.name == "name" && s.kind == SymKind::Method)
+            .map(|s| s.name.as_str())
+            .collect();
+        let lit_methods: Vec<&str> = lit.symbols.iter()
+            .filter(|s| s.name == "name" && s.kind == SymKind::Method)
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(
+            kit_methods, lit_methods,
+            "`has 'name'` should synthesize the same accessor Methods under \
+             SyntheticUse \"Moo\" as under literal `use Moo`",
+        );
+        assert_eq!(kit_methods.len(), 1, "ro getter is exactly one Method");
+    }
+
+    /// `use_dedup` short-circuits cycles. The stub plugin reacts to
+    /// `use Co::Base` by emitting `SyntheticUse "Co::Base"` — if the
+    /// gate didn't catch it, the on_use re-dispatch would loop and
+    /// produce many duplicate Module symbols / Import entries.
+    /// With dedup, the second emission is a no-op.
+    #[test]
+    fn synthetic_use_self_cycle_is_bounded() {
+        struct LoopPlugin;
+        impl FrameworkPlugin for LoopPlugin {
+            fn id(&self) -> &str { "loop-test" }
+            fn triggers(&self) -> &[Trigger] {
+                static T: [Trigger; 1] = [Trigger::Always];
+                &T
+            }
+            fn on_use(&self, ctx: &UseContext) -> Vec<EmitAction> {
+                if ctx.module_name != "Co::Base" { return Vec::new(); }
+                vec![EmitAction::SyntheticUse {
+                    module: "Co::Base".into(),
+                    args: vec![],
+                    imports: vec![],
+                    span: ctx.span,
+                }]
+            }
+            fn on_signature_help(&self, _: &SigHelpQueryContext) -> Option<PluginSigHelpAnswer> { None }
+            fn on_completion(&self, _: &CompletionQueryContext) -> Option<PluginCompletionAnswer> { None }
+        }
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(LoopPlugin));
+        let fa = build_with("package Foo; use Co::Base;\n", Arc::new(reg));
+
+        let co_base_imports = fa.imports.iter()
+            .filter(|i| i.module_name == "Co::Base")
+            .count();
+        assert_eq!(
+            co_base_imports, 1,
+            "self-cycle must collapse to one Import entry; use_dedup gate kicked in"
+        );
+
+        let module_syms = fa.symbols.iter()
+            .filter(|s| s.kind == SymKind::Module && s.name == "Co::Base")
+            .count();
+        assert_eq!(module_syms, 1, "self-cycle must emit one Module symbol");
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -422,6 +422,45 @@ pub enum EmitAction {
         at: Span,
         inferred_type: InferredType,
     },
+
+    /// Inject a `use` statement as if it appeared in source at `span`.
+    /// Equivalent in every respect to the user having written
+    /// `use <module> <args>` at that point — same plugin dispatch,
+    /// same framework detection, same Import/Module symbol emission,
+    /// same `package_uses` / `package_parents` / `framework_imports`
+    /// writes.
+    ///
+    /// Powers "style kits" (`Import::Base` subclasses, `ToolKit`,
+    /// company-wide `use Co::Base -Class` shims) — a single user-facing
+    /// `use` line collapses a dozen real `use`s, and the LSP needs to
+    /// see those reals to make `has`, `with`, `extends`, etc. work.
+    /// Kit plugins react to the user's outer use via `on_use`, then
+    /// emit one `SyntheticUse` per inner real-use the kit performs.
+    ///
+    /// Re-entry is the point: the synthetic re-dispatches every
+    /// applicable `on_use` hook, including the emitting plugin's own.
+    /// `Builder.use_dedup` breaks cycles by `(package, module, args)`.
+    ///
+    /// All four fields mirror what `visit_use` extracts from a real
+    /// CST node, so the synthetic path is call-compatible with the
+    /// real path's worker — no `synthetic: bool` flag inside the
+    /// builder.
+    SyntheticUse {
+        module: String,
+        /// Raw arg tokens, exactly as `extract_mojo_base_args` would
+        /// produce from a real CST. Includes barewords like `-Class`
+        /// and quoted parents like `'Mojolicious::Plugin'`.
+        #[serde(default)]
+        args: Vec<String>,
+        /// qw-style imports (the named-symbol list a real
+        /// `extract_use_import_list` would yield).
+        #[serde(default)]
+        imports: Vec<String>,
+        /// Span the synthetic use is "attributed to" — typically the
+        /// emitting plugin's `ctx.span` (the original real `use` that
+        /// triggered the kit expansion).
+        span: Span,
+    },
 }
 
 // ---- Plugin trait ----

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -439,12 +439,35 @@ pub enum EmitAction {
     ///
     /// Re-entry is the point: the synthetic re-dispatches every
     /// applicable `on_use` hook, including the emitting plugin's own.
-    /// `Builder.use_dedup` breaks cycles by `(package, module, args)`.
+    /// `Builder.use_dedup` breaks cycles by
+    /// `(package, module, args, imports)`.
     ///
     /// All four fields mirror what `visit_use` extracts from a real
     /// CST node, so the synthetic path is call-compatible with the
     /// real path's worker — no `synthetic: bool` flag inside the
     /// builder.
+    ///
+    /// **Provenance.** The synthesized Module symbol carries the
+    /// emitting plugin's `Namespace::Framework { id }` tag (vs. real
+    /// `use` lines, whose Module symbol stays on `Namespace::Language`).
+    /// `--dump-package` / outline / completion filters use the
+    /// namespace channel to surface "this came from plugin X" for
+    /// every other plugin-emitted symbol; SyntheticUse joins the same
+    /// channel. Anything downstream of the synthetic (re-entered
+    /// `on_use` hooks, has-synthesizers, etc.) gets its OWN emitter's
+    /// id through the regular `apply_emit_action` path — so a
+    /// `co-base → Moo → has` chain ends up with the Module tagged
+    /// `co-base` and each synthesized accessor tagged `moo`.
+    ///
+    /// **Known limitation: `use constant`.** `accumulate_use_constant`
+    /// reads the value side of the fat-comma pair from the CST. A
+    /// synthetic `SyntheticUse { module: "constant", ... }` has no
+    /// source to scan, so `constant_strings` does NOT get populated —
+    /// the rest of the use-handling (Module symbol, package_uses,
+    /// Import entry, plugin re-dispatch) still runs. Kit plugins
+    /// that need to inject constants should request a dedicated
+    /// `EmitAction::ConstantString { name, values }` (not yet
+    /// available — add when a real plugin needs it).
     SyntheticUse {
         module: String,
         /// Raw arg tokens, exactly as `extract_mojo_base_args` would


### PR DESCRIPTION
## Summary
- Plugins can now inject `use X args...` as if the user had written it — `EmitAction::SyntheticUse { module, args, imports, span }`. Same machinery as a real `use`: framework detection, `package_uses`, `package_parents`, `framework_imports`, Import / Module symbol emission, and the `on_use` plugin re-dispatch.
- Refactored `visit_use` into a thin CST shim + a value-taking `process_use(...)` worker shared by real and synthetic uses — **no `synthetic: bool` flag inside**. Per-build `use_dedup: HashSet<(pkg, module, args)>` breaks cycles uniformly across both paths.
- Rhai surface is zero-code: `from_dynamic::<EmitAction>` picks up the new variant via serde, with `serde(default)` on args/imports so kit plugins can omit them.

Unlocks "style kits" — `Import::Base` subclasses, `ToolKit`, company-wide `use Co::Base -Class` shims. A kit plugin reacts to the user's outer `use` and emits one `SyntheticUse` per inner real-`use` the kit performs; downstream `has` / `with` / `extends` then work automatically because the framework mode gets flipped by the synthetic.

Design corpus entry: `docs/prompt-synthetic-use.md`.

## Test plan
- [x] `cargo test` — 554 passing, including 2 new under `mod synthetic_use`:
  - `synthetic_use_moo_matches_literal_use_moo` — kit plugin emitting `SyntheticUse "Moo"` produces identical `package_framework` / `framework_imports` / has-synthesized accessor symbols as a literal `use Moo`.
  - `synthetic_use_self_cycle_is_bounded` — plugin emitting `SyntheticUse` for the module it reacts to collapses to one Import + one Module symbol via the dedup gate.
- [x] `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)