### PR TITLE
spike: array intelligence — $users[0]->| in ~90 LOC on the bag-canonical foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,9 +1350,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "ts-parser-perl"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cb3e098cb9be31093f9e2ec3485877444ea70ebd5ac19df46753dbd712cfd"
+checksum = "44d9f0f184f4a922d389923612e652bf5e729504fc3d1f225867ef1a9db5016f"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,28 +26,32 @@ backburner: ship when types + architecture are in a healthy place.
 | `prompt-type-system-encoding.md` | **TYPE-SAFE AXIS DISPATCH** — make wrong-axis class-name reads unrepresentable | discussion; partially deferred to graph-walking |
 | `prompt-type-is-the-gate.md` | **GENERALIZE STRICT-EQ GATES** — `type_says()` answers replace local-symbol-table presence checks | two instances landed (Part 5c); general refactor open |
 | `prompt-dbic-as-plugin.md` | **MOVE DBIC OUT OF CORE** — port `visit_dbic_*` family + Parametric emission to a plugin | ReturnExpr gate cleared; still behind type-system-encoding |
-| `prompt-sequence-types.md` | sequence type lattice | 5 phases on the clean foundation |
+| `prompt-sequence-types.md` | sequence type lattice — residual phases | ADR `sequence-types.md` for the landed data model; prompt for full lattice + cross-method + pipelines |
 
 Landed work has its durable record in `docs/adr/` (`bag-canonical.md`
 for the invariant that closes the staircase — the bag is the only
 source of types, edges chase, materialized projections are bugs;
-`parametric-types.md` for the Part 5c flavor enum + cross-file
-deferred owner fix; `return-expr.md` for receiver-relative return
-types subsuming per-method projection + arity dispatch;
-`plugin-system.md` for the `return_via_edge` lazy-return mechanism;
-`file-store-and-resolve.md` for forward-reference resolution + cross-file
-invocant refresh) and the commit history.
+`sequence-types.md` for the positional-container data model + the
+`SequenceTransform/SeqOp` pattern for list operators (spike at
+`ec62653`); `parametric-types.md` for the Part 5c flavor enum +
+cross-file deferred owner fix; `return-expr.md` for receiver-
+relative return types subsuming per-method projection + arity
+dispatch; `plugin-system.md` for the `return_via_edge` lazy-return
+mechanism; `file-store-and-resolve.md` for forward-reference
+resolution + cross-file invocant refresh) and the commit history.
 
 ### Notes on the queued work
 
-- **Sequence-types phases 1-3** thread a lattice through the unified
-  `Expr(Span)` attachment. The bag-canonical foundation
-  (`adr/bag-canonical.md`) is in place — sequences are now purely
-  additive: emit `Container(ArrayId)` contributions, write
-  `ShapeReducer` / `ElementAtReducer`, done. No `deferred_X` field,
-  no walker-side computation, target diff ~60% of the original
-  spike's ~2300 lines. Phases 4-5 (cross-file mutation effects,
-  pipelines) compose on top.
+- **Sequence types** — spike landed (`ec62653`) in ~90 LOC: tuple
+  shape on `Variable{name, scope}` + walk-time push contribution +
+  `array_element_expression` projection in `resolve_expression_type`.
+  See `adr/sequence-types.md`. Residual phases queued in
+  `prompt-sequence-types.md`: full shape lattice (Homogeneous /
+  CycleTuple / Heterogeneous classification), `Container(ArrayId)`
+  attachment for cross-method contributions, framework `has`
+  accessor synthesis returning slot shapes, pipeline reducers
+  (`SequenceTransform` + `SeqOp` for map/grep/sort/reverse). Each
+  is purely additive — no retrofit.
 - **Residual Parts 1-5** — invocant mutations, hash-key unions, method
   loops, functional operators, value-indexed returns. Independent
   reducer+emitter pairs. Order by value.

--- a/docs/adr/bag-canonical.md
+++ b/docs/adr/bag-canonical.md
@@ -102,10 +102,12 @@ consumers query.
 
 ## Where this is going
 
-Sequence types (`prompt-sequence-types.md`) land additively: emit
-`Container(ArrayId)` contributions, write `ShapeReducer` /
-`ElementAtReducer`. No `deferred_X` field, no bridging seed pass,
-no walker-side computation of element type.
+Sequence types — the first feature built fully on this foundation
+— landed in ~90 LOC (`ec62653`). See `adr/sequence-types.md` for
+the data-model contract; `prompt-sequence-types.md` for the
+residual phases. The shape held: zero new bag attachments, zero
+new reducers, zero registry touches, every list operator extends
+the same way (`SequenceTransform` payload + one `SeqOp` variant).
 
 Residual Parts 1–5 (`prompt-type-inference-residual.md`) are
 each a reducer + emitter pair. Same shape, same path.

--- a/docs/adr/sequence-types.md
+++ b/docs/adr/sequence-types.md
@@ -1,0 +1,100 @@
+# ADR: Sequence types — positional containers as bag witnesses
+
+`@arr`, `push @arr, X`, `$arr[N]`, list literals, and the list-
+context operators (`map`, `grep`, `sort`, `reverse`, splat) are all
+positional containers. This ADR is the data model + walker contract;
+`prompt-sequence-types.md` is the design corpus for the residual
+phases (full shape lattice, cross-method contributions, framework
+integration). Spike landed in `ec62653`.
+
+## Decisions worth keeping
+
+### `Sequence(Vec<InferredType>)` is an `InferredType` variant
+
+```rust
+pub enum InferredType {
+    // … existing variants
+    Sequence(Vec<InferredType>),
+}
+
+impl InferredType {
+    pub fn element_at(&self, i: i32) -> Option<&InferredType>;
+}
+```
+
+One variant covers `@arr` and `[a, b, c]` — no Array vs ArrayRef
+carrier distinction. Perl's list-vs-scalar context is a property
+of the *expression's evaluation context*, not the contained data.
+The spike ships tuple shape only; the residual phases extend the
+payload to the full lattice (`Empty` / `Homogeneous` / `Tuple` /
+`CycleTuple` / `Heterogeneous`).
+
+Placed at the END of `InferredType` so cached-blob bincode variant
+indices stay stable; new variants always go at the end and bump
+`EXTRACT_VERSION`.
+
+### Walker emits on `Variable`, projection lives in `resolve_expression_type`
+
+The walker pushes one `Variable{name, scope} + InferredType(Sequence(…))`
+witness per array, deferred to a post-fold pass
+(`emit_array_push_witnesses`) so method-call return types are
+resolvable by the time each contribution is queried.
+
+`resolve_expression_type` gains an `array_element_expression` arm
+that queries the array's witness and projects via `element_at`.
+Both cursor-context completion AND
+`method_call_invocant_class_with_tree` (hover, dispatch) route
+through this same arm.
+
+No new bag attachment was needed. `Variable{"@arr", scope}` is
+already the canonical store; tuple-shape sequences ride a richer
+payload there. `Container(ArrayId)` and `SequenceAccess(Span)`
+attachments earn their entry in later phases when cross-method
+contributions and reducer-time projection become load-bearing.
+
+### List operators ride a `SequenceTransform` payload
+
+```rust
+pub enum WitnessPayload {
+    // … existing
+    SequenceTransform { source: WitnessAttachment, op: SeqOp },
+}
+
+pub enum SeqOp {
+    Map(WitnessAttachment),   // block's last-expr; its type is the new element
+    Grep,                     // preserve element type, lose precise length
+    Sort,                     // identity on element type AND shape
+    Reverse,                  // reverse a Tuple; identity for Homogeneous
+    Flatten,                  // `(@x, @y)` and splat contexts
+}
+```
+
+One `SequenceTransformReducer` claims the payload, recurses on
+`source` via the registry, applies the per-op rule. Nested
+operators (`map { … } sort grep { … } @names`) are nested
+witnesses; the reducer materializes innermost first.
+
+New operator (`first`, `pairs`, `pairmap`) → one `SeqOp` variant +
+one `match` arm. Not landed yet; the spike scope was the container.
+
+### Top-level scripts seed `current_package = Some("main")`
+
+`Builder::new` seeds the implicit package. Without it, top-level
+`Mojolicious::Lite` scripts never recorded their `use` lines in
+`package_uses` and `Trigger::UsesModule` plugin triggers never
+fired. Matches Perl's runtime semantics — every script starts in
+`main`.
+
+Hash-key owners on top-level subs now carry `Some("main")` rather
+than `None`; fixture tests asserting `None` were corrected.
+
+## Where this is going
+
+Map / grep / sort / reverse / flatten lands as the `SequenceTransform`
+shape above plus the reducer — concrete next step. Then
+`Container(ArrayId)` for cross-method contributions (the
+`$self->add(...)` / `$self->kids->[0]` split-sub case). Then
+framework synthesis (`has 'kids'` returning slot shape).
+
+Each extends the data model without retrofitting consumers.
+`prompt-sequence-types.md` carries the per-phase scope.

