### PR TITLE
Cross-file SUPER::X return typing (SuperCallReturn)

### DIFF
--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -125,37 +125,26 @@ assertion is "no diagnostic at this site."
 
 ---
 
-## 5. Parser-version regression
+## 5. `--type-at` single-file CLI boundary
 
-### `ti-12` — `$self = shift->SUPER::new` no longer types (ts-parser-perl 1.1.0)
+### `ti-12` — `$self = shift->SUPER::new` types only via the cross-file path
 - **Cursor:** `Minion.pm:108:6` (the `$self` in `my $self = shift->SUPER::new;`)
 - **Expect:** `$self` typed `Minion` (the enclosing class).
-- **Actual:** `No type info` on **1.1.0**; returned `Minion` on **1.0.3**.
-- **Construct:** `my $self = shift->SUPER::new;` in a `Mojo::Base`-derived class.
-- **Root cause (narrowed; obvious causes ruled out):** A/B'd both parser versions.
-  Findings:
-  - **Cross-file only.** Single-file `--type-at` and `--dump-package` show `$self`
-    with NO type constraint (`vars_in_scope` = `$class`, `$e`) on **both** 1.0.3
-    and 1.1.0, and the minimal `my $self = shift->SUPER::new` is `None` on both.
-    Only the substrate/batch path (root + `PERL5LIB` + module index) yields
-    `Minion` on 1.0.3 / `None` on 1.1.0. So `$self`'s type is a *query-time*
-    bag-edge chase (`Variable $self → Edge(Expr(shift->SUPER::new))`), not a TC.
-  - **CST identical.** The `shift->SUPER::new` parse is byte-identical across
-    versions (invocant `func1op_call_expression` for bare `shift`, method token
-    `"SUPER::new"`) — verified, not assumed.
-  - **Not the local suspects.** `use Mojo::Base 'Mojo::EventEmitter'` parses
-    identically (base extraction intact); `Mojo::Base::new` returns `None` on
-    both (so the `Minion` did NOT come from the parent's `new` return) — it's a
-    constructor/invocant-class fallback (`shift`→Minion, `->…new` → invocant
-    class) resolved cross-file.
-  - **Conclusion:** 1.1.0 disrupted the cross-file `new`/SUPER chain-return
-    resolution via a parse change in *some other file the resolution walk
-    touches* (an ancestor in Minion's MRO, or the module-index method-return
-    path) — not Minion's own decl. Needs chain-typer instrumentation to pin the
-    exact hop.
-- **Reproduce:** `gold-corpus/run.pl --emit type-at Minion.pm 108 6` (→ `Minion`
-  on 1.0.3, `None` on 1.1.0). The minimal single-file repro does NOT reproduce.
-- **Difficulty:** unknown (exact broken hop open; obvious causes eliminated).
+- **Resolved in the LSP.** `SUPER::X` return typing now composes end-to-end:
+  `emit_method_call_return_edges` emits a `SuperCallReturn` witness (look `X` up
+  on the *enclosing package's parent*, default the receiver to the invocant /
+  enclosing class). `Mojo::Base::new` is receiver-polymorphic
+  (`bless …, ref $class || $class` → `ReturnExpr::ReceiverOr`), so the parent
+  ctor blesses into `Minion` and `$self` types `Minion`. Locked in by the **gold**
+  `hover-minion-super-new` (same cursor, full LSP startup) and the unit test
+  `test_super_new_types_to_calling_class`.
+- **Why this row stays xfail:** the `--type-at` CLI mode is *single-file*
+  (`cli_type_at` parses one file, no module index), so it cannot reach
+  `Mojo::Base` cross-file to resolve `SUPER::new`. This is an inherent boundary
+  of that debug CLI mode, not an LSP limitation — every cross-file query mode
+  (`--hover`, `--definition`, the LSP server) takes a `<root>` and resolves it.
+- **Reproduce:** `gold-corpus/run.pl hover` → `hover-minion-super-new` passes
+  (`Minion`); `--type-at Minion.pm 108 6` returns `No type info` (no root).
 
 ---
 
@@ -164,56 +153,55 @@ assertion is "no diagnostic at this site."
 New gaps surfaced while mining gold from fresh CPAN modules. Each is pinned at
 xfail (expected-correct confirmed from source; tool genuinely wrong).
 
-### `hover-mojo-url-clone-via-new` / `ti-mojo-url-abs-clone-chain` — clone via `$self->new` types as HashRef
-`Mojo::URL::clone` does `my $clone = $self->new; @$clone{…}=…; return $clone` →
-expected `Mojo::URL`, actual `HashRef`.
+### `hover-mojo-url-clone-via-new` / `ti-mojo-url-abs-clone-chain` — clone via `$self->new` — **MOSTLY FIXED**
+`Mojo::URL::clone` does `my $clone = $self->new; @$clone{…}=…; return $clone`.
+The **variable** `$clone` now types `Mojo::URL` end-to-end — at the assignment,
+through the hash-slice mutation, and at `return $clone` (verified via `--hover`
+at every point). Two landed pieces:
 
-**PARTIALLY FIXED.** Receiver-polymorphic constructors now type correctly:
-`bless {}, $class` / `bless {}, ref $self || $self` emit `ReturnExpr::ReceiverOr`
-(the call-site receiver, else the enclosing class as fallback). So `Mojo::URL->new`
-→ `Mojo::URL`, `Child->new` (inherited ctor) → `Child`, and the `SUPER::new` chain
-composes — all at **query time**. The fold already lets a class dominate a hashref
-rep, verified: a *local*-ctor `my $x = $self->new; $x->{k}=…; return $x` returns the
-class, not HashRef.
+1. **Receiver-polymorphic constructors** (`bless {}, $class` /
+   `bless {}, ref $self || $self`) emit `ReturnExpr::ReceiverOr` — the call-site
+   receiver, else the enclosing class as fallback. So `Mojo::URL->new` →
+   `Mojo::URL`, `Child->new` (inherited ctor) → `Child`. The fold lets a class
+   dominate a hashref rep, so a hash-slice-mutated clone keeps the class.
+2. **`SUPER::X` return typing** via the `SuperCallReturn` witness:
+   `emit_method_call_return_edges` detects a `SUPER::`-prefixed method, looks `X`
+   up on the *enclosing package's parents* (not the invocant's own class), and
+   defaults the receiver to the invocant / enclosing class — preferring a dynamic
+   outer receiver only when it `is_subclass_of` the enclosing class. So
+   `Mojo::URL::new`'s body `shift->SUPER::new` resolves to `Mojo::Base::new` with
+   receiver `Mojo::URL`, whose `ReturnExpr::ReceiverOr` substitutes `Mojo::URL`.
 
-**Residual (root-caused — `SUPER::X` return resolution, not the assignment edge).**
-The chaseable edge already exists: `my $clone = $self->new` gives `Variable($clone)
-→ Edge(Expression($self->new))`, the fold materializes edges before reducing, and
-class-dominates-rep is in place (a *local*-ctor clone — incl. hash-slice deref —
-correctly returns the class). The actual break is one level deeper: `$self->new`
-resolves to `Mojo::URL::new`, whose body is `shift->SUPER::new`, and **`SUPER::X`
-return typing does not resolve — even same-file** (verified: `Child::new = $c->
-SUPER::new` → `None`). `emit_method_call_return_edges` emits `MethodOnClass{Child,
-"SUPER::new"}` (invocant class + literal `SUPER::new`), which never resolves.
+Locked in by the **gold** `hover-minion-super-new` and the unit test
+`test_super_new_types_to_calling_class`.
 
-Two-part fix:
-  1. In `emit_method_call_return_edges`, when the method is `SUPER::X`, emit
-     `MethodOnClass{<parent of the enclosing package>, X}` (SUPER dispatches to the
-     *writing* package's parents, not the invocant's own class — and skips the
-     enclosing class to avoid `Child::new → Child::new` recursion).
-  2. Make the receiver preservation inheritance-aware: `materialize`'s
-     `fresh_dispatch_receiver(incoming, target_class)` resets the receiver to
-     `target_class` when `incoming != target_class`, which for SUPER drops `Child`
-     for `Base` and yields `Base`. A receiver that *is-a* the dispatch class should
-     be **preserved** (it is more specific and still valid), so the inherited
-     `ReturnExpr::ReceiverOr` substitutes the caller's class. Needs the inheritance
-     check via `q.context` (it carries `module_index` + `package_parents`).
+**Residual — the SUB's stored *return type* (not the variable).** The fixture
+`hover-mojo-url-clone-via-new` cursors the `sub clone` declaration, which reports
+the sub's *declared* return type — still `HashRef`/null, NOT `Mojo::URL`. Root
+cause is **build-time vs query-time**: `clone`'s `return_types` entry is seeded
+in the fold (`seed_return_types_from_bag`) at build time, where the module index
+isn't consulted, so the cross-file `$self->new → SUPER::new → Mojo::Base::new`
+chain that the variable resolves *at query time* isn't visible to the build-time
+seed. Only locally-available evidence (the `@$clone{…}` hash-slice rep) survives
+into the stored return type. The variable hover recomputes with the module index
+and gets `Mojo::URL`; the sub-return seed does not. **This is the same class of
+gap as `ClassIsa`/`param_types` ancestry-gated *emission* deferred to the
+ReceiverGated seam** (a sub-return whose value depends on a cross-file chain must
+resolve on a query-time seam, not the build-time `return_types` map). Distinct
+from SUPER itself — kept xfail. **Subsystem:** build-time `return_types` seed vs
+query-time cross-file method-return composition. **Difficulty:** medium–high.
 
-**Attempted (and backed out) — necessary but NOT sufficient.** Both parts were
-implemented and part (1) verified firing correctly (`SUPER::new` → emits
-`MethodOnClass{Base, new}`, `encl=Child`). But it surfaced a deeper blocker: with
-the SUPER edge present, even a *direct* `find_method_return_type("Base", "new")`
-on the same FA returns `None` — i.e. the presence of a sibling SUPER-delegating
-`new` **corrupts the base class's own resolution**. The CallReturn chase reaches
-`MethodOnClass{Base, new}` with `receiver=Child` but the nested `query_rec`
-returns `None` while the standalone query returns `Base`, which points at a
-shared-`QueryState` memo / cycle-guard interaction in the fold's write-back (the
-SUPER edge is processed at build time, feeding `seed_return_types_from_bag`).
-**So the real prerequisite is understanding that registry/fold interaction** — the
-two-part change alone regresses base resolution. **Subsystem:** `SUPER::` dispatch
-+ the shared-state memo/cycle behavior in `query_rec` during the fold.
-**Difficulty:** high — needs the memo/cycle interaction nailed before the
-two-part change is safe.
+**Note on the earlier "base-class corruption" red herring.** A first SUPER
+attempt appeared to make `find_method_return_type("Base", "new")` return `None`
+whenever a sibling SUPER-delegating `new` was present, which was blamed on a
+shared-`QueryState` memo / cycle-guard interaction. That was a **test artifact**,
+not a memo bug: the probe blessed via `bless {}, ref $c || $c`, but
+`bless_class_is_receiver` only recognises the canonical invocant names
+(`$self` / `$class` / `$this` / `$proto`) — `$c` is not one, so the ctor fell to
+`bless_class_of(||)` → `None`. Re-running with `$class`/`$self` shows same-file
+SUPER resolving with no cross-query contamination. The memo is per-top-level
+query (dropped on return) and keyed on `(bag, attachment, receiver, arity)`, so
+it never leaks across queries — the corruption never existed.
 
 ### `diag-mojo-cookiejar-helper-fp` / `diag-mojo-daemon-callback-fp` — first-param-self over-reach in OO classes
 In an OO class, a plain helper (`sub _compare { my ($cookie,…)=@_ }`) or an
@@ -237,7 +225,7 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | diag-09 / diag-10 | typeglob-codegen synthesis | medium |
 | def-16-codegen-type-function | Type::Library synthesis | medium |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
-| ti-12 + mojo-url clone-via-new | cross-file receiver-polymorphic ctor (`bless {}, ref $self \|\| $self`) → `Receiver` emission + no-receiver fallback | **high** |
+| mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |
 
 Quickest wins: the signature-help invocant gate, imported-names in completion,

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -222,21 +222,26 @@ mirror how FunctionCall already treats `Foo::Bar::baz()`:
 - **Completion** — both `Foo::Bar::` (bare) and `$obj->Foo::Bar::` (on a variable
   invocant) complete the qualifier package's subs; the tree cursor-context detects
   a `::`-bearing method token after `->` and routes to `QualifiedPath`.
-- **SUPER navigation** — `$self->SUPER::m` resolves to the enclosing package's
-  parent method: `qualified_dispatch_class` maps `SUPER` → first parent, so
-  goto-def jumps to the parent's `m`, hover shows it, and renaming the parent
-  method rewrites the SUPER call (a dangling SUPER call would be a broken rename —
-  see the updated `rename-11-urn-canonical-precision`, which now asserts the isbn
-  SUPER call IS renamed while the subclass override and unrelated `_generic.pm`
-  are not). `$self->SUPER::` completion falls through to ordinary method
-  completion (SUPER isn't a package), so inherited methods still show.
+- **SUPER navigation** — `$self->SUPER::m` resolves to whichever ancestor
+  actually defines `m`, walking the **full parent MRO** (`resolve_super_method`
+  = the shared ancestor DFS with `skip_self`, so it searches every `@ISA` entry
+  and skips the current package). goto-def jumps to it, hover shows it, and
+  renaming the defining ancestor's method rewrites the SUPER call (a dangling
+  SUPER call would be a broken rename — see the updated
+  `rename-11-urn-canonical-precision`, which asserts the isbn SUPER call IS
+  renamed while the subclass override and unrelated `_generic.pm` are not).
+  references/rename resolve SUPER **lazily** in `refs_to` (the ref carries the
+  `SUPER::` marker + its enclosing scope, and `refs_to` runs with the module
+  index), so a SUPER call into a *cross-file* parent in a dependency file —
+  which the build-time stamp can't name — still resolves. `$self->SUPER::`
+  completion falls through to ordinary method completion (SUPER isn't a
+  package), so inherited methods still show.
 
 Proven by `test_fq_method_call_dispatches_from_named_class` (return typing),
 `test_fq_method_call_nav_dispatches_from_named_class` (goto-def / rename / class
-resolution / tail-span), `test_super_method_nav_resolves_to_parent` (SUPER nav),
-and `test_tree_context_fq_method_is_qualified_path` (completion context).
-**Residual:** multi-parent `SUPER::m` nav resolves only the *first* parent (Perl
-walks the full parent MRO); single inheritance — the common case — is exact.
+resolution / tail-span), `test_super_method_nav_resolves_to_parent` +
+`test_super_resolves_across_all_parents` (SUPER nav incl. multi-parent + skip-
+self), and `test_tree_context_fq_method_is_qualified_path` (completion context).
 
 ### `return bless {BLOCK}, CLASS` class arg stranding — **FIXED**
 tree-sitter-perl parses `return bless {}, $class` as `return((bless {}), $class)`:
