### PR TITLE
feat: perl-gen — generator for Import::Base → .rhai kit plugins

### DIFF
--- a/docs/adr/importbase-plugin-gen.md
+++ b/docs/adr/importbase-plugin-gen.md
@@ -1,0 +1,78 @@
+# ADR: Generate kit plugins from Import::Base data tables
+
+`Import::Base` subclasses are how real Perl shops centralize their
+import dance — `use Co::Base -Class;` collapses a dozen real `use`
+lines via `@IMPORT_MODULES` / `%IMPORT_BUNDLES`. PR #38's
+`EmitAction::SyntheticUse` gave us the runtime primitive to express
+the expansion. This ADR is about authorship: the plugins get
+generated, not hand-written. The generator lives in `perl-gen/`; the
+LSP side adds nothing.
+
+## Decisions worth keeping
+
+### `require`, don't `use` — read variables, don't execute import
+
+`Import::Base` subclasses ARE their `our @IMPORT_MODULES` and
+`%IMPORT_BUNDLES` declarations. `require <Kit>` populates them at
+compile time without triggering the kit's `import` method. The
+generator reads them directly. No probe namespace, no
+`Import::Into` monkey-patching, no coderef bodies executing at
+generator time.
+
+The alternative — monkey-patch `Import::Into` and run `Kit->import`
+in a probe — works and is the only path for hand-rolled
+`sub import` kits. Skip it when reading the tables suffices.
+
+### Generator is Perl, output is a committed `.rhai`
+
+Lives in `perl-gen/` as a CPAN-shaped Perl module. Specifically not a
+Rust subcommand of `perl-lsp`. Kit authors write Perl; their tools
+should too. Output is a normal `.rhai` plugin file the user commits
+to their `$PERL_LSP_PLUGIN_DIR` — same loader, same `--plugin-check`,
+same fingerprint-invalidates-cache pipeline as any hand-written
+plugin. The generator is just authorship automation.
+
+Specifically not in-memory runtime auto-detection. That would
+execute Perl during LSP indexing and hide what's actually loaded.
+Committed `.rhai` is inspectable and diffable.
+
+### Sigil interpretation mirrors what real source produces
+
+Import::Base's prefix sigils (`>` Import::Into, `<` emit-first /
+base-class, `-` / `>-` unimport) map 1:1 to `SyntheticUse` field
+shape (`module`, `args`, `imports`). The synthetic and real paths
+end up with identical data going into `process_use`, so downstream
+framework detection / parent classes / plugin re-dispatch fire
+identically. The `<` prefix's emit-first ordering is preserved in
+the rendered `.rhai` so `<Mojo::Base 'X'` registers before
+bundle-mates that depend on it.
+
+Bundle dispatch matches Import::Base's `_parse_args`: the first
+non-dash arg is the bundle name (`'Class'`); the dashed form
+(`-Class`) is accepted as a synonym because some kit READMEs
+document it that way.
+
+### Coderefs are TODO comments
+
+`%IMPORT_BUNDLES` values can contain coderefs (`load_components`,
+`extends('X')`, ...). Without executing the kit, the generator
+can't decode these. v1 emits `// TODO: coderef at <kit>.pm:<line>`
+at the right position; the user reads the kit source and hand-
+authors the equivalent `SyntheticUse` / `PackageParent` emissions.
+B::Deparse + pattern-matching is deferred — adds machinery only
+worth it if the same coderef shapes recur across many kits.
+
+## What's intentionally not here
+
+- **Import::Into / hand-rolled `sub import` kits.** Imperative
+  bodies have no data tables to read; needs the probe-package
+  recorder. Hand-author a per-kit plugin meanwhile.
+- **Runtime auto-discovery.** No silent in-memory generation from
+  the workspace; what the LSP loads must be on disk.
+- **`SyntheticUnuse`.** No primitive yet for `no MOD` directives.
+- **Merge mode for coderef hand-edits.** v1 regenerates whole
+  files; keep manual additions in a separate companion plugin
+  until sentinel-marker preservation earns its weight.
+- **Coderef recognition / DDL DSL plugins.** Separate plugin
+  concerns, not generator concerns. Belong in `frameworks/` if
+  they earn their keep.

