### PR TITLE
test(e2e): plugin coverage — mojo / minion / events / dbic parametric

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,6 +80,16 @@ resolution + cross-file invocant refresh) and the commit history.
   (type-of-arg, truthiness, `wantarray`) become new `ArgGuard`
   variants — no new reducers. Do **not** ship more guard-shaped facts
   that need their own reducer; fold them into `ArgGuard`.
+- **DBIC parametric column-key completion at `->search({ | })`.**
+  Goto-def from a typed key in `$rs->search({ name => 'X' })` lands
+  on the `add_columns` def (proves the parametric chain resolves),
+  but completion at an *empty* `->search({ | })` returns no items.
+  The `find_call_context` path routes empty-hash-arg key completion
+  through `complete_keyval_args`, which has no parametric-ResultSet
+  branch — it should ask the call's typed receiver
+  (`Parametric(ResultSet { row })`) for its column-key set and emit
+  those alongside any built-in `keyval_args`. Pin already lives in
+  `test_e2e_dbic_parametric.lua`'s header comment.
 - **Cursor-context qualified-path detection should lean on the parser.**
   `extract_package_from_prefix` in `cursor_context.rs` walks the source
   text backward to recover the `Foo::Bar` chunk preceding the cursor's

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -3,7 +3,17 @@ set -euo pipefail
 
 export PERL5LIB="${PERL5LIB:-$PWD/test_files/lib}"
 
-suites=(test_e2e.lua test_e2e_types.lua test_e2e_cross_file.lua test_e2e_inheritance.lua test_e2e_frameworks.lua test_e2e_array_hop.lua)
+suites=(
+  test_e2e.lua
+  test_e2e_types.lua
+  test_e2e_cross_file.lua
+  test_e2e_inheritance.lua
+  test_e2e_frameworks.lua
+  test_e2e_array_hop.lua
+  test_e2e_mojo_plugins.lua
+  test_e2e_mojo_events.lua
+  test_e2e_dbic_parametric.lua
+)
 
 total_passed=0
 total_failed=0

--- a/test_e2e_dbic_parametric.lua
+++ b/test_e2e_dbic_parametric.lua
@@ -1,0 +1,92 @@
+-- E2E tests for DBIC parametric ResultSet — uses test_files/dbic_parametric_demo.pl.
+-- Usage: nvim --headless --clean -u test_nvim_init.lua -l test_e2e_dbic_parametric.lua
+--
+-- Walks the typing chain residual Part 5c added:
+--   $schema->resultset('Schema::Result::User')
+--     → Parametric(ResultSet { base, row })
+--   ->find(1)
+--     → RowOf projection → ClassName("Schema::Result::User")
+--   ->name / ->email
+--     → resolves through the row's add_columns synthesis
+--
+-- AND validates column-key narrowing in search args:
+--   $rs->search({ email => 'x@y' })  — `name` resolves to add_columns def.
+
+vim.opt.rtp:prepend(".")
+
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+local b   = require("test.buf")
+
+local buf = lsp.open_and_attach("test_files/dbic_parametric_demo.pl")
+
+-- The parametric chain involves several reducer rounds. Poll on a
+-- single expected effect (greet on $users[0]-style) before asserting.
+local function wait_for_label(buf, line, col, needle)
+  for _ = 1, 40 do
+    local labels = lsp.completion_labels(buf, line, col)
+    for _, l in ipairs(labels) do
+      if l == needle then return labels end
+    end
+    vim.wait(250)
+  end
+  return lsp.completion_labels(buf, line, col)
+end
+
+-- ── (a) chain end-state: $user->name resolves through RowOf ─────────
+
+t.test("$user typed from ->find(...) carries Schema::Result::User", function()
+  local N = "$user typed from ->find(...) carries Schema::Result::User"
+  -- Cursor on `$user` in `my $who = $user->name;` — hover should
+  -- mention the resolved row class.
+  local line, col = b.find_pos(buf, "$user->name;")
+  if not t.ok(N, line, "couldn't find $user->name") then return end
+  local text = lsp.hover_text(buf, line, col)
+  if not t.ok(N, text, "no hover on $user") then return end
+  if t.ok(N, text:find("Schema::Result::User", 1, true) ~= nil,
+    "expected Schema::Result::User in hover, got: " .. text)
+  then t.pass(N) end
+end)
+
+t.test("$user-> completion offers column accessors", function()
+  local N = "$user-> completion offers column accessors"
+  local line, col = b.find_pos(buf, "$user->name;")
+  if not t.ok(N, line, "couldn't find $user->name") then return end
+  local arrow_col = col + #"$user->"
+  local labels = wait_for_label(buf, line, arrow_col, "name")
+  local ok = t.contains(N, labels, "name", "completions")
+  ok = t.contains(N, labels, "email", "completions") and ok
+  ok = t.contains(N, labels, "id", "completions") and ok
+  if ok then t.pass(N) end
+end)
+
+-- ── (b) column-key narrowing in search args ─────────────────────────
+
+-- Note: completion-at-empty-search-hash (typing `$rs->search({ | })`
+-- and expecting `name`/`email`/`id`) is a separate code path that
+-- routes through `complete_keyval_args`, not through HashKey/parametric
+-- narrowing. It's a follow-up — goto-def from a typed key and column-
+-- accessor completion on a `find()` row already prove the parametric
+-- chain wires through end-to-end.
+
+t.test("goto-def from column-key in search lands on add_columns", function()
+  local N = "goto-def from column-key in search lands on add_columns"
+  -- Cursor on `name` inside `$rs->search({ email => 'x@y' });` — gd
+  -- should jump to the line where `name => { data_type => ... }`
+  -- is declared inside `__PACKAGE__->add_columns(...)`. Same mid-
+  -- word landing as the completion test above.
+  local line, col = b.find_pos(buf, "email => 'x@y'")
+  if not t.ok(N, line, "couldn't find email => 'x@y'") then return end
+  local loc = lsp.def_location(buf, line, col + 1)
+  if not t.ok(N, loc, "no goto-def from search key") then return end
+  -- The add_columns body has `    name  => { data_type => 'varchar', ...},`.
+  local def_line = b.find_line(buf, "    email => { data_type")
+  if not t.ok(N, def_line, "couldn't find add_columns line for `name`") then return end
+  -- 0-indexed: find_line is 0-indexed, def_location.line is 0-indexed.
+  if t.ok(N, loc.line == def_line,
+    string.format("expected goto-def line %d (add_columns), got line %d",
+      def_line, loc.line or -1))
+  then t.pass(N) end
+end)
+
+t.finish()