@@ -274,7 +279,6 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | diag-08 (loader call) | XS loader recognition | **low** |
 | diag-09 / diag-10 | typeglob-codegen synthesis | medium |
 | def-16-codegen-type-function | Type::Library synthesis | medium |
-| multi-parent `SUPER::m` nav (single-inheritance is exact) | first-parent only vs full parent MRO | low |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -156,107 +156,21 @@ assertion is "no diagnostic at this site."
 New gaps surfaced while mining gold from fresh CPAN modules. Each is pinned at
 xfail (expected-correct confirmed from source; tool genuinely wrong).
 
-### `hover-mojo-url-clone-via-new` / `ti-mojo-url-abs-clone-chain` — clone via `$self->new` — **MOSTLY FIXED**
+### `hover-mojo-url-clone-via-new` / `ti-mojo-url-abs-clone-chain` — clone sub's stored *return type*
 `Mojo::URL::clone` does `my $clone = $self->new; @$clone{…}=…; return $clone`.
-The **variable** `$clone` now types `Mojo::URL` end-to-end — at the assignment,
-through the hash-slice mutation, and at `return $clone` (verified via `--hover`
-at every point). Two landed pieces:
-
-1. **Receiver-polymorphic constructors** (`bless {}, $class` /
-   `bless {}, ref $self || $self`) emit `ReturnExpr::ReceiverOr` — the call-site
-   receiver, else the enclosing class as fallback. So `Mojo::URL->new` →
-   `Mojo::URL`, `Child->new` (inherited ctor) → `Child`. The fold lets a class
-   dominate a hashref rep, so a hash-slice-mutated clone keeps the class.
-2. **`SUPER::X` return typing** via the `SuperCallReturn` witness:
-   `emit_method_call_return_edges` detects a `SUPER::`-prefixed method, looks `X`
-   up on the *enclosing package's parents* (not the invocant's own class), and
-   defaults the receiver to the invocant / enclosing class — preferring a dynamic
-   outer receiver only when it `is_subclass_of` the enclosing class. So
-   `Mojo::URL::new`'s body `shift->SUPER::new` resolves to `Mojo::Base::new` with
-   receiver `Mojo::URL`, whose `ReturnExpr::ReceiverOr` substitutes `Mojo::URL`.
-
-Locked in by the **gold** `hover-minion-super-new` and the unit test
-`test_super_new_types_to_calling_class`.
-
-**Residual — the SUB's stored *return type* (not the variable).** The fixture
-`hover-mojo-url-clone-via-new` cursors the `sub clone` declaration, which reports
-the sub's *declared* return type — still `HashRef`/null, NOT `Mojo::URL`. Root
-cause is **build-time vs query-time**: `clone`'s `return_types` entry is seeded
-in the fold (`seed_return_types_from_bag`) at build time, where the module index
-isn't consulted, so the cross-file `$self->new → SUPER::new → Mojo::Base::new`
-chain that the variable resolves *at query time* isn't visible to the build-time
-seed. Only locally-available evidence (the `@$clone{…}` hash-slice rep) survives
-into the stored return type. The variable hover recomputes with the module index
-and gets `Mojo::URL`; the sub-return seed does not. **This is the same class of
-gap as `ClassIsa`/`param_types` ancestry-gated *emission* deferred to the
-ReceiverGated seam** (a sub-return whose value depends on a cross-file chain must
-resolve on a query-time seam, not the build-time `return_types` map). Distinct
-from SUPER itself — kept xfail. **Subsystem:** build-time `return_types` seed vs
-query-time cross-file method-return composition. **Difficulty:** medium–high.
-
-**Note on the earlier "base-class corruption" red herring.** A first SUPER
-attempt appeared to make `find_method_return_type("Base", "new")` return `None`
-whenever a sibling SUPER-delegating `new` was present, which was blamed on a
-shared-`QueryState` memo / cycle-guard interaction. That was a **test artifact**,
-not a memo bug: the probe blessed via `bless {}, ref $c || $c`, but
-`bless_class_is_receiver` only recognises the canonical invocant names
-(`$self` / `$class` / `$this` / `$proto`) — `$c` is not one, so the ctor fell to
-`bless_class_of(||)` → `None`. Re-running with `$class`/`$self` shows same-file
-SUPER resolving with no cross-query contamination. The memo is per-top-level
-query (dropped on return) and keyed on `(bag, attachment, receiver, arity)`, so
-it never leaks across queries — the corruption never existed.
-
-### Fully-qualified method calls (`$obj->Foo::Bar::m`) — **supported across the LSP**
-Perl dispatches `$obj->Foo::Bar::m` from the *named* class `Foo::Bar` (its MRO),
-not the invocant's class. Now handled across every feature on two seams that
-mirror how FunctionCall already treats `Foo::Bar::baz()`:
-- **Return typing** — `emit_method_call_return_edges` peels the qualifier off
-  any `::`-bearing method token and emits `QualifiedCallReturn{MethodOnClass{
-  Foo::Bar, m}, …}`.
-- **Navigation** — `method_call_invocant_class` returns the qualifier as the
-  dispatch class; consumers resolve the method on the bare tail
-  (`unqualified_target_name()`), and `method_name_span` narrows to the tail
-  (`fq_tail_span`) so rename rewrites only `m`. This single class seam +
-  bare-name projection drives goto-def, references, rename/prepareRename, hover,
-  document-highlight, and signature-help.
-- **Completion** — both `Foo::Bar::` (bare) and `$obj->Foo::Bar::` (on a variable
-  invocant) complete the qualifier package's subs; the tree cursor-context detects
-  a `::`-bearing method token after `->` and routes to `QualifiedPath`.
-- **SUPER navigation** — `$self->SUPER::m` resolves to whichever ancestor
-  actually defines `m`, walking the **full parent MRO** (`resolve_super_method`
-  = the shared ancestor DFS with `skip_self`, so it searches every `@ISA` entry
-  and skips the current package). goto-def jumps to it, hover shows it, and
-  renaming the defining ancestor's method rewrites the SUPER call (a dangling
-  SUPER call would be a broken rename — see the updated
-  `rename-11-urn-canonical-precision`, which asserts the isbn SUPER call IS
-  renamed while the subclass override and unrelated `_generic.pm` are not).
-  references/rename resolve SUPER **lazily** in `refs_to` (the ref carries the
-  `SUPER::` marker + its enclosing scope, and `refs_to` runs with the module
-  index), so a SUPER call into a *cross-file* parent in a dependency file —
-  which the build-time stamp can't name — still resolves. `$self->SUPER::`
-  completion falls through to ordinary method completion (SUPER isn't a
-  package), so inherited methods still show.
-
-Proven by `test_fq_method_call_dispatches_from_named_class` (return typing),
-`test_fq_method_call_nav_dispatches_from_named_class` (goto-def / rename / class
-resolution / tail-span), `test_super_method_nav_resolves_to_parent` +
-`test_super_resolves_across_all_parents` (SUPER nav incl. multi-parent + skip-
-self), and `test_tree_context_fq_method_is_qualified_path` (completion context).
-
-### `return bless {BLOCK}, CLASS` class arg stranding — **FIXED**
-tree-sitter-perl parses `return bless {}, $class` as `return((bless {}), $class)`:
-the brace block greedily ends the parenless `bless`, stranding the class arg as a
-sibling of the `return_expression` in the enclosing `list_expression`. Perl parses
-`bless` as a list operator (the comma binds to bless), so that sibling IS the
-class. `bless_args` splices it back (gated to the parenless `ambiguous_function_
-call_expression` so an explicit `bless({}), $x` 2-element return isn't misread).
-This masked for non-inherited ctors (enclosing package == the class) but broke
-foreign-literal (`bless {}, 'Other'` → enclosing, not `Other`) and bare-`{}`
-receiver-poly ctors (`return bless {}, ref $class || $class` → enclosing, not
-`ReceiverOr`, so inherited/SUPER ctors lost the subclass). Locked in by
-`test_bless_return_strands_class_arg_recovered`,
-`test_bless_positional_self_is_receiver` (`$_[0]` is the positional invocant,
-already recognised via `is_positional_receiver`).
+The **variable** `$clone` types `Mojo::URL` correctly. The fixture cursors the
+`sub clone` declaration, which reports the sub's *declared* return type — still
+`HashRef`/null, NOT `Mojo::URL`. Root cause is **build-time vs query-time**:
+`clone`'s `return_types` entry is seeded in the fold
+(`seed_return_types_from_bag`) at build time, where the module index isn't
+consulted, so the cross-file `$self->new → SUPER::new → Mojo::Base::new` chain
+the variable resolves *at query time* isn't visible to the build-time seed —
+only the local `@$clone{…}` hash-slice rep survives. Same class of gap as
+`ClassIsa`/`param_types` ancestry-gated *emission* deferred to the ReceiverGated
+seam: a sub-return whose value depends on a cross-file chain must resolve on a
+query-time seam, not the build-time `return_types` map. **Subsystem:** build-time
+`return_types` seed vs query-time cross-file method-return composition.
+**Difficulty:** medium–high.
 
 ### `diag-mojo-cookiejar-helper-fp` / `diag-mojo-daemon-callback-fp` — first-param-self over-reach in OO classes
 In an OO class, a plain helper (`sub _compare { my ($cookie,…)=@_ }`) or an

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -219,20 +219,24 @@ mirror how FunctionCall already treats `Foo::Bar::baz()`:
   (`fq_tail_span`) so rename rewrites only `m`. This single class seam +
   bare-name projection drives goto-def, references, rename/prepareRename, hover,
   document-highlight, and signature-help.
-- **Completion** — `Foo::Bar::` (package-qualified) completes the package's subs
-  natively.
+- **Completion** — both `Foo::Bar::` (bare) and `$obj->Foo::Bar::` (on a variable
+  invocant) complete the qualifier package's subs; the tree cursor-context detects
+  a `::`-bearing method token after `->` and routes to `QualifiedPath`.
+- **SUPER navigation** — `$self->SUPER::m` resolves to the enclosing package's
+  parent method: `qualified_dispatch_class` maps `SUPER` → first parent, so
+  goto-def jumps to the parent's `m`, hover shows it, and renaming the parent
+  method rewrites the SUPER call (a dangling SUPER call would be a broken rename —
+  see the updated `rename-11-urn-canonical-precision`, which now asserts the isbn
+  SUPER call IS renamed while the subclass override and unrelated `_generic.pm`
+  are not). `$self->SUPER::` completion falls through to ordinary method
+  completion (SUPER isn't a package), so inherited methods still show.
 
-Proven by `test_fq_method_call_dispatches_from_named_class` (return typing) and
+Proven by `test_fq_method_call_dispatches_from_named_class` (return typing),
 `test_fq_method_call_nav_dispatches_from_named_class` (goto-def / rename / class
-resolution / tail-span). **Minor residuals:**
-- **SUPER navigation** (`$self->SUPER::m` goto-def/refs/rename) is deliberately
-  NOT swept: `qualified_dispatch_class` returns `None` for `SUPER` so a subclass
-  SUPER call isn't pulled into a rename of the parent's method (precision — see
-  `rename-11-urn-canonical-precision`). SUPER *return typing* works; SUPER nav is
-  a tracked follow-up that needs override-vs-call rename policy first.
-- **`$obj->Foo::Bar::` completion** on a *variable* invocant (vs the common
-  `Foo::Bar::`) — rare, returns nothing; the cursor-context method-vs-qualified
-  detection picks the unresolved-invocant method path first.
+resolution / tail-span), `test_super_method_nav_resolves_to_parent` (SUPER nav),
+and `test_tree_context_fq_method_is_qualified_path` (completion context).
+**Residual:** multi-parent `SUPER::m` nav resolves only the *first* parent (Perl
+walks the full parent MRO); single inheritance — the common case — is exact.
 
 ### `return bless {BLOCK}, CLASS` class arg stranding — **FIXED**
 tree-sitter-perl parses `return bless {}, $class` as `return((bless {}), $class)`:
@@ -270,8 +274,7 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | diag-08 (loader call) | XS loader recognition | **low** |
 | diag-09 / diag-10 | typeglob-codegen synthesis | medium |
 | def-16-codegen-type-function | Type::Library synthesis | medium |
-| SUPER navigation (`$self->SUPER::m` goto-def/refs/rename) — return typing done | needs override-vs-call rename policy | medium |
-| `$obj->Foo::Bar::` completion on a variable invocant (`Foo::Bar::` works) | cursor-context method-vs-qualified detection | low |
+| multi-parent `SUPER::m` nav (single-inheritance is exact) | first-parent only vs full parent MRO | low |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -206,19 +206,33 @@ SUPER resolving with no cross-query contamination. The memo is per-top-level
 query (dropped on return) and keyed on `(bag, attachment, receiver, arity)`, so
 it never leaks across queries — the corruption never existed.
 
-### Fully-qualified method calls (`$obj->Foo::Bar::m`) — **return typing FIXED, goto-def still a follow-up**
+### Fully-qualified method calls (`$obj->Foo::Bar::m`) — **supported across the LSP**
 Perl dispatches `$obj->Foo::Bar::m` from the *named* class `Foo::Bar` (its MRO),
-not the invocant's class. The qualifier-peeling seam in `emit_method_call_
-return_edges` (shared with `SUPER`) now routes FQ calls through
-`QualifiedCallReturn{MethodOnClass{Foo::Bar, m}, …}`, so **return typing** works:
-`$obj->Maker::build()` types to `Maker::build`'s return (proven by
-`test_fq_method_call_dispatches_from_named_class` — it discriminates "dispatched
-from `Maker`" from "dispatched from the invocant", which would pick a different
-`build`). **Residual:** goto-def / references / rename for a FQ method token
-(`Foo::Bar::m`) still resolve against the invocant's class with the whole token
-as the method name, so they return empty — a separate seam (`refs_to` / method
-resolution) from return typing. **Subsystem:** method-call ref resolution.
-**Difficulty:** medium.
+not the invocant's class. Now handled across every feature on two seams that
+mirror how FunctionCall already treats `Foo::Bar::baz()`:
+- **Return typing** — `emit_method_call_return_edges` peels the qualifier off
+  any `::`-bearing method token and emits `QualifiedCallReturn{MethodOnClass{
+  Foo::Bar, m}, …}`.
+- **Navigation** — `method_call_invocant_class` returns the qualifier as the
+  dispatch class; consumers resolve the method on the bare tail
+  (`unqualified_target_name()`), and `method_name_span` narrows to the tail
+  (`fq_tail_span`) so rename rewrites only `m`. This single class seam +
+  bare-name projection drives goto-def, references, rename/prepareRename, hover,
+  document-highlight, and signature-help.
+- **Completion** — `Foo::Bar::` (package-qualified) completes the package's subs
+  natively.
+
+Proven by `test_fq_method_call_dispatches_from_named_class` (return typing) and
+`test_fq_method_call_nav_dispatches_from_named_class` (goto-def / rename / class
+resolution / tail-span). **Minor residuals:**
+- **SUPER navigation** (`$self->SUPER::m` goto-def/refs/rename) is deliberately
+  NOT swept: `qualified_dispatch_class` returns `None` for `SUPER` so a subclass
+  SUPER call isn't pulled into a rename of the parent's method (precision — see
+  `rename-11-urn-canonical-precision`). SUPER *return typing* works; SUPER nav is
+  a tracked follow-up that needs override-vs-call rename policy first.
+- **`$obj->Foo::Bar::` completion** on a *variable* invocant (vs the common
+  `Foo::Bar::`) — rare, returns nothing; the cursor-context method-vs-qualified
+  detection picks the unresolved-invocant method path first.
 
 ### `return bless {BLOCK}, CLASS` class arg stranding — **FIXED**
 tree-sitter-perl parses `return bless {}, $class` as `return((bless {}), $class)`:
@@ -256,7 +270,8 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | diag-08 (loader call) | XS loader recognition | **low** |
 | diag-09 / diag-10 | typeglob-codegen synthesis | medium |
 | def-16-codegen-type-function | Type::Library synthesis | medium |
-| FQ method goto-def/refs/rename (`$obj->Foo::Bar::m`) — return typing done | method-call ref resolution (`refs_to`) | medium |
+| SUPER navigation (`$self->SUPER::m` goto-def/refs/rename) — return typing done | needs override-vs-call rename policy | medium |
+| `$obj->Foo::Bar::` completion on a variable invocant (`Foo::Bar::` works) | cursor-context method-vs-qualified detection | low |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -130,14 +130,17 @@ assertion is "no diagnostic at this site."
 ### `ti-12` — `$self = shift->SUPER::new` types only via the cross-file path
 - **Cursor:** `Minion.pm:108:6` (the `$self` in `my $self = shift->SUPER::new;`)
 - **Expect:** `$self` typed `Minion` (the enclosing class).
-- **Resolved in the LSP.** `SUPER::X` return typing now composes end-to-end:
-  `emit_method_call_return_edges` emits a `SuperCallReturn` witness (look `X` up
-  on the *enclosing package's parent*, default the receiver to the invocant /
-  enclosing class). `Mojo::Base::new` is receiver-polymorphic
-  (`bless …, ref $class || $class` → `ReturnExpr::ReceiverOr`), so the parent
-  ctor blesses into `Minion` and `$self` types `Minion`. Locked in by the **gold**
-  `hover-minion-super-new` (same cursor, full LSP startup) and the unit test
-  `test_super_new_types_to_calling_class`.
+- **Resolved in the LSP.** Explicitly-qualified method dispatch (`SUPER::X` and
+  fully-qualified `Foo::Bar::X`) now composes end-to-end. `emit_method_call_
+  return_edges` peels the dispatch class from any `::`-bearing method token via
+  one seam — `SUPER` → the *enclosing package's parents*, any other qualifier →
+  that literal class — and emits a `QualifiedCallReturn` witness that looks the
+  method up on the named class while typing the result relative to the invocant.
+  `Mojo::Base::new` is receiver-polymorphic (`bless …, ref $class || $class` →
+  `ReturnExpr::ReceiverOr`), so the parent ctor blesses into `Minion` and `$self`
+  types `Minion`. Locked in by the **gold** `hover-minion-super-new` and the
+  unit tests `test_super_new_types_to_calling_class`,
+  `test_fq_method_call_dispatches_from_named_class`.
 - **Why this row stays xfail:** the `--type-at` CLI mode is *single-file*
   (`cli_type_at` parses one file, no module index), so it cannot reach
   `Mojo::Base` cross-file to resolve `SUPER::new`. This is an inherent boundary
@@ -203,6 +206,35 @@ SUPER resolving with no cross-query contamination. The memo is per-top-level
 query (dropped on return) and keyed on `(bag, attachment, receiver, arity)`, so
 it never leaks across queries — the corruption never existed.
 
+### Fully-qualified method calls (`$obj->Foo::Bar::m`) — **return typing FIXED, goto-def still a follow-up**
+Perl dispatches `$obj->Foo::Bar::m` from the *named* class `Foo::Bar` (its MRO),
+not the invocant's class. The qualifier-peeling seam in `emit_method_call_
+return_edges` (shared with `SUPER`) now routes FQ calls through
+`QualifiedCallReturn{MethodOnClass{Foo::Bar, m}, …}`, so **return typing** works:
+`$obj->Maker::build()` types to `Maker::build`'s return (proven by
+`test_fq_method_call_dispatches_from_named_class` — it discriminates "dispatched
+from `Maker`" from "dispatched from the invocant", which would pick a different
+`build`). **Residual:** goto-def / references / rename for a FQ method token
+(`Foo::Bar::m`) still resolve against the invocant's class with the whole token
+as the method name, so they return empty — a separate seam (`refs_to` / method
+resolution) from return typing. **Subsystem:** method-call ref resolution.
+**Difficulty:** medium.
+
+### `return bless {BLOCK}, CLASS` class arg stranding — **FIXED**
+tree-sitter-perl parses `return bless {}, $class` as `return((bless {}), $class)`:
+the brace block greedily ends the parenless `bless`, stranding the class arg as a
+sibling of the `return_expression` in the enclosing `list_expression`. Perl parses
+`bless` as a list operator (the comma binds to bless), so that sibling IS the
+class. `bless_args` splices it back (gated to the parenless `ambiguous_function_
+call_expression` so an explicit `bless({}), $x` 2-element return isn't misread).
+This masked for non-inherited ctors (enclosing package == the class) but broke
+foreign-literal (`bless {}, 'Other'` → enclosing, not `Other`) and bare-`{}`
+receiver-poly ctors (`return bless {}, ref $class || $class` → enclosing, not
+`ReceiverOr`, so inherited/SUPER ctors lost the subclass). Locked in by
+`test_bless_return_strands_class_arg_recovered`,
+`test_bless_positional_self_is_receiver` (`$_[0]` is the positional invocant,
+already recognised via `is_positional_receiver`).
+
 ### `diag-mojo-cookiejar-helper-fp` / `diag-mojo-daemon-callback-fp` — first-param-self over-reach in OO classes
 In an OO class, a plain helper (`sub _compare { my ($cookie,…)=@_ }`) or an
 anonymous callback (`on(request => sub { my $tx = shift; … })` ) has its first
@@ -224,6 +256,7 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | diag-08 (loader call) | XS loader recognition | **low** |
 | diag-09 / diag-10 | typeglob-codegen synthesis | medium |
 | def-16-codegen-type-function | Type::Library synthesis | medium |
+| FQ method goto-def/refs/rename (`$obj->Foo::Bar::m`) — return typing done | method-call ref resolution (`refs_to`) | medium |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |

--- a/gold-corpus/README.md
+++ b/gold-corpus/README.md
@@ -37,7 +37,7 @@ A process abort (the scanner-overflow class) is always a hard **CRASH** fail. Ou
 | outline (documentSymbol) | [outline.md](outline.md) | 10 | 0 | 2 | 1 |
 | definition (goto-def) | [definition.md](definition.md) | 18 | 2 | 0 | 0 |
 | references | [references.md](references.md) | 20 | 1 | 0 | 1 |
-| hover | [hover.md](hover.md) | 18 | 1 | 4 | 1 |
+| hover | [hover.md](hover.md) | 19 | 1 | 4 | 1 |
 | type-at | [type-at.md](type-at.md) | 12 | 2 | 2 | 5 |
 | rename | [rename.md](rename.md) | 8 | 0 | 1 | 2 |
 | workspace-symbol | [workspace-symbol.md](workspace-symbol.md) | 14 | 0 | 0 | 1 |

--- a/gold-corpus/fixtures/hover.json
+++ b/gold-corpus/fixtures/hover.json
@@ -259,6 +259,22 @@
       "status": "gold"
     },
     {
+      "id": "hover-minion-super-new",
+      "difficulty": "tricky",
+      "semantic_area": "oo-isa",
+      "file": "Minion.pm",
+      "line": 108,
+      "col": 6,
+      "expect": {
+        "all": [
+          "my $self = shift->SUPER::new;",
+          "type: Minion"
+        ],
+        "none": []
+      },
+      "status": "gold"
+    },
+    {
       "id": "hover-minion-emit-inherited",
       "difficulty": "tricky",
       "semantic_area": "oo-isa",

--- a/gold-corpus/fixtures/rename.json
+++ b/gold-corpus/fixtures/rename.json
@@ -97,7 +97,8 @@
       "line": 90,
       "col": 4,
       "newname": "RENAMED",
-      "expect": {"all":["urn.pm","\"line\":\"90\""],"none":["isbn.pm","_generic.pm"]},
+      "comment": "Renames URI::urn::canonical: the def (urn.pm:90) AND the subclass SUPER call that targets it (isbn.pm:97, $self->SUPER::canonical). NOT isbn's own canonical override (isbn.pm:94) nor _generic.pm's $rel->canonical (dispatches to a different class).",
+      "expect": {"all":["urn.pm","\"line\":\"90\"","isbn.pm","\"line\":\"97\""],"none":["_generic.pm","\"line\":\"94\""]},
       "status": "gold"
     }
   ]

--- a/gold-corpus/fixtures/type-at.json
+++ b/gold-corpus/fixtures/type-at.json
@@ -152,7 +152,8 @@
         ],
         "none": []
       },
-      "status": "xfail"
+      "status": "xfail",
+      "note": "type-at CLI is single-file (no module index), so SUPER::new can't reach Mojo::Base cross-file. The LSP path DOES resolve this — see hover-minion-super-new (gold)."
     },
     {
       "id": "ti-13",

--- a/gold-corpus/hover.md
+++ b/gold-corpus/hover.md
@@ -20,6 +20,7 @@ Positions are 0-based on input, 1-based on output. Run via `gold-corpus/run.pl h
 | hover-minion-has-app-mojo | simple | mojo | `Minion.pm:16:4` | all: has app => sub; package Minion; Application for job queue | gold | has app => sub {...} ... Application for job queue |
 | hover-minion-var-worker | simple | type-inference | `Minion.pm:151:6` | all: my $worker = Minion::Worker->new(minion => $self);; type: Minion::Worker | gold | my $worker = Minion::Worker->new(minion => $self); type: Minion::Worker |
 | hover-minion-self-shift-classic | simple | classic | `Minion.pm:94:7` | all: my ($self, $id) = @_;; type: Minion | gold | my ($self, $id) = @_; type: Minion |
+| hover-minion-super-new | tricky | oo-isa | `Minion.pm:108:6` | all: my $self = shift->SUPER::new;; type: Minion | gold | my $self = shift->SUPER::new; type: Minion |
 | hover-minion-emit-inherited | tricky | oo-isa | `Minion.pm:152:9` | all: sub emit(); class Minion (from Mojo::EventEmitter); Emit event. | provisional | sub emit() class Minion (from Mojo::EventEmitter) returns: HashRef ... Emit event. |
 
 ## Dropped (non-lib, absent from installed tree)

--- a/gold-corpus/rename.md
+++ b/gold-corpus/rename.md
@@ -13,7 +13,7 @@ Positions are 0-based on input, 1-based on output. Run via `gold-corpus/run.pl r
 | rename-06-build-exporter | tricky | exporter | `Sub/Exporter.pm:703:4` | all: Exporter.pm; "line":"703"; "line":"933"; "line":"934"; "line":"602" | xfail | Exporter.pm: 703 (def), 933 (export bareword), 934 (call); cross-file FQ. MISSES in-body call at 602. |
 | rename-08-authority | tricky | oo-isa | `URI/_generic.pm:37:4` | all: _generic.pm; _server.pm; file.pm; ldapi.pm; "line":"37" | provisional | _generic.pm:37 (def); _server.pm:54,65,74,91,114,120,137; file.pm:38; ldapi.pm:13,18. MISSES intra-file dynamically-typed locals. |
 | rename-09-base-constant | simple | constants | `URI/_punycode.pm:14:13` | all: _punycode.pm; "line":"14"; "line":"79" | xfail | _punycode.pm: 14 (def), 47,48,49,51,71(x2),118(x2),122,124. MISSES line 79: $w *= (BASE - $t). |
-| rename-11-urn-canonical-precision | tricky | oo-isa | `URI/urn.pm:90:4` | all: urn.pm; "line":"90" / none: isbn.pm; _generic.pm | gold | urn.pm: line 90 (URI::urn::canonical def) ONLY. No other same-named canonical defs touched. |
+| rename-11-urn-canonical-precision | tricky | oo-isa | `URI/urn.pm:90:4` | all: urn.pm; "line":"90"; isbn.pm; "line":"97" / none: _generic.pm; "line":"94" | gold | Renames the URI::urn::canonical def (urn.pm:90) AND the subclass SUPER call targeting it (isbn.pm:97, `$self->SUPER::canonical`). NOT isbn's own override (isbn.pm:94) nor _generic.pm's `$rel->canonical` (different dispatch class). |
 
 ## Dropped (non-lib, absent from installed tree)
 

--- a/gold-corpus/type-at.md
+++ b/gold-corpus/type-at.md
@@ -13,7 +13,7 @@ Positions are 0-based on input, 1-based on output. Run via `gold-corpus/run.pl t
 | ti-09 | tricky | oo-isa | `Type/Tiny.pm:397:5` | all: Type::Tiny | gold | Type::Tiny |
 | ti-10 | tricky | a4 | `Type/Tiny.pm:400:6` | all: Numeric | gold | Numeric |
 | ti-11 | simple | mojo | `Minion.pm:26:9` | all: Minion | gold | Minion |
-| ti-12 | tricky | oo-isa | `Minion.pm:108:6` | all: Minion | xfail | (1.1.0 regression: `$self = shift->SUPER::new` no longer types) |
+| ti-12 | tricky | oo-isa | `Minion.pm:108:6` | all: Minion | xfail | type-at CLI is single-file (no module index); SUPER::new can't reach Mojo::Base cross-file. LSP resolves it — see hover-minion-super-new (gold). |
 | ti-13 | simple | type-inference | `Minion.pm:110:6` | all: String | gold | String |
 | ti-14 | tricky | type-inference | `Minion.pm:151:5` | all: Minion::Worker | gold | Minion::Worker |
 | ti-15 | simple | moose | `Dist/Zilla.pm:90:7` | all: Dist::Zilla | gold | Dist::Zilla |

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12140,6 +12140,39 @@ impl<'a> Builder<'a> {
             if self.route_branded_refs.contains(&i) {
                 continue;
             }
+            // `$obj->SUPER::X` dispatches X on the parents of the package where
+            // the call is WRITTEN, skipping that package.
+            if let Some(method) = r.target_name.strip_prefix("SUPER::") {
+                let Some(encl) = self.package_at_pos(r.span.start) else { continue };
+                // SUPER blesses into the INVOCANT's class (the caller), not the
+                // parent — default the receiver to the call's invocant class,
+                // falling back to the enclosing package.
+                let receiver_class = self
+                    .method_call_invocant
+                    .get(&i)
+                    .cloned()
+                    .unwrap_or_else(|| encl.to_string());
+                let parents = self.package_parents.get(encl).cloned().unwrap_or_default();
+                let arity = self.method_call_arity.get(&i).copied().unwrap_or(0);
+                for parent in parents {
+                    edges.push(Witness {
+                        attachment: WitnessAttachment::Expression(crate::witnesses::RefIdx(
+                            i as u32,
+                        )),
+                        source: WitnessSource::Builder("method_call_return".into()),
+                        payload: WitnessPayload::SuperCallReturn {
+                            method_lookup: WitnessAttachment::MethodOnClass {
+                                class: parent,
+                                name: method.to_string(),
+                            },
+                            receiver_class: receiver_class.clone(),
+                            arity,
+                        },
+                        span: r.span,
+                    });
+                }
+                continue;
+            }
             let Some(class) = self.method_call_invocant.get(&i) else {
                 continue;
             };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6173,7 +6173,7 @@ impl<'a> Builder<'a> {
             "function_call_expression" | "ambiguous_function_call_expression"
                 if self.is_bless_call(node) =>
             {
-                let args = self.extract_call_args(node);
+                let args = self.bless_args(node);
                 match args.get(1) {
                     // Receiver-polymorphic: `bless X, $class` / `bless X, ref
                     // $self || $self` returns the class it was CALLED ON, so
@@ -10783,8 +10783,55 @@ impl<'a> Builder<'a> {
     /// → current package; a string/bareword literal → its text; a missing
     /// 2nd arg (`bless {}`) → current package (Perl's one-arg bless blesses
     /// into the caller's package).
+    /// `bless`'s effective arguments, recovering the class arg that
+    /// tree-sitter-perl strands in `return bless {BLOCK}, CLASS`. The brace
+    /// block greedily ends the (parenless) call, so `CLASS` lands as a sibling
+    /// of the `return_expression` in the enclosing `list_expression`. Perl
+    /// parses `bless` as a list operator (the comma binds to bless, not
+    /// return), so that stranded sibling IS the class — splice it back. Only
+    /// the parenless `ambiguous_function_call_expression` strands; an explicit
+    /// `bless({}), $x` delimits its args, so its trailing list element is a
+    /// genuine second return value, not a dropped class.
+    fn bless_args(&self, node: Node<'a>) -> Vec<Node<'a>> {
+        let mut args = self.extract_call_args(node);
+        if node.kind() == "ambiguous_function_call_expression"
+            && args.len() == 1
+            && args[0].kind() == "anonymous_hash_expression"
+        {
+            if let Some(class) = self.bless_stranded_class(node) {
+                args.push(class);
+            }
+        }
+        args
+    }
+
+    /// The class arg stranded after `return bless {BLOCK}` — the head's next
+    /// named sibling in the `list_expression` that captured the tail (walking
+    /// past an optional `return_expression`). See `bless_args`.
+    fn bless_stranded_class(&self, node: Node<'a>) -> Option<Node<'a>> {
+        let head = match node.parent() {
+            Some(p) if p.kind() == "return_expression" => p,
+            _ => node,
+        };
+        let list = head.parent()?;
+        if list.kind() != "list_expression" {
+            return None;
+        }
+        let mut take_next = false;
+        for i in 0..list.named_child_count() {
+            let c = list.named_child(i)?;
+            if take_next {
+                return Some(c);
+            }
+            if c.id() == head.id() {
+                take_next = true;
+            }
+        }
+        None
+    }
+
     fn visit_bless_call(&mut self, node: Node<'a>) {
-        let args = self.extract_call_args(node);
+        let args = self.bless_args(node);
         let obj = match args.first() {
             Some(n) => *n,
             None => return,
@@ -12112,6 +12159,19 @@ impl<'a> Builder<'a> {
     /// attachment. Refs without a filled class skip emission —
     /// without a known class there's no class-keyed slot to target.
     ///
+    /// Resolve the qualifier of a `::`-bearing method token to the class(es)
+    /// the lookup starts at. `SUPER` is the one language keyword that does NOT
+    /// name a literal class: it means "the parents of the package the call is
+    /// written in" (and may have several). Every other qualifier IS the literal
+    /// class (`Foo::Bar`); a leading-`::` token (`->::m`) means `main`.
+    fn qualified_dispatch_classes(&self, qualifier: &str, enclosing: &str) -> Vec<String> {
+        match qualifier {
+            "SUPER" => self.package_parents.get(enclosing).cloned().unwrap_or_default(),
+            "" => vec!["main".to_string()],
+            class => vec![class.to_string()],
+        }
+    }
+
     /// Clear-and-emit on tag `method_call_return` so repeat calls
     /// inside the worklist driver stay idempotent.
     fn emit_method_call_return_edges(&mut self) {
@@ -12140,29 +12200,32 @@ impl<'a> Builder<'a> {
             if self.route_branded_refs.contains(&i) {
                 continue;
             }
-            // `$obj->SUPER::X` dispatches X on the parents of the package where
-            // the call is WRITTEN, skipping that package.
-            if let Some(method) = r.target_name.strip_prefix("SUPER::") {
+            // A `::`-bearing method token names an EXPLICIT dispatch class —
+            // Perl looks the method up on the named class, not the invocant's:
+            //   `SUPER::m`     → the parents of the package the call is WRITTEN
+            //                    in (SUPER skips the writing package);
+            //   `Foo::Bar::m`  → the fully-qualified class `Foo::Bar`.
+            // Either way the call still blesses into the INVOCANT's class, so
+            // the result is typed relative to the invocant (falling back to the
+            // enclosing package). One seam, both spellings.
+            if let Some((qualifier, method)) = r.target_name.rsplit_once("::") {
                 let Some(encl) = self.package_at_pos(r.span.start) else { continue };
-                // SUPER blesses into the INVOCANT's class (the caller), not the
-                // parent — default the receiver to the call's invocant class,
-                // falling back to the enclosing package.
                 let receiver_class = self
                     .method_call_invocant
                     .get(&i)
                     .cloned()
                     .unwrap_or_else(|| encl.to_string());
-                let parents = self.package_parents.get(encl).cloned().unwrap_or_default();
                 let arity = self.method_call_arity.get(&i).copied().unwrap_or(0);
-                for parent in parents {
+                let lookup_classes = self.qualified_dispatch_classes(qualifier, encl);
+                for class in lookup_classes {
                     edges.push(Witness {
                         attachment: WitnessAttachment::Expression(crate::witnesses::RefIdx(
                             i as u32,
                         )),
                         source: WitnessSource::Builder("method_call_return".into()),
-                        payload: WitnessPayload::SuperCallReturn {
+                        payload: WitnessPayload::QualifiedCallReturn {
                             method_lookup: WitnessAttachment::MethodOnClass {
-                                class: parent,
+                                class,
                                 name: method.to_string(),
                             },
                             receiver_class: receiver_class.clone(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7561,7 +7561,11 @@ impl<'a> Builder<'a> {
                                             .unwrap_or("")
                                             .to_string(),
                                         invocant_span: invocant.map(node_to_span),
-                                        method_name_span: node_to_span(method),
+                                        // A fully-qualified call (`$o->Foo::Bar::m`)
+                                        // keeps the full path in `target_name` but
+                                        // narrows the renamable span to the `m` tail
+                                        // (rule #7), mirroring FunctionCall.
+                                        method_name_span: crate::file_analysis::fq_tail_span(method, name),
                                     },
                                     span: node_to_span(n),
                                     scope,
@@ -9615,8 +9619,13 @@ impl<'a> Builder<'a> {
         let method_name = method_node
             .and_then(|n| n.utf8_text(self.source).ok())
             .map(|s| s.to_string());
-        let method_name_span = method_node.map(|n| node_to_span(n))
-            .unwrap_or_else(|| node_to_span(node));
+        // A fully-qualified call (`$o->Foo::Bar::m`) keeps the full path in
+        // `target_name` but narrows the renamable span to the `m` tail (rule
+        // #7), mirroring FunctionCall — so rename rewrites only the method.
+        let method_name_span = match (method_node, method_name.as_deref()) {
+            (Some(n), Some(name)) => crate::file_analysis::fq_tail_span(n, name),
+            _ => node_to_span(node),
+        };
         let invocant_node = node.child_by_field_name("invocant");
         let invocant_text = invocant_node
             .and_then(|n| n.utf8_text(self.source).ok())
@@ -10792,6 +10801,13 @@ impl<'a> Builder<'a> {
     /// the parenless `ambiguous_function_call_expression` strands; an explicit
     /// `bless({}), $x` delimits its args, so its trailing list element is a
     /// genuine second return value, not a dropped class.
+    ///
+    /// KLUDGE (tree-sitter-perl parser bug): the correct parse is `bless` as a
+    /// list operator grabbing the whole `{BLOCK}, CLASS` list. A fix is going
+    /// upstream; once a tree-sitter-perl release parses `return bless {}, X`
+    /// with both args under the call, DELETE `bless_args` + `bless_stranded_
+    /// class` and call `extract_call_args` directly at both bless sites. See
+    /// mem `tree-sitter-perl-parse-gotcha-return`.
     fn bless_args(&self, node: Node<'a>) -> Vec<Node<'a>> {
         let mut args = self.extract_call_args(node);
         if node.kind() == "ambiguous_function_call_expression"

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14202,3 +14202,25 @@ fn test_braced_invocant_bless_is_receiver_poly() {
         "a sigil-deref bless target must NOT be treated as the receiver"
     );
 }
+
+#[test]
+fn test_super_new_types_to_calling_class() {
+    // `$self->SUPER::new` looks `new` up on the parent (`Base`), but `Base::new`
+    // is receiver-polymorphic (`bless {}, ref $class || $class`), so it blesses
+    // into the SUBCLASS — `Child::new` must return `Child`, not `Base`. And a
+    // `clone` that calls `$self->new` composes through the SUPER hop back to
+    // `Child`.
+    let fa = build_fa(
+        "package Base;\nsub new { my $class = shift; bless {}, ref $class || $class }\nsub parse { $_[0] }\npackage Child;\nuse parent -norequire, 'Base';\nsub new { my $self = shift; @_ > 1 ? $self->SUPER::new->parse(@_) : $self->SUPER::new }\nsub clone { my $self = shift; my $c = $self->new; @$c{qw(a)} = (1); return $c }\n",
+    );
+    assert_eq!(
+        fa.find_method_return_type("Child", "new", None, Some(0)),
+        Some(InferredType::ClassName("Child".into())),
+        "SUPER::new on a receiver-polymorphic parent ctor blesses into the subclass"
+    );
+    assert_eq!(
+        fa.find_method_return_type("Child", "clone", None, Some(0)),
+        Some(InferredType::ClassName("Child".into())),
+        "clone's $self->new composes through the SUPER hop back to the subclass"
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14224,3 +14224,59 @@ fn test_super_new_types_to_calling_class() {
         "clone's $self->new composes through the SUPER hop back to the subclass"
     );
 }
+
+#[test]
+fn test_fq_method_call_dispatches_from_named_class() {
+    // `$obj->Maker::build()` is a fully-qualified method call: Perl dispatches
+    // `build` from `Maker`, NOT from the invocant's class. `Maker::build` is
+    // receiver-polymorphic (returns the invocant's class), so the FQ call types
+    // to `Invoker` (the invocant). If we wrongly dispatched from the invocant's
+    // class, we'd pick `Invoker::build` → `Numeric` — so asserting `Invoker`
+    // also proves the named class won.
+    let fa = build_fa(
+        "package Maker;\nsub build { my $class = shift; return bless {}, ref $class || $class }\npackage Invoker;\nsub new { my $c = shift; return bless {}, ref $c || $c }\nsub build { return 42 }\npackage main;\nmy $obj = Invoker->new;\nmy $r = $obj->Maker::build();\n",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$r", Point::new(7, 4)),
+        Some(InferredType::ClassName("Invoker".into())),
+        "FQ call dispatches build from Maker (receiver-poly → invocant), not from Invoker"
+    );
+}
+
+#[test]
+fn test_bless_return_strands_class_arg_recovered() {
+    // tree-sitter-perl strands the class arg of `return bless {BLOCK}, CLASS`
+    // (the brace block greedily ends the parenless call). We splice it back, so
+    // the foreign literal class is honored instead of falling to the enclosing
+    // package.
+    let lit = build_fa("package P;\nsub make { return bless {}, 'Widget' }\n");
+    assert_eq!(
+        lit.find_method_return_type("P", "make", None, Some(0)),
+        Some(InferredType::ClassName("Widget".into())),
+        "return bless {{}}, 'Widget' must type to Widget, not the enclosing package"
+    );
+    // The receiver-polymorphic spelling with `return` is the common inherited
+    // ctor — recovery makes it ReceiverOr so a subclass types to itself.
+    let poly = build_fa(
+        "package Base;\nsub new { my $class = shift; return bless {}, ref $class || $class }\npackage Child;\nuse parent -norequire, 'Base';\nsub make { my $self = shift; return $self->new }\n",
+    );
+    assert_eq!(
+        poly.find_method_return_type("Child", "make", None, Some(0)),
+        Some(InferredType::ClassName("Child".into())),
+        "inherited receiver-poly ctor (return bless {{}}, ref $class || $class) types to the subclass"
+    );
+}
+
+#[test]
+fn test_bless_positional_self_is_receiver() {
+    // `$_[0]` is the positional spelling of the invocant — a receiver-poly ctor
+    // written `bless {}, ref $_[0] || $_[0]` types to the calling subclass.
+    let fa = build_fa(
+        "package Base;\nsub new { return bless {}, ref $_[0] || $_[0] }\npackage Child;\nuse parent -norequire, 'Base';\nsub make { my $self = shift; return $self->new }\n",
+    );
+    assert_eq!(
+        fa.find_method_return_type("Child", "make", None, Some(0)),
+        Some(InferredType::ClassName("Child".into())),
+        "bless {{}}, ref $_[0] || $_[0] is receiver-polymorphic via the positional self"
+    );
+}

--- a/src/cursor_context.rs
+++ b/src/cursor_context.rs
@@ -364,6 +364,29 @@ pub fn detect_cursor_context_tree_with_index(
                 // Check if cursor is after -> (in the method position)
                 if let Some(invocant_node) = current.child_by_field_name("invocant") {
                     if invocant_node.end_position() < point {
+                        // `$obj->Foo::Bar::` / `$obj->Foo::ba` — a fully-qualified
+                        // method is being typed. The qualifier names the dispatch
+                        // PACKAGE, so complete its subs (same as a bare `Foo::Bar::`),
+                        // not the invocant's own methods. SUPER isn't a package, so
+                        // it falls through to ordinary method completion.
+                        if let Some(method) = current.child_by_field_name("method") {
+                            if let Ok(mtext) = method.utf8_text(source) {
+                                if let Some(idx) = mtext.rfind("::") {
+                                    let qualifier = &mtext[..idx];
+                                    let ms = method.start_position();
+                                    let past_qualifier = point.row == ms.row
+                                        && point.column >= ms.column + idx + 2;
+                                    if qualifier != "SUPER"
+                                        && past_qualifier
+                                        && is_perl_package_name(qualifier)
+                                    {
+                                        return Some(CursorContext::QualifiedPath {
+                                            package: qualifier.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
                         // stub_expression means the parser absorbed "()" from a function
                         // call like `get_config()->`. The real invocant is the parent
                         // ambiguous_function_call_expression (i.e. the full `get_config()` call).

--- a/src/cursor_context_tests.rs
+++ b/src/cursor_context_tests.rs
@@ -218,6 +218,34 @@ fn test_tree_context_method_on_function_call() {
 }
 
 #[test]
+fn test_tree_context_fq_method_is_qualified_path() {
+    // `$obj->Foo::Bar::` while typing a fully-qualified method: the qualifier
+    // names the dispatch PACKAGE, so completion targets that package's subs,
+    // not the (untyped) invocant's methods.
+    let source = "my $obj = X->new;\nmy $r = $obj->Foo::Bar::";
+    let (tree, fa) = build_fa(source);
+    let col = source.lines().nth(1).unwrap().len();
+    let ctx = detect_cursor_context_tree(&tree, source.as_bytes(), Point::new(1, col), &fa);
+    assert!(
+        matches!(ctx, Some(CursorContext::QualifiedPath { ref package }) if package == "Foo::Bar"),
+        "expected QualifiedPath(Foo::Bar), got {:?}",
+        ctx,
+    );
+
+    // SUPER is not a package — it must fall through to ordinary method
+    // completion (so inherited methods still show), not QualifiedPath(SUPER).
+    let s2 = "package C;\nsub m { my $self = shift; $self->SUPER::";
+    let (t2, fa2) = build_fa(s2);
+    let c2 = s2.lines().nth(1).unwrap().len();
+    let ctx2 = detect_cursor_context_tree(&t2, s2.as_bytes(), Point::new(1, c2), &fa2);
+    assert!(
+        !matches!(ctx2, Some(CursorContext::QualifiedPath { .. })),
+        "SUPER:: must not be treated as a package path, got {:?}",
+        ctx2,
+    );
+}
+
+#[test]
 fn test_tree_context_method_on_chained_call() {
     // $f->get_bar()-> where get_bar returns Object(Bar)
     let source = "package Foo;\nsub new { bless {}, shift }\nsub get_bar {\n    return Bar->new();\n}\npackage Bar;\nsub new { bless {}, shift }\npackage main;\nmy $f = Foo->new();\n$f->get_bar()->";

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -5192,21 +5192,12 @@ impl FileAnalysis {
     /// another package resolve (e.g. `$r->get('/x')->to(...)`). Pass
     /// `None` only for CLI debug / isolated tests.
     ///
-    /// Resolve the dispatch class named by a method token's `::` qualifier
+    /// Resolve the dispatch class named by a *literal* `::` qualifier
     /// (`$obj->Foo::Bar::m` → `Foo::Bar`). A leading `::` (`->::m`) is `main`.
-    ///
-    /// `SUPER::m` dispatches to the enclosing package's parent — `$self->
-    /// SUPER::m` is a reference to that *specific* parent method (so goto-def
-    /// jumps to it, and renaming the parent method rewrites the SUPER call;
-    /// leaving it dangling would be a broken rename). First parent only: Perl's
-    /// SUPER walks the full parent MRO, but single inheritance is the common
-    /// case; multi-parent SUPER nav is a rare residual.
-    fn qualified_dispatch_class(&self, qualifier: &str, scope: ScopeId) -> Option<String> {
+    /// `SUPER` is not a literal class — it's resolved by `resolve_super_method`
+    /// (the enclosing package's parent MRO), not here.
+    fn qualified_dispatch_class(&self, qualifier: &str, _scope: ScopeId) -> Option<String> {
         match qualifier {
-            "SUPER" => {
-                let encl = self.enclosing_class_for_scope(scope)?;
-                self.package_parents.get(&encl).and_then(|ps| ps.first().cloned())
-            }
             "" => Some("main".to_string()),
             class => Some(class.to_string()),
         }
@@ -5225,6 +5216,19 @@ impl FileAnalysis {
         // The qualifier rides the method token (`target_name`), independent of
         // the invocant expression, so it wins ahead of invocant resolution.
         if let Some((qualifier, _)) = r.target_name.rsplit_once("::") {
+            if qualifier == "SUPER" {
+                // SUPER searches the enclosing package's parents' MRO; the
+                // dispatch class is whichever ancestor actually defines it
+                // (multi-parent safe). `None` when the index isn't available
+                // yet (build-time stamp of a dependency file, cross-file
+                // parent) — every query-time consumer re-resolves with the
+                // index: open docs via the enrichment re-stamp, goto-def via the
+                // cross-file path, references/rename via `refs_to`'s SUPER arm.
+                let encl = self.enclosing_class_for_scope(r.scope)?;
+                return self
+                    .resolve_super_method(&encl, r.unqualified_target_name(), module_index)
+                    .map(|res| res.class().to_string());
+            }
             return self.qualified_dispatch_class(qualifier, r.scope);
         }
         if invocant.is_empty() {
@@ -5503,7 +5507,7 @@ impl FileAnalysis {
     }
 
     /// Walk the scope chain to find the enclosing class or package.
-    fn enclosing_class_for_scope(&self, scope: ScopeId) -> Option<String> {
+    pub(crate) fn enclosing_class_for_scope(&self, scope: ScopeId) -> Option<String> {
         for sid in self.scope_chain(scope).iter() {
             let s = self.scope(*sid);
             if let ScopeKind::Class { ref name } = s.kind {
@@ -5624,6 +5628,21 @@ impl FileAnalysis {
         &self,
         class_name: &str,
         module_index: Option<&ModuleIndex>,
+        visit: impl FnMut(&str) -> std::ops::ControlFlow<()>,
+    ) {
+        self.for_each_ancestor_class_opt(class_name, module_index, false, visit)
+    }
+
+    /// MRO walk shared by every inheritance consumer. `skip_self`: when true,
+    /// the starting class is NOT visited but its parents' MRO still is — this
+    /// is exactly `SUPER::` semantics (search the enclosing package's parents,
+    /// skipping the package itself). The seen-set still records the start so a
+    /// diamond that loops back to it is skipped.
+    fn for_each_ancestor_class_opt(
+        &self,
+        class_name: &str,
+        module_index: Option<&ModuleIndex>,
+        skip_self: bool,
         mut visit: impl FnMut(&str) -> std::ops::ControlFlow<()>,
     ) {
         // Perl's default MRO is left-to-right depth-first: for
@@ -5638,11 +5657,15 @@ impl FileAnalysis {
         // `@ISA` order before the reverse-push.
         let mut seen: HashSet<String> = HashSet::new();
         let mut stack: Vec<String> = vec![class_name.to_string()];
+        let mut first = true;
         while let Some(cur) = stack.pop() {
             if !seen.insert(cur.clone()) { continue; }
             if seen.len() > 21 { break; } // matches the legacy depth guard
-            if let std::ops::ControlFlow::Break(()) = visit(&cur) {
-                return;
+            let is_root = std::mem::replace(&mut first, false);
+            if !(skip_self && is_root) {
+                if let std::ops::ControlFlow::Break(()) = visit(&cur) {
+                    return;
+                }
             }
             let parents = parents_of(
                 &cur,
@@ -5694,6 +5717,72 @@ impl FileAnalysis {
         chain
     }
 
+    /// Does `cls` ITSELF define/bridge `method_name`? The per-class check —
+    /// no ancestor walk — factored out of the MRO loop so normal dispatch and
+    /// `SUPER::` share one definition of "this class has the method". (a) local
+    /// symbols packaged under `cls`, (b) local plugin-namespace entities
+    /// bridged to `cls`, (c) cross-file: `cls`'s own module, cross-package
+    /// typeglob installs, and plugin bridges from other files.
+    fn method_resolution_on_class(
+        &self,
+        cls: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<MethodResolution> {
+        // (a) Local symbols in this file packaged under `cls`.
+        for &sid in self.symbols_named(method_name) {
+            let sym = self.symbol(sid);
+            if matches!(sym.kind, SymKind::Sub | SymKind::Method)
+                && self.symbol_in_class(sid, cls)
+            {
+                return Some(MethodResolution::Local { class: cls.to_string(), sym_id: sid });
+            }
+        }
+        // (b) Local plugin-namespace entities bridged to `cls`.
+        for ns in &self.plugin_namespaces {
+            if !ns.bridges.iter().any(|b| matches!(b, Bridge::Class(c) if c == cls)) { continue; }
+            for sym_id in &ns.entities {
+                let Some(sym) = self.symbols.get(sym_id.0 as usize) else { continue };
+                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
+                if sym.name == method_name {
+                    return Some(MethodResolution::Local { class: cls.to_string(), sym_id: *sym_id });
+                }
+            }
+        }
+        // (c) Cross-file: the cached module for `cls` itself (real
+        // CPAN/user-defined methods) plus plugin-emitted methods registered via
+        // bridges from other workspace files (rule #8 — `for_each_entity_
+        // bridged_to`).
+        if let Some(idx) = module_index {
+            if let Some(cached) = idx.get_cached(cls) {
+                if cached.has_sub(method_name) {
+                    return Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: None });
+                }
+            }
+            // Cross-package typeglob install: the method is attributed to `cls`
+            // but lives in a differently-named module file (`*{'DateTime::'.
+            // $sub} = …` inside `package DateTime::PP`). Record the home module.
+            if let Some(home) = idx.module_declaring_method_in_package(method_name, cls) {
+                return Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: Some(home) });
+            }
+            // Plugin-bridged method (a Mojo helper synthesized in another file,
+            // bridged to `cls`). Record the registration module so the def
+            // lookup hits the right file, not `cls`'s own module.
+            let mut bridged_module: Option<String> = None;
+            idx.for_each_entity_bridged_to(cls, |mod_name, _cached, sym| {
+                if bridged_module.is_some() { return; }
+                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { return; }
+                if sym.name == method_name {
+                    bridged_module = Some(mod_name.to_string());
+                }
+            });
+            if bridged_module.is_some() {
+                return Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: bridged_module });
+            }
+        }
+        None
+    }
+
     /// Walk the inheritance chain to find a method (DFS, matches Perl's default MRO).
     pub fn resolve_method_in_ancestors(
         &self,
@@ -5703,80 +5792,31 @@ impl FileAnalysis {
     ) -> Option<MethodResolution> {
         let mut result: Option<MethodResolution> = None;
         self.for_each_ancestor_class(class_name, module_index, |cls| {
-            // (a) Local symbols in this file packaged under `cls`.
-            for &sid in self.symbols_named(method_name) {
-                let sym = self.symbol(sid);
-                if matches!(sym.kind, SymKind::Sub | SymKind::Method)
-                    && self.symbol_in_class(sid, cls)
-                {
-                    result = Some(MethodResolution::Local {
-                        class: cls.to_string(),
-                        sym_id: sid,
-                    });
-                    return std::ops::ControlFlow::Break(());
-                }
+            match self.method_resolution_on_class(cls, method_name, module_index) {
+                Some(r) => { result = Some(r); std::ops::ControlFlow::Break(()) }
+                None => std::ops::ControlFlow::Continue(()),
             }
-            // (b) Local plugin-namespace entities bridged to `cls`.
-            for ns in &self.plugin_namespaces {
-                if !ns.bridges.iter().any(|b| matches!(b, Bridge::Class(c) if c == cls)) { continue; }
-                for sym_id in &ns.entities {
-                    let Some(sym) = self.symbols.get(sym_id.0 as usize) else { continue };
-                    if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
-                    if sym.name == method_name {
-                        result = Some(MethodResolution::Local {
-                            class: cls.to_string(),
-                            sym_id: *sym_id,
-                        });
-                        return std::ops::ControlFlow::Break(());
-                    }
-                }
+        });
+        result
+    }
+
+    /// `$self->SUPER::m` dispatch: resolve `method_name` over `enclosing`'s
+    /// parents' MRO, skipping `enclosing` itself (Perl's SUPER searches the
+    /// current package's parents). Walks the FULL DFS MRO — every parent in
+    /// `@ISA`, not just the first — so a method defined on a later parent (or a
+    /// grandparent reached only through it) resolves exactly as Perl would.
+    pub fn resolve_super_method(
+        &self,
+        enclosing: &str,
+        method_name: &str,
+        module_index: Option<&ModuleIndex>,
+    ) -> Option<MethodResolution> {
+        let mut result: Option<MethodResolution> = None;
+        self.for_each_ancestor_class_opt(enclosing, module_index, true, |cls| {
+            match self.method_resolution_on_class(cls, method_name, module_index) {
+                Some(r) => { result = Some(r); std::ops::ControlFlow::Break(()) }
+                None => std::ops::ControlFlow::Continue(()),
             }
-            // (c) Cross-file: the cached module for `cls` itself
-            // (real CPAN/user-defined methods on the class) plus
-            // plugin-emitted methods registered via bridges from
-            // other workspace files. Per rule #8 the bridge index
-            // is the lookup — see `for_each_entity_bridged_to`.
-            if let Some(idx) = module_index {
-                if let Some(cached) = idx.get_cached(cls) {
-                    if cached.has_sub(method_name) {
-                        // Real method in `cls`'s own module.
-                        result = Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: None });
-                        return std::ops::ControlFlow::Break(());
-                    }
-                }
-                // Cross-package typeglob install: the method is attributed
-                // to `cls` but lives in a differently-named module file
-                // (`*{'DateTime::'.$sub} = …` inside `package DateTime::PP`).
-                // The class's own module doesn't declare it; the symbol's
-                // package does. Record the actual home module so the def
-                // lookup hits the right file.
-                if let Some(home) = idx.module_declaring_method_in_package(method_name, cls) {
-                    result = Some(MethodResolution::CrossFile {
-                        class: cls.to_string(),
-                        def_module: Some(home),
-                    });
-                    return std::ops::ControlFlow::Break(());
-                }
-                // Plugin-bridged method (e.g. a Mojo helper synthesized in
-                // another file, bridged to `cls`). The SAME bridge walk
-                // completion uses — record which module the symbol actually
-                // lives in (its registration key, not a re-derived package
-                // name) so consumers don't re-look-it-up in `cls`'s module,
-                // where a bridged helper doesn't exist.
-                let mut bridged_module: Option<String> = None;
-                idx.for_each_entity_bridged_to(cls, |mod_name, _cached, sym| {
-                    if bridged_module.is_some() { return; }
-                    if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { return; }
-                    if sym.name == method_name {
-                        bridged_module = Some(mod_name.to_string());
-                    }
-                });
-                if bridged_module.is_some() {
-                    result = Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: bridged_module });
-                    return std::ops::ControlFlow::Break(());
-                }
-            }
-            std::ops::ControlFlow::Continue(())
         });
         result
     }
@@ -6543,6 +6583,15 @@ pub enum MethodResolution {
     CrossFile { class: String, def_module: Option<String> },
 }
 
+impl MethodResolution {
+    /// The class the method resolved on (both variants carry it).
+    pub fn class(&self) -> &str {
+        match self {
+            MethodResolution::Local { class, .. } | MethodResolution::CrossFile { class, .. } => class,
+        }
+    }
+}
+
 /// Result of resolving a sub/method call — local symbol or cross-file metadata.
 pub enum ResolvedSub<'a> {
     /// Found locally in this file's symbols.
@@ -7139,8 +7188,16 @@ impl FileAnalysis {
         // A fully-qualified / SUPER call token (`$o->Foo::Bar::m`, `SUPER::m`)
         // names its dispatch class explicitly — split it so lookups use the
         // bare tail scoped to the qualifier, overriding the invocant-derived
-        // class (Perl ignores the invocant's class for the lookup).
+        // class (Perl ignores the invocant's class for the lookup). SUPER
+        // resolves over the enclosing package's parent MRO.
         let (fq_class, name) = match name.rsplit_once("::") {
+            Some(("SUPER", tail)) => {
+                let c = self
+                    .enclosing_class_for_scope(scope)
+                    .and_then(|e| self.resolve_super_method(&e, tail, module_index))
+                    .map(|r| r.class().to_string());
+                (c, tail)
+            }
             Some((qual, tail)) => (self.qualified_dispatch_class(qual, scope), tail),
             None => (None, name),
         };

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2116,7 +2116,7 @@ impl FileAnalysis {
             let target = self
                 .method_call_invocant_class(r, module_index)
                 .map(|cn| {
-                    match self.resolve_method_in_ancestors(&cn, &r.target_name, module_index) {
+                    match self.resolve_method_in_ancestors(&cn, r.unqualified_target_name(), module_index) {
                         Some(MethodResolution::Local { sym_id, .. }) => MethodTarget::Local {
                             sym_id,
                             invocant_class: cn,
@@ -4306,7 +4306,7 @@ impl FileAnalysis {
                                 .method_call_invocant_type(r, module_index)
                                 .as_ref()
                                 .and_then(|ty| ty.as_parametric())
-                                .and_then(|p| p.method_arg_owner(&r.target_name))
+                                .and_then(|p| p.method_arg_owner(r.unqualified_target_name()))
                                 .or_else(|| {
                                     class_name
                                         .as_ref()
@@ -4455,7 +4455,10 @@ impl FileAnalysis {
                     results.push((*method_name_span, r.access));
                     for other in &self.refs {
                         if std::ptr::eq(other, r) { continue; }
-                        if other.target_name != r.target_name { continue; }
+                        // Match on the bare method tail so a plain `$x->m()` and
+                        // a fully-qualified `$y->Foo::Bar::m()` group together
+                        // (the class check below still pins same-class dispatch).
+                        if other.unqualified_target_name() != r.unqualified_target_name() { continue; }
                         if !matches!(other.kind, RefKind::MethodCall { .. }) { continue; }
                         let Some(ocn) = self.method_call_invocant_class(other, module_index) else { continue };
                         if ocn != wanted_class { continue; }
@@ -4536,7 +4539,7 @@ impl FileAnalysis {
                             }
                         }
                         (RefKind::MethodCall { method_name_span, .. },
-                         SymKind::Sub | SymKind::Method) if r.target_name == sym.name => {
+                         SymKind::Sub | SymKind::Method) if r.unqualified_target_name() == sym.name => {
                             // Same-class match only; unresolved or
                             // different-class invocants are excluded.
                             // Method-call ref.span covers the whole
@@ -4602,8 +4605,9 @@ impl FileAnalysis {
                     if let Some(mr) = method_hover {
                         if matches!(mr.kind, RefKind::MethodCall { .. }) {
                             let class_name = self.method_call_invocant_class(mr, module_index);
+                            let mname = mr.unqualified_target_name();
                             if let Some(ref cn) = class_name {
-                                match self.resolve_method_in_ancestors(cn, &mr.target_name, module_index) {
+                                match self.resolve_method_in_ancestors(cn, mname, module_index) {
                                     Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
                                         let sym = self.symbol(sym_id);
                                         let line = source_line_at(source, sym.selection_span.start.row);
@@ -4613,7 +4617,7 @@ impl FileAnalysis {
                                             cn.to_string()
                                         };
                                         let mut text = format!("```perl\n{}\n```\n\n*class {} — resolved from `{}`*", line.trim(), class_label, r.target_name);
-                                        if let Some(ref rt) = self.find_method_return_type(cn, &mr.target_name, module_index, None) {
+                                        if let Some(ref rt) = self.find_method_return_type(cn, mname, module_index, None) {
                                             text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(&rt)));
                                         }
                                         if let SymbolDetail::Sub { ref doc, .. } = sym.detail {
@@ -4629,8 +4633,8 @@ impl FileAnalysis {
                                             // inherited method in `class`'s own module.
                                             let module = def_module.as_deref().unwrap_or(class.as_str());
                                             if let Some(cached) = idx.get_cached(module) {
-                                                if let Some(sub_info) = cached.sub_info(&mr.target_name) {
-                                                    let sig = format_cross_file_signature(&mr.target_name, &sub_info);
+                                                if let Some(sub_info) = cached.sub_info(mname) {
+                                                    let sig = format_cross_file_signature(mname, &sub_info);
                                                     let mut text = format!("```perl\n{}\n```\n\n*class {} — resolved from `{}`*", sig, class, r.target_name);
                                                     if let Some(rt) = sub_info.return_type(Some(idx)) {
                                                         text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(&rt)));
@@ -4718,8 +4722,10 @@ impl FileAnalysis {
                         .resolved_method_target
                         .as_ref()
                         .map(|t| t.invocant_class().to_string());
+                    // The bare method name (FQ `$o->Foo::Bar::m` resolves `m`).
+                    let method = r.unqualified_target_name();
                     if let Some(ref cn) = class_name {
-                        match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
+                        match self.resolve_method_in_ancestors(cn, method, module_index) {
                             Some(MethodResolution::Local { sym_id, class: ref defining_class, .. }) => {
                                 let sym = self.symbol(sym_id);
                                 let line = source_line_at(source, sym.selection_span.start.row);
@@ -4729,7 +4735,7 @@ impl FileAnalysis {
                                     cn.to_string()
                                 };
                                 let mut text = format!("```perl\n{}\n```\n\n*class {}*", line.trim(), class_label);
-                                if let Some(ref rt) = self.find_method_return_type(cn, &r.target_name, module_index, None) {
+                                if let Some(ref rt) = self.find_method_return_type(cn, method, module_index, None) {
                                     text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(&rt)));
                                 }
                                 return Some(text);
@@ -4740,13 +4746,13 @@ impl FileAnalysis {
                                     // inherited method in `class`'s own module.
                                     let module = def_module.as_deref().unwrap_or(class.as_str());
                                     if let Some(cached) = idx.get_cached(module) {
-                                        if let Some(sub_info) = cached.sub_info(&r.target_name) {
+                                        if let Some(sub_info) = cached.sub_info(method) {
                                             let class_label = if class != cn {
                                                 format!("{} (from {})", cn, class)
                                             } else {
                                                 cn.to_string()
                                             };
-                                            let sig = format_cross_file_signature(&r.target_name, &sub_info);
+                                            let sig = format_cross_file_signature(method, &sub_info);
                                             let mut text = format!("```perl\n{}\n```\n\n*class {}*", sig, class_label);
                                             if let Some(rt) = sub_info.return_type(Some(idx)) {
                                                 text.push_str(&format!("\n\n*returns: {}*", format_inferred_type(&rt)));
@@ -4763,7 +4769,7 @@ impl FileAnalysis {
                         }
                     }
                     // Fallback
-                    for &sid in self.symbols_named(&r.target_name) {
+                    for &sid in self.symbols_named(method) {
                         let sym = self.symbol(sid);
                         if matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                             return Some(self.format_symbol_hover(sym, source, module_index));
@@ -4879,8 +4885,10 @@ impl FileAnalysis {
                 }
                 RefKind::MethodCall { .. } => {
                     if let Some(class) = self.method_call_invocant_class(r, module_index) {
+                        // FQ `$o->Foo::Bar::m` renames the bare `m` tail; the
+                        // qualifier scopes the class (same as Function above).
                         return Some(RenameKind::Method {
-                            name: r.target_name.clone(),
+                            name: r.unqualified_target_name().to_string(),
                             class,
                         });
                     }
@@ -5061,9 +5069,11 @@ impl FileAnalysis {
                 }
                 RefKind::MethodCall { .. } => {
                     let class_name = self.method_call_invocant_class(r, module_index);
+                    // Bare method name (FQ `$o->Foo::Bar::m` resolves `m`).
+                    let method = r.unqualified_target_name();
                     // Try inheritance-aware resolution first
                     if let Some(ref cn) = class_name {
-                        match self.resolve_method_in_ancestors(cn, &r.target_name, module_index) {
+                        match self.resolve_method_in_ancestors(cn, method, module_index) {
                             Some(MethodResolution::Local { sym_id, .. }) => {
                                 return Some((sym_id, true));
                             }
@@ -5072,7 +5082,7 @@ impl FileAnalysis {
                                 // a local symbol only when its package
                                 // equals the resolved class — no
                                 // same-name cross-class latching.
-                                for &sid in self.symbols_named(&r.target_name) {
+                                for &sid in self.symbols_named(method) {
                                     let sym = self.symbol(sid);
                                     if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
                                     if sym.package.as_deref() == Some(cn.as_str()) {
@@ -5090,7 +5100,7 @@ impl FileAnalysis {
                         // the class locally, produce no target —
                         // better than cross-linking a same-named
                         // method on a different class.
-                        for &sid in self.symbols_named(&r.target_name) {
+                        for &sid in self.symbols_named(method) {
                             let sym = self.symbol(sid);
                             if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { continue; }
                             if sym.package.as_deref() == Some(cn.as_str()) {
@@ -5108,7 +5118,7 @@ impl FileAnalysis {
                     // last-resort name match. Only reaches here for
                     // refs the builder AND the runtime resolver both
                     // failed on (rare: ERROR-recovered invocants).
-                    for &sid in self.symbols_named(&r.target_name) {
+                    for &sid in self.symbols_named(method) {
                         if matches!(self.symbol(sid).kind, SymKind::Sub | SymKind::Method) {
                             return Some((sid, true));
                         }
@@ -5181,6 +5191,26 @@ impl FileAnalysis {
     /// `module_index` lets chain receivers whose return type lives in
     /// another package resolve (e.g. `$r->get('/x')->to(...)`). Pass
     /// `None` only for CLI debug / isolated tests.
+    ///
+    /// Resolve the dispatch class named by a method token's `::` qualifier
+    /// (`$obj->Foo::Bar::m` → `Foo::Bar`). A leading `::` (`->::m`) is `main`.
+    ///
+    /// `SUPER` is deliberately NOT resolved here: it's a keyword, not a literal
+    /// class, and sweeping `$self->SUPER::m` calls into a rename of the
+    /// parent's `m` would break method-rename precision (a subclass's SUPER
+    /// call is a reference to a *specific* parent method, distinct from plain
+    /// dispatch — see gold `rename-11-urn-canonical-precision`). Returning
+    /// `None` keeps SUPER nav an honest miss; SUPER *return typing* is handled
+    /// separately on the witness seam (`QualifiedCallReturn`). SUPER navigation
+    /// is a tracked follow-up.
+    fn qualified_dispatch_class(&self, qualifier: &str, _scope: ScopeId) -> Option<String> {
+        match qualifier {
+            "SUPER" => None,
+            "" => Some("main".to_string()),
+            class => Some(class.to_string()),
+        }
+    }
+
     pub fn method_call_invocant_class(
         &self,
         r: &Ref,
@@ -5189,6 +5219,13 @@ impl FileAnalysis {
         let RefKind::MethodCall { invocant, invocant_span, .. } = &r.kind else {
             return None;
         };
+        // Fully-qualified / SUPER dispatch: `$obj->Foo::Bar::m` looks `m` up on
+        // the NAMED class — Perl ignores the invocant's class for the lookup.
+        // The qualifier rides the method token (`target_name`), independent of
+        // the invocant expression, so it wins ahead of invocant resolution.
+        if let Some((qualifier, _)) = r.target_name.rsplit_once("::") {
+            return self.qualified_dispatch_class(qualifier, r.scope);
+        }
         if invocant.is_empty() {
             return None;
         }
@@ -5241,13 +5278,14 @@ impl FileAnalysis {
                         if let Some(recv_class) =
                             self.method_call_invocant_class(recv, module_index)
                         {
-                            if recv.target_name == "new" {
+                            let recv_method = recv.unqualified_target_name();
+                            if recv_method == "new" {
                                 return Some(recv_class);
                             }
                             if let Some(cn) = self
                                 .find_method_return_type(
                                     &recv_class,
-                                    &recv.target_name,
+                                    recv_method,
                                     module_index,
                                     None,
                                 )
@@ -7096,17 +7134,24 @@ impl FileAnalysis {
         point: Point,
         module_index: Option<&ModuleIndex>,
     ) -> Option<ResolvedSub<'s>> {
+        let scope = self.scope_at(point).unwrap_or(ScopeId(0));
+        // A fully-qualified / SUPER call token (`$o->Foo::Bar::m`, `SUPER::m`)
+        // names its dispatch class explicitly — split it so lookups use the
+        // bare tail scoped to the qualifier, overriding the invocant-derived
+        // class (Perl ignores the invocant's class for the lookup).
+        let (fq_class, name) = match name.rsplit_once("::") {
+            Some((qual, tail)) => (self.qualified_dispatch_class(qual, scope), tail),
+            None => (None, name),
+        };
         // Resolve class name for scoped lookup
-        let class_name = if is_method {
+        let class_name = if fq_class.is_some() {
+            fq_class
+        } else if is_method {
             invocant.and_then(|inv| {
                 if !inv.starts_with('$') && !inv.starts_with('@') && !inv.starts_with('%') {
                     Some(inv.to_string())
                 } else {
-                    self.resolve_invocant_class(
-                        inv,
-                        self.scope_at(point).unwrap_or(ScopeId(0)),
-                        point,
-                    )
+                    self.resolve_invocant_class(inv, scope, point)
                 }
             })
         } else {

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -5195,17 +5195,18 @@ impl FileAnalysis {
     /// Resolve the dispatch class named by a method token's `::` qualifier
     /// (`$obj->Foo::Bar::m` → `Foo::Bar`). A leading `::` (`->::m`) is `main`.
     ///
-    /// `SUPER` is deliberately NOT resolved here: it's a keyword, not a literal
-    /// class, and sweeping `$self->SUPER::m` calls into a rename of the
-    /// parent's `m` would break method-rename precision (a subclass's SUPER
-    /// call is a reference to a *specific* parent method, distinct from plain
-    /// dispatch — see gold `rename-11-urn-canonical-precision`). Returning
-    /// `None` keeps SUPER nav an honest miss; SUPER *return typing* is handled
-    /// separately on the witness seam (`QualifiedCallReturn`). SUPER navigation
-    /// is a tracked follow-up.
-    fn qualified_dispatch_class(&self, qualifier: &str, _scope: ScopeId) -> Option<String> {
+    /// `SUPER::m` dispatches to the enclosing package's parent — `$self->
+    /// SUPER::m` is a reference to that *specific* parent method (so goto-def
+    /// jumps to it, and renaming the parent method rewrites the SUPER call;
+    /// leaving it dangling would be a broken rename). First parent only: Perl's
+    /// SUPER walks the full parent MRO, but single inheritance is the common
+    /// case; multi-parent SUPER nav is a rare residual.
+    fn qualified_dispatch_class(&self, qualifier: &str, scope: ScopeId) -> Option<String> {
         match qualifier {
-            "SUPER" => None,
+            "SUPER" => {
+                let encl = self.enclosing_class_for_scope(scope)?;
+                self.package_parents.get(&encl).and_then(|ps| ps.first().cloned())
+            }
             "" => Some("main".to_string()),
             class => Some(class.to_string()),
         }

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -380,6 +380,31 @@ fn test_fq_method_call_nav_dispatches_from_named_class() {
 /// `$self->SUPER::m` dispatches to the enclosing package's PARENT method —
 /// goto-def jumps to it and renaming the parent method rewrites the SUPER call
 /// (a dangling SUPER call would be a broken rename).
+/// SUPER walks the FULL parent MRO, not just the first parent: with
+/// `@ISA = (A, B)`, `$self->SUPER::m` finds `m` on B when only B defines it,
+/// and it skips the enclosing class itself (Perl's SUPER searches parents).
+#[test]
+fn test_super_resolves_across_all_parents() {
+    let src = "package A;\nsub a_only { 1 }\npackage B;\nsub b_only { 2 }\npackage Child;\nuse parent -norequire, 'A', 'B';\nsub go { my $self = shift; return $self->SUPER::b_only }\n";
+    let fa = build_fa_from_source(src);
+    // Method only on the SECOND parent — first-parent-only would miss it.
+    assert_eq!(
+        fa.resolve_super_method("Child", "b_only", None).map(|r| r.class().to_string()).as_deref(),
+        Some("B"),
+        "SUPER must search all parents, not just the first"
+    );
+    assert_eq!(
+        fa.resolve_super_method("Child", "a_only", None).map(|r| r.class().to_string()).as_deref(),
+        Some("A"),
+    );
+    // SUPER skips the enclosing class: Child defines `go`, but SUPER::go from
+    // Child must not resolve to Child::go.
+    assert!(
+        fa.resolve_super_method("Child", "go", None).is_none(),
+        "SUPER skips the current package"
+    );
+}
+
 #[test]
 fn test_super_method_nav_resolves_to_parent() {
     use crate::file_analysis::{RefKind, RenameKind};

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -377,6 +377,45 @@ fn test_fq_method_call_nav_dispatches_from_named_class() {
     }
 }
 
+/// `$self->SUPER::m` dispatches to the enclosing package's PARENT method —
+/// goto-def jumps to it and renaming the parent method rewrites the SUPER call
+/// (a dangling SUPER call would be a broken rename).
+#[test]
+fn test_super_method_nav_resolves_to_parent() {
+    use crate::file_analysis::{RefKind, RenameKind};
+    let src = "package Base;\nsub greet { return 1 }\npackage Child;\nuse parent -norequire, 'Base';\nsub greet { my $self = shift; return $self->SUPER::greet }\n";
+    let fa = build_fa_from_source(src);
+
+    let sref = fa
+        .refs
+        .iter()
+        .find(|r| matches!(r.kind, RefKind::MethodCall { .. }) && r.target_name == "SUPER::greet")
+        .expect("SUPER method ref present");
+    assert_eq!(
+        fa.method_call_invocant_class(sref, None).as_deref(),
+        Some("Base"),
+        "SUPER dispatches to the enclosing package's parent"
+    );
+    let span = if let RefKind::MethodCall { method_name_span, .. } = &sref.kind {
+        *method_name_span
+    } else {
+        unreachable!()
+    };
+    // goto-def on the SUPER call lands on `Base::greet` (line 1).
+    let def = fa
+        .find_definition(span.start, None, None, None)
+        .expect("SUPER goto-def resolves");
+    assert_eq!(def.start.row, 1, "SUPER::greet resolves to Base::greet, got {:?}", def);
+    // Renaming targets the parent method on `Base` (so the SUPER call tracks).
+    match fa.rename_kind_at(span.start, None) {
+        Some(RenameKind::Method { name, class }) => {
+            assert_eq!(name, "greet");
+            assert_eq!(class, "Base");
+        }
+        other => panic!("expected Method rename on Base, got {:?}", other),
+    }
+}
+
 /// A qualified call to package Foo's `baz` must not resolve to a same-named
 /// `baz` in another package — `resolved_package` isolates the qualifier.
 #[test]

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -331,6 +331,52 @@ fn test_qualified_call_local_goto_def_and_references() {
     );
 }
 
+/// Fully-qualified METHOD call (`$obj->Widget::build()`): Perl dispatches
+/// `build` from the NAMED class `Widget`, ignoring the invocant's class. So
+/// goto-def / hover / rename resolve against `Widget` even when `$obj` is
+/// untyped, the rename narrows to the `build` tail, and references find the
+/// call site.
+#[test]
+fn test_fq_method_call_nav_dispatches_from_named_class() {
+    use crate::file_analysis::{RefKind, RenameKind};
+    // `$obj` is deliberately untyped — only the qualifier names the class.
+    let src = "package Widget;\nsub build { my ($class, $n) = @_; return 1 }\npackage main;\nmy $obj = get_thing();\nmy $r = $obj->Widget::build();\n";
+    let fa = build_fa_from_source(src);
+
+    // The FQ method ref keeps the full path in target_name but resolves its
+    // dispatch class to the qualifier.
+    let mref = fa
+        .refs
+        .iter()
+        .find(|r| matches!(r.kind, RefKind::MethodCall { .. }) && r.target_name == "Widget::build")
+        .expect("FQ method ref present");
+    assert_eq!(
+        fa.method_call_invocant_class(mref, None).as_deref(),
+        Some("Widget"),
+        "FQ call dispatches from the named class, not the (untyped) invocant"
+    );
+    // method_name_span is narrowed to the `build` tail (col 22), not the
+    // whole `Widget::build` token (col 14) — so rename rewrites only `build`.
+    if let RefKind::MethodCall { method_name_span, .. } = &mref.kind {
+        assert_eq!(method_name_span.start.column, 22, "rename span is the bare tail");
+    }
+
+    // goto-def on the `build` tail (line 4, col 22) lands on `sub build`.
+    let def = fa
+        .find_definition(Point::new(4, 22), None, None, None)
+        .expect("FQ method goto-def resolves to the local sub");
+    assert_eq!(def.start.row, 1, "should land on `sub build`, got {:?}", def);
+
+    // rename resolves to the bare method on the qualifier class.
+    match fa.rename_kind_at(Point::new(4, 22), None) {
+        Some(RenameKind::Method { name, class }) => {
+            assert_eq!(name, "build");
+            assert_eq!(class, "Widget");
+        }
+        other => panic!("expected Method rename, got {:?}", other),
+    }
+}
+
 /// A qualified call to package Foo's `baz` must not resolve to a same-named
 /// `baz` in another package — `resolved_package` isolates the qualifier.
 #[test]

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 65;
+pub const EXTRACT_VERSION: i64 = 66;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 67;
+pub const EXTRACT_VERSION: i64 = 68;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 66;
+pub const EXTRACT_VERSION: i64 = 67;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -417,18 +417,36 @@ fn collect_from_analysis(
                 // unrelated same-named methods on other classes stay out
                 // (never on the chain).
                 let scope = callable_scope_for_refs.as_ref().unwrap();
-                match (r.resolved_method_target.as_ref(), scope) {
-                    (Some(edge), Some(pkg)) => {
-                        let cn = edge.invocant_class();
-                        cn == pkg || rename_chain_cache
-                            .entry(cn.to_string())
-                            .or_insert_with(|| {
-                                analysis.method_rename_chain(cn, r.unqualified_target_name(), module_index)
-                            })
-                            .iter()
-                            .any(|c| c == pkg)
+                let method = r.unqualified_target_name();
+                // SUPER calls resolve LAZILY here, not off the frozen edge: the
+                // build-time stamp can't name the dispatch class for a SUPER
+                // call into a CROSS-FILE parent (dependency files stamp without
+                // the index), and the answer needs the full parent MRO anyway.
+                // The ref already carries the SUPER marker (`target_name`) and
+                // its enclosing class (`scope`), and `refs_to` runs with the
+                // index — so resolve the defining ancestor on demand. It IS the
+                // referenced method, so a plain class equality is the match.
+                if r.target_name.starts_with("SUPER::") {
+                    match (analysis.enclosing_class_for_scope(r.scope), scope) {
+                        (Some(encl), Some(pkg)) => analysis
+                            .resolve_super_method(&encl, method, module_index)
+                            .is_some_and(|res| res.class() == pkg.as_str()),
+                        _ => false,
                     }
-                    _ => false,
+                } else {
+                    match (r.resolved_method_target.as_ref(), scope) {
+                        (Some(edge), Some(pkg)) => {
+                            let cn = edge.invocant_class();
+                            cn == pkg || rename_chain_cache
+                                .entry(cn.to_string())
+                                .or_insert_with(|| {
+                                    analysis.method_rename_chain(cn, method, module_index)
+                                })
+                                .iter()
+                                .any(|c| c == pkg)
+                        }
+                        _ => false,
+                    }
                 }
             }
             (TargetKind::Package, RefKind::PackageRef) => true,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -398,49 +398,40 @@ fn collect_from_analysis(
             }
             (TargetKind::Sub { .. } | TargetKind::Method { .. },
              RefKind::MethodCall { .. }) => {
-                // Method-shaped call: match on the build-time-frozen
-                // dispatch edge (`resolved_method_target`), NOT a
-                // query-time re-derivation of the invocant class. The
-                // edge was stamped once (PostFold / enrichment) by the
-                // bag-routed resolver, so a call that resolved at build
-                // time stays matched regardless of query-time inference
-                // flakiness, and genuinely unresolved sites (no edge)
-                // are honestly excluded. This is the NAV unification —
-                // references read a stored edge, the same discipline
-                // `Variable` refs use with `resolves_to`.
+                // Method-shaped call: prefer the build-time-frozen dispatch
+                // edge (`resolved_method_target`) — stamped once (PostFold /
+                // enrichment) by the bag-routed resolver, so a call that
+                // resolved at build time stays matched regardless of query-time
+                // inference flakiness. This is the NAV unification — references
+                // read a stored edge, the same discipline `Variable` refs use
+                // with `resolves_to`.
                 //
-                // Inheritance: the edge carries the frozen invocant
-                // class; `method_rename_chain` (deterministic over
-                // package_parents + module_index) yields
-                // `[invocant_class, ..., defining_class]`, so `$child->m`
-                // matches a target on any class T on that chain, and
-                // unrelated same-named methods on other classes stay out
-                // (never on the chain).
+                // Inheritance: the edge carries the frozen invocant class;
+                // `method_rename_chain` yields `[invocant_class, ...,
+                // defining_class]`, so `$child->m` matches a target on any class
+                // on that chain, and unrelated same-named methods stay out.
+                //
+                // When the edge is ABSENT, the build-time stamp couldn't name
+                // the dispatch class — which for a DEPENDENCY file means the
+                // invocant needed cross-file info the build-time pass lacks (a
+                // SUPER call into a cross-file parent, a chain receiver typed
+                // from another module; enrichment re-stamps OPEN docs only). We
+                // re-resolve lazily here — `refs_to` runs with the index —
+                // rather than silently excluding the site. `method_call_
+                // invocant_class` resolves SUPER via the full parent MRO too.
                 let scope = callable_scope_for_refs.as_ref().unwrap();
                 let method = r.unqualified_target_name();
-                // SUPER calls resolve LAZILY here, not off the frozen edge: the
-                // build-time stamp can't name the dispatch class for a SUPER
-                // call into a CROSS-FILE parent (dependency files stamp without
-                // the index), and the answer needs the full parent MRO anyway.
-                // The ref already carries the SUPER marker (`target_name`) and
-                // its enclosing class (`scope`), and `refs_to` runs with the
-                // index — so resolve the defining ancestor on demand. It IS the
-                // referenced method, so a plain class equality is the match.
-                if r.target_name.starts_with("SUPER::") {
-                    match (analysis.enclosing_class_for_scope(r.scope), scope) {
-                        (Some(encl), Some(pkg)) => analysis
-                            .resolve_super_method(&encl, method, module_index)
-                            .is_some_and(|res| res.class() == pkg.as_str()),
-                        _ => false,
-                    }
-                } else {
-                    match (r.resolved_method_target.as_ref(), scope) {
-                        (Some(edge), Some(pkg)) => {
-                            let cn = edge.invocant_class();
-                            cn == pkg || rename_chain_cache
-                                .entry(cn.to_string())
+                {
+                    let resolved_class = match r.resolved_method_target.as_ref() {
+                        Some(edge) => Some(edge.invocant_class().to_string()),
+                        None => analysis.method_call_invocant_class(r, module_index),
+                    };
+                    match (resolved_class, scope) {
+                        (Some(cn), Some(pkg)) => {
+                            cn == *pkg || rename_chain_cache
+                                .entry(cn.clone())
                                 .or_insert_with(|| {
-                                    analysis.method_rename_chain(cn, method, module_index)
+                                    analysis.method_rename_chain(&cn, method, module_index)
                                 })
                                 .iter()
                                 .any(|c| c == pkg)

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -375,11 +375,11 @@ fn collect_from_analysis(
         _ => None,
     };
     for r in &analysis.refs {
-        // A qualified call (`Foo::baz()`) keeps its whole path in
-        // `target_name`; match it on the bare callable tail (the
-        // `resolved_package` check in the FunctionCall arm below still pins
-        // the right package). Every other ref kind matches by exact name.
-        let name_matches = if matches!(r.kind, RefKind::FunctionCall { .. }) {
+        // A qualified call (`Foo::baz()` / `$o->Foo::Bar::baz()`) keeps its
+        // whole path in `target_name`; match it on the bare callable tail (the
+        // dispatch-class checks in the call arms below still pin the right
+        // package/class). Every other ref kind matches by exact name.
+        let name_matches = if matches!(r.kind, RefKind::FunctionCall { .. } | RefKind::MethodCall { .. }) {
             r.unqualified_target_name() == target.name
         } else {
             r.target_name == target.name
@@ -423,7 +423,7 @@ fn collect_from_analysis(
                         cn == pkg || rename_chain_cache
                             .entry(cn.to_string())
                             .or_insert_with(|| {
-                                analysis.method_rename_chain(cn, &r.target_name, module_index)
+                                analysis.method_rename_chain(cn, r.unqualified_target_name(), module_index)
                             })
                             .iter()
                             .any(|c| c == pkg)

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -334,15 +334,17 @@ pub fn find_definition(
         // Cross-file method goto-def: resolve inherited methods through module index
         if matches!(r.kind, RefKind::MethodCall { .. }) {
             use crate::file_analysis::MethodResolution;
+            // FQ `$o->Foo::Bar::m` dispatches the bare `m` on the named class.
+            let method = r.unqualified_target_name();
             let class_name = analysis.method_call_invocant_class(r, Some(module_index));
             if let Some(ref cn) = class_name {
-                if let Some(MethodResolution::CrossFile { ref class, ref def_module }) = analysis.resolve_method_in_ancestors(cn, &r.target_name, Some(module_index)) {
+                if let Some(MethodResolution::CrossFile { ref class, ref def_module }) = analysis.resolve_method_in_ancestors(cn, method, Some(module_index)) {
                     // One path for both: a real inherited method lives in
                     // `class`'s own module; a plugin-bridged helper lives in
                     // `def_module` (the bridging file). Same lookup either way.
                     let module = def_module.as_deref().unwrap_or(class);
                     if let Some(cached) = module_index.get_cached(module) {
-                        if let Some(sub_info) = cached.sub_info(&r.target_name) {
+                        if let Some(sub_info) = cached.sub_info(method) {
                             if let Ok(module_uri) = Url::from_file_path(&cached.path) {
                                 let line = sub_info.def_line();
                                 let def_range = Range {

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -151,6 +151,19 @@ pub enum WitnessPayload {
     /// `MethodOnClass{class, method}` at the call's `count_call_args`);
     /// chased like `Edge` but overrides `q.arity_hint` with `arity`.
     CallReturn { target: WitnessAttachment, arity: u32 },
+    /// `$obj->SUPER::m(...)` dispatch: look `m` up on `method_lookup` (the
+    /// enclosing package's PARENT class) but default the receiver to
+    /// `receiver_class` (the invocant / enclosing class) — `SUPER::new`
+    /// blesses into the CALLER's class, not the parent, so a parent ctor
+    /// returning `ReturnExpr::ReceiverOr` must substitute the caller. The
+    /// dynamic outer receiver wins when it is a subclass of `receiver_class`.
+    /// (A plain `CallReturn` can't express this: its receiver defaults to the
+    /// dispatch class, which for SUPER is the parent — wrong.)
+    SuperCallReturn {
+        method_lookup: WitnessAttachment,
+        receiver_class: String,
+        arity: u32,
+    },
     /// **Symbol-declarative return type.** A receiver-relative /
     /// arity-relative expression that `ReturnExprReducer` substitutes at
     /// query time using `q.receiver` and `q.arity_hint`. Subsumes both
@@ -1228,13 +1241,49 @@ fn receiver_key(r: &Option<InferredType>) -> Option<String> {
 fn fresh_dispatch_receiver(
     incoming: &Option<InferredType>,
     class: &str,
+    ctx: Option<&BagContext>,
 ) -> Option<InferredType> {
     if let Some(t) = incoming {
-        if t.class_name() == Some(class) {
-            return Some(t.clone());
+        if let Some(cn) = t.class_name() {
+            // Preserve a receiver that IS the dispatch class — or a SUBCLASS of
+            // it (SUPER:: dispatch, inherited methods): more specific, still valid.
+            if cn == class || ctx.is_some_and(|c| is_subclass_of(cn, class, c)) {
+                return Some(t.clone());
+            }
         }
     }
     Some(InferredType::ClassName(class.to_string()))
+}
+
+/// Is `child` a (transitive) subclass of `ancestor`? Bounded BFS over `parents_of`.
+fn is_subclass_of(child: &str, ancestor: &str, ctx: &BagContext) -> bool {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut queue: std::collections::VecDeque<String> =
+        std::collections::VecDeque::from([child.to_string()]);
+    let mut steps = 0;
+    while let Some(c) = queue.pop_front() {
+        steps += 1;
+        if steps > 64 {
+            break;
+        }
+        if !seen.insert(c.clone()) {
+            continue;
+        }
+        for p in crate::file_analysis::parents_of(
+            &c,
+            ctx.package_parents,
+            ctx.module_index,
+            ctx.app_surface_consumers,
+        ) {
+            if p == ancestor {
+                return true;
+            }
+            if !seen.contains(&p) {
+                queue.push_back(p);
+            }
+        }
+    }
+    false
 }
 
 /// Depth backstop for `query_rec`. The `(bag, attachment)` visited set is
@@ -1572,7 +1621,7 @@ impl ReducerRegistry {
                                         WitnessAttachment::MethodOnClass { .. }
                                     ) =>
                                 {
-                                    fresh_dispatch_receiver(&q.receiver, class)
+                                    fresh_dispatch_receiver(&q.receiver, class, q.context)
                                 }
                                 _ => q.receiver.clone(),
                             };
@@ -1610,12 +1659,36 @@ impl ReducerRegistry {
                     // query's — that's the whole point of this variant.
                     let receiver = match target {
                         WitnessAttachment::MethodOnClass { class, .. } => {
-                            fresh_dispatch_receiver(&q.receiver, class)
+                            fresh_dispatch_receiver(&q.receiver, class, q.context)
                         }
                         _ => q.receiver.clone(),
                     };
                     let sub_q = ReducerQuery {
                         attachment: target,
+                        point: q.point,
+                        framework: q.framework,
+                        arity_hint: Some(*arity),
+                        receiver,
+                        context: q.context,
+                    };
+                    if let ReducedValue::Type(t) = &*self.query_rec(bag, &sub_q, state) {
+                        out.push(Witness {
+                            attachment: w.attachment.clone(),
+                            source: w.source.clone(),
+                            payload: WitnessPayload::InferredType(t.clone()),
+                            span: w.span,
+                        });
+                    }
+                }
+                WitnessPayload::SuperCallReturn { method_lookup, receiver_class, arity } => {
+                    // Look the method up on the parent, but the receiver is the
+                    // INVOCANT (enclosing) class — prefer a dynamic outer
+                    // receiver only when it's a subclass of it (same rule as a
+                    // fresh dispatch onto `receiver_class`).
+                    let receiver =
+                        fresh_dispatch_receiver(&q.receiver, receiver_class, q.context);
+                    let sub_q = ReducerQuery {
+                        attachment: method_lookup,
                         point: q.point,
                         framework: q.framework,
                         arity_hint: Some(*arity),

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -151,15 +151,22 @@ pub enum WitnessPayload {
     /// `MethodOnClass{class, method}` at the call's `count_call_args`);
     /// chased like `Edge` but overrides `q.arity_hint` with `arity`.
     CallReturn { target: WitnessAttachment, arity: u32 },
-    /// `$obj->SUPER::m(...)` dispatch: look `m` up on `method_lookup` (the
-    /// enclosing package's PARENT class) but default the receiver to
-    /// `receiver_class` (the invocant / enclosing class) — `SUPER::new`
-    /// blesses into the CALLER's class, not the parent, so a parent ctor
-    /// returning `ReturnExpr::ReceiverOr` must substitute the caller. The
+    /// **Explicitly-qualified method dispatch** — the method token carried a
+    /// `::` so Perl dispatches from a *named* class, not the invocant's: look
+    /// the method up on `method_lookup` but type the result relative to
+    /// `receiver_class` (the invocant / enclosing class). Two spellings, one
+    /// rule (see `emit_method_call_return_edges`):
+    ///   - `$obj->SUPER::m` → `method_lookup` is `MethodOnClass{<enclosing
+    ///     package's parent>, m}` (SUPER searches the *writing* package's
+    ///     `@ISA`, skipping it);
+    ///   - `$obj->Foo::Bar::m` → `method_lookup` is `MethodOnClass{Foo::Bar,
+    ///     m}` (fully-qualified: search starts at the named class).
+    /// In both, the call still blesses into the CALLER's class, so a ctor
+    /// returning `ReturnExpr::ReceiverOr` must substitute the invocant — the
     /// dynamic outer receiver wins when it is a subclass of `receiver_class`.
     /// (A plain `CallReturn` can't express this: its receiver defaults to the
-    /// dispatch class, which for SUPER is the parent — wrong.)
-    SuperCallReturn {
+    /// dispatch class, which here is the parent / named class — wrong.)
+    QualifiedCallReturn {
         method_lookup: WitnessAttachment,
         receiver_class: String,
         arity: u32,
@@ -1680,11 +1687,11 @@ impl ReducerRegistry {
                         });
                     }
                 }
-                WitnessPayload::SuperCallReturn { method_lookup, receiver_class, arity } => {
-                    // Look the method up on the parent, but the receiver is the
-                    // INVOCANT (enclosing) class — prefer a dynamic outer
-                    // receiver only when it's a subclass of it (same rule as a
-                    // fresh dispatch onto `receiver_class`).
+                WitnessPayload::QualifiedCallReturn { method_lookup, receiver_class, arity } => {
+                    // Look the method up on the named/parent class, but the
+                    // receiver is the INVOCANT (enclosing) class — prefer a
+                    // dynamic outer receiver only when it's a subclass of it
+                    // (same rule as a fresh dispatch onto `receiver_class`).
                     let receiver =
                         fresh_dispatch_receiver(&q.receiver, receiver_class, q.context);
                     let sub_q = ReducerQuery {


### PR DESCRIPTION
Stacked on #47 (base = `fix-receiver-ctor`) so the diff is just the SUPER work.

## What

`$obj->SUPER::m(...)` now composes its return type across files. Before, `emit_method_call_return_edges` emitted `MethodOnClass{invocant, "SUPER::new"}` (invocant class + the literal `SUPER::`-prefixed name), which never resolved — so any chain bottoming out in a parent ctor lost its type at the file boundary.

## How

A new `WitnessPayload::SuperCallReturn` encodes the SUPER dispatch contract a plain `CallReturn` can't express:

- Look the method up on the **enclosing package's parents** (SUPER skips the *writing* package, not the invocant's own class).
- Default the receiver to the **invocant / enclosing class** — `SUPER::new` blesses into the *caller's* class, not the parent. A receiver-polymorphic parent ctor (`bless …, ref $class || $class` → `ReturnExpr::ReceiverOr`, from #47) then substitutes the caller.
- A dynamic outer receiver is preferred only when it `is_subclass_of` the dispatch class. `fresh_dispatch_receiver` gained the same inheritance-aware preservation, shared by both call sites.

So `Mojo::URL::clone`'s `$self->new` → `Mojo::URL::new` (`shift->SUPER::new`) → `Mojo::Base::new` with receiver `Mojo::URL` → **`Mojo::URL`**, and Minion's `my $self = shift->SUPER::new` → **`Minion`**, all at query time across files.

## Verification

- New gold `hover-minion-super-new`; unit `test_super_new_types_to_calling_class`.
- 872 unit tests + 4 cli tests pass; gold corpus **165 PASS / 0 FAIL / 0 XPASS / 0 CRASH**.
- `EXTRACT_VERSION` 65→66 (new serialized witness variant).

## Notes for review

- The earlier "base-class corruption" memo/cycle theory was a **test artifact** — the probe blessed via `bless {}, ref $c || $c`, but `bless_class_is_receiver` only recognises canonical invocant names, so `$c` fell through to `bless_class_of`→None. KNOWN-GAPS corrected.
- **Residual, kept xfail** (`hover-mojo-url-clone-via-new`): the clone *sub-return type* (vs the variable, which now types fine) still resolves `HashRef`. Its `return_types` entry is seeded at build time without the module index, so the cross-file chain isn't visible to the build-time seed — same class as the `ClassIsa`/`param_types` ancestry-gated emission already deferred to the ReceiverGated query-time seam. Distinct from SUPER itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)