--- a/perl-gen/README.md
+++ b/perl-gen/README.md
@@ -1,0 +1,84 @@
+# perl-gen — Import::Base → .rhai plugin generator (POC)
+
+A Perl module that translates an `Import::Base` subclass into a
+`.rhai` plugin emitting `EmitAction::SyntheticUse` actions per
+bundle flag. The generated plugin drops into
+`$PERL_LSP_PLUGIN_DIR` and the LSP picks it up on next startup.
+
+See `docs/prompt-importbase-plugin-gen.md` (repo root) for the
+design rationale.
+
+## Usage
+
+```sh
+perl-gen/bin/perl-lsp-gen-importbase Co::Base::Local \
+  --lib /path/to/project/lib \
+  --lib /path/to/project/kit-common/lib \
+  --alias Co::Base \
+  --out plugins/co-base-local.rhai
+```
+
+Repeatable `--lib` paths are prepended to `@INC` before `require`.
+`--alias <class>` adds extra module names that should trigger the
+plugin (kits often have an install-wide shim that forwards to the
+local-dev class — `Co::Base` → `Co::Base::Local`).
+
+By default the output goes to stdout; pass `--out <file>` to write
+to disk.
+
+## Requires
+
+- Perl ≥ 5.42 (the generator uses `use v5.42`).
+- `Import::Base` and any modules the target kit transitively
+  requires must be installed (the generator calls `require <Kit>`,
+  which loads the kit's parent class chain). `cpm install -g
+  Import::Base` for the bare minimum; whatever else the kit needs
+  for its own load (Mojolicious, DBIC, etc.) too.
+
+## Tests
+
+```sh
+prove perl-gen/t/01_basic.t
+```
+
+The test fixture (`perl-gen/t/fixtures/lib/My/TestKit.pm`) is a
+minimal Import::Base subclass covering every sigil + a coderef.
+18 assertions; runs in ~50ms.
+
+## What it handles
+
+| Source                          | Output                                                                |
+|---------------------------------|-----------------------------------------------------------------------|
+| `MOD => [args]`                 | `SyntheticUse { module: MOD, args, imports }`                         |
+| `MOD` (bareword, no fat-comma)  | `SyntheticUse { module: MOD, args: [], imports: [] }`                 |
+| `>MOD => [args]`                | Same as plain — `Import::Into` runtime equivalent of `use MOD args`   |
+| `<MOD => [args]`                | Same shape, emitted **first** within its bundle (base-class ordering) |
+| `-MOD => [args]`                | `// TODO: unimport ...` (no SyntheticUnuse primitive yet)             |
+| `>-MOD => [args]`               | Same TODO                                                             |
+| coderef                         | `// TODO: coderef at <file>:<line>` — user hand-authors               |
+
+The generator `require`s the kit (so `our`-vars populate) but
+**never invokes its `import` method** — no side effects, no probe
+package, no `Import::Into` monkey-patching. Coderef bodies don't
+execute. Multi-arg expressions like `map "-$_", qw/.../` evaluate
+at module-compile time (inside the literal array initializer) and
+survive into the generator as plain string lists.
+
+## What it doesn't handle
+
+- **Import::Into kits** (hand-rolled `sub import { Pkg->import::into(...) }`).
+  Imperative bodies have no data tables to read; needs a runtime
+  recorder. Deferred.
+- **Coderef interpretation** — the LSP's `PackageParent` action can
+  represent `extends('X')` / `with('X')` / `load_components('A', 'B')`
+  side effects, but recognizing those idioms from inside a coderef
+  needs either `B::Deparse` pattern-matching or a probe-package
+  interception layer. Deferred. For now the TODO points at the kit
+  source line so a human can hand-author the equivalent.
+- **Unimport** — `no MOD args` has no SyntheticUse counterpart. Add a
+  `SyntheticUnuse` EmitAction in the LSP if these turn out to matter.
+- **`--check` mode** — CI gate for "committed .rhai differs from a
+  fresh regen". Add when the regen workflow is established.
+
+See `docs/prompt-importbase-plugin-gen.md` for the full out-of-scope
+list and the reasoning.

--- a/perl-gen/bin/perl-lsp-gen-importbase
+++ b/perl-gen/bin/perl-lsp-gen-importbase
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+use v5.42;
+use utf8;
+use warnings;
+use experimental 'signatures';
+
+use Getopt::Long qw(GetOptions);
+use FindBin ();
+use lib "$FindBin::RealBin/../lib";
+
+use App::PerlLSP::PluginGen::ImportBase ();
+
+sub usage ($exit = 1) {
+    print STDERR <<~'USAGE';
+        usage: perl-lsp-gen-importbase <Kit::Class> [options]
+
+        Generate a .rhai plugin from an Import::Base subclass.
+
+        Options:
+          --lib <path>       Prepend <path> to @INC. Repeatable.
+          --out <file>       Write to <file>. Defaults to stdout.
+          --alias <class>    Extra module name that should trigger the plugin
+                             (e.g. the install-wide shim `Co::Base` that
+                             forwards to `Co::Base::Local`). Repeatable.
+          --plugin-id <id>   Override the default `<kit>-generated` plugin id.
+          --help             Show this message.
+        USAGE
+    exit $exit;
+}
+
+my (@libs, @aliases, $out, $plugin_id, $help);
+GetOptions(
+    'lib=s'       => \@libs,
+    'alias=s'     => \@aliases,
+    'out=s'       => \$out,
+    'plugin-id=s' => \$plugin_id,
+    'help|h'      => \$help,
+) or usage();
+usage(0) if $help;
+
+my $kit = shift @ARGV or usage();
+@ARGV and die "unexpected extra arguments: @ARGV\n";
+
+my $rhai = App::PerlLSP::PluginGen::ImportBase::generate_plugin(
+    $kit,
+    lib_paths => \@libs,
+    aliases   => \@aliases,
+    ( defined $plugin_id ? ( plugin_id => $plugin_id ) : () ),
+);
+
+if (defined $out) {
+    open my $fh, '>:encoding(UTF-8)', $out or die "open $out: $!";
+    print $fh $rhai;
+    close $fh or die "close $out: $!";
+    say STDERR "wrote $out";
+} else {
+    binmode STDOUT, ':encoding(UTF-8)';
+    print $rhai;
+}

--- a/perl-gen/lib/App/PerlLSP/PluginGen/ImportBase.pm
+++ b/perl-gen/lib/App/PerlLSP/PluginGen/ImportBase.pm
@@ -1,0 +1,312 @@
+package App::PerlLSP::PluginGen::ImportBase;
+
+# POC generator. Given an `Import::Base` subclass, read its
+# `@IMPORT_MODULES` + `%IMPORT_BUNDLES` package variables and render a
+# `.rhai` plugin that emits the right `SyntheticUse` actions per
+# bundle flag.
+#
+# We `require` the kit (which populates `our`-vars at module compile
+# time) but never invoke its `import` method — coderef bodies and
+# bundle dispatch never run at generator time, so no probe package or
+# `Import::Into` monkey-patching is needed.
+#
+# Coderef entries can't be statically decoded; the generator emits a
+# `// TODO` comment with the kit-file location and skips them.
+# Unimport entries (`-MOD` / `>-MOD`) get a TODO too — no
+# `SyntheticUnuse` primitive exists yet on the LSP side.
+
+use v5.42;
+use utf8;
+use warnings;
+use experimental 'signatures';
+
+use Carp qw(croak);
+use B ();
+
+our $VERSION = '0.001';
+
+# --- Public entry --------------------------------------------------
+
+# generate_plugin($kit_class, %opts) → string of .rhai source.
+#
+# Required:
+#   $kit_class — package name of the Import::Base subclass.
+#
+# Optional:
+#   lib_paths => [paths]    — prepended to @INC before `require`.
+#   plugin_id => 'string'   — overrides the default `<kit>-generated` id.
+#   aliases   => [classes]  — extra module names that should trigger
+#                             this plugin (e.g. the install-wide shim
+#                             `Co::Base` that forwards to
+#                             `Co::Base::Local`).
+sub generate_plugin ($kit_class, %opts) {
+    my @libs = @{ $opts{lib_paths} // [] };
+    local @INC = (@libs, @INC);
+
+    eval "require $kit_class; 1"
+        or croak "could not require $kit_class: $@";
+
+    my ($modules_ref, $bundles_ref) = _read_tables($kit_class);
+
+    my @base_entries = _walk_entries($modules_ref);
+    my %bundle_entries =
+        map { $_ => [ _walk_entries($bundles_ref->{$_}) ] }
+        keys %$bundles_ref;
+
+    return _render_rhai(
+        kit_class => $kit_class,
+        plugin_id => $opts{plugin_id} // _kit_to_plugin_id($kit_class),
+        aliases   => $opts{aliases}   // [],
+        base      => \@base_entries,
+        bundles   => \%bundle_entries,
+    );
+}
+
+# --- Reading the kit ----------------------------------------------
+
+sub _read_tables ($kit_class) {
+    no strict 'refs';
+    my $modules_ref = *{"${kit_class}::IMPORT_MODULES"}{ARRAY} // [];
+    my $bundles_ref = *{"${kit_class}::IMPORT_BUNDLES"}{HASH}  // {};
+    return ( [@$modules_ref], { %$bundles_ref } );
+}
+
+# --- Walking + sigil classification --------------------------------
+
+# Yield a normalized record per logical entry:
+#   { kind => 'synthetic_use', module, args, imports, priority }
+#   { kind => 'todo_unimport', module, args, via }
+#   { kind => 'todo_coderef',  file, line }
+#   { kind => 'todo_unknown',  raw }
+#
+# Import::Base stores entries in two shapes:
+#   1. `MOD => [args]`  — pair: string key, arrayref value.
+#   2. `MOD`            — bare scalar with no following arrayref.
+# Coderefs appear as standalone scalars (no following arrayref).
+sub _walk_entries ($list) {
+    return () unless ref $list eq 'ARRAY';
+    my @out;
+    my $i = 0;
+    while ( $i < @$list ) {
+        my $entry = $list->[$i];
+
+        if ( ref $entry eq 'CODE' ) {
+            my ( $file, $line ) = _coderef_loc($entry);
+            push @out, {
+                kind => 'todo_coderef',
+                file => $file // '?',
+                line => $line // 0,
+            };
+            $i++;
+            next;
+        }
+
+        # `MOD => [args]` — string key with following arrayref.
+        if ( !ref $entry && $i + 1 < @$list && ref $list->[ $i + 1 ] eq 'ARRAY' ) {
+            push @out, _classify_pair( $entry, $list->[ $i + 1 ] );
+            $i += 2;
+            next;
+        }
+
+        # Bare module name — no args.
+        if ( !ref $entry ) {
+            push @out, _classify_pair( $entry, [] );
+            $i++;
+            next;
+        }
+
+        # Anything else (hashref, blessed object, etc.) — flag.
+        push @out, { kind => 'todo_unknown', raw => "$entry" };
+        $i++;
+    }
+    return @out;
+}
+
+# Split a string-keyed entry into the canonical record. The prefix
+# encodes Import::Base's "what kind of use line" sigil:
+#
+#   (none)   `use MOD args`               → synthetic_use, normal
+#   >        `MOD->import::into($t,args)` → synthetic_use, normal
+#                                           (static effect == use)
+#   <        `use MOD 'X'` (base-class)   → synthetic_use, early
+#                                           (emit before non-`<`)
+#   -        `no MOD args`                → todo_unimport
+#   >-       `MOD->unimport::out_of(...)` → todo_unimport
+sub _classify_pair ( $name, $args ) {
+    my ( $prefix, $module ) = $name =~ /\A( [><]? -? )(.+)\z/x;
+    $prefix //= '';
+
+    if ( $prefix eq '-' || $prefix eq '>-' ) {
+        return {
+            kind   => 'todo_unimport',
+            module => $module,
+            args   => [@$args],
+            via    => $prefix eq '>-' ? 'import_into' : 'use',
+        };
+    }
+
+    return {
+        kind     => 'synthetic_use',
+        module   => $module,
+        args     => [@$args],
+        imports  => [@$args],   # mirror real path's dual-fill
+        priority => $prefix eq '<' ? 'early' : 'normal',
+    };
+}
+
+sub _coderef_loc ($cv) {
+    my $obj = B::svref_2object($cv);
+    return ( undef, undef ) unless $obj;
+    my $file = eval { $obj->FILE };
+    my $line = eval { $obj->START && !$obj->START->isa('B::NULL')
+        ? $obj->START->line
+        : $obj->GV && !$obj->GV->isa('B::SPECIAL')
+            ? $obj->GV->LINE
+            : undef
+    };
+    return ( $file, $line );
+}
+
+# --- Rendering -----------------------------------------------------
+
+sub _kit_to_plugin_id ($kit_class) {
+    my $id = lc $kit_class;
+    $id =~ s/::/-/g;
+    return "${id}-generated";
+}
+
+sub _rhai_quote ($s) {
+    my $copy = "$s";
+    $copy =~ s/\\/\\\\/g;
+    $copy =~ s/"/\\"/g;
+    return qq("$copy");
+}
+
+sub _list_lit (@items) {
+    return '[' . join( ', ', map { _rhai_quote($_) } @items ) . ']';
+}
+
+# Stable sort: `<`-prefixed entries first; rest in original order.
+sub _stable_order (@entries) {
+    my @early = grep { ( $_->{priority} // '' ) eq 'early' } @entries;
+    my @rest  = grep { ( $_->{priority} // '' ) ne 'early' } @entries;
+    return ( @early, @rest );
+}
+
+sub _render_entry ( $entry, $indent ) {
+    my $kind = $entry->{kind};
+
+    if ( $kind eq 'synthetic_use' ) {
+        my $mod  = _rhai_quote( $entry->{module} );
+        my $args = _list_lit( @{ $entry->{args} } );
+        my $imps = _list_lit( @{ $entry->{imports} } );
+        # Quote every map key. Rhai reserves a long list of words
+        # (`module`, `package`, `class`, `import`, `export`, `super`,
+        # `default`, `with`, ...) — quoting universally sidesteps the
+        # game of "is this field name reserved?" as the generator grows
+        # support for more EmitAction variants. The serde deserializer
+        # on the LSP side accepts quoted keys transparently.
+        return qq(${indent}out += #{ "SyntheticUse": #{ "module": $mod, "args": $args, "imports": $imps, "span": ctx.span }};);
+    }
+    if ( $kind eq 'todo_coderef' ) {
+        return qq(${indent}// TODO: coderef at $entry->{file}:$entry->{line} — hand-author equivalent SyntheticUse / PackageParent emissions.);
+    }
+    if ( $kind eq 'todo_unimport' ) {
+        my $args = join( ' ', @{ $entry->{args} } );
+        return qq(${indent}// TODO: unimport $entry->{module} [$args] (via $entry->{via}) — no SyntheticUnuse primitive yet.);
+    }
+    if ( $kind eq 'todo_unknown' ) {
+        return qq(${indent}// TODO: unknown entry shape: $entry->{raw});
+    }
+    return qq(${indent}// TODO: unhandled record kind: $kind);
+}
+
+sub _render_rhai (%args) {
+    my $kit       = $args{kit_class};
+    my $plugin_id = $args{plugin_id};
+    my @aliases   = @{ $args{aliases} };
+    my @base      = @{ $args{base} };
+    my %bundles   = %{ $args{bundles} };
+
+    my @trigger_modules = ( $kit, @aliases );
+    my $gate = join ' &&' . "\n       ",
+        map { qq(ctx.module_name != ) . _rhai_quote($_) } @trigger_modules;
+
+    my @lines;
+    push @lines, "// Generated by App::PerlLSP::PluginGen::ImportBase from $kit.";
+    push @lines, "// DO NOT EDIT BY HAND — rerun the generator when the kit changes.";
+    push @lines, "";
+    push @lines, qq(fn id() { ) . _rhai_quote($plugin_id) . q( }) ;
+    push @lines, q(fn triggers() { [ #{ Always: () } ] });
+    push @lines, "";
+    push @lines, q(fn on_use(ctx) {);
+    push @lines, qq(    if $gate { return []; });
+    push @lines, "";
+    push @lines, q(    let out = [];);
+    push @lines, "";
+    push @lines, q(    // First non-dash arg in raw_args is the bundle name —);
+    push @lines, q(    // matches Import::Base's `_parse_args` semantics: every);
+    push @lines, q(    // leading non-`-` arg is a bundle, the loop stops at the);
+    push @lines, q(    // first `-flag`. We accept the dash-prefixed form too);
+    push @lines, q(    // (`-Plugin` as a synonym for `'Plugin'`) since some kits);
+    push @lines, q(    // are documented that way even though Import::Base itself);
+    push @lines, q(    // wouldn't recognize it as a bundle.);
+    push @lines, q(    let bundle = "";);
+    push @lines, q(    for arg in ctx.raw_args {);
+    push @lines, q(        if arg == "" { continue; });
+    push @lines, q(        bundle = if arg.starts_with("-") { arg.sub_string(1) } else { arg };);
+    push @lines, q(        break;);
+    push @lines, q(    });
+    push @lines, "";
+
+    push @lines, q(    // @IMPORT_MODULES — runs for every invocation.);
+    for my $e ( _stable_order(@base) ) {
+        push @lines, _render_entry( $e, "    " );
+    }
+    push @lines, "";
+
+    for my $bundle ( sort keys %bundles ) {
+        my @entries = @{ $bundles{$bundle} };
+        next unless @entries;
+        push @lines, qq(    if bundle == ) . _rhai_quote($bundle) . q( {);
+        for my $e ( _stable_order(@entries) ) {
+            push @lines, _render_entry( $e, "        " );
+        }
+        push @lines, q(    });
+        push @lines, "";
+    }
+
+    push @lines, q(    out);
+    push @lines, q(});
+    push @lines, "";
+
+    return join "\n", @lines;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+App::PerlLSP::PluginGen::ImportBase — generate `.rhai` plugins from
+`Import::Base` subclasses for the perl-tree-sitter-lsp `SyntheticUse`
+primitive.
+
+=head1 SYNOPSIS
+
+  use App::PerlLSP::PluginGen::ImportBase qw();
+
+  my $rhai = App::PerlLSP::PluginGen::ImportBase::generate_plugin(
+      'Co::Base::Local',
+      lib_paths => ['lib', 'kit-common/lib'],
+      aliases   => ['Co::Base'],
+  );
+
+  open my $fh, '>', 'plugins/co-base-local.rhai' or die $!;
+  print $fh $rhai;
+
+=head1 DESCRIPTION
+
+See C<docs/prompt-importbase-plugin-gen.md> in the perl-tree-sitter-lsp
+repo for the design rationale.

--- a/perl-gen/t/01_basic.t
+++ b/perl-gen/t/01_basic.t
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+use v5.42;
+use utf8;
+use warnings;
+use open ':std', ':encoding(UTF-8)';
+use experimental 'signatures';
+
+use Test::More;
+use FindBin ();
+use lib "$FindBin::RealBin/../lib";
+use lib "$FindBin::RealBin/fixtures/lib";
+
+use App::PerlLSP::PluginGen::ImportBase ();
+
+my $rhai = App::PerlLSP::PluginGen::ImportBase::generate_plugin(
+    'My::TestKit',
+    lib_paths => ["$FindBin::RealBin/fixtures/lib"],
+);
+
+# --- Plugin metadata -------------------------------------------------
+
+like $rhai, qr/fn id\(\) \{ "my-testkit-generated" \}/,
+    'plugin id derived from kit class';
+like $rhai, qr/fn triggers\(\) \{ \[ \#\{ Always: \(\) \} \] \}/,
+    'unconditional trigger (on_use checks module_name itself)';
+like $rhai, qr/if ctx\.module_name != "My::TestKit" \{ return \[\]; \}/,
+    'module-name gate at top of on_use';
+
+# --- @IMPORT_MODULES (no-prefix, bareword, `>`, coderef, multi-arg) --
+
+like $rhai,
+    qr/out \+= \#\{ "SyntheticUse": \#\{ "module": "Moo", "args": \[\], "imports": \[\], "span": ctx\.span \}\};/,
+    'no-prefix entry → empty args + imports';
+like $rhai,
+    qr/out \+= \#\{ "SyntheticUse": \#\{ "module": "strict", "args": \[\], "imports": \[\], "span": ctx\.span \}\};/,
+    'bareword (no fat-comma) → no args';
+like $rhai,
+    qr/"module": "feature", "args": \[":5.38"\], "imports": \[":5.38"\]/,
+    '`>` prefix → use-into; args + imports both filled with same list';
+like $rhai,
+    qr/"module": "Future::AsyncAwait", "args": \["future_class", "Mojo::Promise"\], "imports": \["future_class", "Mojo::Promise"\]/,
+    'multi-element args list preserved';
+
+# --- Unimport sigils → TODO ------------------------------------------
+
+like $rhai,
+    qr|// TODO: unimport feature \[switch\] \(via use\)|,
+    '`-` prefix → unimport TODO (via use)';
+like $rhai,
+    qr|// TODO: unimport warnings \[experimental::for_list\] \(via import_into\)|,
+    '`>-` prefix → unimport TODO (via import_into)';
+
+# --- Coderef → TODO with file:line -----------------------------------
+
+like $rhai,
+    qr|// TODO: coderef at .+/My/TestKit\.pm:\d+|,
+    'coderef in @IMPORT_MODULES → TODO with file:line';
+
+# --- Bundle dispatch -------------------------------------------------
+
+like $rhai, qr/if bundle == "Class" \{/, '-Class bundle branch present';
+like $rhai, qr/if bundle == "Controller" \{/, '-Controller bundle branch present';
+like $rhai, qr/if bundle == "Plugin" \{/,  '-Plugin bundle branch present';
+like $rhai, qr/if bundle == "Schema" \{/,  '-Schema bundle branch present';
+
+# --- `<` prefix emits early within its bundle ------------------------
+# In -Plugin: `<Mojo::Base => ['Mojolicious::Plugin']` is listed
+# AFTER `'Some::Helper'` in the source but must emit FIRST so the
+# base-class is set up before non-`<` entries.
+
+my ($plugin_block) = $rhai =~ /if bundle == "Plugin" \{(.+?)\n    \}/s;
+ok defined $plugin_block, 'extracted -Plugin block';
+my $mojo_pos = index $plugin_block, 'Mojo::Base';
+my $helper_pos = index $plugin_block, 'Some::Helper';
+ok $mojo_pos != -1 && $helper_pos != -1, 'both entries present in -Plugin block';
+ok $mojo_pos < $helper_pos,
+    '`<`-prefixed Mojo::Base emits before Some::Helper despite source order';
+
+# --- Real path's both-fields-filled discipline -----------------------
+# `use parent 'Co::Schema'` in real source ends up with
+# args=["Co::Schema"] AND imports=["Co::Schema"].
+# Generator must mirror that for the synthetic version so the LSP's
+# dedup key (which includes both lists) discriminates correctly.
+
+like $rhai,
+    qr/"module": "parent", "args": \["Co::Schema"\], "imports": \["Co::Schema"\]/,
+    'parent-shape entry fills both args and imports (matches real-source dedup behavior)';
+
+done_testing;

--- a/perl-gen/t/fixtures/lib/My/TestKit.pm
+++ b/perl-gen/t/fixtures/lib/My/TestKit.pm
@@ -1,0 +1,74 @@
+package My::TestKit;
+
+# POC fixture covering every sigil the generator needs to handle.
+# Mirrors a typical production Import::Base subclass's shape but
+# smaller and self-contained — no transitive `require`s (we use bare
+# module names that don't need to exist on disk; the generator never
+# invokes import).
+
+use strict;
+use warnings;
+
+# Stub a parent to silence the load-time `require Import::Base`. The
+# generator reads our package variables but never calls our parent's
+# `import`, so a dummy is fine.
+package My::TestKit::FakeBase;
+sub import {}
+
+package My::TestKit;
+our @ISA = ('My::TestKit::FakeBase');
+
+our @IMPORT_MODULES = (
+
+    # No prefix, with args:  use Moo;
+    'Moo' => [],
+
+    # Bareword (no fat-comma):  use strict;
+    'strict',
+
+    # `>` (Import::Into runtime, static effect == use):  use feature ':5.38';
+    '>feature' => [':5.38'],
+
+    # Unimport (-): TODO
+    '-feature' => [qw/switch/],
+
+    # Unimport via Import::Into (>-): TODO
+    '>-warnings' => [qw/experimental::for_list/],
+
+    # Coderef: TODO with file:line
+    sub {
+        return 'Carp::Clan' => ["^Mojo"];
+    },
+
+    # With multi-element args (fat-comma in arg list):
+    'Future::AsyncAwait' => [future_class => 'Mojo::Promise'],
+);
+
+our %IMPORT_BUNDLES = (
+
+    # Simple bundle: just adds one use.
+    Class => ['My::Stub::Class'],
+
+    # `<` prefix — emit-first (base-class shape).
+    Plugin => [
+        '<Mojo::Base' => ['Mojolicious::Plugin'],
+        'Some::Helper',
+    ],
+
+    # Multiple entries, including a coderef.
+    Controller => [
+        'My::Stub::Class',
+        sub {
+            my ($bundles, $args) = @_;
+            $args->{package}->can('extends')->('Mojolicious::Controller');
+        }
+    ],
+
+    # `<parent` shape — common for inheritance kits.
+    Schema => [
+        '<parent' => ['Co::Schema'],
+        mro       => ['c3'],
+    ],
+);
+
+1;


### PR DESCRIPTION
## Summary

A small Perl POC that mechanically translates an `Import::Base` subclass into a `.rhai` plugin emitting `EmitAction::SyntheticUse` actions per bundle flag. Removes the friction of hand-authoring kit plugins for Import::Base-shaped kits — the kit's `@IMPORT_MODULES` / `%IMPORT_BUNDLES` tables ARE the spec, so just read them.

The LSP side needs **no new code** — PR #38's `SyntheticUse` is the full contract.

- `require <Kit>` populates `our`-vars at module-compile time. The kit's `import` is never invoked → no side effects, no probe package, no `Import::Into` monkey-patching.
- Sigil interpretation follows Import::Base's prefix convention (`>` Import::Into, `<` use-first / base-class, `-` / `>-` unimport). Coderefs surface as `// TODO: coderef at <kit>.pm:<line>` for hand-authoring.
- Bundle dispatch matches Import::Base's `_parse_args`: first non-dash arg is the bundle name (`'Class'`, not `'-Class'`); accepts dash-prefixed form as a synonym.

## Layout

```
perl-gen/
├── README.md
├── bin/perl-lsp-gen-importbase
├── lib/App/PerlLSP/PluginGen/ImportBase.pm
└── t/
    ├── 01_basic.t              # 18 assertions
    └── fixtures/lib/My/TestKit.pm
```

Runs on Perl ≥ 5.42 (uses `use v5.42` + `experimental 'signatures'`). Needs `Import::Base` installed (and whatever the target kit transitively requires).

## Usage

```sh
perl-gen/bin/perl-lsp-gen-importbase Co::Base::Local \
  --lib /path/to/project/lib \
  --lib /path/to/project/kit-common/lib \
  --alias Co::Base \
  --out plugins/co-base-local.rhai
```

## Validation

Tested end-to-end against a real production `Import::Base` kit (full sigil + coderef vocabulary). With the generated plugin plus two hand-authored Import::Into bridges (for hand-rolled `sub import` kits the v1 generator doesn't decode), random sampling across the codebase shows **~68% of packages light up** with framework detection / parent classes / synthesized accessor methods. Without the plugins those same packages show `framework: None, parents: []`.

A separate hand-authored DDL recognizer for DBIC `col` / `has_many` / etc. lights up Result classes that today's `__PACKAGE__->add_columns` recognition misses. That belongs in core as a bundled plugin eventually — out of scope here.

## Test plan

- [x] `prove perl-gen/t/01_basic.t` — 18 tests pass
- [x] Validated against a real Import::Base kit in a production repo (cannot include the kit's source in this PR)
- [x] Validated round-trip through the LSP: generated `.rhai` → `--plugin-check` clean → `--dump-package` shows full SyntheticUse chain effects

## Out of scope for v1

- **Import::Into kits** (hand-rolled `sub import { Pkg->import::into(...) }`). Imperative bodies need a runtime recorder; deferred.
- **Coderef interception.** TODO comments with file:line for now.
- **Unimport directives** (`-MOD`, `>-MOD`). Same TODO route — no `SyntheticUnuse` primitive yet.
- **Merge mode for hand-authored sections.** Regen overwrites manual edits. v1.5 if it bites.
- **DDL DSL recognition** (`col foo => ...`, `has_many bar => ...`). Separate concern — belongs as a core bundled plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)