--- a/test_e2e_mojo_events.lua
+++ b/test_e2e_mojo_events.lua
@@ -1,0 +1,97 @@
+-- E2E tests for the mojo-events plugin — uses the cross-file
+-- consumer fixture (test_files/plugin_events_consumer.pl).
+-- Usage: nvim --headless --clean -u test_nvim_init.lua -l test_e2e_mojo_events.lua
+--
+-- The producer (test_files/lib/Demo/Plugin/Producer.pm) wires up
+-- 'ready' / 'failed' / 'done' handlers via $self->on(EVT, sub {...}).
+-- The consumer (open file here) calls $p->emit(EVT, ...). Plugin
+-- emits HashKeyDef on the producer side + HashKeyAccess on the
+-- consumer side, paired by class+name — cross-file `gr` reaches
+-- both, and sig help on emit() surfaces the producer's handler
+-- signature.
+
+vim.opt.rtp:prepend(".")
+
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+local b   = require("test.buf")
+
+local buf = lsp.open_and_attach("test_files/plugin_events_consumer.pl")
+
+-- Cross-file resolution needs the workspace index to warm up. Poll
+-- on a known cross-file effect (sig help with a producer param)
+-- before asserting.
+local function wait_for_xfile_sig(buf, line, col, needle, ms_budget)
+  ms_budget = ms_budget or 10000
+  local elapsed = 0
+  while elapsed < ms_budget do
+    local sig = lsp.signature_label(buf, line, col)
+    if sig and sig:find(needle, 1, true) then return sig end
+    vim.wait(250)
+    elapsed = elapsed + 250
+  end
+  return lsp.signature_label(buf, line, col)
+end
+
+-- ── cross-file sig help on $p->emit('ready', |) ─────────────────────
+
+t.test("emit sig help surfaces cross-file handler params", function()
+  local N = "emit sig help surfaces cross-file handler params"
+  -- The fixture line: `$p->emit('ready', );` — cursor right after
+  -- the comma, sig help should see Producer.pm's
+  -- `->on('ready', sub ($self, $ts, $who) {...})` and surface ($ts, $who).
+  local line, col = b.find_pos(buf, "$p->emit('ready', );")
+  if not t.ok(N, line, "couldn't find emit('ready') site") then return end
+  -- Skip past `$p->emit('ready', ` to land in the args slot.
+  local arg_col = col + #"$p->emit('ready', "
+  local sig = wait_for_xfile_sig(buf, line, arg_col, "$ts")
+  if not t.ok(N, sig, "no sig help inside emit('ready', |)") then return end
+  if t.ok(N, sig:find("$ts", 1, true) ~= nil,
+    "expected $ts in handler sig, got: " .. sig)
+  then t.pass(N) end
+end)
+
+-- ── const-folded event name still resolves ──────────────────────────
+
+t.test("const-folded event name flows through to sig help", function()
+  local N = "const-folded event name flows through to sig help"
+  -- `my $evt = 'done'; $p->emit($evt, );` — the builder's
+  -- constant_strings table resolves $evt before the plugin sees it,
+  -- so sig help should resolve `done`'s handler (param $reason).
+  local line, col = b.find_pos(buf, "$p->emit($evt, );")
+  if not t.ok(N, line, "couldn't find $p->emit($evt, );") then return end
+  local arg_col = col + #"$p->emit($evt, "
+  local sig = wait_for_xfile_sig(buf, line, arg_col, "$reason")
+  if not t.ok(N, sig, "no sig help on const-folded emit") then return end
+  if t.ok(N, sig:find("$reason", 1, true) ~= nil,
+    "expected $reason from const-folded `done` handler, got: " .. sig)
+  then t.pass(N) end
+end)
+
+-- ── goto-def on emit string lands in the producer's ->on call ───────
+
+t.test("gd on event name in emit jumps to ->on call cross-file", function()
+  local N = "gd on event name in emit jumps to ->on call cross-file"
+  -- Cursor on 'ready' inside `$p->emit('ready', );` — gd should
+  -- jump to the FIRST ->on('ready', ...) in Producer.pm.
+  local line, col = b.find_pos(buf, "$p->emit('ready', );")
+  if not t.ok(N, line, "couldn't find emit('ready') site") then return end
+  -- Land cursor on the `r` of 'ready' inside the string.
+  local ready_col = col + #"$p->emit('"
+  local loc = lsp.def_location(buf, line, ready_col)
+  if not t.ok(N, loc, "no goto-def from event name") then return end
+  if t.ok(N, loc.uri and loc.uri:find("Producer.pm", 1, true) ~= nil,
+    "expected goto-def to land in Producer.pm, got uri: " .. (loc.uri or "<nil>"))
+  then t.pass(N) end
+end)
+
+-- ── diagnostics (Mojo internals + cross-file warmup) ─────────────────
+lsp.assert_no_diagnostics(t, buf, {
+  "'on' is not defined",
+  "'once' is not defined",
+  "'emit' is not defined",
+  "'unsubscribe' is not defined",
+  "'has_subscribers' is not defined",
+}, 5)
+
+t.finish()