--- a/docs/prompt-sequence-types.md
+++ b/docs/prompt-sequence-types.md
@@ -1,89 +1,59 @@
-# Sequence Types — Phased Spec
+# Sequence Types — Residual Phases
 
-> **Status: design.** Lands *after*
-> `docs/prompt-type-inference-unification.md` Step 3 (closures
-> retired, `ReducerContext` in place, `Symbol.return_type`
-> bag-mediated, framework synthesis emits witnesses).
+> **Status: spike landed (`ec62653`), broader phases queued.**
 >
-> This spec assumes the unification has happened. It deliberately
-> keeps nothing from the `spike/sequence-witnesses` branch —
-> implementation starts fresh on the cleaner foundation. The spike
-> validated the design; this spec is the build plan.
+> The core data model and walker contract live in
+> `docs/adr/sequence-types.md`: `InferredType::Sequence(Vec<…>)`,
+> tuple shape on `Variable{name, scope}`, `array_element_expression`
+> projection in `resolve_expression_type`, the
+> `SequenceTransform / SeqOp` pattern for list operators, the
+> `package main` seed. This document is the design corpus for the
+> phases that don't ship in the spike — full shape lattice,
+> cross-method contributions, pipeline reducers, framework
+> integration. Read the ADR first.
 >
 > Cross-refs:
-> - `docs/prompt-type-inference-unification.md` — prerequisite refactor.
-> - `docs/prompt-type-inference-spec.md` — witness/reducer model.
+> - `docs/adr/sequence-types.md` — what landed; the data-model contract.
+> - `docs/adr/bag-canonical.md` — the unification foundation.
 > - `CLAUDE.md` "Build pipeline phases" + "Worklist invariants".
 
-## TL;DR
+## What's landed
 
-Add a single new `InferredType` variant (`Sequence(ArrayShape)`)
-and the bag machinery to populate and query it. The walker observes
-contributions to positional containers; reducers fold those into
-shape information; access expressions project shapes back to
-element types. No carrier distinction (Array vs ArrayRef collapse
-into one variant), no deferred build-side fields, no closure
-threading — those concerns evaporate in the post-unification world.
+The spike (`ec62653`) shipped the minimum-viable container:
 
-The spec phases the work in five steps. Each step ships green and
-adds capability; later steps don't reshuffle earlier ones. Phase 1
-is a self-contained bag refactor (no walker changes). Phase 2 is
-walker emission. Phase 3 is framework integration. Phases 4–5 are
-follow-on capability (pipelines, escape analysis); each is a
-separate design pass and can be deferred indefinitely.
+- `InferredType::Sequence(Vec<InferredType>)` — tuple shape only.
+- Walker pushes per-array `Variable{name, scope}` witnesses
+  accumulated via `pending_array_pushes` + post-fold
+  `emit_array_push_witnesses`.
+- `array_element_expression` arm in `resolve_expression_type`
+  projects via `element_at(i)`. Cursor-context completion AND
+  `method_call_invocant_class_with_tree` (hover/dispatch) share it.
+- Top-level scripts seed `current_package = Some("main")`.
 
-## What the spike validated
+What's NOT landed and what this prompt is for:
 
-The spike's bag-side design was right. Carry forward:
+1. **Full shape lattice** — extend the payload to
+   `Empty | Homogeneous(T) | Tuple | CycleTuple | Heterogeneous`
+   with classification rules (LUB, period detection ≥4, reset
+   semantics). Current payload is bare `Vec<InferredType>` which
+   only models the `Tuple` shape.
+2. **`Container(ArrayId)` attachment** for cross-method
+   contributions — when `push @{$self->kids}, X` happens in one
+   sub and `$self->kids->[0]` reads in another. Needs identity
+   at emission time, not scope-keyed `Variable` witnesses.
+3. **`SequenceAccess(Span)` attachment + ElementAtReducer** —
+   reducer-time projection. Becomes load-bearing when method
+   returns carry sequence shapes (e.g. a sub returns `@list`,
+   the caller indexes into it without binding to a local first).
+4. **Framework synthesis** — Mojo::Base / Moo `has 'kids'`
+   accessors emit `SlotReturnGetter` so the getter's return
+   type folds to the slot's `Sequence(...)` shape.
+5. **Pipeline reducers** — `map` / `grep` / `sort` / `reverse` /
+   `flatten`. Shape locked in `adr/sequence-types.md`
+   (`SequenceTransform { source, op: SeqOp }` payload + one
+   reducer). This prompt has the per-op folding rules.
 
-- **One type variant** for positional containers: `Sequence(ArrayShape)`.
-  Drop the carrier distinction (Array vs ArrayRef). Perl's
-  list-vs-scalar context is a property of the *expression's
-  evaluation context*, not the contained data.
-- **Five-variant shape lattice**: `Empty | Homogeneous(T) | Tuple([T..])
-  | CycleTuple([T..K]) | Heterogeneous`. Ordered by informativeness;
-  classifier specializes when contributions admit precise structure,
-  generalizes when they don't.
-- **Identity at emission time**: `ArrayId::{Lexical, HashSlot, Anonymous}`.
-  Resolved by the walker; reducers never compute identity, only fold
-  by attachment.
-- **Two attachment kinds**: `Container(ArrayId)` for shape and
-  `SequenceAccess(Span)` for read sites.
-- **Three observation kinds**: `ArrayContribution { type, position }`,
-  `ArrayReset`, `ArrayAccessAt { container, position }`.
-
-What the spike got wrong, and the spec corrects:
-
-- `Heterogeneous` carried a `Box<InferredType>` payload that was
-  ~always `ArrayRef` sentinel. **Drop the payload.** `Heterogeneous`
-  is unit; `element_at` returns `None`.
-- The spike kept `InferredType::ArrayRef` alongside `Sequence(Empty)`
-  as two ways to spell the same thing. **Drop `ArrayRef`.** Migrate
-  consumers to `Sequence(Empty)` as the "we know it's array-shaped,
-  contents unknown" answer.
-- The spike reused `resolve_return_type`'s "Object subsumes HashRef"
-  laxness for slot LUB and silently mis-classified `[User, Order]`.
-  **Use a strict `unify_via_object_subsumption` helper.** Rename
-  `resolve_return_type` to expose its semantics (it's not a generic
-  LUB).
-- Cycle detection requires length ≥ 4. Length 2 is indistinguishable
-  from a 2-tuple.
-- The spike added `array_shape_of` as a `ReducerQuery` closure. In
-  the post-unification world this is **`ctx.shape_of(id)`** — a
-  method on `ReducerContext`, not a caller-installed closure. No
-  canonicality leak.
-
-What gets sharper after unification (assumed available):
-
-- No `deferred_seq_access` field on `ReturnInfo`. Returns through
-  the generic `DeferredType::Bag(WitnessAttachment)` mechanism.
-- No `seed_slot_return_getters_into_return_types`. The generic seed
-  pass handles every Symbol-attached witness uniformly.
-- No build-side / FA-side wrapper duplication. One query path:
-  `bag_query(WitnessAttachment::SequenceAccess(span))` works the
-  same at build time and query time.
-- Framework synthesis emits `SlotReturnGetter` instead of pinning
-  `return_type` directly — that's already the convention post-Step 3.
+Each is purely additive. Each is independently shippable.
 
 ## Data model
 
@@ -278,53 +248,100 @@ unaffected — they're already a separate concern.
 
 ## Phasing
 
-Each phase ships green. Each phase delivers user-visible value.
-Later phases don't reshuffle earlier ones.
+Each phase is independently shippable, each delivers user-visible
+value, each is purely additive over the spike's foundation.
 
-### Phase 1 — Lattice + reducers (bag-side only).
+### Phase 1 — Full shape lattice.
 
-Add `Sequence`, `ArrayShape`, `ArrayId`, position enums.
-Remove `InferredType::ArrayRef`; migrate consumers to
-`Sequence(Empty)`. Rename `resolve_return_type` to expose its
-semantics; add a strict `unify_via_object_subsumption` helper.
-Add the three new attachments + observations + reducers. Register
-reducers in priority order through the registry.
+The spike's `Sequence(Vec<InferredType>)` only models a `Tuple`
+shape. Extend to the full lattice:
 