--- a/test_e2e_mojo_plugins.lua
+++ b/test_e2e_mojo_plugins.lua
@@ -1,0 +1,136 @@
+-- E2E tests for the Mojo plugin family — uses test_files/plugin_mojo_demo.pl.
+-- Usage: nvim --headless --clean -u test_nvim_init.lua -l test_e2e_mojo_plugins.lua
+--
+-- Covers four plugins in one fixture (the demo file deliberately
+-- exercises all of them):
+--
+--   mojo-helpers   — $app->helper('name' => sub {...}) → synthesized Method
+--                    on Mojolicious::Controller, including dotted chains
+--                    ($c->users->create)
+--   mojo-routes    — $r->get('/x')->to('Users#list') → cross-file MethodCall
+--                    ref on the controller action
+--   mojo-lite      — top-level `get '/path' => sub {...}` → Handler with
+--                    url_for dispatch keyed by URL path
+--   minion         — $minion->add_task(NAME => sub {...}) → Handler keyed by
+--                    task name; $minion->enqueue(NAME, [args]) references it
+
+vim.opt.rtp:prepend(".")
+
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+local b   = require("test.buf")
+
+local buf = lsp.open_and_attach("test_files/plugin_mojo_demo.pl")
+
+-- Outline names from plugin-synthesized symbols carry a `<word>` prefix
+-- so SymbolKind's lossy mapping (Helper/Action/Route → FUNCTION) doesn't
+-- erase the kind cue. We assert by substring, not equality.
+local function names_contain(names, needle)
+  for _, n in ipairs(names) do
+    if n:find(needle, 1, true) then return true end
+  end
+  return false
+end
+
+local function assert_outline_has(test_name, needle)
+  local names = lsp.symbol_names(buf)
+  if not t.ok(test_name, names_contain(names, needle),
+    "outline missing '" .. needle .. "', got: [" .. table.concat(names, ", ") .. "]")
+  then return false end
+  return true
+end
+
+-- ── mojo-helpers ────────────────────────────────────────────────────
+
+t.test("mojo-helpers: outline includes synthesized helpers", function()
+  local N = "mojo-helpers: outline includes synthesized helpers"
+  local ok = assert_outline_has(N, "<helper> current_user")
+  ok = assert_outline_has(N, "<helper> users.create") and ok
+  ok = assert_outline_has(N, "<helper> users.delete") and ok
+  -- Three-level dotted chain.
+  ok = assert_outline_has(N, "<helper> admin.users.purge") and ok
+  if ok then t.pass(N) end
+end)
+
+t.test("mojo-helpers: helper sig shows params in outline name", function()
+  local N = "mojo-helpers: helper sig shows params in outline name"
+  -- `users.create` registers `sub ($c, $name, $email)` — the helper
+  -- params (minus the $c invocant) should land in the outline name
+  -- so users see the helper's signature at a glance.
+  if assert_outline_has(N, "users.create ($name, $email)") then
+    t.pass(N)
+  end
+end)
+
+-- ── mojo-routes (controller action dispatch) ─────────────────────────
+
+t.test("mojo-routes: ->to('Ctrl#action') becomes a <action> outline entry", function()
+  local N = "mojo-routes: ->to('Ctrl#action') becomes a <action> outline entry"
+  local ok = assert_outline_has(N, "<action> Users#list")
+  ok = assert_outline_has(N, "<action> Users#create") and ok
+  -- Multi-segment controller — the `Admin::Dashboard#index` form is
+  -- the load-bearing assertion that the action parser handles
+  -- nested package names.
+  ok = assert_outline_has(N, "<action> Admin::Dashboard#index") and ok
+  if ok then t.pass(N) end
+end)
+
+-- ── mojo-lite (top-level route verbs) ────────────────────────────────
+
+t.test("mojo-lite: top-level verbs register routes keyed by path", function()
+  local N = "mojo-lite: top-level verbs register routes keyed by path"
+  -- get / post / any are exported from Mojolicious::Lite; plugin
+  -- emits a Handler-kind symbol with the path as name.
+  local ok = assert_outline_has(N, "<route> GET /users/profile")
+  ok = assert_outline_has(N, "<route> POST /users/profile") and ok
+  ok = assert_outline_has(N, "<route> ANY /fallback") and ok
+  if ok then t.pass(N) end
+end)
+
+-- ── minion (task registration) ───────────────────────────────────────
+
+t.test("minion: add_task registers tasks with the callback's signature", function()
+  local N = "minion: add_task registers tasks with the callback's signature"
+  -- `add_task(send_email => sub ($job, $to, $subject, $body) {})` —
+  -- $job is the invocant (stripped); the visible params surface in
+  -- the outline so the user can read the task's contract at a glance.
+  local ok = assert_outline_has(N, "<task> send_email ($to, $subject, $body)")
+  ok = assert_outline_has(N, "<task> resize_image ($path, $width, $height)") and ok
+  if ok then t.pass(N) end
+end)
+
+t.test("minion: enqueue sig help surfaces the registered task's params", function()
+  local N = "minion: enqueue sig help surfaces the registered task's params"
+  -- `$minion->enqueue(send_email => ['alice@example.com', 'hi',  'body']);`
+  -- — sig help on the first inner arg should reflect the registered
+  -- task signature ($to, $subject, $body).
+  local line, col = b.find_pos(buf, "enqueue(send_email  => ['alice")
+  if not t.ok(N, line, "couldn't find enqueue site") then return end
+  -- Position past `enqueue(send_email  => [` — cursor sits at the
+  -- first arrayref element, which is arg 0 of the registered task.
+  local search_col = col + #"enqueue(send_email  => ['"
+  local sig = lsp.signature_label(buf, line, search_col)
+  if not t.ok(N, sig, "no sig help at enqueue first arg") then return end
+  -- The task registered `$to` as the first non-invocant param.
+  -- Plugin must surface it; otherwise the sig help is just enqueue's
+  -- own shape, which would NOT mention $to.
+  if t.ok(N, sig:find("$to", 1, true) ~= nil,
+    "sig help should mention '$to', got: " .. sig)
+  then t.pass(N) end
+end)
+
+-- ── diagnostics ──────────────────────────────────────────────────────
+-- Allow Mojo internals we don't index (render, session, redirect_to,
+-- enqueue_p, perform_jobs) — the demo file uses them but they're
+-- declared in Mojo core which isn't in the workspace.
+lsp.assert_no_diagnostics(t, buf, {
+  "'render' is not defined",
+  "'session' is not defined",
+  "'redirect_to' is not defined",
+  "'enqueue_p' is not defined",
+  "'perform_jobs' is not defined",
+  "'on' is not defined",
+  "'emit' is not defined",
+}, 5)
+
+t.finish()

--- a/test_files/dbic_parametric_demo.pl
+++ b/test_files/dbic_parametric_demo.pl
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+# DBIC parametric ResultSet demo. Exercises the typing chain that
+# residual Part 5c landed:
+#
+#   $schema->resultset('Schema::Result::User')
+#       → Parametric(ResultSet { base: "DBIx::Class::ResultSet",
+#                                row:  "Schema::Result::User" })
+#   …->find(1)
+#       → RowOf<that ResultSet> → ClassName("Schema::Result::User")
+#   …->name
+#       → resolves through the row's add_columns synthesis
+#
+# Plus the column-key narrowing on search:
+#
+#   $rs->search({ name => 'X' })
+#       → `name` is a HashKeyAccess on Schema::Result::User
+#
+# Used by test_e2e_dbic_parametric.lua.
+
+use strict;
+use warnings;
+
+# ── Inline schema. Real codebases split this into one file per
+# package; the inline form keeps the demo self-contained and the
+# e2e fixture single-file.
+
+package Schema::Result::User;
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->add_columns(
+    id    => { data_type => 'integer', is_auto_increment => 1 },
+    name  => { data_type => 'varchar', size => 64 },
+    email => { data_type => 'varchar', size => 128 },
+);
+
+__PACKAGE__->set_primary_key('id');
+
+package main;
+
+# `$schema` is presumed; in real code it'd come from a connect() call.
+my $schema;
+
+# ── (a) chain: resultset -> find -> column accessor ──
+#
+# `$user` lands as ClassName("Schema::Result::User") via the
+# RowOf<ResultSet { row }> projection. Hover on `$user` mentions
+# User; completion on `$user->` narrows to its accessors.
+my $user = $schema->resultset('Schema::Result::User')->find(1);
+my $who  = $user->name;
+
+# ── (b) column-key in search args ──
+#
+# Cursor on `name` in the hashref → HashKeyAccess on
+# Schema::Result::User → goto-def lands on the add_columns line.
+my $rs = $schema->resultset('Schema::Result::User');
+my $rows = $rs->search({ email => 'x@y' });
+
+1;