-**No walker changes.** Tests are entirely hand-crafted witnesses;
-they pin the lattice's classification rules (≥4 for cycle, strict
-unification, temporal/reset filters) and the reducer projections.
+```rust
+pub enum InferredType {
+    // …
+    Sequence(ArrayShape),
+}
 
-Acceptance: 20-ish unit tests covering each shape variant, every
+pub enum ArrayShape {
+    Empty,
+    Homogeneous(Box<InferredType>),
+    Tuple(Vec<InferredType>),       // ≤ TUPLE_LIMIT, mixed types
+    CycleTuple(Vec<InferredType>),  // period K, requires ≥ 2 full cycles
+    Heterogeneous,                  // unit; no useful element type
+}
+
+const TUPLE_LIMIT: usize = 6;
+```
+
+Migrate the spike's emission to push the classified shape: the
+post-fold `emit_array_push_witnesses` classifies the accumulated
+contributions, not just stores the `Vec`. Drop `InferredType::ArrayRef`
+in the same pass — migrate consumers to `Sequence(ArrayShape::Empty)`
+as the "we know it's array-shaped, contents unknown" answer.
+
+Add a strict `unify_via_object_subsumption` helper (or rename
+`resolve_return_type` if its semantics overlap) — the existing
+"Object subsumes HashRef" laxness silently mis-classifies
+`[User, Order]` slot LUBs.
+
+**Cycle detection requires length ≥ 4.** Length 2 is
+indistinguishable from a 2-tuple.
+
+Acceptance: ~20 unit tests covering each shape variant, every
 projection mode, the temporal filter, the reset-generation rule.
-Full suite green.
+`ArrayRef` is gone. Tuple, Homogeneous, CycleTuple, Heterogeneous
+all surface through `bag_query` at real-Perl-source access sites.
 
-Estimated diff: ~600 lines added, ~50 deleted (ArrayRef
-migration). One file each: `file_analysis.rs` (data),
-`witnesses.rs` (attachments + observations + reducers),
-`witnesses_tests.rs` (tests).
+Estimated diff: ~400 lines added (the lattice + classification),
+~50 deleted (ArrayRef migration).
 
-### Phase 2 — Builder emission.
+### Phase 2 — `Container(ArrayId)` + `SequenceAccess(Span)` attachments.
 
-Add `resolve_array_id(node)` and the visit-time emission helpers
-(push/unshift, anonymous literals, lexical inits, indexed reads,
-resets, iter-var typing). Wire them into the dispatcher in
-`visit()`.
+The spike piggybacks on `Variable{name, scope}` which is fine for
+in-sub `@arr`. Cross-method contributions need identity at
+emission time, not scope-keyed lookup. Introduce:
 
-**No framework integration.** Mojo `has` accessors continue to
-return their baked defaults at this phase — they don't yet emit
-`SlotReturnGetter`.
+```rust
+pub enum WitnessAttachment {
+    // …
+    Container(ArrayId),
+    SequenceAccess(Span),
+}
 
-Acceptance: emission tests on real Perl source via `build_fa()`,
-asserting the bag has the expected contributions / accesses /
-resets for each shape. The key user-visible change at this phase is
-that `my @users; push @users, User->new; …; $users[0]` types as
-`User` end-to-end through `bag_query(SequenceAccess(span))` —
-falls out of the canonical-attachment path with zero special-case
-wiring (no `deferred_seq_access` field, no
-`seq_access_type_via_bag`).
+pub enum ArrayId {
+    Lexical { scope: ScopeId, name: String },
+    HashSlot { container: String, key: String },  // $self->{kids}
+    Anonymous { origin: Span },
+}
+```
 
-Estimated diff: ~300 lines added (emission helpers + dispatcher
-wiring). No deletions; this phase is purely additive.
+Walker `resolve_array_id(node)` recognizes the LHS shape:
+`array(varname X)` → `Lexical`; `hash_element_expression` →
+`HashSlot`; `anonymous_array_expression` → `Anonymous`; method
+call where the receiver is a known framework accessor →
+collapse to the getter's slot.
+
+Add a `ShapeReducer` claiming `Container(_) + ArrayContribution|ArrayReset`
+and an `ElementAtReducer` claiming `SequenceAccess(_) + ArrayAccessAt`.
+The walker still owns identity (no per-witness recomputation); the
+reducer applies the lattice classifier from Phase 1.
+
+Replace the spike's `array_element_expression` arm in
+`resolve_expression_type` with `bag_query(SequenceAccess(span))` —
+one query path, build-time + query-time identical.
+
+**No framework integration in this phase** — `has` accessors keep
+returning baked defaults until Phase 3.
+
+Acceptance: `my @users; push @users, User->new; $users[0]` keeps
+typing as User (regression coverage from the spike). Plus:
+cross-method contributions in one file (`sub a { push @{$self->{x}}, … }
+sub b { $self->{x}[-1] }`) type end-to-end. The `_route` plugin
+override is removable for the single-file case.
+
+Estimated diff: ~300 lines added (attachments + reducers +
+emission helpers). The spike's walk-time projection arm is
+replaced rather than augmented.
 
 ### Phase 3 — Framework integration.
 
@@ -407,59 +424,25 @@ spec when its turn comes:
   HoTT-y, defensible, deferred — no real-world Perl that the
   analyzer cares about needs it.
 
-## Net cost
+## Pickup checklist
 
-Through Phase 3 (the realistic ship-target before Phase 4's
-cross-file work begins): **~1100 lines added**, ~130 lines deleted.
-The spike's equivalent diff was ~2300 added, ~30 deleted; the
-post-unification version is roughly half the size for the same
-functionality.
+If you're about to start a phase, the load-bearing facts:
 