### PR DESCRIPTION
## Summary

Closes the e2e gap before tagging v0.3.0. The plugin features that shipped post-v0.2.4 (Mojo helpers / Mojolicious::Lite / mojo-events / mojo-routes / Minion / DBIC parametric ResultSet) had unit tests at the builder + witness-bag layer but no suites driving the LSP through nvim. This PR adds three suites bringing the e2e total from **94 → 108** passing.

### New suites

- **`test_e2e_mojo_plugins.lua`** (7 tests) against `plugin_mojo_demo.pl` — helper outline + signatures (`current_user`, `users.create`, `admin.users.purge`), `mojo-routes` `->to('Ctrl#act')` including multi-segment `Admin::Dashboard#index`, Mojolicious::Lite verbs (`<route> GET /users/profile`), Minion `add_task` outline + `enqueue` sig help that surfaces the registered task's `($to, $subject, $body)`.
- **`test_e2e_mojo_events.lua`** (4 tests) against `plugin_events_consumer.pl` + cross-file `Demo::Plugin::Producer` — sig help on `$p->emit('ready', |)` surfaces the cross-file handler's `($ts, $who)`, const-folded event names flow through (`my $evt = 'done'`), goto-def on the emit string jumps cross-file to the matching `->on` in Producer.pm.
- **`test_e2e_dbic_parametric.lua`** (3 tests) against a new `test_files/dbic_parametric_demo.pl` — `$user` from `$schema->resultset(...)->find(1)` hovers as the row class (RowOf<ResultSet> projection), `$user->` completion offers column accessors (`id`/`name`/`email`), goto-def from a typed key in `$rs->search({ email => 'x@y' })` lands on the column def in `__PACKAGE__->add_columns(...)`.

`run_e2e.sh` expanded from a single-line list to a one-per-line array so future suite additions don't churn the diff.

### Roadmap entry

One gap surfaced and captured under "Hardening, slot anywhere":

> **DBIC parametric column-key completion at `->search({ | })`.** Goto-def from a typed key works (chain resolves); completion at the *empty* hash returns nothing because `complete_keyval_args` has no parametric-ResultSet branch yet. Should ask the call's typed receiver `Parametric(ResultSet { row })` for its column-key set.

## Test plan

- [x] `./run_e2e.sh` — TOTAL: 108 passed, 0 failed across 9 suites
- [x] `cargo test` — unaffected (no source changes)
- [ ] Pair with v0.3.0 tag once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)