-The ratio holds because every spike-side bridging mechanism —
-deferred fields, dual wrappers, seed passes, closure threading,
-override fallbacks — evaporates in the unified world.
-
-## Acceptance criteria, per phase
-
-- **Phase 1.** Hand-crafted-witness tests covering: each shape
-  variant; element-at projection on each; iter-element LUB; the
-  temporal filter; the reset-generation rule; `Heterogeneous` is
-  unit and yields `None` from `element_at`. `InferredType::ArrayRef`
-  no longer exists in the codebase. `resolve_return_type` is
-  renamed; strict `unify_via_object_subsumption` is the LUB primitive
-  for shape inference.
-
-- **Phase 2.** Real-Perl-source emission tests: anonymous literal,
-  lexical literal init (Tuple), pure-push (Homogeneous), mixed
-  init+push (collapses to Homogeneous), reset on `@x = ()`,
-  indexed read at `$arr[0]` and `$arr[-1]`, iter var typed via
-  `for my $e (@arr)`. Each test asserts both the bag's contents
-  and the resulting type at the access site through `bag_query`.
-
-- **Phase 3.** Mojo::Base `has 'kids'` getter return type folds to
-  `Sequence(<shape>)` when the slot has contributions; falls back
-  to a witness-emitted default when it doesn't. The
-  Mojolicious::Routes::Route `_route` override is removed; the
-  *intra-file* chain (synthetic Route fixture exercising
-  `add_child` + `children->[-1]` within one parsed file) types
-  end-to-end without it. The cross-file real-Mojo case may still
-  need the override pending Phase 4.
-
-- **Phase 4.** Real Mojolicious's `_route` types end-to-end with
-  no override anywhere. Effect-signature inference is robust to
-  recursion / cycles in the callee body (terminates in
-  `MAX_FOLD_ITERATIONS`).
-
-- **Phase 5.** `map`, `grep`, `sort`, splat / concat all type
-  through the pipeline reducer. Block-return inference for
-  `map { … }` is consistent with the rest of return-type inference
-  (i.e., goes through the bag, not a special path).
-
-## Closing note
-
-The spike taught us the design; the unification clears the way
-for the implementation to be small. This spec is the build plan
-on the cleared ground. Each phase is independently shippable, each
-delivers user-visible value, and the final shape — through Phase 3
-or 5 — is roughly half the code the spike needed for the same
-capability.
+- The data model is in `src/file_analysis.rs::InferredType`.
+  `Sequence(Vec<InferredType>)` lives at the END of the enum;
+  keep new variants at the end and bump `EXTRACT_VERSION` in
+  `src/module_cache.rs`.
+- Walker emission queues live on `Builder`. The spike uses
+  `pending_array_pushes: Vec<(ScopeId, String, Vec<Span>)>` —
+  Phase 2's `Container(ArrayId)` shift replaces the scope+name
+  key with `ArrayId`.
+- The post-fold pass is `Builder::emit_array_push_witnesses`,
+  called after `fold_to_fixed_point` so method-call return types
+  are resolvable.
+- Walker queues anything `expr_payload` can't resolve at walk
+  time via `unresolved_expr_nodes` — retried post-walk against
+  the final symbol table + refs. New emission shapes inherit
+  this for free.
+- Test pattern: `spike_array_hop_with_helper_and_cross_file_completion`
+  in `src/builder_tests.rs` shows the build-FA + module-index +
+  resolve / complete / hover assertions.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -191,6 +191,7 @@ fn build_with_plugins_inner(
         fold_ranges: Vec::new(),
         imports: Vec::new(),
         return_infos: Vec::new(),
+        pending_array_pushes: Vec::new(),
         last_expr_span: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
         method_call_bindings: Vec::new(),
@@ -207,10 +208,17 @@ fn build_with_plugins_inner(
         plugin_namespaces: Vec::new(),
         type_provenance: std::collections::HashMap::new(),
         bag: crate::witnesses::WitnessBag::new(),
-        unresolved_call_targets: Vec::new(),
+        unresolved_expr_nodes: Vec::new(),
         package_framework: std::collections::HashMap::new(),
         scope_stack: Vec::new(),
-        current_package: None,
+        // Perl's implicit top-level package. Without this seed,
+        // top-level scripts (`Mojolicious::Lite` apps, one-off
+        // `.pl` files) have `current_package = None` until they
+        // hit an explicit `package` statement — which means
+        // `package_uses` never records the file's `use` lines and
+        // `Trigger::UsesModule` plugin triggers don't fire. Same
+        // as Perl's own runtime: every script starts in `main`.
+        current_package: Some("main".to_string()),
         next_scope_id: 0,
         next_symbol_id: 0,
         package_ranges: Vec::new(),
@@ -294,7 +302,7 @@ fn build_with_plugins_inner(
     // them now against the final symbol table and push the
     // `Expr(span) → Edge(Symbol(sid))` witness the walk would have.
     // See `docs/prompt-forward-reference-resolution.md`.
-    b.resolve_forward_call_targets();
+    b.resolve_forward_expr_witnesses();
 
     // Phase 6: worklist driver. Replaces the manually-ordered
     // `fold → chain → fold → chain` sequence with one fixed-point
@@ -320,6 +328,14 @@ fn build_with_plugins_inner(
     // otherwise spin forever.
     let chain_idx = build_chain_typing_index(tree);
     b.fold_to_fixed_point(&chain_idx);
+    // PostFold filled `invocant_class` on MethodCall refs after the
+    // worklist exited; re-emit method-call return edges so
+    // Expression(refidx) chases resolve through to
+    // MethodOnClass{class, method} for any invocant freshly known.
+    // Then push array contributions: spans queryable through the
+    // freshly-published edges.
+    b.emit_method_call_return_edges();
+    b.emit_array_push_witnesses();
 
     // Test-only: re-run the worklist fold one more time to pin
     // idempotency. Production callers always pass `false`; only
@@ -923,6 +939,16 @@ struct Builder<'a> {
     imports: Vec<Import>,
     /// Return values collected during the walk (explicit `return` + implicit last expr).
     return_infos: Vec<ReturnInfo>,
+    /// Pending `push @arr, X, Y` contributions queued at walk time
+    /// and re-resolved in the worklist (phase 6) once method-call
+    /// return types are filled. Stored as
+    /// `(scope, arr_name, contribution_spans)` triples — re-emitted
+    /// each iteration as `Variable{arr_name, scope} +
+    /// InferredType(Sequence(...))` with the latest known per-arg
+    /// types. Clear-and-emit on `source_tag = "array_push"`. Spike
+    /// scope: tuple shape only; cross-scope and conditional
+    /// branches not yet handled.
+    pending_array_pushes: Vec<(ScopeId, String, Vec<Span>)>,
     /// For each Sub/Method scope, the body span of the last
     /// top-level expression statement. Used as the implicit-return
     /// query key — `seed_return_types_from_bag` reads `Expr(span)` via
@@ -991,14 +1017,25 @@ struct Builder<'a> {
     /// the analysis is constructed — no second seeding pass.
     bag: crate::witnesses::WitnessBag,
     /// Walk-time symbol-table lookups that came up empty for a name
-    /// resolvable to a local sub. Perl's name resolution for subs is
-    /// forward-tolerant (`sub a { b() } sub b {…}` is legal), but the
-    /// walk emits witnesses live, so a forward-defined callee silently
-    /// produces no witness in `expr_payload`'s call arms. Re-resolved
-    /// against the final symbol table by `resolve_forward_call_targets`
-    /// between `populate_witness_bag` and `fold_to_fixed_point`. See
-    /// `docs/prompt-forward-reference-resolution.md`.
-    unresolved_call_targets: Vec<UnresolvedCallTarget>,
+    /// Nodes that `emit_expr_witness` couldn't resolve at walk
+    /// time. Two common shapes:
+    ///   * **Forward-defined sub call** — `sub a { b() } sub b {…}`
+    ///     is legal Perl, but the walk emits witnesses live and the
+    ///     callee isn't in the symbol table yet when `b()` is
+    ///     visited.
+    ///   * **Walked-before-children parent** — `visit_function_call`
+    ///     fires before its arg subtree is walked, so any
+    ///     `emit_expr_witness` called inside the parent visitor on
+    ///     a method-call arg finds no matching `MethodCall` ref
+    ///     yet (refs are pushed during `visit_method_call_expression`,
+    ///     which runs later).
+    ///
+    /// `resolve_forward_expr_witnesses` retries `expr_payload` on
+    /// each queued node post-walk — refs are complete + the
+    /// symbol table is final by then, so the live and recovery
+    /// paths produce byte-identical witnesses (same span, same
+    /// `expression` source tag).
+    unresolved_expr_nodes: Vec<Node<'a>>,
     /// Per-package framework fact, computed from `framework_modes` once
     /// the walk finishes. Available before `resolve_return_types` so
     /// the bag-aware return-arm fold can ask the framework-aware
@@ -1089,18 +1126,6 @@ enum FrameworkMode {
     Moo,
     Moose,
     MojoBase,
-}
-
-/// Queued by `emit_expr_witness` whenever a name-driven call kind
-/// (`function_call_expression`, `bareword`, `scoped_identifier`) couldn't
-/// emit its `Edge(Symbol(_))` witness because the callee wasn't in the
-/// symbol table yet. Re-resolved post-walk against the final symbols.
-#[derive(Debug, Clone)]
-struct UnresolvedCallTarget {
-    /// Bare sub name (e.g. `longmess_heavy`, stripped of any `Pkg::` prefix).
-    name: String,
-    /// `Expr(span)` attachment that the missing witness should land on.
-    expr_span: Span,
 }
 
 impl<'a> Builder<'a> {
@@ -4030,10 +4055,10 @@ impl<'a> Builder<'a> {
     }
 
     /// Find a local Sub or Method symbol by bare name. Used by
-    /// `expr_payload`'s function/bareword arms (walk-time) and
-    /// `resolve_forward_call_targets` (post-walk) — both want the same
-    /// "is there a local sub I could route a call edge to" answer, so
-    /// they share this lookup.
+    /// `expr_payload`'s function/bareword arms — both at walk
+    /// time and post-walk via `resolve_forward_expr_witnesses`'s
+    /// retry. One lookup, two emission paths, byte-identical
+    /// witnesses.
     fn find_callee_symbol(&self, bare: &str) -> Option<SymbolId> {
         self.symbols
             .iter()
@@ -4196,9 +4221,8 @@ impl<'a> Builder<'a> {
             // Function / bareword / scoped-identifier call — extract the
             // callee's bare name and Edge to its `Symbol(sid)`. Failures
             // (target not yet in symbol table) are recovered post-walk by
-            // `resolve_forward_call_targets`; same `forward_callee_name`
-            // helper is the source of truth for "what name does this node
-            // refer to" so the live and recovery paths can't diverge.
+            // `resolve_forward_expr_witnesses`, which re-calls this same
+            // `expr_payload` against the final symbol table.
             "function_call_expression"
             | "ambiguous_function_call_expression"
             | "bareword"
@@ -4260,25 +4284,30 @@ impl<'a> Builder<'a> {
                 payload,
                 span,
             });
-        } else if let Some(name) = self.forward_callee_name(node) {
-            // Sub call by bare name whose target wasn't in the symbol
-            // table yet — Perl resolves these at symbol-table time, not
-            // parse time, so the lookup is legitimately deferred. Queue
-            // for `resolve_forward_call_targets` to retry post-walk.
-            self.unresolved_call_targets.push(UnresolvedCallTarget {
-                name,
-                expr_span: span,
-            });
+        } else {
+            // `expr_payload` returned None — either the callee
+            // sym isn't in the table yet (forward-defined sub),
+            // or our parent visitor fired before this node's own
+            // walker emitted its Ref (push-before-children
+            // ordering). Both cases share one recovery: queue the
+            // node and re-call `expr_payload` post-walk against
+            // the now-final symbol table + refs.
+            //
+            // Don't queue node kinds `expr_payload` doesn't claim
+            // — `expr_payload`'s match is the single source of
+            // truth for "can this resolve later." Anything that
+            // returns None for a structural reason (unsupported
+            // syntax) will return None again post-walk, and the
+            // retry is a no-op.
+            self.unresolved_expr_nodes.push(node);
         }
     }
 
-    /// Bare callee name for an expression node whose `expr_payload` arm
-    /// resolves to `Edge(Symbol(sid))`. `None` for any other kind. Sole
-    /// source of truth for "what sub-name does this node reference" —
-    /// `expr_payload`'s call arm calls this for the live lookup, and
-    /// `emit_expr_witness` calls it again to queue forward-ref retries
-    /// when the live lookup misses. Keeping a single extractor is what
-    /// makes the live and post-walk paths impossible to diverge.
+    /// Bare callee name for an expression node whose `expr_payload`
+    /// arm resolves to `Edge(Symbol(sid))`. `None` for any other
+    /// kind. Sole source of truth for "what sub-name does this node
+    /// reference" — `expr_payload`'s call arm calls this for the
+    /// live lookup.
     fn forward_callee_name(&self, node: Node<'a>) -> Option<String> {
         let raw = match node.kind() {
             "function_call_expression" | "ambiguous_function_call_expression" => {
@@ -4290,27 +4319,27 @@ impl<'a> Builder<'a> {
         Some(bare_name(raw).to_string())
     }
 
-    /// Post-walk: re-resolve every queued `(name, expr_span)` pair
-    /// against the now-final symbol table and push the
-    /// `Expr(span) → Edge(Symbol(sid))` witness that
-    /// `emit_expr_witness` would have pushed live if the target had
-    /// existed. Same source tag (`expression`) and span as the
-    /// walk-time path so reducers can't tell the two emission sites
-    /// apart. Names that still don't resolve (cross-file imports
-    /// without a local sym, typos) are silently dropped — the bag is
-    /// monotone, no negative witnesses.
-    fn resolve_forward_call_targets(&mut self) {
-        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        let queued = std::mem::take(&mut self.unresolved_call_targets);
-        for entry in queued {
-            let Some(sid) = self.find_callee_symbol(&entry.name) else {
-                continue;
-            };
+    /// Post-walk: re-call `expr_payload` on every queued node. By
+    /// this point the symbol table is final (forward sub refs
+    /// resolve) and every node's Ref has been emitted (parent
+    /// visitors that fired before child walks now have refs to
+    /// chase). Same `expression` source tag and span as the
+    /// walk-time path, so reducers can't tell the two emission
+    /// sites apart. Nodes that still return None (cross-file
+    /// imports without a local sym, syntax `expr_payload` doesn't
+    /// claim) are silently dropped — the bag is monotone, no
+    /// negative witnesses.
+    fn resolve_forward_expr_witnesses(&mut self) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessSource};
+        let queued = std::mem::take(&mut self.unresolved_expr_nodes);
+        for node in queued {
+            let Some(payload) = self.expr_payload(node) else { continue };
+            let span = node_to_span(node);
             self.bag.push(Witness {
-                attachment: WitnessAttachment::Expr(entry.expr_span),
+                attachment: WitnessAttachment::Expr(span),
                 source: WitnessSource::Builder("expression".into()),
-                payload: WitnessPayload::Edge(WitnessAttachment::Symbol(sid)),
-                span: entry.expr_span,
+                payload,
+                span,
             });
         }
     }
@@ -4767,6 +4796,15 @@ impl<'a> Builder<'a> {
             Ok(t) => t,
             Err(_) => return,
         };
+        // Generic array contribution — `push @arr, X, Y` extends
+        // `@arr`'s `Sequence` shape. Walk-time projection: resolve
+        // each X / Y through `emit_expr_witness + bag_query_expr_span`,
+        // look up the running Sequence for `@arr` in scope, append.
+        // Latest-wins Variable witness keeps the running answer
+        // queryable at any later point. Spike scope: tuple shape
+        // only — no Homogeneous / Cycle classification yet.
+        self.emit_array_push_contribution(arr_name, &children[1..]);
+
         let is_export = arr_name.ends_with("@EXPORT") && !arr_name.ends_with("@EXPORT_OK");
         let is_export_ok = arr_name.ends_with("@EXPORT_OK");
         if !is_export && !is_export_ok { return; }
@@ -4782,6 +4820,75 @@ impl<'a> Builder<'a> {
             } else {
                 self.export_ok.extend(values);
             }
+        }
+    }
+
+    /// Queue an array contribution for the worklist's re-emittable
+    /// pass. We can't resolve method-call return types at walk time
+    /// (phase 6 fills them); we just record the contribution shape
+    /// and let `emit_array_push_witnesses` re-emit each iteration.
+    fn emit_array_push_contribution(&mut self, arr_name: &str, args: &[Node<'a>]) {
+        if args.is_empty() { return; }
+        let scope = self.current_scope();
+        // Emit the Expr(span) witness for each arg now — the worklist
+        // will look them up by span later. Walk-time emission is the
+        // contract for "this expression's type is queryable from the
+        // bag once the worklist settles."
+        let spans: Vec<Span> = args
+            .iter()
+            .map(|n| {
+                self.emit_expr_witness(*n);
+                node_to_span(*n)
+            })
+            .collect();
+        self.pending_array_pushes
+            .push((scope, arr_name.to_string(), spans));
+    }
+
+    /// Post-fold pass: drain `pending_array_pushes`'s queued
+    /// contributions into `Variable{arr_name, scope} +
+    /// InferredType(Sequence(...))` witnesses. Runs once after
+    /// `fold_to_fixed_point` (which fills `invocant_class`) +
+    /// `emit_method_call_return_edges` (which publishes
+    /// `Expression(refidx) → Edge(MethodOnClass{...})`), so by
+    /// the time we read each contribution's type, the method-call
+    /// chain has resolved end-to-end. Each contribution's
+    /// `Expr(span)` was queued by `emit_expr_witness` at walk time
+    /// and resolved by `resolve_forward_expr_witnesses` post-walk,
+    /// so `bag_query_expr_span` chases through to the materialized
+    /// type — no per-pass backfill needed here.
+    fn emit_array_push_witnesses(&mut self) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        self.bag.remove_by_source_tag("array_push");
+        // Group by (scope, arr_name) so successive pushes
+        // accumulate into one Sequence.
+        let mut grouped: std::collections::HashMap<(ScopeId, String), Vec<Span>> =
+            std::collections::HashMap::new();
+        for (scope, name, spans) in &self.pending_array_pushes {
+            grouped
+                .entry((*scope, name.clone()))
+                .or_default()
+                .extend(spans.iter().copied());
+        }
+        for ((scope, name), spans) in grouped {
+            let resolved: Vec<InferredType> = spans
+                .iter()
+                .filter_map(|sp| self.bag_query_expr_span(*sp))
+                .collect();
+            if resolved.is_empty() { continue; }
+            // Zero-span "applies forever after this point" — matches
+            // the chain-assignment / TC-mirror convention. A
+            // non-zero scoped span would get filtered out by
+            // `FrameworkAwareTypeFold`'s narrowing rule for any
+            // query point outside the span.
+            let last = *spans.last().expect("non-empty by construction");
+            let zero = Span { start: last.end, end: last.end };
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::Variable { name, scope },
+                source: WitnessSource::Builder("array_push".into()),
+                payload: WitnessPayload::InferredType(InferredType::Sequence(resolved)),
+                span: zero,
+            });
         }
     }
 

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1427,7 +1427,11 @@ fn test_hash_key_def_implicit_return_gets_sub_owner() {
         assert_eq!(
             *owner,
             HashKeyOwner::Sub {
-                package: None,
+                // Top-level scripts default to `main` per Perl's
+                // own semantics; the implicit-package seed in
+                // `Builder::new` makes this an explicit `Some("main")`
+                // rather than `None`.
+                package: Some("main".to_string()),
                 name: "get_config".to_string()
             },
             "implicit return hash key should have Sub get_config owner, got {:?}",
@@ -1517,7 +1521,11 @@ fn test_hash_key_def_in_return_gets_sub_owner() {
         assert_eq!(
             *owner,
             HashKeyOwner::Sub {
-                package: None,
+                // Top-level scripts default to `main` per Perl's
+                // own semantics; the implicit-package seed in
+                // `Builder::new` makes this an explicit `Some("main")`
+                // rather than `None`.
+                package: Some("main".to_string()),
                 name: "get_config".to_string()
             },
             "host def should have Sub get_config owner, got {:?}",
@@ -1539,7 +1547,7 @@ fn test_hash_key_def_in_return_gets_sub_owner() {
         assert_eq!(
             *owner,
             Some(HashKeyOwner::Sub {
-                package: None,
+                package: Some("main".to_string()),
                 name: "get_config".to_string()
             }),
             "host ref should have Sub get_config owner, got {:?}",
@@ -9095,4 +9103,198 @@ has 'name' => (is => 'ro');
         assert!(all_names.contains("a"), "missing import name 'a': {:?}", all_names);
         assert!(all_names.contains("b"), "missing import name 'b': {:?}", all_names);
     }
+}
+
+/// **Spike: array intelligence on the bag-canonical foundation.**
+///
+/// The headline scenario, top-to-bottom:
+///
+/// ```perl
+/// # Some/User.pm (cross-file)
+/// package Some::User;
+/// use Mojo::Base -base;
+/// has 'name';
+/// sub greet { ... }
+/// sub email { ... }
+///
+/// # main
+/// package MyApp;
+/// use Mojolicious::Lite;
+/// use constant DEFAULT_NAME => 'alice';
+///
+/// helper make_user => sub {
+///     my ($c, $name) = @_;
+/// .   return Some::User->new(name => $name);
+/// };
+///
+/// sub action {
+///     my $c = Mojolicious::Controller->new;
+///     my @users;
+///     push @users, $c->make_user(DEFAULT_NAME);   # const fold + plugin helper
+///     push @users, $c->make_user('bob');
+///     $users[0]->                                  # ← method completion here
+/// }
+/// ```
+///
+/// The chain through `$users[0]`:
+///   1. mojo-helpers plugin synthesizes `make_user` on
+///      `Mojolicious::Controller` with `return_via_edge` pointing
+///      at the anon-sub's body.
+///   2. Coderef-return edge resolves the body's last expression
+///      (`Some::User->new(...)`) → `ClassName("Some::User")`.
+///   3. `push @users, $c->make_user(...)` contributes
+///      `ClassName("Some::User")` to `@users`'s `Sequence` shape.
+///   4. `$users[0]` projects the Sequence to its first element.
+///   5. Method / hash-key completion on the projected class crosses
+///      the file boundary into `Some::User.pm`.
+///
+/// The **new** code on this branch is purely the array hop —
+/// declaration emission, `push` contribution, and projection at
+/// `$users[N]`. Everything else (helper synth, coderef return,
+/// const fold, cross-file dispatch, Mojo::Base hash-key defs)
+/// drops out of the existing bag-canonical machinery for free.
+#[test]
+fn spike_array_hop_with_helper_and_cross_file_completion() {
+    use crate::module_index::ModuleIndex;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    let user_pm = r#"
+package Some::User;
+use Mojo::Base -base;
+has 'name';
+sub greet { my $self = shift; "hi $self->{name}" }
+sub email { my $self = shift; "$self->{name}\@x.com" }
+1;
+"#;
+    let user_fa = build_fa(user_pm);
+
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(
+        PathBuf::from("/tmp/Some/User.pm"),
+        Arc::new(user_fa),
+    );
+
+    let app_src = r#"
+package MyApp;
+use Mojolicious::Lite;
+use constant DEFAULT_NAME => 'alice';
+
+my $app = Mojolicious->new;
+$app->helper(make_user => sub {
+    my ($c, $name) = @_;
+    return Some::User->new(name => $name);
+});
+
+sub action {
+    my $c = Mojolicious::Controller->new;
+    my @users;
+    push @users, $c->make_user(DEFAULT_NAME);
+    push @users, $c->make_user('bob');
+    $users[0]->greet();
+}
+"#;
+    let app_fa = build_fa(app_src);
+
+    // Load-bearing: walk the tree to find the `$users[0]` node and
+    // ask `resolve_expression_type` what it is. This is the receiver
+    // resolution path the chain typer + cursor context both go
+    // through for completion.
+    let tree = parse(app_src);
+    fn find_array_element<'a>(node: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == "array_element_expression" {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(hit) = find_array_element(child) {
+                return Some(hit);
+            }
+        }
+        None
+    }
+    let elem_node = find_array_element(tree.root_node())
+        .expect("test source contains `$users[0]`");
+    let resolved = app_fa
+        .resolve_expression_type(elem_node, app_src.as_bytes(), Some(&idx))
+        .expect("$users[0] resolves to a type");
+    assert_eq!(
+        resolved.class_name(),
+        Some("Some::User"),
+        "the array hop survives the chain: helper(coderef) → push → \
+         $users[0] → Some::User. got: {:?}",
+        resolved,
+    );
+
+    // Cross-file method completion on the resolved class. Mojo::Base
+    // accessor (`name`) + user-defined methods come through unified.
+    let methods = app_fa.complete_methods_for_class("Some::User", Some(&idx));
+    let method_names: std::collections::HashSet<&str> =
+        methods.iter().map(|c| c.label.as_str()).collect();
+    assert!(method_names.contains("greet"), "cross-file user method 'greet' missing");
+    assert!(method_names.contains("email"), "cross-file user method 'email' missing");
+    assert!(method_names.contains("name"), "Mojo::Base accessor 'name' missing");
+
+    // Hash-key completion on the same class — synthesized by
+    // `has 'name'`, reachable across files. Cross-file hash-key
+    // completion flows through enrichment; the local
+    // `complete_hash_keys_for_class` doesn't gate on `ModuleIndex`,
+    // so this stays a soft observation for the spike rather than a
+    // hard assert. The load-bearing claim is the array hop, not the
+    // FA-side hash-key API.
+    let keys = app_fa.complete_hash_keys_for_class("Some::User", Point::new(0, 0));
+    let key_names: std::collections::HashSet<&str> =
+        keys.iter().map(|c| c.label.as_str()).collect();
+    let _ = key_names; // intentionally not asserted in the spike
+
+    // Hover on `$users[0]->greet` — the tree-aware
+    // `method_call_invocant_class_with_tree` path. The string-side
+    // `method_call_invocant_class` couldn't resolve `$users[0]`
+    // (it isn't a Variable witness name); the tree-aware variant
+    // dispatches through `resolve_expression_type` on the actual
+    // CST node, hitting the same array_element_expression arm
+    // cursor_context uses for completion. One projection rule,
+    // both entry points.
+    fn find_method_call<'a>(
+        node: tree_sitter::Node<'a>,
+        src: &[u8],
+        method: &str,
+    ) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == "method_call_expression" {
+            if let Some(m) = node.child_by_field_name("method") {
+                if m.utf8_text(src).ok() == Some(method) {
+                    return Some(node);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(hit) = find_method_call(child, src, method) {
+                return Some(hit);
+            }
+        }
+        None
+    }
+    let greet_call = find_method_call(tree.root_node(), app_src.as_bytes(), "greet")
+        .expect("test source contains `$users[0]->greet()`");
+    let method_node = greet_call
+        .child_by_field_name("method")
+        .expect("method-call has a method child");
+    let hover = app_fa.hover_info(
+        method_node.start_position(),
+        app_src,
+        Some(&tree),
+        Some(&idx),
+    );
+    let hover_text = hover.expect("hover on `$users[0]->greet` returns text");
+    assert!(
+        hover_text.contains("Some::User"),
+        "hover on `$users[0]->greet` should mention Some::User; got: {}",
+        hover_text,
+    );
+    assert!(
+        hover_text.contains("greet"),
+        "hover should include the method name; got: {}",
+        hover_text,
+    );
 }

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -542,6 +542,17 @@ pub enum InferredType {
     /// body via a `Gate` discriminator. See
     /// `docs/adr/parametric-types.md`.
     Parametric(ParametricType),
+    /// Positional container — `my @arr = (...)` or
+    /// `push @arr, ...` contributions accumulated walk-side. The
+    /// `Vec` stores per-index types; `element_at(i)` projects.
+    /// Spike scope: tuple shape only, no Homogeneous / Cycle /
+    /// Heterogeneous classification yet.
+    ///
+    /// Placed at the END of the enum so bincode-serialized cache
+    /// blobs keep their existing variant indices stable. Inserting
+    /// new variants in the middle would shift every subsequent
+    /// variant's wire-format index and silently misread old blobs.
+    Sequence(Vec<InferredType>),
 }
 
 /// Concrete parametric flavors + type-level operators. Each
@@ -695,6 +706,17 @@ impl InferredType {
             InferredType::Parametric(p) => p.class_name(),
             _ => None,
         }
+    }
+
+    /// Project a `Sequence(...)` to its element at index `i`. Negative
+    /// indices wrap from the end (Perl `$arr[-1]`). `None` for any
+    /// non-Sequence type or out-of-bounds index.
+    pub fn element_at(&self, i: i32) -> Option<&InferredType> {
+        let InferredType::Sequence(elems) = self else { return None };
+        let n = elems.len() as i32;
+        let idx = if i < 0 { n + i } else { i };
+        if idx < 0 || idx >= n { return None; }
+        elems.get(idx as usize)
     }
 
     /// True if this is any object-shaped variant (ClassName,
@@ -2252,6 +2274,21 @@ impl FileAnalysis {
                 let text = node.utf8_text(source).ok()?;
                 Some(InferredType::ClassName(text.to_string()))
             }
+            "array_element_expression" => {
+                // `$arr[N]` — look up `@arr`'s Sequence shape via the
+                // bag, project the index. The bag answer is whatever
+                // the walker's last `push` / `my @arr = (...)`
+                // contribution left on `Variable{"@arr", scope}`.
+                let arr = node.child_by_field_name("array")?;
+                let name = arr
+                    .named_child(0)
+                    .and_then(|n| n.utf8_text(source).ok())?;
+                let idx_node = node.child_by_field_name("index")?;
+                let idx: i32 = idx_node.utf8_text(source).ok()?.parse().ok()?;
+                let arr_var = format!("@{}", name);
+                self.inferred_type_via_bag(&arr_var, point)
+                    .and_then(|t| t.element_at(idx).cloned())
+            }
             "method_call_expression" => {
                 let invocant_node = node.child_by_field_name("invocant")?;
                 let invocant_type = self.resolve_expression_type(invocant_node, source, module_index)?;
@@ -3348,7 +3385,7 @@ impl FileAnalysis {
     }
 
     /// Hover info: return display text for the symbol at cursor.
-    pub fn hover_info(&self, point: Point, source: &str, _tree: Option<&tree_sitter::Tree>, module_index: Option<&ModuleIndex>) -> Option<String> {
+    pub fn hover_info(&self, point: Point, source: &str, tree: Option<&tree_sitter::Tree>, module_index: Option<&ModuleIndex>) -> Option<String> {
         // Check refs first
         if let Some(r) = self.ref_at(point) {
             match &r.kind {
@@ -3361,7 +3398,9 @@ impl FileAnalysis {
                             && mr.target_name != r.target_name);
                     if let Some(mr) = method_hover {
                         if matches!(mr.kind, RefKind::MethodCall { .. }) {
-                            let class_name = self.method_call_invocant_class(mr, module_index);
+                            let class_name = self.method_call_invocant_class_with_tree(
+                                mr, tree, Some(source.as_bytes()), module_index,
+                            );
                             if let Some(ref cn) = class_name {
                                 match self.resolve_method_in_ancestors(cn, &mr.target_name, module_index) {
                                     Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -3466,7 +3505,9 @@ impl FileAnalysis {
                     }
                 }
                 RefKind::MethodCall { .. } => {
-                    let class_name = self.method_call_invocant_class(r, module_index);
+                    let class_name = self.method_call_invocant_class_with_tree(
+                        r, tree, Some(source.as_bytes()), module_index,
+                    );
                     if let Some(ref cn) = class_name {
                         match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
                             Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
@@ -3930,6 +3971,23 @@ impl FileAnalysis {
         r: &Ref,
         module_index: Option<&ModuleIndex>,
     ) -> Option<String> {
+        self.method_call_invocant_class_with_tree(r, None, None, module_index)
+    }
+
+    /// Tree-aware variant. When a `tree` + `source` are available
+    /// (every LSP-facing reader has them), this routes non-trivial
+    /// invocants (`$arr[N]`, future shapes) through
+    /// `resolve_expression_type` on the actual CST node — the same
+    /// arm the cursor-context completion path uses. Without the
+    /// tree, falls through to the string-based bag query.
+    /// One resolution rule, two entry points, no shape drift.
+    pub fn method_call_invocant_class_with_tree(
+        &self,
+        r: &Ref,
+        tree: Option<&tree_sitter::Tree>,
+        source: Option<&[u8]>,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<String> {
         let RefKind::MethodCall { invocant, invocant_span, .. } = &r.kind else {
             return None;
         };
@@ -3946,6 +4004,33 @@ impl FileAnalysis {
         // variables — so we resolve here directly.
         if invocant == "shift" || invocant == "$_[0]" || invocant == "@_[0]" {
             return self.enclosing_class_for_scope(r.scope);
+        }
+
+        // Tree-aware fast path: find the invocant's CST node and
+        // dispatch through `resolve_expression_type`. That arm
+        // already handles `array_element_expression` (and any
+        // future non-trivial invocant shape) — keeping hover /
+        // dispatch on the same projection logic completion uses.
+        if let (Some(tree), Some(source), Some(span)) = (tree, source, invocant_span) {
+            let node = tree.root_node().descendant_for_point_range(span.start, span.end);
+            if let Some(node) = node {
+                // Only take this path for shapes the string-based
+                // bag query can't handle. `scalar` / `array` /
+                // `hash` invocants are simple variables — the
+                // existing string lookup is fine and consistent
+                // with every other variable-typed call site.
+                let needs_tree = !matches!(
+                    node.kind(),
+                    "scalar" | "array" | "hash" | "bareword" | "package" | "scoped_identifier"
+                );
+                if needs_tree {
+                    if let Some(t) = self.resolve_expression_type(node, source, module_index) {
+                        if let Some(cn) = t.class_name() {
+                            return Some(cn.to_string());
+                        }
+                    }
+                }
+            }
         }
 
         // `__PACKAGE__` is rewritten to the enclosing package at
@@ -6058,6 +6143,7 @@ pub fn inferred_type_to_tag(ty: &InferredType) -> String {
             Some(c) => format!("Object:{}", c),
             None => "Parametric".to_string(),
         },
+        InferredType::Sequence(_) => "Sequence".to_string(),
     }
 }
 
@@ -6098,6 +6184,14 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
         InferredType::Numeric => "Numeric".to_string(),
         InferredType::String => "String".to_string(),
         InferredType::Parametric(p) => format_parametric_type(p),
+        InferredType::Sequence(elems) => {
+            // Angle brackets, not `[...]` — markdown renderers treat
+            // bracketed text as link syntax and either swallow it
+            // or render it as a broken link. Matches the
+            // `Parametric<T1, T2>` style.
+            let parts: Vec<String> = elems.iter().map(format_inferred_type).collect();
+            format!("Sequence<{}>", parts.join(", "))
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,10 @@ async fn main() {
             cli_clear_cache(args.get(2).map(|s| s.as_str()));
             return;
         }
+        Some("--parse") if args.len() >= 3 => {
+            cli_parse(&args[2]);
+            return;
+        }
         _ => {}
     }
 
@@ -129,6 +133,8 @@ fn print_usage() {
     eprintln!("  perl-lsp --clear-cache [<root>]                        Wipe the module cache for");
     eprintln!("                                                         <root>, or every project if");
     eprintln!("                                                         <root> is omitted");
+    eprintln!("  perl-lsp --parse <file|-->                             Print tree-sitter parse tree");
+    eprintln!("                                                         (`-` reads from stdin)");
     eprintln!();
     eprintln!("  perl-lsp --version                                     Print version");
 }
@@ -997,4 +1003,95 @@ fn cli_clear_cache(root: Option<&str>) {
             std::process::exit(1);
         }
     }
+}
+
+/// Pretty-print the tree-sitter parse tree for a Perl source file.
+/// `<file>` may be `-` to read from stdin. Mirrors `tree-sitter parse`
+/// output shape — `(node_kind [row, col] - [row, col]` per line,
+/// 2-space indent per depth, field names prefixed (`field: kind`).
+fn cli_parse(path: &str) {
+    use std::io::Read;
+    let source = if path == "-" {
+        let mut s = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut s) {
+            eprintln!("read stdin: {}", e);
+            std::process::exit(1);
+        }
+        s
+    } else {
+        match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("read {}: {}", path, e);
+                std::process::exit(1);
+            }
+        }
+    };
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&ts_parser_perl::LANGUAGE.into())
+        .expect("set Perl language");
+    let Some(tree) = parser.parse(&source, None) else {
+        eprintln!("parse failed");
+        std::process::exit(1);
+    };
+    use std::io::IsTerminal;
+    let color = std::io::stdout().is_terminal();
+    // 6 rainbow ANSI 256-color picks. Both the paren AND the node
+    // kind name share the depth's color — that's the visual cue
+    // for "this paren matches this kind." Field names + line
+    // ranges get distinct colors so they don't blur into the
+    // rainbow.
+    const RAINBOW: [&str; 6] = [
+        "\x1b[38;5;196m", // red
+        "\x1b[38;5;208m", // orange
+        "\x1b[38;5;226m", // yellow
+        "\x1b[38;5;46m",  // green
+        "\x1b[38;5;39m",  // blue
+        "\x1b[38;5;165m", // magenta
+    ];
+    const FIELD: &str = "\x1b[38;5;245m"; // gray
+    const RANGE: &str = "\x1b[38;5;242m"; // darker gray
+    const RESET: &str = "\x1b[0m";
+    fn walk(node: tree_sitter::Node, field: Option<&str>, depth: usize, color: bool) {
+        let pad = "  ".repeat(depth);
+        let (hue, fc, rc, rs) = if color {
+            (RAINBOW[depth % 6], FIELD, RANGE, RESET)
+        } else {
+            ("", "", "", "")
+        };
+        let prefix = field
+            .map(|f| format!("{}{}: {}", fc, f, rs))
+            .unwrap_or_default();
+        let s = node.start_position();
+        let e = node.end_position();
+        print!(
+            "{}{}{}({}{} {}[{}, {}] - [{}, {}]{}",
+            pad,
+            prefix,
+            hue,
+            node.kind(),
+            rs,
+            rc,
+            s.row,
+            s.column,
+            e.row,
+            e.column,
+            rs,
+        );
+        let mut cursor = node.walk();
+        let mut field_idx: u32 = 0;
+        for child in node.children(&mut cursor) {
+            let fname = node.field_name_for_child(field_idx);
+            field_idx += 1;
+            if !child.is_named() {
+                continue;
+            }
+            println!();
+            walk(child, fname, depth + 1, color);
+        }
+        print!("{}){}", hue, rs);
+    }
+    walk(tree.root_node(), None, 0, color);
+    println!();
 }

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 31;
+pub const EXTRACT_VERSION: i64 = 32;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -1198,6 +1198,7 @@ fn receiver_discriminant(r: &Option<InferredType>) -> u8 {
         InferredType::Numeric => 7,
         InferredType::String => 8,
         InferredType::Parametric(_) => 9,
+        InferredType::Sequence(_) => 10,
     }
 }
 

--- a/test_files/array_hop_demo.pl
+++ b/test_files/array_hop_demo.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/env perl
+# Spike fixture: the array hop. End-to-end chain through the
+# bag-canonical typing arch — every hop is exercised on its own
+# infrastructure, the new code on the spike branch is purely the
+# array contribution + projection.
+#
+# ┌─ const fold ─────────────────────────────────────────────┐
+# │  use constant DEFAULT_NAME => 'alice'                     │
+# └──────────────────┬────────────────────────────────────────┘
+#                    │ folds to 'alice' at call sites
+# ┌─ Mojo helper ────▼────────────────────────────────────────┐
+# │  $app->helper(make_user => sub {                          │
+# │      return Some::User->new(name => $name);               │
+# │  });                                                      │
+# │  ↓ plugin synth (mojo-helpers): Method on                 │
+# │    Mojolicious::Controller, return_via_edge → anon body   │
+# └──────────────────┬────────────────────────────────────────┘
+#                    │
+# ┌─ coderef return ─▼────────────────────────────────────────┐
+# │  anon body last expr is `Some::User->new(...)`            │
+# │  → ClassName("Some::User") via constructor pattern        │
+# └──────────────────┬────────────────────────────────────────┘
+#                    │
+# ┌─ array contribution (NEW) ─▼──────────────────────────────┐
+# │  push @users, $c->make_user(DEFAULT_NAME);                │
+# │  push @users, $c->make_user('bob');                       │
+# │  → Variable{"@users", scope} + Sequence([User, User])     │
+# └──────────────────┬────────────────────────────────────────┘
+#                    │
+# ┌─ array projection (NEW) ───▼──────────────────────────────┐
+# │  $users[0]                                                │
+# │  → Sequence.element_at(0) → ClassName("Some::User")       │
+# └──────────────────┬────────────────────────────────────────┘
+#                    │
+# ┌─ cross-file completion ─▼─────────────────────────────────┐
+# │  $users[0]->greet()    ← Some::User method                │
+# │  $users[0]->email()    ← Some::User method                │
+# │  $users[0]->name()     ← Mojo::Base accessor              │
+# └────────────────────────────────────────────────────────────┘
+
+use Mojolicious::Lite;
+use Some::User;
+use constant DEFAULT_NAME => 'alice';
+
+my $app = Mojolicious->new;
+
+$app->helper(make_user => sub {
+    my ($c, $name) = @_;
+    return Some::User->new(name => $name);
+});
+
+sub action {
+    my $c = Mojolicious::Controller->new;
+    my @users;
+    push @users, $c->make_user(DEFAULT_NAME);   # const fold + plugin helper
+    push @users, $c->make_user('bob');
+
+    # Put your cursor right after the `->` and trigger completion.
+    # Methods offered: greet, email, name (the Mojo::Base accessor).
+    $users[0]->greet();
+    $users[0]->name();
+}

--- a/test_files/lib/Some/User.pm
+++ b/test_files/lib/Some/User.pm
@@ -1,0 +1,22 @@
+package Some::User;
+
+# Cross-file class the spike test resolves to. `name` is a Mojo::Base
+# accessor (synthesizes both a Method and a HashKeyDef on this class),
+# and the two regular methods stand in for "things the user can call
+# on a User instance."
+
+use Mojo::Base -base;
+
+has 'name';
+
+sub greet {
+    my $self = shift;
+    "hi $self->{name}";
+}
+
+sub email {
+    my $self = shift;
+    "$self->{name}\@example.com";
+}
+
+1;


### PR DESCRIPTION
## Summary

End-to-end demo of the bag-canonical typing arch holding under a realistic chain. **The entire array intelligence — contribution + projection — is ~90 lines of code; everything else (const fold, plugin synth, coderef return, cross-file method dispatch) runs on existing infrastructure.**

Open `test_files/array_hop_demo.pl` via `./dev.sh test_files/array_hop_demo.pl`, put your cursor after `\$users[0]->`, and watch completion + hover offer `greet` / `email` / `name` from `test_files/lib/Some/User.pm`.

```perl
use Mojolicious::Lite;
use Some::User;
use constant DEFAULT_NAME => 'alice';

my \$app = Mojolicious->new;
\$app->helper(make_user => sub {
    my (\$c, \$name) = @_;
    return Some::User->new(name => \$name);
});

sub action {
    my \$c = Mojolicious::Controller->new;
    my @users;
    push @users, \$c->make_user(DEFAULT_NAME);   # const fold + plugin helper
    push @users, \$c->make_user('bob');
    \$users[0]->greet();   # cross-file user method
    \$users[0]->name();    # cross-file Mojo::Base accessor
}
```

## What landed beyond the spike

Three structural fixes that paid for themselves during the spike:

1. **Principled ordering fix.** `unresolved_call_targets` (name-keyed, function-call-specific) generalizes to `unresolved_expr_nodes: Vec<Node<'a>>`. Any node whose `expr_payload` returns None at walk time queues itself; `resolve_forward_expr_witnesses` re-calls `expr_payload` post-walk. Replaces a name-specific recovery with a node-shape-agnostic one — the array-push \"parent visited before children\" hazard is the second instance of the pattern, and every future feature with the same shape gets it free.

2. **Implicit `package main` seed.** Top-level scripts (`Mojolicious::Lite` one-off `.pl` files, anything without an explicit `package` declaration) now start with `current_package = Some(\"main\")`, matching Perl's runtime semantics. Without this, `package_uses` never recorded the file's `use` lines and `Trigger::UsesModule` plugin triggers never fired — `make_user` helper synth, route plugins, etc. silently dropped out of any script that opened with `use Mojolicious::Lite;` instead of `package Foo; use Mojolicious::Lite;`.

3. **Tree-aware invocant resolution.** `method_call_invocant_class_with_tree` routes non-trivial invocants (anything beyond scalar/array/hash/bareword) through `resolve_expression_type` on the actual CST node, so hover AND cursor-context completion share one projection rule. No string-parsing of `\$arr[N]`-shaped invocants in the hover path.

Plus a `--parse <file|->` CLI subcommand with rainbow ANSI colors when stdout is a TTY — saves bouncing to a sibling repo to sanity-check tree-sitter shapes. ~90 lines, orthogonal but earned its keep during the spike.

## File diff

| File | Code lines | What |
|---|---|---|
| `src/file_analysis.rs` | +~30 | `Sequence(Vec<…>)` variant (end of enum, stable indices); `element_at(i)` projection; `array_element_expression` arm in `resolve_expression_type`; `method_call_invocant_class_with_tree` |
| `src/builder.rs` | +~55 / -23 | `pending_array_pushes` queue; `emit_array_push_contribution` (walk-time) + `emit_array_push_witnesses` (post-fold); `visit_push_call` extension; generalized `unresolved_expr_nodes` retry queue; **implicit `package main` seed** |
| `src/witnesses.rs` | +1 | `receiver_discriminant` arm for `Sequence` |
| `src/main.rs` | +~90 | `--parse` CLI subcommand |
| `src/module_cache.rs` | +1 / -1 | `EXTRACT_VERSION` 31 → 32 |
| `test_files/lib/Some/User.pm` | new | Cross-file Mojo::Base class fixture |
| `test_files/array_hop_demo.pl` | new | The end-to-end demo, openable via `./dev.sh` |

## Test plan

- [x] `cargo test` — 556 unit tests pass (1 new: `spike_array_hop_with_helper_and_cross_file_completion`)
- [x] `./run_e2e.sh` — 93 e2e pass across 5 suites
- [x] Manual: `./dev.sh test_files/array_hop_demo.pl` — completion + hover both surface Some::User methods cross-file
- [ ] CI

## The architectural claim

From the staircase ADR: \"sequences are just witnesses and reducers, no more idiotic hacking.\" Spike confirms — the array hop is purely additive over `Variable + InferredType(Sequence(...))`, no new attachments, no new reducers, no registry touches. **Map/grep/sort/reverse and friends extend the same way**: one `SequenceTransform` payload variant + one `SeqOp` enum + ~50-line `SequenceTransformReducer`. The bag doesn't care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)