### PR TITLE
Nested hash-key intelligence (all 3 tiers) + gold-corpus cost report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to perl-lsp are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are the published
 crate / VS Code extension versions.
 
+## Unreleased
+
+### Structural hash shapes & nested drills
+
+- **Hash literals carry their keys in the type.** `{ host => 'x', port => 5432 }`
+  is a shape, not a bare HashRef: `->{key}` narrows to the per-key type through
+  assignment hops, double-drills (`$config->{db}{host}` → String), sub-return
+  literals, and imports (cross-file drill hops included). Array literals type as
+  per-index tuples — the mixed drill `$obj->{users}[0]{name}` chains end-to-end,
+  and hover shows `Sequence<…>`.
+- **`$row->{name}` on a typed row** (DBIC and friends) resolves to the column
+  def — goto-def, references, hover.
+- **Both spellings.** `my %h = (k => v)` types through the same shape builder
+  as the hashref literal; `$h{k}` reads check against `%h`'s shape. Spreads —
+  hash and array (`my %opts = (default => 1, @_)`) — mark the shape open.
+- **Mutation is modeled, not guessed.** An unconditional `$v->{k} = …` write
+  extends the shape (the read drills back typed); a conditional, dynamic-key,
+  closure, or slice write (every slice spelling: `@h{…}`, `%h{k}`, `@$h{…}`,
+  `$h->@{…}`, `$h->%{…}`) switches it open.
+- **New diagnostic: `unknown-hash-key`** (hint severity). A read of a key a
+  CLOSED literal shape doesn't define — the typo catcher — naming the known
+  keys. Fires only when the shape is the variable's whole story (never
+  reassigned, never escaped into a call/alias/invocant); calibrated to **zero
+  false positives across the 2,293-module substrate**. Design:
+  `docs/adr/structural-shapes.md`.
+
+### Gold corpus
+
+- **Cost report.** Every suite run ends with per-capability timing
+  (n/total/mean/max wall ms), per-root startup latency, child CPU, and peak
+  RSS — so feature work sees what it costs as it lands. `METRICS_OUT=<file>`
+  writes JSON for run-over-run comparison; `--emit --root <dir>` authors rows
+  against per-row-root fixtures.
+- New committed `nested-fixture/` workspace pinning the shape work (typo hints
+  in both spellings, mutation extension, drill type-at/hover/def/refs).
+- Harness fix: `normalize()` decoded character strings as bytes, so any
+  non-ASCII response character silently dropped a row to the text fallback
+  where `none` assertions vacuously pass.
+
 ## v0.4.0
 
 A large release: cross-file intelligence everywhere, framework and exporter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ When a comment grows past a few lines, that's a smell: either the code wants a c
 
 ## Type inference (witness bag)
 
-**The bag is the only source of types.** Type production is `bag.push(...)`; type consumption is `bag_query_attachment(att)` through `ReducerRegistry::query`. There is no second source. `Builder::infer_expression_type` is gone; closed-syntax cases live in `expr_payload`'s match called by `emit_expr_witness`. `Builder.resolved_returns` is gone; walk-time synthesis pushes `Symbol(sid)` witnesses directly. See `docs/adr/bag-canonical.md` for the load-bearing decisions.
+**The bag is the only source of types.** Type production is `bag.push(...)`; type consumption is `bag_query_attachment(att)` through `ReducerRegistry::query`. There is no second source. `Builder::infer_expression_type` is gone; closed-syntax cases live in `expr_payload`'s match called by `emit_expr_witness`. `Builder.resolved_returns` is gone; walk-time synthesis pushes `Symbol(sid)` witnesses directly. See `docs/adr/bag-canonical.md` for the load-bearing decisions; `docs/adr/structural-shapes.md` for structural hash shapes (`HashWithKeys`, `Projected` drills, mutation extension, the whole-story trust gate).
 
 **Edges, not values.** If a registry query on attachment `A` already resolves through an edge chase, do NOT re-push the materialized `InferredType(t)` onto `A` as a "cache." The registry's chase IS the canonical flow; the materialization is a parallel store that drifts. Every published witness is either (a) a source value the walker uniquely knows (a literal's type, a plugin's declaration, a framework's `ReturnExpr`) or (b) an `Edge` to another attachment.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ backburner: ship when types + architecture are in a healthy place.
 | Doc | Axis | Status |
 |---|---|---|
 | `prompt-type-inference-residual.md` | **WHAT'S MISSING** — Parts 1–5 fact classes | each is a reducer+emitter pair |
-| `prompt-nested-hashkey.md` | hash-key intelligence on Parametric values + structural hashes + array-element narrowing | Tier 1 partially landed; Tiers 2/3 queued |
+| `prompt-nested-hashkey.md` | structural hash shapes + drills + the unknown-key diagnostic | LANDED (PR #50) — decisions in `adr/structural-shapes.md`; file keeps residuals |
 | `prompt-type-system-encoding.md` | **TYPE-SAFE AXIS DISPATCH** — make wrong-axis class-name reads unrepresentable | discussion; partially deferred to graph-walking |
 | `prompt-type-is-the-gate.md` | **GENERALIZE STRICT-EQ GATES** — `type_says()` answers replace local-symbol-table presence checks | two instances landed (Part 5c); general refactor open |
 | `prompt-dbic-as-plugin.md` | **MOVE DBIC OUT OF CORE** — port `visit_dbic_*` family + Parametric emission to a plugin | ReturnExpr gate cleared; still behind type-system-encoding |

--- a/docs/adr/structural-shapes.md
+++ b/docs/adr/structural-shapes.md
@@ -1,0 +1,158 @@
+# ADR: Structural hash shapes — `HashWithKeys`, mutation extension, and the whole-story gate
+
+Hash literals carry their keys in the type: `{ host => 'x' }` is not a
+bare `HashRef`, it's a shape — and `->{key}` narrows through it, across
+assignment hops, double-drills, sub returns, and imports. This ADR is
+the data model + lattice + trust contract; `prompt-nested-hashkey.md`
+keeps the residual phases. Landed across the `nested-hashkey` branch
+(PR #50). Arrays got the same treatment earlier — see
+`sequence-types.md`; the two variants share every rule below that
+mentions them together.
+
+## Decisions worth keeping
+
+### `HashWithKeys { keys, open }` is an `InferredType` variant
+
+```rust
+InferredType::HashWithKeys {
+    keys: Vec<(String, Option<Box<InferredType>>)>,
+    open: bool,
+}
+```
+
+`Vec`, not `HashMap` — order-preserving for stable display, and real
+hashes have ≤10 keys so linear lookup beats hashing. A key's value
+slot is `Option` so an unresolvable value keeps its key in the shape
+without claiming a type. Placed at the END of the enum (same rule as
+`Sequence`): cached-blob bincode variant indices stay stable; new
+variants go at the end and bump `EXTRACT_VERSION`.
+
+`open: false` is a CLAIM: the key set is exhaustive, an unknown key is
+a miss consumers may act on (the diagnostic, completion ranking).
+`open: true` withdraws it — a spread (`%$other`, `%other`, and array
+spreads like `@_`: `my %h = (default => 1, @_)` is the
+args-with-defaults idiom), a dynamic key, or a widening write means
+unknown keys may exist. Everything trust-shaped in this ADR exists to
+keep `open: false` honest.
+
+### One shape builder, both spellings
+
+`Builder::hash_literal_type` types `{ k => v, … }` AND
+`my %h = (k => v, …)` — a list literal assigned to a hash variable IS
+the hash literal; its meaning comes from the LHS sigil, so the
+assignment visit routes it through the same builder rather than
+minting a second path. Pair-walking is separator-agnostic and
+positional (fat-comma carries no code semantics — CLAUDE.md), and a
+spread occupies ONE list slot, so pairing skips it as a unit.
+
+### Structure dominates rep; structured-vs-structured subsumes on equality only
+
+Two `subsumes_narrowing` rules keep shapes sound under latest-wins
+reduction:
+
+- `HashWithKeys` subsumes `HashRef` (and `Sequence` subsumes
+  `ArrayRef`): a deref site re-deriving the coarse rep cannot
+  downgrade the shape it's reading through.
+- Two structured types subsume only on EQUALITY: a genuinely
+  different shape — a reassignment, a mutation extension — must win
+  as latest. Anything cleverer (key-subset subsumption) would let a
+  stale wider shape mask a legitimate replacement.
+
+Return-arm folding stays coarse: arms that are all hash-shaped unify
+to `HashRef`, not to a key union — arm disagreement is not a shape
+claim.
+
+### Drills are `Projected` edge witnesses, not values
+
+```rust
+WitnessPayload::Projected { base: WitnessAttachment, step: ProjectionStep }
+pub enum ProjectionStep { HashKey(String), ArrayIndex(i32) }
+```
+
+"Edges, not values" applied to `->{k}` / `->[N]`: the walker emits the
+projection relationship; the registry materializes the base at query
+time — where the module index is in hand, so imported shapes project
+too — and narrows by the step (`key_value_type` / `element_at`). This
+single payload is what made cross-file drill hops work: the chase had
+dead-ended only because drill expressions emitted no witness at all.
+
+A `Variable` base scope-walks like the `Edge(Variable)` materialize
+arm (the shape witness lives on the decl scope, not the access scope).
+Container-form reads (`$h{k}`, grammar field `hash:`) project off the
+hash variable's own attachment directly.
+
+### Canonical `%h` is the one identity for the container spelling
+
+`$h{k}` reads `%h`, not scalar `$h` — same node kind as the deref
+form, different variable. The `HashKeyAccess` ref's `var_text`, the
+shape witness attachment, and the `KeyWrite` all carry the canonical
+`%h`, so the three producers and every consumer agree without
+translation. The grammar disambiguates for free (`hash:` field with
+`container_variable` vs a plain `scalar` child); the one residual trap
+— postfix deref slices — uses field `hashref:` instead, encoded once
+in the slice-write arm.
+
+### Mutation is modeled on the shape, not gated away
+
+The route-branding lesson (`route-branding.md`): an effect on a value
+belongs on the value's TYPE, not in consumer-side suppression lists.
+`$v->{k} = …` is therefore not a trust break — the walk records a
+`KeyWrite` (var, key-or-dynamic, scope, span, RHS span, syntactic
+conditionality), and the mutation-extension pass
+(`witnesses::emit_mutation_extension_witnesses`) folds them into
+Variable shape witnesses:
+
+- **Unconditional static-key write → EXTEND.** The key joins the
+  closed shape, its value typed from the RHS expression; the read
+  drills back typed, and a typo beside it still hints.
+- **Dynamic key, conditional write, scope-crossing write, or slice
+  write → OPEN.** Conditionality is syntactic
+  (`cst::is_conditionally_executed`: if/unless, postfix modifiers,
+  ternary, loops, short-circuit chains — over-marking is the safe
+  direction, it only widens) plus structural at the pass (the write's
+  scope chain crossing any boundary before the attachment scope:
+  nested block or closure, execution unknowable). Slice writes land
+  several keys at once; all six spellings (`@h{…}`/`%h{k}`,
+  `@$h{…}`/`%$h{k}`, `$h->@{…}`/`$h->%{…}`) record an open-switching
+  `KeyWrite`.
+
+Extension witnesses use zero-width spans at the write position — the
+same temporal contract as TC mirrors: invisible to reads before the
+write, latest-wins after. The pass is re-emittable in the worklist
+fold (clear-and-emit, tag `mutation_extension`) and append-only at
+enrichment — post-finalize removal would shift the sealed
+`base_witness_count`, and duplicate pushes are idempotent under
+latest-wins, truncated away by the next enrichment cycle. `KeyWrite`s
+persist on `FileAnalysis` precisely so enrichment can re-run the pass
+once imported shapes land.
+
+### The whole-story gate is two clauses, each naming its modeled replacement
+
+`FileAnalysis::closed_shape_is_whole_story(var)` =
+not escaped ∧ not reassigned. The unknown-hash-key diagnostic fires
+only behind it.
+
+- **Escape** (`escaped_scalars`, builder-recorded): a scalar READ in
+  any non-element-access position — call argument, RHS alias,
+  invocant, sigil deref — hands the reference to code that may mutate
+  the referent. Slice bases are excluded (a slice read copies values
+  out). Hashes are sharper: bare `func(%h)` flattens to copies — the
+  callee cannot add keys — so only `\%h` ref-taking escapes.
+- **Reassignment** (`reassigned_scalars`): a Write targeting the
+  variable itself (`$v = …`, `%h = …`). Element writes are NOT here —
+  they're mutations, modeled above.
+
+Each clause is the trust-gate stand-in for a lattice widening that
+isn't modeled yet (escape widening; conditional-reassignment
+disagreement — `$spec = {…} unless ref $spec`). When one gets
+modeled, its clause comes OUT of the gate, the way key writes did.
+
+### Calibration is part of done
+
+Every change to the gate, the lattice, or the emission set re-runs
+whole-substrate diagnostics (2,293 pinned CPAN modules). The
+diagnostic ships at ZERO false positives there; the 23 pre-gate FPs
+(Capture::Tiny, Params::ValidationCompiler, Mojolicious::Renderer, …)
+are the corpus the clauses were derived against, and the gold rows in
+`gold-corpus/fixtures/nested-*.json` pin both halves — the hint that
+must fire and the writes/spreads/escapes that must stay silent.

--- a/docs/prompt-nested-hashkey.md
+++ b/docs/prompt-nested-hashkey.md
@@ -1,198 +1,47 @@
-# Nested hash-key intelligence
+# Nested hash-key intelligence — residuals
 
-**Status: ALL THREE TIERS LANDED (June 2026, `nested-hashkey`
-branch).** Tier 1: `$row->{name}` resolves to the column def via the
-post-fold variable-owner upgrade. Tier 2: `HashWithKeys` (per-key value
-types, `open` spread flag) with `->{key}` narrowing through assignment
-hops, double-drills, and sub-return literals; two lattice rules made it
-sound (all-hash-shaped return arms unify coarse; structure dominates
-rep in `subsumes_narrowing` + the plain-type fold). Tier 3: array
-literals type as per-index `Sequence` tuples (heterogeneous answers
-per index instead of bailing), `->[N]` projects, and the mixed drill
-`$obj->{users}->[0]->{name}` chains end-to-end. Displays stay coarse
-("HashRef") for hashes; sequences display `Sequence<…>` elided past 4
-elements. The closed-shape-miss diagnostic landed (whole-story
-gated), and mutation effects are modeled: the mutation-extension pass
-(`witnesses::emit_mutation_extension_witnesses`) folds `$v->{k} = …`
-writes into the shape — unconditional static-key writes EXTEND a
-closed shape (value typed from the RHS), conditional / dynamic /
-scope-crossing writes switch it open. Still open below: the remaining
-deferred items.
+**Status: LANDED (June 2026, PR #50).** All three tiers plus the
+follow-through: `$row->{name}` → column def (post-fold owner upgrade),
+`HashWithKeys` structural narrowing through hops / double-drills /
+sub returns / imports, `Sequence` index projection and the mixed
+drill, cross-file drill hops (`Projected` edge payload), the
+closed-shape unknown-key diagnostic (whole-story gated, HINT),
+mutation modeled on the shape (extend / open), and the literal
+`%hash` spelling with every slice form. **The load-bearing decisions
+live in `docs/adr/structural-shapes.md`** (data model, lattice rules,
+Projected drills, canonical `%h`, mutation extension, the trust gate,
+calibration discipline); `docs/adr/sequence-types.md` owns the array
+side. This file keeps only what's still open.
 
-Builds on the sealed-enum `ParametricType` shape landed in
-Part 5c (`docs/adr/parametric-types.md`). Each flavor carries
-its own data fields, so recursive nesting (`HashRef<ArrayRef
-<Str>>` etc.) lives in flavor-specific `Box<InferredType>`
-slots — no `Vec<TypeArg>` shoehorning. This work is about
-*emitting* the right flavor for hash-shaped data and
-*consuming* it via narrowing.
+## Residuals
 
-## What "nested hash-key intelligence" means
-
-Three increasingly ambitious cases:
-
-```perl
-# Tier 1 — hash-key access on a Parametric value
-my $row = $rs->find($id);     # Parametric{ResultSet, [Class("Users")]}
-$row->{name};                 # cursor on `name` should resolve to the column def
-
-# Tier 2 — structurally-typed hash drill-down
-my $config = { db => { host => 'localhost', port => 5432 } };
-$config->{db};                # → HashWithKeys{host: String, port: Numeric}
-$config->{db}->{host};        # → String
-
-# Tier 3 — mixed array/hash drill
-my $obj = { users => [ { name => 'A', id => 1 } ] };
-$obj->{users};                # → ArrayRef<HashWithKeys{name: String, id: Numeric}>
-$obj->{users}->[0]->{name};   # → String
-```
-
-Today: tier 1 fails because `add_columns` synthesizes only `Method`
-symbols, not `HashKeyDef`. Tiers 2/3 fail because there's no
-structurally-typed hash variant — hash literals get folded to
-`HashRef` (rep-only) and any per-key type information is lost.
-
-## Tier 1 — hash-key access on a Parametric value
-
-**Goal:** `$row->{name}` lands on the `name` column def, same as
-`$row->name` does today.
-
-**Diff sketch:**
-- `Builder::visit_dbic_add_columns` synthesizes `HashKeyDef` symbols
-  alongside the existing `Method` symbols, owner
-  `HashKeyOwner::Class(current_package)`. Mirrors what Mojo `has`
-  already does.
-- `FileAnalysis::find_definition`'s `RefKind::HashKeyAccess` arm:
-  when invocant types as `Parametric`, look up
-  `HashKeyOwner::Class(type_args[0].as_class())` (DBIC's row class)
-  in addition to / instead of the receiver's base class. Today it
-  consults the receiver class via `resolve_hash_owner_from_tree`.
-
-**Cost: ~30 LOC + tests.** Reuses every consumer path; no new
-variant. Ships the moment `add_columns` synths HashKeyDef.
-
-**Test cases:**
-- `$row->{name}` lands on column def (basic).
-- `$row->{not_a_column}` returns None.
-- Cross-file: producer defines columns, consumer accesses
-  `$row->{name}` after `$rs->find($id)`. Composes through Parametric
-  threading.
-
-## Tier 2 — structurally-typed hashes (`HashWithKeys`)
-
-**Goal:** Hash literals with literal keys carry per-key type info;
-`->{key}` access narrows to the per-key type.
-
-**New variant:**
-```rust
-InferredType::HashWithKeys {
-    keys: Vec<(String, TypeArg)>,
-    /// True if the literal includes a `...` / `%$other` spread, so
-    /// keys are open-ended. Closed (false) → unknown keys are an
-    /// error/diagnostic; open (true) → unknown keys may resolve via
-    /// the spread source.
-    open: bool,
-}
-```
-
-`Vec<(String, TypeArg)>` (not `HashMap`) — order-preserving for
-stable display, plus most hashes have ≤10 keys so linear lookup
-beats hashing.
-
-**Builder emission rule:**
-- `{ k => V₁, k₂ => V₂, … }` literal → `HashWithKeys { keys: [(k,
-  type_of(V₁)), ...], open: false }`. Already half-done in the
-  HashKeyDef synthesis path; needs the type side.
-- `{ %$other, k => V }` → `HashWithKeys { keys: [...], open: true }`
-  (the `open` flag carries the spread).
-- Hash assigned to a `my %h` → infer at use sites (Tier 3 territory).
-
-**Reducer additions:**
-- `HashKeyAccess` chain narrowing — when `expr->{KEY}` follows an
-  expression typed `HashWithKeys`, the result types as the
-  per-key entry. Mirrors the variable narrowing in
-  `FrameworkAwareTypeFold` but for hash-access spans.
-- Constraint composition: if the producing literal had `open: true`,
-  unknown keys fall through to the spread's source.
-
-**Diagnostic opportunity:** Closed-shape access to a missing key
-(`$config->{typeo}` when `typeo` isn't a literal key) is a
-diagnostic — same family as PL-class checks. Defer to the diagnostic
-framework workstream; emit the witness now, surface later.
-
-**Cost: ~150 LOC + tests.** Real work.
-
-**Test cases:**
-- Direct literal: `my $c = { host => 'x' }; $c->{host}` → String def.
-- Nested: `my $c = { db => { host => 'x' } }; $c->{db}->{host}` →
-  String narrowing through `db`.
-- Re-bound: `my %h = (k => 1); my $r = \%h; $r->{k}` → Numeric.
-- Sub return literal: `sub cfg { { host => 'x' } } cfg()->{host}`.
-- Open shape: `my $c = { %$base, host => 'x' }` — keys from `$base`
-  contribute when `host` isn't a hit.
-
-## Tier 3 — array element narrowing + mixed drill
-
-**Goal:** `$obj->{users}->[0]->{name}` chains through array element
-type and hash narrowing.
-
-**Reuses Parametric for arrays:**
-- `[1, 'x']` → `Parametric { base: "ArrayRef", type_args:
-  [TypeArg::Type(Numeric), TypeArg::Type(String)] }` for known
-  element types. Or `Parametric { base: "ArrayRef", type_args:
-  [TypeArg::Type(Union { ... })] }` if we add a `Union` variant.
-  Decide at implementation time; for the CRM's idiom (`[ Foo->new,
-  Foo->new ]` — homogeneous), `Parametric { base: "ArrayRef",
-  type_args: [TypeArg::Class("Foo")] }` is the common case.
-
-**Reducer:** `expr->[N]` and `expr->[N..M]` narrow to the element
-type. `[N]` of a homogeneous `Parametric{ArrayRef, [T]}` returns T;
-heterogeneous (`type_args.len() > 1`) is more complex — bail to
-unknown for now, address with sum types (Part 5b) when motivated.
-
-**Cost: ~50 LOC on top of tier 2.**
-
-**Test cases:**
-- `[ Foo->new ]->[0]->method` types correctly.
-- `$obj->{users}->[0]->{name}` end-to-end.
-- Heterogeneous `[1, 'x']->[0]` → unknown (we don't claim).
-
-## Sequencing & priority
-
-1. **Tier 1** — bundle into Part 5c PR if cheap, otherwise next PR.
-   Pure win; no new variant; just synthesizes HashKeyDef + extends
-   one consumer arm.
-2. **Tier 2** — own PR. Adds `HashWithKeys` variant + emission for
-   hash literals + chain narrowing. Land before Tier 3.
-3. **Tier 3** — own PR. Reuses Parametric for arrays + element
-   narrowing. Composes with Tier 2 for the mixed drill.
-
-## Out of scope
-
-- **Inferring hash structure from `bless` targets.** `bless { a => 1,
-  b => 2 }, 'Foo'` produces a Foo with hash structure {a, b} —
-  the existing `bless`-target handling already records this for
-  HashKeyDef synthesis on `Foo`; Tier 2 would let the type system
-  see the per-key types too. Bundle if obvious; defer otherwise.
-- **JSON / YAML / TOML loaded data.** Could in principle be a Tier 2
-  emission if we parse the schema, but that's a separate plugin
-  domain.
-- **Mutation-induced widening.** LANDED — see the mutation-extension
-  pass note up top. Literal `%hash` variables LANDED too: `my %h =
-  (k => v)` types through the same `hash_literal_type` builder
-  (array spreads like `@_` open the shape), container-form reads
-  (`$h{k}`) project off the canonical `%h`, KeyWrites and the
-  diagnostic key the same name, and the hash gates are sharper than
-  the scalar ones (bare `func(%h)` flattens to copies — not an
-  escape; only `\%h` ref-taking is). Slice writes
-  (`@h{qw(a b)} = …`, `%h{k} = …`, `@$h{…}`) record an open-switching
-  KeyWrite — several keys at once, conservatively widened. Residual
-  flavors still open: array index writes on `Sequence` tuples, and
-  conditional-reassignment disagreement
-  (`$spec = {…} unless ref $spec` — still a trust-gate suppression
-  via `reassigned_scalars`, not a lattice fold).
+- **Conditional-reassignment disagreement.** `$spec = { optional =>
+  !$spec } unless ref $spec` — one arm has a known shape, the other
+  keeps an unknown value. Today this is a trust-gate suppression
+  (`reassigned_scalars`); the modeled fix is a lattice fold where the
+  two assignment witnesses disagree-to-widen (BranchArmFold's shape,
+  applied to conditional reassignment). When it lands, the
+  reassignment clause comes out of the gate the way key writes did.
+- **Escape widening.** A var passed as a call argument could keep a
+  WIDENED shape (open) instead of losing diagnostics entirely.
+  Today: gate suppression via `escaped_scalars`. Worth modeling only
+  with interprocedural appetite — the gate is cheap and sound.
+- **Array index writes on `Sequence` tuples.** `$items->[3] = …` on a
+  closed tuple neither extends nor opens it today (`record_key_write`
+  skips array first hops). The hash-side machinery (KeyWrite +
+  extension pass) is the template.
+- **Batch diagnostics enrichment parity.** Cross-file-typed shapes
+  can't hint under `--batch`/`--check` — `batch_diagnostics` walks
+  raw workspace entries while `publish_diagnostics` enriches open
+  docs first. Tracked as the `nested-closed-shape-typo-crossfile`
+  xfail row + `gold-corpus/KNOWN-GAPS.md`; closing it re-baselines
+  the diagnostics suite.
+- **Inferring hash structure from `bless` targets.** `bless { a => 1
+  }, 'Foo'` already records HashKeyDef synthesis on `Foo`; letting
+  the type system see the per-key types too is unbundled future work.
+- **JSON / YAML / TOML loaded data.** A schema-reading plugin
+  emission story, separate domain.
 - **Recursive type constraints from Type::Tiny / Moose.** `isa =>
-  HashRef[ArrayRef[Str]]` ASTs. This is a separate plugin emission
-  story (`use Types::Standard` plugin extends Moo synthesis to
-  read the constraint expression and emit recursive Parametric).
-  Tracked under residual Part 5c, future phase.
+  HashRef[ArrayRef[Str]]` ASTs — a `use Types::Standard` plugin
+  extending Moo synthesis to emit recursive Parametric. Tracked under
+  residual Part 5c.

--- a/docs/prompt-nested-hashkey.md
+++ b/docs/prompt-nested-hashkey.md
@@ -1,13 +1,19 @@
 # Nested hash-key intelligence
 
-**Status:** Tier 1 partially landed in the parametric ResultSet
-PR — `add_columns` synthesizes `HashKeyDef` symbols on the row
-class, and `ParametricType::ResultSet`'s `hash_key_class()` /
-`method_arg_owner()` route hash-key access to the row class.
-What's NOT in Tier 1 yet: direct `$row->{name}` access on a
-typed row (DBIC's HRI shape; not currently supported anyway).
-Tiers 2/3 (structurally-typed hash literals, mixed array/hash
-drill) remain queued.
+**Status: ALL THREE TIERS LANDED (June 2026, `nested-hashkey`
+branch).** Tier 1: `$row->{name}` resolves to the column def via the
+post-fold variable-owner upgrade. Tier 2: `HashWithKeys` (per-key value
+types, `open` spread flag) with `->{key}` narrowing through assignment
+hops, double-drills, and sub-return literals; two lattice rules made it
+sound (all-hash-shaped return arms unify coarse; structure dominates
+rep in `subsumes_narrowing` + the plain-type fold). Tier 3: array
+literals type as per-index `Sequence` tuples (heterogeneous answers
+per index instead of bailing), `->[N]` projects, and the mixed drill
+`$obj->{users}->[0]->{name}` chains end-to-end. Displays stay coarse
+("HashRef") for hashes; sequences display `Sequence<…>` elided past 4
+elements. Still open below: the deferred items (mutation-induced
+widening, Type::Tiny recursive constraints) and the closed-shape-miss
+diagnostic (the `open` flag now carries everything it needs).
 
 Builds on the sealed-enum `ParametricType` shape landed in
 Part 5c (`docs/adr/parametric-types.md`). Each flavor carries

--- a/docs/prompt-nested-hashkey.md
+++ b/docs/prompt-nested-hashkey.md
@@ -11,9 +11,13 @@ literals type as per-index `Sequence` tuples (heterogeneous answers
 per index instead of bailing), `->[N]` projects, and the mixed drill
 `$obj->{users}->[0]->{name}` chains end-to-end. Displays stay coarse
 ("HashRef") for hashes; sequences display `Sequence<…>` elided past 4
-elements. Still open below: the deferred items (mutation-induced
-widening, Type::Tiny recursive constraints) and the closed-shape-miss
-diagnostic (the `open` flag now carries everything it needs).
+elements. The closed-shape-miss diagnostic landed (whole-story
+gated), and mutation effects are modeled: the mutation-extension pass
+(`witnesses::emit_mutation_extension_witnesses`) folds `$v->{k} = …`
+writes into the shape — unconditional static-key writes EXTEND a
+closed shape (value typed from the RHS), conditional / dynamic /
+scope-crossing writes switch it open. Still open below: the remaining
+deferred items.
 
 Builds on the sealed-enum `ParametricType` shape landed in
 Part 5c (`docs/adr/parametric-types.md`). Each flavor carries
@@ -173,9 +177,14 @@ unknown for now, address with sum types (Part 5b) when motivated.
 - **JSON / YAML / TOML loaded data.** Could in principle be a Tier 2
   emission if we parse the schema, but that's a separate plugin
   domain.
-- **Mutation-induced widening.** `my $h = { a => 1 }; $h->{b} = 'x';
-  $h->{c}` — closed→open transition mid-flow. Touchable with the
-  invocant-mutation reducer (Part 1 residual). Defer.
+- **Mutation-induced widening.** LANDED — see the mutation-extension
+  pass note up top. Residual flavors still open: literal `%hash`
+  variables (`my %h = (a => 1); $h{b}` — no shape TC is minted for
+  hash-sigil variables, so neither extension nor the diagnostic apply;
+  the same model, second spelling), array index writes on `Sequence`
+  tuples, and conditional-reassignment disagreement (`$spec = {…}
+  unless ref $spec` — still a trust-gate suppression via
+  `reassigned_scalars`, not a lattice fold).
 - **Recursive type constraints from Type::Tiny / Moose.** `isa =>
   HashRef[ArrayRef[Str]]` ASTs. This is a separate plugin emission
   story (`use Types::Standard` plugin extends Moo synthesis to

--- a/docs/prompt-nested-hashkey.md
+++ b/docs/prompt-nested-hashkey.md
@@ -178,13 +178,19 @@ unknown for now, address with sum types (Part 5b) when motivated.
   emission if we parse the schema, but that's a separate plugin
   domain.
 - **Mutation-induced widening.** LANDED — see the mutation-extension
-  pass note up top. Residual flavors still open: literal `%hash`
-  variables (`my %h = (a => 1); $h{b}` — no shape TC is minted for
-  hash-sigil variables, so neither extension nor the diagnostic apply;
-  the same model, second spelling), array index writes on `Sequence`
-  tuples, and conditional-reassignment disagreement (`$spec = {…}
-  unless ref $spec` — still a trust-gate suppression via
-  `reassigned_scalars`, not a lattice fold).
+  pass note up top. Literal `%hash` variables LANDED too: `my %h =
+  (k => v)` types through the same `hash_literal_type` builder
+  (array spreads like `@_` open the shape), container-form reads
+  (`$h{k}`) project off the canonical `%h`, KeyWrites and the
+  diagnostic key the same name, and the hash gates are sharper than
+  the scalar ones (bare `func(%h)` flattens to copies — not an
+  escape; only `\%h` ref-taking is). Slice writes
+  (`@h{qw(a b)} = …`, `%h{k} = …`, `@$h{…}`) record an open-switching
+  KeyWrite — several keys at once, conservatively widened. Residual
+  flavors still open: array index writes on `Sequence` tuples, and
+  conditional-reassignment disagreement
+  (`$spec = {…} unless ref $spec` — still a trust-gate suppression
+  via `reassigned_scalars`, not a lattice fold).
 - **Recursive type constraints from Type::Tiny / Moose.** `isa =>
   HashRef[ArrayRef[Str]]` ASTs. This is a separate plugin emission
   story (`use Types::Standard` plugin extends Moo synthesis to

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -182,6 +182,17 @@ there's no clean static signal distinguishing a method from a helper in an OO
 class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 **Difficulty:** high (inherently ambiguous).
 
+### `nested-closed-shape-typo-crossfile` — batch diagnostics lack enrichment parity
+The unknown-hash-key hint fires on `$config->{db_host}` in the editor, where
+`publish_diagnostics` enriches the open doc (`enrich_imported_types_with_keys`)
+before `collect_diagnostics`, so the `cfg()` import's `HashWithKeys` return
+types `$config`. `batch_diagnostics` (`--batch`/`--check`) walks raw workspace
+entries with no enrichment pass, so cross-file-typed shapes can't hint there.
+Closing it means an enriched diagnostics pass in batch — which will also shift
+the unresolved-method rows (more invocants resolve), so it wants its own
+calibration run. **Subsystem:** `main.rs::batch_diagnostics`.
+**Difficulty:** medium (mechanical, but re-baselines the diagnostics suite).
+
 ---
 
 ## Triage summary
@@ -196,6 +207,7 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
 | diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |
+| nested-closed-shape-typo-crossfile | batch diagnostics enrichment parity | medium (re-baselines suite) |
 
 Quickest wins: the signature-help invocant gate, imported-names in completion,
 the `bootstrap` loader recognition, and the `(shift, shift)` param extraction —

--- a/gold-corpus/README.md
+++ b/gold-corpus/README.md
@@ -65,11 +65,12 @@ the numbers as JSON for run-over-run comparison.
 against the committed workspace at `nested-fixture/` (per-row `root`,
 same mechanism as re-export below) and exercise the structural typing
 tiers: the mixed drill `$obj->{users}->[0]->{name}` (type-at), imported
-array-literal tuples (`Sequence<…>` hover), and `$row->{name}` → column
-def (definition + references, cross-file). The two xfail rows pin the
-known gap: drill HOPS through an imported literal (`my $db =
-$config->{db}` where `cfg()` is imported) don't type yet — assignment
-chain typing runs at build, index-less.
+array-literal tuples (`Sequence<…>` hover), drill hops through an
+imported literal (`my $db = $config->{db}` hover — the `Projected`
+edge payload), `$row->{name}` → column def (definition + references,
+cross-file), and the closed-shape unknown-key hint (diagnostics: the
+local-literal typo is gold; the cross-file-typed typo is xfail — batch
+diagnostics have no enrichment parity, see KNOWN-GAPS.md).
 
 **Re-export fixture.** Three rows (`fixtures/reexport.json`, capability `definition` — folded under `definition` in `--list`) run against a small **committed, self-contained workspace** at `reexport-fixture/` instead of the snapshot substrate, via a per-row `root`. They flex the transitive export-surface feature: `goto-def` from a consumer of a re-exporter resolves to the *original* sub through both re-export forms — static splice (`our @EXPORT = (@RexBase::EXPORT)`) and loop-push (`push @EXPORT, @{"${m}::EXPORT"}`). The harness groups rows by `root` and runs one `--batch` per root.
 

--- a/gold-corpus/README.md
+++ b/gold-corpus/README.md
@@ -70,7 +70,10 @@ imported literal (`my $db = $config->{db}` hover — the `Projected`
 edge payload), `$row->{name}` → column def (definition + references,
 cross-file), and the closed-shape unknown-key hint (diagnostics: the
 local-literal typo is gold; the cross-file-typed typo is xfail — batch
-diagnostics have no enrichment parity, see KNOWN-GAPS.md).
+diagnostics have no enrichment parity, see KNOWN-GAPS.md; the
+mutation-extension rows pin that an unconditional write joins the
+shape — the written key reads back typed, the typo beside it still
+hints).
 
 **Re-export fixture.** Three rows (`fixtures/reexport.json`, capability `definition` — folded under `definition` in `--list`) run against a small **committed, self-contained workspace** at `reexport-fixture/` instead of the snapshot substrate, via a per-row `root`. They flex the transitive export-surface feature: `goto-def` from a consumer of a re-exporter resolves to the *original* sub through both re-export forms — static splice (`our @EXPORT = (@RexBase::EXPORT)`) and loop-push (`push @EXPORT, @{"${m}::EXPORT"}`). The harness groups rows by `root` and runs one `--batch` per root.
 

--- a/gold-corpus/README.md
+++ b/gold-corpus/README.md
@@ -54,6 +54,23 @@ A process abort (the scanner-overflow class) is always a hard **CRASH** fail. Ou
 
 The substrate is installed lib content only — it contains **no test files (`t/*.t`), `bin/`, or examples**. Rows whose original cursor lived in a test file, or whose module is not in the snapshot (e.g. JSON::PP, Time::HiRes), are listed in each capability's "Dropped" section. Rows that leaned on test-file call sites were re-authored to the surviving in-lib locations.
 
+**Cost report.** Every suite run ends with a per-capability timing table
+(wall-time per query, attributed by row id), per-root startup latency
+(first-response time: workspace index + cache warm), child CPU
+(user/sys), and peak RSS (`/proc` VmHWM, Linux-only) — so feature work
+sees what it costs as it lands. Set `METRICS_OUT=<file>` to also write
+the numbers as JSON for run-over-run comparison.
+
+**Nested-hashkey fixture.** Rows under `fixtures/nested-*.json` run
+against the committed workspace at `nested-fixture/` (per-row `root`,
+same mechanism as re-export below) and exercise the structural typing
+tiers: the mixed drill `$obj->{users}->[0]->{name}` (type-at), imported
+array-literal tuples (`Sequence<…>` hover), and `$row->{name}` → column
+def (definition + references, cross-file). The two xfail rows pin the
+known gap: drill HOPS through an imported literal (`my $db =
+$config->{db}` where `cfg()` is imported) don't type yet — assignment
+chain typing runs at build, index-less.
+
 **Re-export fixture.** Three rows (`fixtures/reexport.json`, capability `definition` — folded under `definition` in `--list`) run against a small **committed, self-contained workspace** at `reexport-fixture/` instead of the snapshot substrate, via a per-row `root`. They flex the transitive export-surface feature: `goto-def` from a consumer of a re-exporter resolves to the *original* sub through both re-export forms — static splice (`our @EXPORT = (@RexBase::EXPORT)`) and loop-push (`push @EXPORT, @{"${m}::EXPORT"}`). The harness groups rows by `root` and runs one `--batch` per root.
 
 ## Already in corpus

--- a/gold-corpus/README.md
+++ b/gold-corpus/README.md
@@ -73,7 +73,7 @@ local-literal typo is gold; the cross-file-typed typo is xfail — batch
 diagnostics have no enrichment parity, see KNOWN-GAPS.md; the
 mutation-extension rows pin that an unconditional write joins the
 shape — the written key reads back typed, the typo beside it still
-hints).
+hints; the literal-hash rows pin the `%plain` spelling of both).
 
 **Re-export fixture.** Three rows (`fixtures/reexport.json`, capability `definition` — folded under `definition` in `--list`) run against a small **committed, self-contained workspace** at `reexport-fixture/` instead of the snapshot substrate, via a per-row `root`. They flex the transitive export-surface feature: `goto-def` from a consumer of a re-exporter resolves to the *original* sub through both re-export forms — static splice (`our @EXPORT = (@RexBase::EXPORT)`) and loop-push (`push @EXPORT, @{"${m}::EXPORT"}`). The harness groups rows by `root` and runs one `--batch` per root.
 

--- a/gold-corpus/fixtures/nested-definition.json
+++ b/gold-corpus/fixtures/nested-definition.json
@@ -1,0 +1,15 @@
+{
+  "capability": "definition",
+  "comment": "Tier 1: $row->{name} on a typed row resolves to the column def — cross-file, the class file carries the add_columns HashKeyDef.",
+  "rows": [
+    {
+      "id": "nested-row-key-to-column-def",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 22,
+      "col": 17,
+      "status": "gold",
+      "expect": { "all": ["NestedRow.pm:7:5"] }
+    }
+  ]
+}

--- a/gold-corpus/fixtures/nested-diagnostics.json
+++ b/gold-corpus/fixtures/nested-diagnostics.json
@@ -1,0 +1,48 @@
+{
+  "capability": "diagnostics",
+  "rows": [
+    {
+      "id": "nested-closed-shape-typo",
+      "difficulty": "simple",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 31,
+      "col": 24,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "\"code\":\"unknown-hash-key\"",
+          "key 'retrys' is not in $local_cfg's literal shape"
+        ],
+        "none": [
+          "is not in $db's",
+          "is not in $obj's",
+          "is not in $row's"
+        ]
+      },
+      "status": "gold",
+      "note": "The deliberate local-literal typo; the whole-story gate keeps every other var silent (and the substrate at zero unknown-hash-key)."
+    },
+    {
+      "id": "nested-closed-shape-typo-crossfile",
+      "difficulty": "tricky",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 27,
+      "col": 21,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "key 'db_host' is not in $config's literal shape"
+        ],
+        "none": []
+      },
+      "status": "xfail",
+      "note": "GAP: $config's shape comes from the cfg() import; publish_diagnostics enriches open docs before collect_diagnostics, but batch_diagnostics walks raw workspace entries -- no enrichment parity, so cross-file-typed shapes can't hint in batch."
+    }
+  ]
+}

--- a/gold-corpus/fixtures/nested-diagnostics.json
+++ b/gold-corpus/fixtures/nested-diagnostics.json
@@ -43,6 +43,27 @@
       },
       "status": "xfail",
       "note": "GAP: $config's shape comes from the cfg() import; publish_diagnostics enriches open docs before collect_diagnostics, but batch_diagnostics walks raw workspace entries -- no enrichment parity, so cross-file-typed shapes can't hint in batch."
+    },
+    {
+      "id": "nested-mutation-extension",
+      "difficulty": "tricky",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 38,
+      "col": 24,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "key 'nmae' is not in $branded's literal shape"
+        ],
+        "none": [
+          "key 'name' is not in"
+        ]
+      },
+      "status": "gold",
+      "note": "The unconditional write extends the closed shape: the written key reads silently, the typo beside it still hints."
     }
   ]
 }

--- a/gold-corpus/fixtures/nested-diagnostics.json
+++ b/gold-corpus/fixtures/nested-diagnostics.json
@@ -64,6 +64,27 @@
       },
       "status": "gold",
       "note": "The unconditional write extends the closed shape: the written key reads silently, the typo beside it still hints."
+    },
+    {
+      "id": "nested-literal-hash-typo",
+      "difficulty": "simple",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 43,
+      "col": 17,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "key 'retrys' is not in %plain's literal shape"
+        ],
+        "none": [
+          "key 'retries' is not in"
+        ]
+      },
+      "status": "gold",
+      "note": "The literal-hash spelling of the typo hint: container-form read checked against %plain's list-literal shape."
     }
   ]
 }

--- a/gold-corpus/fixtures/nested-hover.json
+++ b/gold-corpus/fixtures/nested-hover.json
@@ -1,0 +1,33 @@
+{
+  "capability": "hover",
+  "comment": "Tier 3 array tuples travel cross-file ($items from an imported literal). The drill HOPS ($db = $config->{db} where cfg() is imported) do not type yet: assignment chain typing runs at build, index-less — xfail until enrichment re-runs the chain pass.",
+  "rows": [
+    {
+      "id": "nested-imported-sequence",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 13,
+      "col": 4,
+      "status": "gold",
+      "expect": { "all": ["Sequence<String"] }
+    },
+    {
+      "id": "nested-crossfile-drill-host",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 9,
+      "col": 4,
+      "status": "xfail",
+      "expect": { "all": ["String"] }
+    },
+    {
+      "id": "nested-crossfile-drill-port",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 10,
+      "col": 4,
+      "status": "xfail",
+      "expect": { "all": ["Numeric"] }
+    }
+  ]
+}

--- a/gold-corpus/fixtures/nested-hover.json
+++ b/gold-corpus/fixtures/nested-hover.json
@@ -1,6 +1,6 @@
 {
   "capability": "hover",
-  "comment": "Tier 3 array tuples travel cross-file ($items from an imported literal). The drill HOPS ($db = $config->{db} where cfg() is imported) do not type yet: assignment chain typing runs at build, index-less — xfail until enrichment re-runs the chain pass.",
+  "comment": "Tier 3 array tuples travel cross-file ($items from an imported literal). Drill hops ($db = $config->{db} where cfg() is imported) resolve at query time through the Projected edge payload.",
   "rows": [
     {
       "id": "nested-imported-sequence",
@@ -17,7 +17,7 @@
       "file": "main.pl",
       "line": 9,
       "col": 4,
-      "status": "xfail",
+      "status": "gold",
       "expect": { "all": ["String"] }
     },
     {
@@ -26,7 +26,7 @@
       "file": "main.pl",
       "line": 10,
       "col": 4,
-      "status": "xfail",
+      "status": "gold",
       "expect": { "all": ["Numeric"] }
     }
   ]

--- a/gold-corpus/fixtures/nested-references.json
+++ b/gold-corpus/fixtures/nested-references.json
@@ -1,0 +1,15 @@
+{
+  "capability": "references",
+  "comment": "Tier 1 references: the row-key access and the column def are one reference set, cross-file.",
+  "rows": [
+    {
+      "id": "nested-row-key-references",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 22,
+      "col": 17,
+      "status": "gold",
+      "expect": { "all": ["\"file\":\"NestedRow.pm\"", "\"file\":\"main.pl\""] }
+    }
+  ]
+}

--- a/gold-corpus/fixtures/nested-typeat.json
+++ b/gold-corpus/fixtures/nested-typeat.json
@@ -1,0 +1,24 @@
+{
+  "capability": "type-at",
+  "comment": "Nested hash-key intelligence (prompt-nested-hashkey.md): in-file structural typing. The mixed drill $obj->{users}->[0]->{name} chains HashWithKeys narrowing → Sequence element projection → HashWithKeys narrowing.",
+  "rows": [
+    {
+      "id": "nested-mixed-drill-string",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 16,
+      "col": 4,
+      "status": "gold",
+      "expect": { "all": ["String"] }
+    },
+    {
+      "id": "nested-mixed-drill-numeric",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 17,
+      "col": 4,
+      "status": "gold",
+      "expect": { "all": ["Numeric"] }
+    }
+  ]
+}

--- a/gold-corpus/fixtures/nested-typeat.json
+++ b/gold-corpus/fixtures/nested-typeat.json
@@ -1,6 +1,6 @@
 {
   "capability": "type-at",
-  "comment": "Nested hash-key intelligence (prompt-nested-hashkey.md): in-file structural typing. The mixed drill $obj->{users}->[0]->{name} chains HashWithKeys narrowing → Sequence element projection → HashWithKeys narrowing.",
+  "comment": "Nested hash-key intelligence (prompt-nested-hashkey.md): in-file structural typing. The mixed drill $obj->{users}->[0]->{name} chains HashWithKeys narrowing \u2192 Sequence element projection \u2192 HashWithKeys narrowing.",
   "rows": [
     {
       "id": "nested-mixed-drill-string",
@@ -9,7 +9,11 @@
       "line": 16,
       "col": 4,
       "status": "gold",
-      "expect": { "all": ["String"] }
+      "expect": {
+        "all": [
+          "String"
+        ]
+      }
     },
     {
       "id": "nested-mixed-drill-numeric",
@@ -18,7 +22,27 @@
       "line": 17,
       "col": 4,
       "status": "gold",
-      "expect": { "all": ["Numeric"] }
+      "expect": {
+        "all": [
+          "Numeric"
+        ]
+      }
+    },
+    {
+      "id": "nested-mutation-extended-value",
+      "difficulty": "simple",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 37,
+      "col": 4,
+      "status": "gold",
+      "expect": {
+        "all": [
+          "String"
+        ]
+      },
+      "note": "$branded->{name} read after the unconditional write -- the mutation-extension pass typed the added key from its RHS."
     }
   ]
 }

--- a/gold-corpus/fixtures/nested-typeat.json
+++ b/gold-corpus/fixtures/nested-typeat.json
@@ -43,6 +43,22 @@
         ]
       },
       "note": "$branded->{name} read after the unconditional write -- the mutation-extension pass typed the added key from its RHS."
+    },
+    {
+      "id": "nested-literal-hash-value",
+      "difficulty": "simple",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 42,
+      "col": 4,
+      "status": "gold",
+      "expect": {
+        "all": [
+          "Numeric"
+        ]
+      },
+      "note": "$plain{retries} container-form read projects off %plain's literal-list shape."
     }
   ]
 }

--- a/gold-corpus/nested-fixture/lib/NestedCfg.pm
+++ b/gold-corpus/nested-fixture/lib/NestedCfg.pm
@@ -1,0 +1,21 @@
+package NestedCfg;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(cfg make_items);
+
+# Nested hash literal — tier 2's structurally-typed shape, exported so
+# consumers exercise the cross-file narrowing path.
+sub cfg {
+    return {
+        db    => { host => 'localhost', port => 5432 },
+        debug => 1,
+    };
+}
+
+# Array literal — tier 3's per-index tuple, cross-file.
+sub make_items {
+    return [ 'apple', 'banana', 'cherry' ];
+}
+
+1;

--- a/gold-corpus/nested-fixture/lib/NestedRow.pm
+++ b/gold-corpus/nested-fixture/lib/NestedRow.pm
@@ -1,0 +1,11 @@
+package NestedRow;
+use strict;
+use warnings;
+use parent 'DBIx::Class::Core';
+
+__PACKAGE__->add_columns(
+    name  => { data_type => 'varchar' },
+    email => { data_type => 'varchar' },
+);
+
+1;

--- a/gold-corpus/nested-fixture/main.pl
+++ b/gold-corpus/nested-fixture/main.pl
@@ -31,4 +31,11 @@ my $oops = $config->{db_host};
 my $local_cfg = { retries => 3, timeout => 10 };
 my $typo = $local_cfg->{retrys};
 
+# Mutation extension: the unconditional write joins the shape -- the
+# read is silent and typed; unknowns on the mutated var still hint.
+my $branded = { path => '/api' };
+$branded->{name} = 'api_root';
+my $bn = $branded->{name};
+my $bt = $branded->{nmae};
+
 print "$host $port $first $uname $uid $n\n";

--- a/gold-corpus/nested-fixture/main.pl
+++ b/gold-corpus/nested-fixture/main.pl
@@ -22,4 +22,13 @@ my $rs  = $schema->resultset('NestedRow');
 my $row = $rs->find(1);
 my $n   = $row->{name};
 
+# Closed-shape typo on a cross-file-typed var: fires in the editor
+# (enriched open doc); the batch diagnostics path has no enrichment
+# parity yet -- tracked xfail.
+my $oops = $config->{db_host};
+
+# Closed-shape typo on a local literal: the gold hint.
+my $local_cfg = { retries => 3, timeout => 10 };
+my $typo = $local_cfg->{retrys};
+
 print "$host $port $first $uname $uid $n\n";

--- a/gold-corpus/nested-fixture/main.pl
+++ b/gold-corpus/nested-fixture/main.pl
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use lib 'lib';
+use NestedCfg qw(cfg make_items);
+
+# Tier 2: structural hash narrowing through an assignment hop and a
+# direct double-drill.
+my $config = cfg();
+my $db     = $config->{db};
+my $host   = $db->{host};
+my $port   = $config->{db}->{port};
+
+# Tier 3: array tuples + the mixed drill.
+my $items = make_items();
+my $first = $items->[0];
+my $obj   = { users => [ { name => 'A', id => 1 } ] };
+my $uname = $obj->{users}->[0]->{name};
+my $uid   = $obj->{users}->[0]->{id};
+
+# Tier 1: $row->{col} on a typed row resolves to the column def.
+my $rs  = $schema->resultset('NestedRow');
+my $row = $rs->find(1);
+my $n   = $row->{name};
+
+print "$host $port $first $uname $uid $n\n";

--- a/gold-corpus/nested-fixture/main.pl
+++ b/gold-corpus/nested-fixture/main.pl
@@ -38,4 +38,9 @@ $branded->{name} = 'api_root';
 my $bn = $branded->{name};
 my $bt = $branded->{nmae};
 
+# The literal-hash spelling: same shapes, same hints.
+my %plain = (retries => 3);
+my $ph = $plain{retries};
+my $pt = $plain{retrys};
+
 print "$host $port $first $uname $uid $n\n";

--- a/gold-corpus/run.pl
+++ b/gold-corpus/run.pl
@@ -43,6 +43,7 @@ use JSON::PP;
 use POSIX qw(WIFSIGNALED);
 use File::Temp qw(tempfile);
 use Time::HiRes qw(time);
+binmode STDOUT, ':utf8';    # responses may carry non-ASCII once decoded
 
 my $bin    = $ENV{BIN}    || File::Spec->rel2abs("$RealBin/../target/release/perl-lsp");
 my $corpus = $ENV{CORPUS} || "$RealBin/local/lib/perl5";
@@ -87,7 +88,11 @@ sub _text_bn { my $s = shift; $s =~ s{/\S*?/([^/\s":]+\.(?:pm|pl|t|pod))}{$1}g; 
 sub normalize {
     my ($cap, $raw) = @_;
     if ($JSON_CAP{$cap}) {
-        my $data = eval { decode_json($raw) };
+        # $raw is already a decoded character string (the batch wrapper was
+        # byte-decoded once); decode_json would croak on any non-ASCII char
+        # and silently drop us to the text fallback — where the no-space
+        # canonical assertions vacuously pass. Character-mode decode only.
+        my $data = eval { JSON::PP->new->decode($raw) };
         return _text_bn($raw) unless defined $data;
         my $walk; $walk = sub {
             my $r = ref $_[0];

--- a/gold-corpus/run.pl
+++ b/gold-corpus/run.pl
@@ -42,6 +42,7 @@ use File::Spec;
 use JSON::PP;
 use POSIX qw(WIFSIGNALED);
 use File::Temp qw(tempfile);
+use Time::HiRes qw(time);
 
 my $bin    = $ENV{BIN}    || File::Spec->rel2abs("$RealBin/../target/release/perl-lsp");
 my $corpus = $ENV{CORPUS} || "$RealBin/local/lib/perl5";
@@ -143,6 +144,8 @@ sub run_batch {
     # request delivery non-blocking, so we only ever read on the parent side.
     my ($tfh, $tpath) = tempfile('corpus-batch-XXXXXX', TMPDIR => 1, UNLINK => 1);
     print $tfh $jsonl; close $tfh;
+    my @cpu0 = times();           # children utime/stime baseline (slots 2,3)
+    my $t0 = time();
     my $pid = open(my $out, '-|');
     die "fork: $!" unless defined $pid;
     if ($pid == 0) {
@@ -151,19 +154,55 @@ sub run_batch {
         $ENV{PERL5LIB} = $p5lib if defined $p5lib;
         exec($bin, '--batch', $root) or exit 127;
     }
-    local $/; my $resp = <$out> // ''; close($out);
+    # Read line-by-line (the binary flushes per response): each arrival
+    # delta is that query's processing cost; the first arrival also
+    # carries startup (workspace index + cache warm). Peak RSS is
+    # sampled from /proc after each line — the last sample before the
+    # child exits is its high-water mark (Linux-only; silently absent
+    # elsewhere).
     my %by_id;
-    for my $line (split /\n/, $resp) {
+    my $met = { wall_s => 0, first_s => undef, per_id => {}, vm_hwm_kb => 0,
+                cpu_user_s => 0, cpu_sys_s => 0, root => $root };
+    my $prev = $t0;
+    while (my $line = <$out>) {
+        my $now = time();
         next unless $line =~ /\S/;
         my $r = eval { decode_json($line) } or next;
-        $by_id{$r->{id}} = $r if defined $r->{id};
+        next unless defined $r->{id};
+        $by_id{$r->{id}} = $r;
+        if (defined $met->{first_s}) {
+            $met->{per_id}{$r->{id}} = $now - $prev;
+        } else {
+            # The first arrival is dominated by startup (workspace index
+            # + cache warm) — report it as startup, not as the first
+            # row's capability cost.
+            $met->{first_s} = $now - $t0;
+        }
+        $prev = $now;
+        if (open(my $st, '<', "/proc/$pid/status")) {
+            while (my $l = <$st>) {
+                $met->{vm_hwm_kb} = $1 if $l =~ /^VmHWM:\s+(\d+)/;
+            }
+            close($st);
+        }
     }
-    return \%by_id;
+    close($out);
+    my @cpu1 = times();
+    $met->{wall_s}     = time() - $t0;
+    $met->{cpu_user_s} = $cpu1[2] - $cpu0[2];
+    $met->{cpu_sys_s}  = $cpu1[3] - $cpu0[3];
+    return wantarray ? (\%by_id, $met) : \%by_id;
 }
 
 # ---- --emit: canonical output for one ad-hoc query (fixture authoring) ----
 if (@ARGV && $ARGV[0] eq '--emit') {
     shift @ARGV;
+    my $emit_root;
+    if (@ARGV && $ARGV[0] eq '--root') {
+        shift @ARGV;
+        $emit_root = shift @ARGV;
+        $emit_root = File::Spec->rel2abs("$RealBin/../$emit_root") unless $emit_root =~ m{^/};
+    }
     my ($cap, @rest) = @ARGV;
     my $spec = $CAP{$cap} or die "unknown capability: $cap\n";
     # line/col arrive as ARGV strings; numify so encode_json emits JSON numbers
@@ -171,7 +210,8 @@ if (@ARGV && $ARGV[0] eq '--emit') {
     my $row = $spec->{check} ? {}
             : $spec->{qarg}  ? { query => $rest[0] }
             :                  { file => $rest[0], line => ($rest[1] // 0) + 0, col => ($rest[2] // 0) + 0, newname => $rest[3] };
-    my $resp = run_batch([ batch_req($cap, $spec, $row, 'emit') ]);
+    my $req = batch_req($cap, $spec, $row, 'emit', $emit_root);
+    my $resp = run_batch([ $req ], $emit_root, $emit_root ? p5lib_for($emit_root) : undef);
     my $r = $resp->{emit};
     if    (!$r)        { print "<<CRASH: process aborted>>\n"; }
     elsif (!$r->{ok})  { print "<<ERR: $r->{err}>>\n"; }
@@ -211,9 +251,11 @@ for my $r (@rows) {
     push @{ $groups{$root} }, batch_req($r->{capability}, $spec, $r, $key, $root);
 }
 my $resp = {};
+my @batch_metrics;
 for my $root (sort keys %groups) {
-    my $by = run_batch($groups{$root}, $root, p5lib_for($root));
+    my ($by, $met) = run_batch($groups{$root}, $root, p5lib_for($root));
     %$resp = (%$resp, %$by);
+    push @batch_metrics, $met;
 }
 
 my (@fail, @xpass, @crash, @skip, @prov); my ($pass, $xfail) = (0, 0);
@@ -250,4 +292,58 @@ print "\n** XPASS (known gap fixed — update fixture):\n", map { "  - $_\n" } @
 print "\nprovisional misses:\n",                         map { "  - $_\n" } @prov  if @prov;
 print "\nskipped:\n",                                    map { "  - $_\n" } @skip  if @skip;
 print "\n";
+
+# ---- cost report: what do features cost? ----
+# Per-capability wall time (each response's arrival delta attributed to
+# its row's capability), per-root startup (first-response latency,
+# dominated by workspace index + cache warm), child CPU, and peak RSS.
+# Written to $METRICS_OUT as JSON when set, for run-over-run comparison.
+{
+    my %by_cap;
+    for my $met (@batch_metrics) {
+        while (my ($id, $dt) = each %{ $met->{per_id} }) {
+            my ($cap) = $id =~ m{^([^/]+)/};
+            $cap //= $id;
+            push @{ $by_cap{$cap} }, $dt;
+        }
+    }
+    my ($cpu_u, $cpu_s, $hwm, $wall) = (0, 0, 0, 0);
+    for my $met (@batch_metrics) {
+        $cpu_u += $met->{cpu_user_s};
+        $cpu_s += $met->{cpu_sys_s};
+        $wall  += $met->{wall_s};
+        $hwm = $met->{vm_hwm_kb} if $met->{vm_hwm_kb} > $hwm;
+    }
+    print "Cost report\n";
+    printf "  %-20s %4s %9s %8s %8s\n", 'capability', 'n', 'total ms', 'mean ms', 'max ms';
+    for my $cap (sort { _sum($by_cap{$b}) <=> _sum($by_cap{$a}) } keys %by_cap) {
+        my @d = @{ $by_cap{$cap} };
+        my $tot = _sum(\@d);
+        my ($max) = sort { $b <=> $a } @d;
+        printf "  %-20s %4d %9.1f %8.1f %8.1f\n",
+            $cap, scalar @d, $tot * 1000, $tot * 1000 / @d, $max * 1000;
+    }
+    for my $met (@batch_metrics) {
+        printf "  startup %-46s %8.1f ms\n",
+            _bn($met->{root}), ($met->{first_s} // 0) * 1000;
+    }
+    printf "  wall %.2fs   cpu user %.2fs sys %.2fs   peak rss %.1f MB\n\n",
+        $wall, $cpu_u, $cpu_s, $hwm / 1024;
+    if (my $mo = $ENV{METRICS_OUT}) {
+        my %caps = map {
+            my @d = @{ $by_cap{$_} };
+            ($_ => { n => scalar @d, total_ms => _sum(\@d) * 1000 });
+        } keys %by_cap;
+        if (open(my $fh, '>', $mo)) {
+            print $fh JSON::PP->new->canonical->encode({
+                wall_s => $wall, cpu_user_s => $cpu_u, cpu_sys_s => $cpu_s,
+                peak_rss_kb => $hwm, capabilities => \%caps,
+                startup_ms => { map { _bn($_->{root}) => ($_->{first_s} // 0) * 1000 } @batch_metrics },
+            });
+            close($fh);
+        }
+    }
+}
+sub _sum { my $t = 0; $t += $_ for @{ $_[0] }; $t }
+
 exit((@fail || @crash || @xpass) ? 1 : 0);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2235,7 +2235,15 @@ impl<'a> Builder<'a> {
                 self.package_for_node(node).map(InferredType::ClassName)
             }
             "array_element_expression" => {
-                let array = node.child_by_field_name("array")?;
+                // Arrow deref on an expression (`$x->[0]`,
+                // `$obj->{users}->[0]`) has no `array` field — the base is
+                // the first named child; its Sequence projects the element.
+                let Some(array) = node.child_by_field_name("array") else {
+                    let base = node.named_child(0)?;
+                    let idx_node = node.child_by_field_name("index")?;
+                    let idx: i32 = idx_node.utf8_text(self.source).ok()?.parse().ok()?;
+                    return self.invocant_type_at_node(base)?.element_at(idx).cloned();
+                };
                 let varname = array.named_child(0)?;
                 let index = node.child_by_field_name("index")?;
                 // `$_[0]` is the positional-receiver pseudo-invocant
@@ -6177,6 +6185,35 @@ impl<'a> Builder<'a> {
         InferredType::HashWithKeys { keys, open }
     }
 
+    /// Type an array literal positionally: `[1, 'x']` →
+    /// `Sequence([Numeric, String])`, so `->[N]` projects per index
+    /// (tuple semantics — the homogeneous case is just every slot
+    /// agreeing). Degrades to plain `ArrayRef` when any element's type
+    /// is unknown or the literal is huge (`Sequence` is a type-per-slot
+    /// tuple, not a summary).
+    fn array_literal_type(&mut self, node: Node<'a>) -> InferredType {
+        const MAX_TUPLE: usize = 64;
+        let list = node
+            .named_child(0)
+            .filter(|c| c.kind() == "list_expression")
+            .unwrap_or(node);
+        let mut flat: Vec<Node<'a>> = Vec::new();
+        crate::cst::flatten_list(list, &mut flat);
+        let elems: Vec<Node<'a>> = flat.into_iter().filter(|n| n.is_named()).collect();
+        if elems.is_empty() || elems.len() > MAX_TUPLE {
+            return InferredType::ArrayRef;
+        }
+        let mut types = Vec::with_capacity(elems.len());
+        for e in &elems {
+            self.emit_expr_witness(*e);
+            match self.bag_query_expr_span(node_to_span(*e)) {
+                Some(t) => types.push(t),
+                None => return InferredType::ArrayRef,
+            }
+        }
+        InferredType::Sequence(types)
+    }
+
     fn expr_payload(&mut self, node: Node<'a>) -> Option<crate::witnesses::WitnessPayload> {
         use crate::witnesses::{RefIdx, WitnessAttachment, WitnessPayload};
         match node.kind() {
@@ -6189,7 +6226,7 @@ impl<'a> Builder<'a> {
                 Some(WitnessPayload::InferredType(self.hash_literal_type(node)))
             }
             "anonymous_array_expression" => {
-                Some(WitnessPayload::InferredType(InferredType::ArrayRef))
+                Some(WitnessPayload::InferredType(self.array_literal_type(node)))
             }
             "quoted_regexp" => Some(WitnessPayload::InferredType(InferredType::Regexp)),
             "anonymous_subroutine_expression" | "refgen_expression" => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -250,6 +250,7 @@ fn build_with_plugins_inner(
         gated_param_types: Vec::new(),
         method_call_invocant: std::collections::HashMap::new(),
         attr_projections: Vec::new(),
+        escaped_scalars: std::collections::HashSet::new(),
         method_call_arity: std::collections::HashMap::new(),
         parametric_emitted_refs: std::collections::HashSet::new(),
         method_call_ref_dedup: std::collections::HashSet::new(),
@@ -501,6 +502,7 @@ fn build_with_plugins_inner(
         provisional_dispatches: b.provisional_dispatches,
         attr_projections: b.attr_projections,
         gated_param_types: b.gated_param_types,
+        escaped_scalars: b.escaped_scalars,
     });
     // Finalize: run the legacy text-based MCB resolver as a fallback.
     // For every assignment the unified typer (run before
@@ -1450,6 +1452,14 @@ struct Builder<'a> {
     /// names derive from an attr (`predicate => has_x`). Flushed into
     /// `FileAnalysis.attr_accessors`.
     attr_projections: Vec<crate::file_analysis::AttrProjection>,
+
+    /// Scalars read in any position other than an element-access base
+    /// (`func($c)`, `my $z = $c`, `$c->method`, `%$c`) — the reference
+    /// escaped to code that may mutate the referent, so a closed literal
+    /// shape is no longer the variable's whole story. Flushed into
+    /// `FileAnalysis.escaped_scalars`; consumed by
+    /// `closed_shape_is_whole_story`.
+    escaped_scalars: std::collections::HashSet<String>,
 
     /// Per-MethodCall-ref arg count, keyed by ref index. Lets
     /// `emit_method_call_return_edges` pin the call site's arity onto its
@@ -6813,6 +6823,16 @@ impl<'a> Builder<'a> {
 
         if let Ok(text) = node.utf8_text(self.source) {
             let access = self.determine_access(node);
+            // A scalar READ anywhere but an element-access base hands the
+            // reference to code that may mutate the referent (call arg,
+            // alias, invocant, deref) — record the escape so closed-shape
+            // consumers know the literal isn't the whole story.
+            if access == AccessKind::Read
+                && text.starts_with('$')
+                && !crate::cst::is_element_access_base(node)
+            {
+                self.escaped_scalars.insert(text.to_string());
+            }
             // Fully-qualified read (`$Foo::Bar::x`): narrow the span to the
             // bare tail (rule #7) so rename rewrites only `x` and the
             // qualifier survives, mirroring the FQ-call narrowing. The full

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2259,17 +2259,26 @@ impl<'a> Builder<'a> {
             }
             "hash_element_expression" => {
                 // A hash element's VALUE type is independent of the
-                // container's class — never `$self`'s class. If a typed
-                // write to this slot was recorded (`SlotType{class,key}`,
-                // seeded at the write site, agreed by `SlotTypeFold`),
-                // that is the honest answer; otherwise untyped.
+                // container's class — never `$self`'s class.
                 let base = node.named_child(0)?;
-                let class = self.invocant_type_at_node(base)?.class_name()?.to_string();
+                let base_ty = self.invocant_type_at_node(base)?;
                 let key_node = node.child_by_field_name("key")?;
                 let (key, is_dynamic) = self.extract_key_text(key_node)?;
                 if is_dynamic {
                     return None;
                 }
+                // Structurally-typed hash: the literal told us the per-key
+                // type — `$config->{db}` narrows to it, and nesting recurses
+                // for free (the inner literal's HashWithKeys rides in the
+                // value slot).
+                if let Some(v) = base_ty.key_value_type(&key) {
+                    return v.cloned();
+                }
+                // Class-typed base: a typed write to this slot
+                // (`SlotType{class,key}`, seeded at the write site, agreed
+                // by `SlotTypeFold`) is the honest answer; otherwise
+                // untyped.
+                let class = base_ty.class_name()?.to_string();
                 self.bag_query_attachment(&crate::witnesses::WitnessAttachment::SlotType {
                     class,
                     key,
@@ -6116,6 +6125,58 @@ impl<'a> Builder<'a> {
     ///   resolved type. Registry materialization chases at query
     ///   time. Ternaries Edge to their own `Expr(span)` since the
     ///   per-arm witnesses live there.
+    /// Type a hash literal structurally: literal keys carry their
+    /// values' types (`{ host => 'x' }` →
+    /// `HashWithKeys{[("host", String)], closed}`). A spread element
+    /// (`%$other`, `%other`) or a dynamic key flips `open` — the key
+    /// set is no longer exhaustive, so consumers can't treat unknown
+    /// keys as misses. No literal keys at all → plain `HashRef`
+    /// (back-compat: `{}` and fully-dynamic hashes keep today's type).
+    fn hash_literal_type(&mut self, node: Node<'a>) -> InferredType {
+        // A spread occupies ONE list slot but flattens to an even count
+        // at runtime, so pairing must skip it as a unit — `pair_nodes`'
+        // strict k/v alternation would mispair everything after it.
+        let list = node
+            .named_child(0)
+            .filter(|c| c.kind() == "list_expression")
+            .unwrap_or(node);
+        let mut flat: Vec<Node<'a>> = Vec::new();
+        crate::cst::flatten_list(list, &mut flat);
+        let named: Vec<Node<'a>> = flat.into_iter().filter(|n| n.is_named()).collect();
+
+        let mut keys: Vec<(String, Option<Box<InferredType>>)> = Vec::new();
+        let mut open = false;
+        let mut i = 0;
+        while i < named.len() {
+            let elem = named[i];
+            if matches!(elem.kind(), "hash" | "hash_deref_expression" | "container_variable") {
+                open = true;
+                i += 1;
+                continue;
+            }
+            let Some(v_node) = named.get(i + 1).copied() else {
+                open = true;
+                break;
+            };
+            i += 2;
+            let Some((key, is_dynamic)) = self.extract_key_text(elem) else {
+                open = true;
+                continue;
+            };
+            if is_dynamic {
+                open = true;
+                continue;
+            }
+            self.emit_expr_witness(v_node);
+            let vt = self.bag_query_expr_span(node_to_span(v_node));
+            keys.push((key, vt.map(Box::new)));
+        }
+        if keys.is_empty() && !open {
+            return InferredType::HashRef;
+        }
+        InferredType::HashWithKeys { keys, open }
+    }
+
     fn expr_payload(&mut self, node: Node<'a>) -> Option<crate::witnesses::WitnessPayload> {
         use crate::witnesses::{RefIdx, WitnessAttachment, WitnessPayload};
         match node.kind() {
@@ -6125,7 +6186,7 @@ impl<'a> Builder<'a> {
             }
             "number" => Some(WitnessPayload::InferredType(InferredType::Numeric)),
             "anonymous_hash_expression" => {
-                Some(WitnessPayload::InferredType(InferredType::HashRef))
+                Some(WitnessPayload::InferredType(self.hash_literal_type(node)))
             }
             "anonymous_array_expression" => {
                 Some(WitnessPayload::InferredType(InferredType::ArrayRef))
@@ -12927,7 +12988,7 @@ impl<'a> Builder<'a> {
             .filter(|b| {
                 return_types
                     .get(bare_name(&b.func_name))
-                    .map_or(false, |t| *t == InferredType::HashRef)
+                    .map_or(false, |t| t.is_hash_shaped())
             })
             .map(|b| (b.variable.as_str(), bare_name(&b.func_name).to_string()))
             .collect();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -465,6 +465,14 @@ fn build_with_plugins_inner(
     // owner class is the chain receiver's type, unknowable until then.
     b.emit_chained_hash_key_refs(&chain_idx);
 
+    // Post-pass: upgrade Variable-owned hash-key derefs whose variable's
+    // type settled to a class DURING the fold (`my $row = $rs->find(1);
+    // $row->{name}` — the RowOf projection lands mid-fold, after
+    // resolve_hash_key_owners ran). A Class owner routes the key to the
+    // class's defs (DBIC columns, Moo slots); variables without a class
+    // type keep their lexical grouping.
+    b.upgrade_variable_hash_key_owners();
+
     // Post-pass 5: fill in tail POD docs for subs that didn't get preceding doc
     b.resolve_tail_pod_docs();
 
@@ -11962,6 +11970,39 @@ impl<'a> Builder<'a> {
     /// to either emits nothing, so a should-miss stays a miss rather
     /// than a wrong-owner latch.
     ///
+    /// Post-fold owner upgrade for variable derefs: `$row->{name}` where
+    /// `$row`'s class only settled during the worklist fold (RowOf
+    /// projections, chain assignments). `resolve_hash_key_owners` ran
+    /// pre-fold and could only stamp the lexical `Variable` owner; this
+    /// re-asks the canonical bag and promotes to `Class(C)` when the
+    /// variable's type yields a class. Untyped variables keep their
+    /// lexical grouping — plain `%config` hashes are untouched.
+    fn upgrade_variable_hash_key_owners(&mut self) {
+        let mut upgrades: Vec<(usize, HashKeyOwner)> = Vec::new();
+        for (i, r) in self.refs.iter().enumerate() {
+            let RefKind::HashKeyAccess {
+                ref var_text,
+                owner: Some(HashKeyOwner::Variable { .. }),
+            } = r.kind
+            else {
+                continue;
+            };
+            if !var_text.starts_with('$') {
+                continue;
+            }
+            let Some(t) = self.bag_query_variable(var_text, r.scope, r.span.start) else {
+                continue;
+            };
+            let Some(class) = t.class_name() else { continue };
+            upgrades.push((i, HashKeyOwner::Class(class.to_string())));
+        }
+        for (i, o) in upgrades {
+            if let RefKind::HashKeyAccess { ref mut owner, .. } = self.refs[i].kind {
+                *owner = Some(o);
+            }
+        }
+    }
+
     /// Runs post-fold (after `emit_method_call_arg_keys`) so
     /// `invocant_type_at_node` answers against the canonical bag.
     fn emit_chained_hash_key_refs(&mut self, idx: &ChainTypingIndex<'a>) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -251,6 +251,8 @@ fn build_with_plugins_inner(
         method_call_invocant: std::collections::HashMap::new(),
         attr_projections: Vec::new(),
         escaped_scalars: std::collections::HashSet::new(),
+        reassigned_scalars: std::collections::HashSet::new(),
+        key_writes: Vec::new(),
         method_call_arity: std::collections::HashMap::new(),
         parametric_emitted_refs: std::collections::HashSet::new(),
         method_call_ref_dedup: std::collections::HashSet::new(),
@@ -503,6 +505,8 @@ fn build_with_plugins_inner(
         attr_projections: b.attr_projections,
         gated_param_types: b.gated_param_types,
         escaped_scalars: b.escaped_scalars,
+        reassigned_scalars: b.reassigned_scalars,
+        key_writes: b.key_writes,
     });
     // Finalize: run the legacy text-based MCB resolver as a fallback.
     // For every assignment the unified typer (run before
@@ -1460,6 +1464,16 @@ struct Builder<'a> {
     /// `FileAnalysis.escaped_scalars`; consumed by
     /// `closed_shape_is_whole_story`.
     escaped_scalars: std::collections::HashSet<String>,
+
+    /// Scalars reassigned after declaration (`$v = …` targeting the
+    /// variable itself; element writes go to `key_writes` instead).
+    /// Flushed into `FileAnalysis.reassigned_scalars`.
+    reassigned_scalars: std::collections::HashSet<String>,
+
+    /// `$var->{key} = …` writes in walk order — input to the
+    /// mutation-extension pass (shape extension / open-widening).
+    /// Flushed into `FileAnalysis.key_writes`.
+    key_writes: Vec<crate::file_analysis::KeyWrite>,
 
     /// Per-MethodCall-ref arg count, keyed by ref index. Lets
     /// `emit_method_call_return_edges` pin the call site's arity onto its
@@ -5986,6 +6000,12 @@ impl<'a> Builder<'a> {
                             .insert(node_to_span(key_node), node_to_span(right));
                     }
                 }
+                if matches!(
+                    left.kind(),
+                    "hash_element_expression" | "array_element_expression"
+                ) {
+                    self.record_key_write(left, Some(right));
+                }
             }
             // Visit LHS children (except the variable_declaration we already handled)
             if left.kind() != "variable_declaration" {
@@ -6832,6 +6852,17 @@ impl<'a> Builder<'a> {
                 && !crate::cst::is_element_access_base(node)
             {
                 self.escaped_scalars.insert(text.to_string());
+            }
+            // Write with the variable itself as assignment target =
+            // reassignment. An element write (`$v->{k} = …`, where this
+            // scalar is the access base and the Write came from the
+            // grandparent rule) is a shape mutation instead — modeled by
+            // the mutation-extension pass, not a trust break.
+            if access == AccessKind::Write
+                && text.starts_with('$')
+                && !crate::cst::is_element_access_base(node)
+            {
+                self.reassigned_scalars.insert(text.to_string());
             }
             // Fully-qualified read (`$Foo::Bar::x`): narrow the span to the
             // bare tail (rule #7) so rename rewrites only `x` and the
@@ -10508,6 +10539,55 @@ impl<'a> Builder<'a> {
         None
     }
 
+    /// Record a `$var->{key} = …` write for the mutation-extension
+    /// pass. Walks subscript chains down to the scalar base: the FIRST
+    /// hop's key is the one the write autovivifies onto the variable's
+    /// own shape (`$v->{a}{b} = …` adds `a`); only a direct single-hop
+    /// write types the key's value from the RHS. Plain `%foo` elements
+    /// (`$foo{k}`, no arrow) are a different variable — skipped.
+    fn record_key_write(&mut self, left: Node<'a>, rhs: Option<Node<'a>>) {
+        let mut innermost = left;
+        loop {
+            let Some(c) = innermost.named_child(0) else { return };
+            match c.kind() {
+                "hash_element_expression" | "array_element_expression" => innermost = c,
+                "scalar" => break,
+                _ => return,
+            }
+        }
+        if innermost.kind() != "hash_element_expression" {
+            return; // array first hop — Sequence mutation, not modeled
+        }
+        if !crate::cst::element_arrow_deref(innermost, self.source) {
+            return;
+        }
+        let Some(container) = innermost.named_child(0) else { return };
+        let Ok(var_text) = container.utf8_text(self.source) else { return };
+        if !var_text.starts_with('$') {
+            return;
+        }
+        let key_node = innermost.child_by_field_name("key");
+        let key = key_node
+            .and_then(|k| self.extract_key_text(k))
+            .and_then(|(t, dynamic)| (!dynamic).then_some(t));
+        let direct = innermost == left;
+        let span = key_node
+            .map(node_to_span)
+            .unwrap_or_else(|| node_to_span(innermost));
+        self.key_writes.push(crate::file_analysis::KeyWrite {
+            var_text: var_text.to_string(),
+            key,
+            scope: self
+                .scope_stack
+                .last()
+                .copied()
+                .unwrap_or(crate::file_analysis::ScopeId(0)),
+            span,
+            rhs_span: if direct { rhs.map(node_to_span) } else { None },
+            conditional: crate::cst::is_conditionally_executed(left),
+        });
+    }
+
     fn determine_access(&self, node: Node<'a>) -> AccessKind {
         if let Some(parent) = node.parent() {
             match parent.kind() {
@@ -11663,6 +11743,24 @@ impl<'a> Builder<'a> {
             }
             self.run_chain_typing_reducer(idx, ChainPassMode::PreFold);
             self.resolve_return_types(idx, &reg, &ref_by_span, &method_sym_by_name);
+            // Mutation extension: fold key writes into variable shapes
+            // (re-emittable, clear-and-emit). After the return-type
+            // passes so call-binding-propagated shapes are visible.
+            {
+                let ctx = crate::witnesses::BagContext {
+                    scopes: &self.scopes,
+                    package_framework: &self.package_framework,
+                    module_index: None,
+                    package_parents: &self.package_parents,
+                    app_surface_consumers: &self.app_surface_consumers,
+                };
+                crate::witnesses::emit_mutation_extension_witnesses(
+                    &mut self.bag,
+                    &ctx,
+                    &self.key_writes,
+                    true,
+                );
+            }
             let cur = self.fold_state_snapshot(&reg);
             if cur == prev {
                 break;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6225,6 +6225,35 @@ impl<'a> Builder<'a> {
             "anonymous_hash_expression" => {
                 Some(WitnessPayload::InferredType(self.hash_literal_type(node)))
             }
+            // Drill expressions edge to their base with a projection step,
+            // so `$config->{db}` resolves at QUERY time through whatever the
+            // base materializes to — including an imported literal's
+            // structural type the build-time chain pass can't see.
+            "hash_element_expression" => {
+                let base = node.named_child(0)?;
+                let key_node = node.child_by_field_name("key")?;
+                let (key, is_dynamic) = self.extract_key_text(key_node)?;
+                if is_dynamic {
+                    return None;
+                }
+                self.emit_expr_witness(base);
+                Some(WitnessPayload::Projected {
+                    base: WitnessAttachment::Expr(node_to_span(base)),
+                    step: crate::witnesses::ProjectionStep::HashKey(key),
+                })
+            }
+            // Arrow-deref element only (`$x->[0]`); the container form
+            // `$arr[N]` keeps its variable-keyed handling.
+            "array_element_expression" if node.child_by_field_name("array").is_none() => {
+                let base = node.named_child(0)?;
+                let idx_node = node.child_by_field_name("index")?;
+                let idx: i32 = idx_node.utf8_text(self.source).ok()?.parse().ok()?;
+                self.emit_expr_witness(base);
+                Some(WitnessPayload::Projected {
+                    base: WitnessAttachment::Expr(node_to_span(base)),
+                    step: crate::witnesses::ProjectionStep::ArrayIndex(idx),
+                })
+            }
             "anonymous_array_expression" => {
                 Some(WitnessPayload::InferredType(self.array_literal_type(node)))
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5892,7 +5892,19 @@ impl<'a> Builder<'a> {
                 // ternaries; Edge payloads resolve through the
                 // registry's materialization.
                 self.emit_expr_witness(right);
-                let inferred = self.bag_query_expr_span(node_to_span(right));
+                let mut inferred = self.bag_query_expr_span(node_to_span(right));
+                // `my %h = (k => v, …)` — the list IS a hash literal in
+                // this position, the hashref's second spelling. The
+                // list's own Expr witness can't carry that (its meaning
+                // depends on the LHS sigil), so type it from the LHS
+                // side through the same shape builder.
+                if inferred.is_none() && right.kind() == "list_expression" {
+                    if let Some(vt) = self.get_var_text_from_lhs(left) {
+                        if vt.starts_with('%') {
+                            inferred = Some(self.hash_literal_type(right));
+                        }
+                    }
+                }
                 if let Some(it) = inferred {
                     if let Some(vt) = self.get_var_text_from_lhs(left) {
                         self.push_type_constraint(TypeConstraint {
@@ -6005,6 +6017,52 @@ impl<'a> Builder<'a> {
                     "hash_element_expression" | "array_element_expression"
                 ) {
                     self.record_key_write(left, Some(right));
+                }
+                // Slice / keyval writes (`@h{qw(a b)} = …`, `%h{k} = …`,
+                // `@$h{…}`) land several keys at once — record an
+                // open-switching write (`key: None`) on the container so
+                // a closed shape can't claim the slice-written keys as
+                // misses.
+                if matches!(left.kind(), "slice_expression" | "keyval_expression") {
+                    {
+                        // Three container spellings: sigil (`@h{…}` →
+                        // canonical `%h`), sigil-deref (`@$h{…}` — the
+                        // varname wraps the scalar; canonical would mint
+                        // a garbage `%$h`, so the inner scalar wins),
+                        // and postfix deref (`$h->@{…}` / `$h->%{…}` —
+                        // grammar field `hashref:`, a plain scalar).
+                        let name = match left.child_by_field_name("hash") {
+                            Some(container) => {
+                                crate::cst::varname_inner_scalar_text(container, self.source)
+                                    .or_else(|| {
+                                        crate::cst::canonical_container_name(
+                                            container,
+                                            self.source,
+                                        )
+                                    })
+                            }
+                            None => left
+                                .child_by_field_name("hashref")
+                                .filter(|c| c.kind() == "scalar")
+                                .and_then(|c| c.utf8_text(self.source).ok())
+                                .map(|s| s.to_string()),
+                        };
+                        if let Some(var_text) = name {
+                            let span = node_to_span(left);
+                            self.key_writes.push(crate::file_analysis::KeyWrite {
+                                var_text,
+                                key: None,
+                                scope: self
+                                    .scope_stack
+                                    .last()
+                                    .copied()
+                                    .unwrap_or(crate::file_analysis::ScopeId(0)),
+                                span,
+                                rhs_span: None,
+                                conditional: true,
+                            });
+                        }
+                    }
                 }
             }
             // Visit LHS children (except the variable_declaration we already handled)
@@ -6187,7 +6245,15 @@ impl<'a> Builder<'a> {
         let mut i = 0;
         while i < named.len() {
             let elem = named[i];
-            if matches!(elem.kind(), "hash" | "hash_deref_expression" | "container_variable") {
+            if matches!(
+                elem.kind(),
+                "hash" | "hash_deref_expression" | "container_variable"
+                    | "array" | "array_deref_expression"
+            ) {
+                // Spread (`%other` / `%$ref` / `@_` / `@rest`) — the
+                // key set is no longer exhaustive. Arrays included:
+                // `my %h = (default => 1, @_)` is the canonical
+                // args-with-defaults idiom.
                 open = true;
                 i += 1;
                 continue;
@@ -6260,12 +6326,26 @@ impl<'a> Builder<'a> {
             // base materializes to — including an imported literal's
             // structural type the build-time chain pass can't see.
             "hash_element_expression" => {
-                let base = node.named_child(0)?;
                 let key_node = node.child_by_field_name("key")?;
                 let (key, is_dynamic) = self.extract_key_text(key_node)?;
                 if is_dynamic {
                     return None;
                 }
+                // Container form `$h{k}` (grammar field `hash:`) — the
+                // subject is `%h`, not scalar `$h`; project off the
+                // hash variable's own attachment (the registry scope-
+                // walks Variable bases the same as Edge(Variable)).
+                if let Some(container) = node.child_by_field_name("hash") {
+                    let name =
+                        crate::cst::canonical_container_name(container, self.source)?;
+                    let scope = self.scope_stack.last().copied()
+                        .unwrap_or_else(|| self.scope_at_point(node.start_position()));
+                    return Some(WitnessPayload::Projected {
+                        base: WitnessAttachment::Variable { name, scope },
+                        step: crate::witnesses::ProjectionStep::HashKey(key),
+                    });
+                }
+                let base = node.named_child(0)?;
                 self.emit_expr_witness(base);
                 Some(WitnessPayload::Projected {
                     base: WitnessAttachment::Expr(node_to_span(base)),
@@ -6859,10 +6939,19 @@ impl<'a> Builder<'a> {
             // grandparent rule) is a shape mutation instead — modeled by
             // the mutation-extension pass, not a trust break.
             if access == AccessKind::Write
-                && text.starts_with('$')
+                && (text.starts_with('$') || text.starts_with('%'))
                 && !crate::cst::is_element_access_base(node)
             {
                 self.reassigned_scalars.insert(text.to_string());
+            }
+            // Hash variables escape only by reference-taking (`\%h`):
+            // a bare `%h` in a call or list FLATTENS TO COPIES — the
+            // callee can't add keys to the original, so it's not an
+            // escape (unlike a scalar, whose value IS the shared ref).
+            if text.starts_with('%')
+                && node.parent().is_some_and(|p| p.kind() == "refgen_expression")
+            {
+                self.escaped_scalars.insert(text.to_string());
             }
             // Fully-qualified read (`$Foo::Bar::x`): narrow the span to the
             // bare tail (rule #7) so rename rewrites only `x` and the
@@ -10395,8 +10484,15 @@ impl<'a> Builder<'a> {
         // Infer HashRef on the operand variable (e.g. $x in $x->{key})
         self.infer_deref_type(node, InferredType::HashRef);
 
-        // Record the hash variable access
-        let var_text = self.get_hash_var_from_element(node);
+        // Record the hash variable access. Container form (`$h{k}`,
+        // grammar field `hash:`) reads `%h`, not scalar `$h` — use the
+        // canonical name so the key ref, the shape witness, and the
+        // KeyWrite all key the same variable.
+        let var_text = match node.child_by_field_name("hash") {
+            Some(c) => crate::cst::canonical_container_name(c, self.source)
+                .or_else(|| self.get_hash_var_from_element(node)),
+            None => self.get_hash_var_from_element(node),
+        };
 
         // Distinguish read vs write by asking determine_access on the
         // element node itself — `$self->{k} = ...` has this element as
@@ -10551,21 +10647,32 @@ impl<'a> Builder<'a> {
             let Some(c) = innermost.named_child(0) else { return };
             match c.kind() {
                 "hash_element_expression" | "array_element_expression" => innermost = c,
-                "scalar" => break,
+                "scalar" | "container_variable" => break,
                 _ => return,
             }
         }
         if innermost.kind() != "hash_element_expression" {
             return; // array first hop — Sequence mutation, not modeled
         }
-        if !crate::cst::element_arrow_deref(innermost, self.source) {
-            return;
-        }
         let Some(container) = innermost.named_child(0) else { return };
-        let Ok(var_text) = container.utf8_text(self.source) else { return };
-        if !var_text.starts_with('$') {
-            return;
-        }
+        // Container form `$h{k}` writes `%h` (canonical name); deref
+        // form `$v->{k}` writes through scalar `$v` — arrow required
+        // (`$foo{k}` without one would be `%foo` mis-keyed to `$foo`).
+        let var_text: String = if container.kind() == "container_variable" {
+            match crate::cst::canonical_container_name(container, self.source) {
+                Some(n) => n,
+                None => return,
+            }
+        } else {
+            if !crate::cst::element_arrow_deref(innermost, self.source) {
+                return;
+            }
+            let Ok(t) = container.utf8_text(self.source) else { return };
+            if !t.starts_with('$') {
+                return;
+            }
+            t.to_string()
+        };
         let key_node = innermost.child_by_field_name("key");
         let key = key_node
             .and_then(|k| self.extract_key_text(k))

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1024,10 +1024,9 @@ fn test_extract_arrayref_literal() {
 
     let fa = build_fa("my $aref = [1, 2, 3];");
     let ty = fa.inferred_type_via_bag("$aref", Point::new(0, 21));
-    assert_eq!(
-        ty,
-        Some(InferredType::ArrayRef),
-        "populated array ref literal"
+    assert!(
+        ty.is_some_and(|t| t.is_array_shaped()),
+        "populated array ref literal",
     );
 }
 
@@ -1085,7 +1084,7 @@ fn test_arrow_hash_deref_infers_hashref() {
 fn test_arrow_array_deref_infers_arrayref() {
     let fa = build_fa("my $x;\n$x->[0];");
     let ty = fa.inferred_type_via_bag("$x", Point::new(1, 8));
-    assert_eq!(ty, Some(InferredType::ArrayRef));
+    assert!(ty.is_some_and(|t| t.is_array_shaped()), "array-shaped");
 }
 
 #[test]
@@ -1107,9 +1106,8 @@ fn test_coderef_call_propagates_return_type() {
     // body span resolves to ArrayRef without name lookup.
     let fa = build_fa("my $cb = sub { [1,2] };\nmy $r = $cb->();\nmy $z;");
     let ty = fa.inferred_type_via_bag("$r", Point::new(2, 0));
-    assert_eq!(
-        ty,
-        Some(InferredType::ArrayRef),
+    assert!(
+        ty.as_ref().is_some_and(|t| t.is_array_shaped()),
         "coderef call must inherit the callable's return type via return_edge: got {:?}",
         ty,
     );
@@ -1119,7 +1117,7 @@ fn test_coderef_call_propagates_return_type() {
 fn test_postfix_array_deref_infers_arrayref() {
     let fa = build_fa("my $x;\nmy @a = $x->@*;\nmy $z;");
     let ty = fa.inferred_type_via_bag("$x", Point::new(2, 0));
-    assert_eq!(ty, Some(InferredType::ArrayRef));
+    assert!(ty.is_some_and(|t| t.is_array_shaped()), "array-shaped");
 }
 
 #[test]
@@ -1227,7 +1225,7 @@ fn test_preinc_infers_numeric() {
 fn test_block_array_deref_infers_arrayref() {
     let fa = build_fa("my $x;\nmy @items = @{$x};\nmy $z;");
     let ty = fa.inferred_type_via_bag("$x", Point::new(2, 0));
-    assert_eq!(ty, Some(InferredType::ArrayRef));
+    assert!(ty.is_some_and(|t| t.is_array_shaped()), "array-shaped");
 }
 
 #[test]
@@ -1259,10 +1257,9 @@ fn test_builtin_push_infers_arrayref() {
     // push @{$aref} triggers array_deref_expression which already infers ArrayRef
     let fa = build_fa("my $aref;\npush @{$aref}, 1;\nmy $z;");
     let ty = fa.inferred_type_via_bag("$aref", Point::new(2, 0));
-    assert_eq!(
-        ty,
-        Some(InferredType::ArrayRef),
-        "push deref should infer ArrayRef"
+    assert!(
+        ty.is_some_and(|t| t.is_array_shaped()),
+        "push deref should infer ArrayRef",
     );
 }
 
@@ -1331,9 +1328,9 @@ fn test_return_type_hashref() {
 #[test]
 fn test_return_type_arrayref() {
     let fa = build_fa("sub get_tags {\n    return [1, 2, 3];\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_tags", None),
-        Some(InferredType::ArrayRef)
+    assert!(
+        fa.sub_return_type_at_arity("get_tags", None).is_some_and(|t| t.is_array_shaped()),
+        "array-shaped",
     );
 }
 
@@ -3437,7 +3434,6 @@ fn test_cross_file_method_override() {
 
 #[test]
 fn test_cross_file_return_type_through_inheritance() {
-    use crate::file_analysis::InferredType;
     use crate::module_index::ModuleIndex;
     use std::path::PathBuf;
 
@@ -4416,11 +4412,10 @@ has flavor => sub { [1, 2, 3] };
         "Sweet::flavor getter returns String (from 'caramel' default), \
          not Sour's ArrayRef"
     );
-    assert_eq!(
-        fa.find_method_return_type("Sour", "flavor", None, Some(0)),
-        Some(InferredType::ArrayRef),
+    assert!(
+        fa.find_method_return_type("Sour", "flavor", None, Some(0)).is_some_and(|t| t.is_array_shaped()),
         "Sour::flavor getter returns ArrayRef (from sub-returning-array \
-         default), not Sweet's String"
+         default), not Sweet's String",
     );
     assert_eq!(
         fa.find_method_return_type("Sweet", "flavor", None, Some(1)),
@@ -4507,10 +4502,9 @@ has items => sub { [] };
 ",
     );
     let rt = fa.find_method_return_type("App", "items", None, Some(0));
-    assert_eq!(
-        rt,
-        Some(InferredType::ArrayRef),
-        "sub {{ [] }} default → ArrayRef getter"
+    assert!(
+        rt.is_some_and(|t| t.is_array_shaped()),
+        "sub {{ [] }} default → ArrayRef getter",
     );
 }
 
@@ -14538,4 +14532,61 @@ my $h = cfg()->{host};
         .inferred_type_via_bag("$h", Point::new(2, 0))
         .expect("$h typed through cfg()->{host}");
     assert_eq!(h, InferredType::String);
+}
+
+// ---- Tier 3 nested-hashkey: array element narrowing + mixed drill ----
+
+/// `->[N]` projects array-literal element types (tuple semantics — the
+/// heterogeneous case answers per index, better than bailing), and the
+/// mixed drill `$obj->{users}->[0]->{name}` chains hash narrowing →
+/// element projection → hash narrowing end-to-end.
+#[test]
+fn array_element_narrowing_and_mixed_drill() {
+    let src = "\
+my $x = [1, 'a'];
+my $n = $x->[0];
+my $s = $x->[1];
+my $obj = { users => [ { name => 'A', id => 1 } ] };
+my $name = $obj->{users}->[0]->{name};
+my $id = $obj->{users}->[0]->{id};
+";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.inferred_type_via_bag("$n", Point::new(2, 0)),
+        Some(InferredType::Numeric),
+        "heterogeneous tuple projects per index",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$s", Point::new(2, 8)),
+        Some(InferredType::String),
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$name", Point::new(5, 0)),
+        Some(InferredType::String),
+        "mixed drill end-to-end",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$id", Point::new(5, 30)),
+        Some(InferredType::Numeric),
+    );
+}
+
+/// Out-of-range and unknown-element honesty: `->[7]` of a 2-tuple is
+/// None; a literal with an untypable element degrades to plain ArrayRef
+/// (no per-slot claims).
+#[test]
+fn array_element_narrowing_negative_space() {
+    let src = "\
+my $x = [1, 'a'];
+my $oob = $x->[7];
+my $mixed = [1, some_call()];
+";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.inferred_type_via_bag("$oob", Point::new(2, 0)),
+        None,
+        "out-of-range projection stays honest",
+    );
+    let m = fa.inferred_type_via_bag("$mixed", Point::new(2, 10));
+    assert_eq!(m, Some(InferredType::ArrayRef), "untypable element degrades whole literal");
 }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14520,6 +14520,60 @@ my $open = { %$config, extra => 'x' };
     );
 }
 
+/// Mutation extension: an unconditional `$v->{k} = …` write EXTENDS a
+/// closed shape (the key joins the list, value typed from the RHS,
+/// `open` preserved); a conditional or dynamic-key write switches the
+/// shape open. Reads before the write keep the original shape.
+#[test]
+fn mutation_extension_on_closed_shapes() {
+    let src = "\
+my $ext = { host => 'x' };
+my $before = $ext->{host};
+$ext->{added} = 42;
+my $after = $ext->{added};
+my $cond = { host => 'x' };
+$cond->{maybe} = 1 if $ENV{X};
+my $dyn = { host => 'x' };
+$dyn->{$ENV{K}} = 1;
+";
+    let fa = build_fa(src);
+
+    // Before the write: the literal's own closed single-key shape.
+    let t0 = fa.inferred_type_via_bag("$ext", Point::new(1, 0)).expect("$ext typed");
+    assert!(
+        matches!(&t0, InferredType::HashWithKeys { keys, open: false } if keys.len() == 1),
+        "pre-write shape: {:?}",
+        t0,
+    );
+
+    // After: extended, still closed, value typed from the RHS.
+    let t1 = fa.inferred_type_via_bag("$ext", Point::new(3, 0)).expect("$ext typed");
+    let InferredType::HashWithKeys { keys, open: false } = &t1 else {
+        panic!("post-write shape: {:?}", t1)
+    };
+    assert_eq!(keys.len(), 2, "{:?}", keys);
+    assert_eq!(keys[1].0, "added");
+    assert_eq!(keys[1].1.as_deref(), Some(&InferredType::Numeric));
+    let after = fa.inferred_type_via_bag("$after", Point::new(4, 0)).expect("$after typed");
+    assert_eq!(after, InferredType::Numeric, "read drills the extended key");
+
+    // Conditional write → open.
+    let tc = fa.inferred_type_via_bag("$cond", Point::new(6, 0)).expect("$cond typed");
+    assert!(
+        matches!(tc, InferredType::HashWithKeys { open: true, .. }),
+        "conditional write opens: {:?}",
+        tc,
+    );
+
+    // Dynamic key → open.
+    let td = fa.inferred_type_via_bag("$dyn", Point::new(8, 0)).expect("$dyn typed");
+    assert!(
+        matches!(td, InferredType::HashWithKeys { open: true, .. }),
+        "dynamic key opens: {:?}",
+        td,
+    );
+}
+
 /// Sub-return literals narrow at call sites: `cfg()->{host}` → String.
 #[test]
 fn hash_literal_narrows_through_sub_return() {

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1010,10 +1010,9 @@ fn test_extract_hashref_literal() {
 
     let fa = build_fa("my $href = { a => 1, b => 2 };");
     let ty = fa.inferred_type_via_bag("$href", Point::new(0, 30));
-    assert_eq!(
-        ty,
-        Some(InferredType::HashRef),
-        "populated hash ref literal"
+    assert!(
+        ty.is_some_and(|t| t.is_hash_shaped()),
+        "populated hash ref literal",
     );
 }
 
@@ -1079,7 +1078,7 @@ fn test_extract_constructor_still_works() {
 fn test_arrow_hash_deref_infers_hashref() {
     let fa = build_fa("my $x;\n$x->{key};");
     let ty = fa.inferred_type_via_bag("$x", Point::new(1, 10));
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1127,7 +1126,7 @@ fn test_postfix_array_deref_infers_arrayref() {
 fn test_postfix_hash_deref_infers_hashref() {
     let fa = build_fa("my $y;\nmy %h = $y->%*;\nmy $z;");
     let ty = fa.inferred_type_via_bag("$y", Point::new(2, 0));
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1235,7 +1234,7 @@ fn test_block_array_deref_infers_arrayref() {
 fn test_block_hash_deref_infers_hashref() {
     let fa = build_fa("my $y;\nmy %t = %{$y};\nmy $z;");
     let ty = fa.inferred_type_via_bag("$y", Point::new(2, 0));
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1323,9 +1322,9 @@ fn test_builtin_length_return_type() {
 #[test]
 fn test_return_type_hashref() {
     let fa = build_fa("sub get_config {\n    return { host => \"localhost\" };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_config", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("get_config", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
 }
 
@@ -1355,9 +1354,9 @@ fn test_return_type_coderef() {
 fn test_return_type_implicit_last_expr() {
     // No explicit return — last expression is the implicit return
     let fa = build_fa("sub get_data {\n    { key => \"val\" };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_data", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("get_data", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
 }
 
@@ -1373,9 +1372,9 @@ fn test_return_type_consistent_returns() {
     // Multiple returns all hashref → HashRef
     let fa =
         build_fa("sub consistent {\n    if (1) { return { a => 1 } }\n    return { b => 2 };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("consistent", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("consistent", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
 }
 
@@ -1383,15 +1382,14 @@ fn test_return_type_consistent_returns() {
 fn test_return_type_propagation_to_call_site() {
     let fa =
         build_fa("sub get_config {\n    return { host => 1 };\n}\nmy $cfg = get_config();\nmy $z;");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_config", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("get_config", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
     let ty = fa.inferred_type_via_bag("$cfg", Point::new(4, 0));
-    assert_eq!(
-        ty,
-        Some(InferredType::HashRef),
-        "call site should get return type"
+    assert!(
+        ty.is_some_and(|t| t.is_hash_shaped()),
+        "call site should get return type",
     );
 }
 
@@ -1438,9 +1436,9 @@ fn test_return_type_self_variable() {
 fn test_return_type_bare_return_filtered() {
     // Bare return + typed return → bare is filtered, typed return wins
     let fa = build_fa("sub get_config {\n    return unless 1;\n    return { host => 1 };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("get_config", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("get_config", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
 }
 
@@ -1455,9 +1453,9 @@ fn test_return_type_all_bare_returns() {
 fn test_return_type_undef_filtered() {
     // return undef + typed return → undef is filtered, typed return wins
     let fa = build_fa("sub maybe {\n    return undef unless 1;\n    return { a => 1 };\n}");
-    assert_eq!(
-        fa.sub_return_type_at_arity("maybe", None),
-        Some(InferredType::HashRef)
+    assert!(
+        fa.sub_return_type_at_arity("maybe", None).is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
 }
 
@@ -1495,7 +1493,7 @@ fn test_resolve_expr_type_function_call() {
     )
     .expect("should find function_call_expression");
     let ty = crate::cursor_context::resolve_expression_type(&fa, call_node, src.as_bytes(), None);
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1520,7 +1518,7 @@ fn test_resolve_expr_type_scalar_variable() {
     let scalar_node =
         find_node_at(tree.root_node(), Point::new(1, 0), "scalar").expect("should find scalar");
     let ty = crate::cursor_context::resolve_expression_type(&fa, scalar_node, src.as_bytes(), None);
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1548,7 +1546,7 @@ fn test_resolve_expr_type_chained_method() {
     }
     assert_eq!(n.kind(), "method_call_expression");
     let ty = crate::cursor_context::resolve_expression_type(&fa, n, src.as_bytes(), None);
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -1592,10 +1590,9 @@ $calc->get_self->get_config->{host};
 
     // Verify get_config returns HashRef
     let get_config_rt = fa.sub_return_type_at_arity("get_config", None);
-    assert_eq!(
-        get_config_rt,
-        Some(InferredType::HashRef),
-        "get_config should return HashRef"
+    assert!(
+        get_config_rt.is_some_and(|t| t.is_hash_shaped()),
+        "get_config should return HashRef",
     );
 
     // The outermost expression is hash_element_expression wrapping the chain
@@ -1617,10 +1614,9 @@ $calc->get_self->get_config->{host};
     let base = n.named_child(0).expect("should have base");
     assert_eq!(base.kind(), "method_call_expression");
     let ty = crate::cursor_context::resolve_expression_type(&fa, base, src.as_bytes(), None);
-    assert_eq!(
-        ty,
-        Some(InferredType::HashRef),
-        "the chain $calc->get_self->get_config should resolve to HashRef"
+    assert!(
+        ty.is_some_and(|t| t.is_hash_shaped()),
+        "the chain $calc->get_self->get_config should resolve to HashRef",
     );
 }
 
@@ -3474,7 +3470,7 @@ sub fetch {
     );
 
     let rt = fa.find_method_return_type("MyFetcher", "fetch", Some(&idx), None);
-    assert_eq!(rt, Some(InferredType::HashRef));
+    assert!(rt.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -3565,7 +3561,7 @@ $cfg;
 ",
     );
     let ty = fa.inferred_type_via_bag("$cfg", Point::new(9, 0));
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -3588,7 +3584,7 @@ $name;
     let bar_ty = fa.inferred_type_via_bag("$bar", Point::new(10, 0));
     assert_eq!(bar_ty, Some(InferredType::ClassName("Bar".into())));
     let name_ty = fa.inferred_type_via_bag("$name", Point::new(11, 0));
-    assert_eq!(name_ty, Some(InferredType::HashRef));
+    assert!(name_ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 #[test]
@@ -3606,7 +3602,7 @@ sub run {
 ",
     );
     let ty = fa.inferred_type_via_bag("$cfg", Point::new(7, 4));
-    assert_eq!(ty, Some(InferredType::HashRef));
+    assert!(ty.is_some_and(|t| t.is_hash_shaped()), "hash-shaped");
 }
 
 // ---- Framework accessor synthesis tests ----
@@ -4528,10 +4524,9 @@ has config => sub { {} };
 ",
     );
     let rt = fa.find_method_return_type("App", "config", None, Some(0));
-    assert_eq!(
-        rt,
-        Some(InferredType::HashRef),
-        "sub {{{{ }}}} default → HashRef getter"
+    assert!(
+        rt.is_some_and(|t| t.is_hash_shaped()),
+        "sub {{{{ }}}} default → HashRef getter",
     );
 }
 
@@ -14473,4 +14468,74 @@ if ($w->has_size) { print $w->size; }
         "references include has_size call: {:?}",
         refs,
     );
+}
+
+// ---- Tier 2 nested-hashkey: structurally-typed hash literals ----
+
+/// `{ host => 'x', port => 5432 }` carries per-key types; `->{key}`
+/// narrows through assignments and direct nesting; a spread flips the
+/// shape open (unknown keys aren't claimable misses either way, but the
+/// shape records it for future diagnostics).
+#[test]
+fn hash_literal_structural_typing_and_narrowing() {
+    let src = "\
+my $config = { db => { host => 'localhost', port => 5432 }, debug => 1 };
+my $db = $config->{db};
+my $host = $db->{host};
+my $port = $config->{db}->{port};
+my $open = { %$config, extra => 'x' };
+";
+    let fa = build_fa(src);
+
+    // The literal's own structure.
+    let cfg = fa
+        .inferred_type_via_bag("$config", Point::new(1, 0))
+        .expect("$config typed");
+    let db_ty = cfg.key_value_type("db").expect("db key present").expect("db value typed");
+    assert!(
+        matches!(db_ty, InferredType::HashWithKeys { open: false, .. }),
+        "nested literal rides the value slot: {:?}",
+        db_ty,
+    );
+    assert!(cfg.key_value_type("typo").is_none(), "closed shape: unknown key is no key");
+
+    // Narrowing through an assignment hop.
+    let db = fa
+        .inferred_type_via_bag("$db", Point::new(2, 0))
+        .expect("$db typed from ->{db}");
+    assert!(matches!(db, InferredType::HashWithKeys { .. }), "got {:?}", db);
+    let host = fa
+        .inferred_type_via_bag("$host", Point::new(3, 0))
+        .expect("$host typed from ->{host}");
+    assert_eq!(host, InferredType::String);
+
+    // Direct double-drill, no intermediate variable.
+    let port = fa
+        .inferred_type_via_bag("$port", Point::new(4, 0))
+        .expect("$port typed from ->{db}->{port}");
+    assert_eq!(port, InferredType::Numeric);
+
+    // Spread → open shape.
+    let open = fa
+        .inferred_type_via_bag("$open", Point::new(4, 9))
+        .expect("$open typed");
+    assert!(
+        matches!(open, InferredType::HashWithKeys { open: true, .. }),
+        "spread flips open: {:?}",
+        open,
+    );
+}
+
+/// Sub-return literals narrow at call sites: `cfg()->{host}` → String.
+#[test]
+fn hash_literal_narrows_through_sub_return() {
+    let src = "\
+sub cfg { return { host => 'x', port => 1 } }
+my $h = cfg()->{host};
+";
+    let fa = build_fa(src);
+    let h = fa
+        .inferred_type_via_bag("$h", Point::new(2, 0))
+        .expect("$h typed through cfg()->{host}");
+    assert_eq!(h, InferredType::String);
 }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14574,6 +14574,71 @@ $dyn->{$ENV{K}} = 1;
     );
 }
 
+/// The literal-hash spelling: `my %h = (k => v)` types through the
+/// same shape builder as the hashref literal, `$h{k}` projects off
+/// `%h` (the canonical container name), mutation extension applies,
+/// and spreads — arrays included (`@_`) — flip the shape open.
+#[test]
+fn literal_hash_structural_typing() {
+    let src = "\
+my %config = (host => 'x', port => 5432);
+my $v = $config{host};
+$config{added} = 42;
+my $a = $config{added};
+my %spread = (default => 1, @_);
+";
+    let fa = build_fa(src);
+    let t = fa.inferred_type_via_bag("%config", Point::new(1, 0)).expect("%config typed");
+    assert!(
+        matches!(&t, InferredType::HashWithKeys { keys, open: false } if keys.len() == 2),
+        "literal-list shape: {:?}",
+        t,
+    );
+    let v = fa.inferred_type_via_bag("$v", Point::new(2, 0)).expect("$v typed");
+    assert_eq!(v, InferredType::String, "container-form read projects");
+    let t2 = fa.inferred_type_via_bag("%config", Point::new(3, 0)).expect("%config typed");
+    assert!(
+        matches!(&t2, InferredType::HashWithKeys { keys, open: false } if keys.len() == 3),
+        "write extends: {:?}",
+        t2,
+    );
+    let a = fa.inferred_type_via_bag("$a", Point::new(4, 0)).expect("$a typed");
+    assert_eq!(a, InferredType::Numeric, "extended key value type");
+    let sp = fa.inferred_type_via_bag("%spread", Point::new(5, 0)).expect("%spread typed");
+    assert!(
+        matches!(sp, InferredType::HashWithKeys { open: true, .. }),
+        "array spread opens: {:?}",
+        sp,
+    );
+}
+
+/// Slice writes — sigil (`@h{…}`), postfix deref (`$r->@{…}`), and
+/// sigil deref (`@$s{…}`) — land several keys at once: each records an
+/// open-switching KeyWrite, so the closed shape widens instead of
+/// claiming the written keys as misses.
+#[test]
+fn slice_writes_open_closed_shapes() {
+    let src = "\
+my %h = (a => 1);
+@h{qw(b c)} = (1, 2);
+my $r = { a => 1 };
+$r->@{qw(d e)} = (3, 4);
+my $s = { a => 1 };
+@$s{qw(f g)} = (5, 6);
+";
+    let fa = build_fa(src);
+    for (var, line) in [("%h", 2), ("$r", 4), ("$s", 6)] {
+        let t = fa
+            .inferred_type_via_bag(var, Point::new(line, 0))
+            .unwrap_or_else(|| panic!("{var} typed"));
+        assert!(
+            matches!(t, InferredType::HashWithKeys { open: true, .. }),
+            "slice write opens {var}: {:?}",
+            t,
+        );
+    }
+}
+
 /// Sub-return literals narrow at call sites: `cfg()->{host}` → String.
 #[test]
 fn hash_literal_narrows_through_sub_return() {

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -294,6 +294,56 @@ pub(crate) fn canonical_container_name<'a>(node: Node<'a>, src: &'a [u8]) -> Opt
     Some(format!("{}{}", target_sigil, bare))
 }
 
+/// True when `node` sits in a conditionally-executed position within
+/// its enclosing sub: under an if/unless block, a postfix modifier, a
+/// ternary arm, a loop, or a short-circuit chain (`and`/`or`; the
+/// `binary_expression` arm over-claims `&&`-and-friends' left operands
+/// too — over-marking is the safe direction, it only widens a shape to
+/// open). Climbs to the nearest sub/file boundary; scope-crossing
+/// conditionality (a write inside a block or closure relative to an
+/// outer variable's scope) is the caller's check — this answers only
+/// what the syntax between here and the boundary says.
+pub(crate) fn is_conditionally_executed(node: Node) -> bool {
+    let mut cur = node.parent();
+    while let Some(p) = cur {
+        match p.kind() {
+            "subroutine_declaration_statement"
+            | "method_declaration_statement"
+            | "anonymous_subroutine_expression"
+            | "source_file" => return false,
+            "conditional_statement"
+            | "postfix_conditional_expression"
+            | "conditional_expression"
+            | "lowprec_logical_expression"
+            | "binary_expression"
+            | "loop_statement"
+            | "for_statement"
+            | "postfix_for_expression"
+            | "postfix_loop_expression" => return true,
+            _ => {}
+        }
+        cur = p.parent();
+    }
+    false
+}
+
+/// `$v->{k}` (arrow deref of the scalar's referent) vs `$foo{k}`
+/// (element of `%foo` spelled with a `$` sigil): same node kind,
+/// different variable — only the arrow form goes through the scalar.
+/// The arrow is an anonymous token, so detect it in the source gap
+/// between the container and the subscript.
+pub(crate) fn element_arrow_deref(element: Node, src: &[u8]) -> bool {
+    let Some(container) = element.named_child(0) else { return false };
+    let Some(sub) = element
+        .child_by_field_name("key")
+        .or_else(|| element.child_by_field_name("index"))
+    else {
+        return false;
+    };
+    src.get(container.end_byte()..sub.start_byte())
+        .is_some_and(|gap| gap.windows(2).any(|w| w == b"->"))
+}
+
 /// True when this node is the *container* of an element access —
 /// `$c` in `$c->{k}` / `$c->[0]` / `$foo{k}` / `$foo[0]`. The element
 /// expressions put the key/index in a named field; the container is the

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -294,6 +294,20 @@ pub(crate) fn canonical_container_name<'a>(node: Node<'a>, src: &'a [u8]) -> Opt
     Some(format!("{}{}", target_sigil, bare))
 }
 
+/// True when this node is the *container* of an element access —
+/// `$c` in `$c->{k}` / `$c->[0]` / `$foo{k}` / `$foo[0]`. The element
+/// expressions put the key/index in a named field; the container is the
+/// other (first) named child. Element-access bases keep the reference
+/// in hand; every other read position (call argument, RHS alias, list,
+/// invocant, sigil deref) lets it escape to code that may mutate it.
+pub(crate) fn is_element_access_base(node: Node) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    matches!(
+        parent.kind(),
+        "hash_element_expression" | "array_element_expression"
+    ) && parent.named_child(0).is_some_and(|c| c == node)
+}
+
 /// `Class->new(...)` — a constructor call with a class-shaped invocant.
 /// Returns the invocant text (`Foo::Bar` or `__PACKAGE__`); `None` for
 /// non-constructor methods and variable/positional invocants, whose class

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -327,6 +327,25 @@ pub(crate) fn is_conditionally_executed(node: Node) -> bool {
     false
 }
 
+/// The scalar wrapped by a container node's deref varname (`@$h{…}` —
+/// `slice_container_variable > varname > scalar`). `None` for plain
+/// (non-deref) containers, whose varname is a leaf.
+pub(crate) fn varname_inner_scalar_text<'a>(node: Node<'a>, src: &'a [u8]) -> Option<String> {
+    for i in 0..node.named_child_count() {
+        let c = node.named_child(i)?;
+        if c.kind() != "varname" {
+            continue;
+        }
+        for j in 0..c.named_child_count() {
+            let gc = c.named_child(j)?;
+            if gc.kind() == "scalar" {
+                return gc.text(src).map(|s| s.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// `$v->{k}` (arrow deref of the scalar's referent) vs `$foo{k}`
 /// (element of `%foo` spelled with a `$` sigil): same node kind,
 /// different variable — only the arrow form goes through the scalar.
@@ -352,10 +371,29 @@ pub(crate) fn element_arrow_deref(element: Node, src: &[u8]) -> bool {
 /// invocant, sigil deref) lets it escape to code that may mutate it.
 pub(crate) fn is_element_access_base(node: Node) -> bool {
     let Some(parent) = node.parent() else { return false };
-    matches!(
-        parent.kind(),
-        "hash_element_expression" | "array_element_expression"
-    ) && parent.named_child(0).is_some_and(|c| c == node)
+    match parent.kind() {
+        "hash_element_expression" | "array_element_expression" => {
+            parent.named_child(0).is_some_and(|c| c == node)
+        }
+        // Postfix deref slice (`$h->@{…}` / `$h->%{…}` / `$a->@[…]`):
+        // the scalar fills the hashref/arrayref field. A slice READ
+        // copies values out — it can't mutate the referent.
+        "slice_expression" | "keyval_expression" => {
+            parent.child_by_field_name("hashref").is_some_and(|c| c == node)
+                || parent.child_by_field_name("arrayref").is_some_and(|c| c == node)
+        }
+        // Sigil-deref slice (`@$h{…}`): the scalar sits under the
+        // container's varname. Plain sigil derefs (`%$h`, `$$h`) keep
+        // their escape classification — only slice containers are
+        // value-copying reads.
+        "varname" => parent.parent().is_some_and(|gp| {
+            matches!(
+                gp.kind(),
+                "slice_container_variable" | "keyval_container_variable"
+            )
+        }),
+        _ => false,
+    }
 }
 
 /// `Class->new(...)` — a constructor call with a class-shaped invocant.

--- a/src/cursor_context_tests.rs
+++ b/src/cursor_context_tests.rs
@@ -211,7 +211,7 @@ fn test_tree_context_method_on_function_call() {
     // Cursor at end of line 3 (after "->")
     let ctx = detect_cursor_context_tree(&tree, source.as_bytes(), Point::new(3, 14), &fa);
     assert!(
-        matches!(ctx, Some(CursorContext::Method { ref invocant_type, .. }) if *invocant_type == Some(InferredType::HashRef)),
+        matches!(ctx, Some(CursorContext::Method { ref invocant_type, .. }) if invocant_type.as_ref().is_some_and(|t| t.is_hash_shaped())),
         "expected Method with HashRef type, got {:?}",
         ctx,
     );
@@ -282,7 +282,7 @@ $calc->get_self->get_config->{";
     let ctx = detect_cursor_context_tree(&tree, source.as_bytes(), cursor, &fa);
     assert!(
         matches!(ctx, Some(CursorContext::HashKey { ref owner_type, ref source_sub, .. })
-                if *owner_type == Some(InferredType::HashRef) && *source_sub == Some("get_config".to_string())),
+                if owner_type.as_ref().is_some_and(|t| t.is_hash_shaped()) && *source_sub == Some("get_config".to_string())),
         "expected HashKey with HashRef type and get_config source, got {:?}",
         ctx,
     );

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -874,6 +874,19 @@ pub enum InferredType {
         controller: Option<String>,
         stash: Vec<(String, String)>,
     },
+    /// `{ host => 'x', port => 5432 }` — a hash literal with literal
+    /// keys, each carrying its value's type when inferable (`None` =
+    /// key present, value type unknown). `open` = a spread (`%$other`)
+    /// or dynamic key makes the key set open-ended, so an unknown key
+    /// is not a claimable miss. `->{key}` narrows via
+    /// [`InferredType::key_value_type`]; nesting recurses naturally
+    /// (the value's own `HashWithKeys` rides in the box). Kept at the
+    /// END for bincode variant-index stability (bump
+    /// `EXTRACT_VERSION`).
+    HashWithKeys {
+        keys: Vec<(String, Option<Box<InferredType>>)>,
+        open: bool,
+    },
 }
 
 /// Concrete parametric flavors + type-level operators. Each
@@ -1008,6 +1021,32 @@ impl InferredType {
         }
     }
 
+    /// `->{key}` narrowing on a structurally-typed hash (rule #10: ask
+    /// the value). `Some(Some(t))` = key present with a known value
+    /// type; `Some(None)` = key present, value type unknown; `None` =
+    /// not a key of this value (or not a keyed hash at all). Closed
+    /// shapes answer `None` for unknown keys; open shapes (spread)
+    /// also answer `None` — the caller can't claim a miss either way,
+    /// the distinction is for future diagnostics.
+    /// Hash-shaped rep, regardless of key knowledge — the predicate
+    /// every "is this a hashref" gate asks instead of `== HashRef`.
+    pub fn is_hash_shaped(&self) -> bool {
+        matches!(
+            self,
+            InferredType::HashRef | InferredType::HashWithKeys { .. }
+        )
+    }
+
+    pub fn key_value_type(&self, key: &str) -> Option<Option<&InferredType>> {
+        match self {
+            InferredType::HashWithKeys { keys, .. } => keys
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, t)| t.as_deref()),
+            _ => None,
+        }
+    }
+
     /// Read the inherited route default for `key` from a branded
     /// route value, where `controller` is a distinguished key and
     /// everything else lives in the stash. `None` for non-route
@@ -1136,6 +1175,15 @@ impl InferredType {
                 InferredType::BrandedRoute { controller: hc, stash: hs, .. },
                 InferredType::BrandedRoute { controller: wc, stash: ws, .. },
             ) => (wc.is_none() || hc.is_some()) && ws.len() <= hs.len(),
+            // Structure dominates rep: a keyed hash is strictly more
+            // informative than the bare `HashRef` a deref-narrowing
+            // observation re-derives. Two keyed hashes only subsume on
+            // equality (a genuine reassignment with different keys must
+            // win as latest).
+            (InferredType::HashWithKeys { .. }, InferredType::HashRef) => true,
+            (a @ InferredType::HashWithKeys { .. }, b @ InferredType::HashWithKeys { .. }) => {
+                a == b
+            }
             // Unit-shape variants subsume themselves; mismatched
             // discriminants don't subsume.
             (a, b) => std::mem::discriminant(a) == std::mem::discriminant(b),
@@ -1206,14 +1254,19 @@ pub fn resolve_return_type(return_types: &[InferredType]) -> Option<InferredType
     if return_types.iter().all(|t| t == first) {
         return Some(first.clone());
     }
-    // Object subsumes HashRef: if some returns are Object(X) and others are HashRef,
-    // the Object wins (overloaded hash access is common in Perl).
+    // All arms hash-shaped but structurally different (`{a=>1}` vs
+    // `{b=>2}`) → degrade to the coarse HashRef rather than Unknown.
+    if return_types.iter().all(|t| t.is_hash_shaped()) {
+        return Some(InferredType::HashRef);
+    }
+    // Object subsumes HashRef: if some returns are Object(X) and others are
+    // hash-shaped, the Object wins (overloaded hash access is common in Perl).
     let mut object = None;
     for t in return_types {
         if t.is_object() {
             object = Some(t.clone());
-        } else if *t != InferredType::HashRef {
-            // Non-HashRef, non-Object disagreement → Unknown
+        } else if !t.is_hash_shaped() {
+            // Non-hash, non-Object disagreement → Unknown
             return None;
         }
     }
@@ -8170,6 +8223,9 @@ pub fn inferred_type_to_tag(ty: &InferredType) -> String {
         InferredType::ClassName(name) => format!("Object:{}", name),
         InferredType::FirstParam { package } => format!("Object:{}", package),
         InferredType::HashRef => "HashRef".to_string(),
+        // Structurally-typed hashes read as plain HashRef on the wire —
+        // the per-key detail drives narrowing, not display (yet).
+        InferredType::HashWithKeys { .. } => "HashRef".to_string(),
         InferredType::ArrayRef => "ArrayRef".to_string(),
         InferredType::CodeRef { .. } => "CodeRef".to_string(),
         InferredType::Regexp => "Regexp".to_string(),
@@ -8223,6 +8279,9 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
         InferredType::ClassName(name) => name.clone(),
         InferredType::FirstParam { package } => package.clone(),
         InferredType::HashRef => "HashRef".to_string(),
+        // Structurally-typed hashes read as plain HashRef on the wire —
+        // the per-key detail drives narrowing, not display (yet).
+        InferredType::HashWithKeys { .. } => "HashRef".to_string(),
         InferredType::ArrayRef => "ArrayRef".to_string(),
         InferredType::CodeRef { .. } => "CodeRef".to_string(),
         InferredType::Regexp => "Regexp".to_string(),

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1677,6 +1677,29 @@ pub struct CallBinding {
     pub span: Span,
 }
 
+/// One `$var->{key} = …` write observed at walk time. The mutation-
+/// extension pass (`witnesses::emit_mutation_extension_witnesses`)
+/// folds these into the variable's structural shape: an unconditional
+/// static-key write extends a closed `HashWithKeys` (the key joins the
+/// shape, its value typed from `rhs_span`); a dynamic key or a
+/// conditionally-executed write switches the shape open. Persisted so
+/// cross-file enrichment can re-run the pass once imported shapes land.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyWrite {
+    pub var_text: String,
+    /// `None` = dynamic key (`$v->{$k}`) — unknowable membership.
+    pub key: Option<String>,
+    pub scope: ScopeId,
+    /// Key-node span — temporal anchor and per-var ordering.
+    pub span: Span,
+    /// RHS expression span — types the extended key's value.
+    pub rhs_span: Option<Span>,
+    /// Syntactically conditional within its sub (if/postfix/ternary/
+    /// loop/short-circuit). Scope-crossing writes (nested block or
+    /// closure relative to the decl scope) are detected in the pass.
+    pub conditional: bool,
+}
+
 /// A method call binding: `$var = $invocant->method()`.
 /// Recorded during build, resolved in post-pass via `find_method_return_type`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2238,6 +2261,21 @@ pub struct FileAnalysis {
     #[serde(default)]
     pub escaped_scalars: HashSet<String>,
 
+    /// Scalars reassigned after declaration (`$v = …` with the
+    /// variable itself as assignment target — element writes are NOT
+    /// reassignment, they're modeled as shape mutations). A closed
+    /// shape on a reassigned scalar isn't trustworthy: the other
+    /// assignment may carry a different (unknown) value. The
+    /// conditional-reassignment lattice disagreement is the modeled
+    /// fix; this set is its trust-gate stand-in.
+    #[serde(default)]
+    pub reassigned_scalars: HashSet<String>,
+
+    /// Hash-key writes, in walk order. Input to the mutation-extension
+    /// pass — see [`KeyWrite`].
+    #[serde(default)]
+    pub key_writes: Vec<KeyWrite>,
+
     // Indices (built in post-pass — skipped by serde; call rebuild_all_indices() after deserialize)
     #[serde(skip, default)]
     scope_starts: Vec<(Point, ScopeId)>, // sorted by start point
@@ -2298,6 +2336,8 @@ pub struct FileAnalysisParts {
     pub gated_param_types: Vec<ReceiverGated<TypeConstraint>>,
     pub attr_projections: Vec<AttrProjection>,
     pub escaped_scalars: HashSet<String>,
+    pub reassigned_scalars: HashSet<String>,
+    pub key_writes: Vec<KeyWrite>,
 }
 
 /// One projection of a field/attr decl — the entity that encodes group
@@ -2421,6 +2461,8 @@ impl FileAnalysis {
             gated_param_types,
             attr_projections,
             escaped_scalars,
+            reassigned_scalars,
+            key_writes,
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
@@ -2452,6 +2494,8 @@ impl FileAnalysis {
             gated_param_types,
             attr_projections,
             escaped_scalars,
+            reassigned_scalars,
+            key_writes,
             scope_starts: Vec::new(),
             symbols_by_name: HashMap::new(),
             symbols_by_scope: HashMap::new(),
@@ -3286,23 +3330,18 @@ impl FileAnalysis {
     }
 
     /// True when a closed literal shape on `var_text` is the variable's
-    /// whole story in this file: the scalar is never written after its
-    /// declaration (no reassignment, no `$v->{k} = …` — both surface as
-    /// a `Variable` ref with `Write` access) and its reference never
-    /// escapes into a call / alias / invocant position. Each clause is
-    /// the trust-gate approximation of a lattice widening that isn't
-    /// modeled yet (mutation widening, conditional-reassignment
-    /// disagreement, escape widening — docs/prompt-nested-hashkey.md);
-    /// the unknown-hash-key diagnostic only fires behind it.
+    /// whole story in this file: the scalar is never reassigned and its
+    /// reference never escapes into a call / alias / invocant position.
+    /// Key writes are NOT a gate clause — the mutation-extension pass
+    /// models them on the shape itself (unconditional writes extend a
+    /// closed shape; conditional/dynamic writes switch it open). The
+    /// two remaining clauses are trust-gate stand-ins for unmodeled
+    /// lattice widenings (conditional-reassignment disagreement, escape
+    /// widening — docs/prompt-nested-hashkey.md); the unknown-hash-key
+    /// diagnostic only fires behind them.
     pub fn closed_shape_is_whole_story(&self, var_text: &str) -> bool {
-        if self.escaped_scalars.contains(var_text) {
-            return false;
-        }
-        !self.refs.iter().any(|r| {
-            matches!(r.kind, RefKind::Variable)
-                && r.access == AccessKind::Write
-                && r.target_name == var_text
-        })
+        !self.escaped_scalars.contains(var_text)
+            && !self.reassigned_scalars.contains(var_text)
     }
 
     /// Get the return type of a named sub/method (local definitions
@@ -3557,6 +3596,30 @@ impl FileAnalysis {
                     }
                 }
             }
+        }
+
+        // Re-run the mutation-extension pass: imported shapes (a var
+        // typed by an imported sub's `HashWithKeys` return) only land
+        // with the TCs pushed above, so build-time extension found no
+        // shape to extend for them. Append-only (`clear = false`) —
+        // post-finalize removal would shift `base_witness_count`;
+        // duplicates are idempotent and truncated by the next cycle.
+        {
+            let key_writes = std::mem::take(&mut self.key_writes);
+            let ctx = crate::witnesses::BagContext {
+                scopes: &self.scopes,
+                package_framework: &self.package_framework,
+                module_index,
+                package_parents: &self.package_parents,
+                app_surface_consumers: &self.app_surface_consumers,
+            };
+            crate::witnesses::emit_mutation_extension_witnesses(
+                &mut self.witnesses,
+                &ctx,
+                &key_writes,
+                false,
+            );
+            self.key_writes = key_writes;
         }
 
         self.resolve_method_call_types(module_index);

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1037,6 +1037,12 @@ impl InferredType {
         )
     }
 
+    /// Array-shaped rep, regardless of element knowledge — the
+    /// `is_hash_shaped` twin for `== ArrayRef` gates.
+    pub fn is_array_shaped(&self) -> bool {
+        matches!(self, InferredType::ArrayRef | InferredType::Sequence(_))
+    }
+
     pub fn key_value_type(&self, key: &str) -> Option<Option<&InferredType>> {
         match self {
             InferredType::HashWithKeys { keys, .. } => keys
@@ -1175,15 +1181,17 @@ impl InferredType {
                 InferredType::BrandedRoute { controller: hc, stash: hs, .. },
                 InferredType::BrandedRoute { controller: wc, stash: ws, .. },
             ) => (wc.is_none() || hc.is_some()) && ws.len() <= hs.len(),
-            // Structure dominates rep: a keyed hash is strictly more
-            // informative than the bare `HashRef` a deref-narrowing
-            // observation re-derives. Two keyed hashes only subsume on
-            // equality (a genuine reassignment with different keys must
-            // win as latest).
+            // Structure dominates rep: a keyed hash / positional tuple is
+            // strictly more informative than the bare ref a deref-
+            // narrowing observation re-derives. Structured-vs-structured
+            // only subsumes on equality (a genuine reassignment with a
+            // different shape must win as latest).
             (InferredType::HashWithKeys { .. }, InferredType::HashRef) => true,
             (a @ InferredType::HashWithKeys { .. }, b @ InferredType::HashWithKeys { .. }) => {
                 a == b
             }
+            (InferredType::Sequence(_), InferredType::ArrayRef) => true,
+            (a @ InferredType::Sequence(_), b @ InferredType::Sequence(_)) => a == b,
             // Unit-shape variants subsume themselves; mismatched
             // discriminants don't subsume.
             (a, b) => std::mem::discriminant(a) == std::mem::discriminant(b),
@@ -1258,6 +1266,11 @@ pub fn resolve_return_type(return_types: &[InferredType]) -> Option<InferredType
     // `{b=>2}`) → degrade to the coarse HashRef rather than Unknown.
     if return_types.iter().all(|t| t.is_hash_shaped()) {
         return Some(InferredType::HashRef);
+    }
+    // Same rule for arrays: structurally different tuples agree on the
+    // coarse ArrayRef.
+    if return_types.iter().all(|t| t.is_array_shaped()) {
+        return Some(InferredType::ArrayRef);
     }
     // Object subsumes HashRef: if some returns are Object(X) and others are
     // hash-shaped, the Object wins (overloaded hash access is common in Perl).
@@ -8293,7 +8306,13 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
             // bracketed text as link syntax and either swallow it
             // or render it as a broken link. Matches the
             // `Parametric<T1, T2>` style.
-            let parts: Vec<String> = elems.iter().map(format_inferred_type).collect();
+            // Elide long tuples — a 64-slot literal's hover shouldn't be
+            // a wall of element types.
+            let mut parts: Vec<String> =
+                elems.iter().take(4).map(format_inferred_type).collect();
+            if elems.len() > 4 {
+                parts.push("…".to_string());
+            }
             format!("Sequence<{}>", parts.join(", "))
         }
         InferredType::TypeConstraintOf(inner) => {

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2228,6 +2228,16 @@ pub struct FileAnalysis {
     #[serde(default)]
     pub attr_projections: Vec<AttrProjection>,
 
+    /// Scalars whose reference escaped the file's view (read in a
+    /// non-element-access position: call argument, alias, invocant,
+    /// sigil deref). A closed literal shape on an escaped scalar is
+    /// not the whole story — the callee may have mutated it. See
+    /// `closed_shape_is_whole_story`. `#[serde(default)]` for blob
+    /// compat; the accompanying `EXTRACT_VERSION` bump re-extracts so
+    /// no blob actually carries an empty set for analyzed code.
+    #[serde(default)]
+    pub escaped_scalars: HashSet<String>,
+
     // Indices (built in post-pass — skipped by serde; call rebuild_all_indices() after deserialize)
     #[serde(skip, default)]
     scope_starts: Vec<(Point, ScopeId)>, // sorted by start point
@@ -2287,6 +2297,7 @@ pub struct FileAnalysisParts {
     pub provisional_dispatches: Vec<ProvisionalDispatch>,
     pub gated_param_types: Vec<ReceiverGated<TypeConstraint>>,
     pub attr_projections: Vec<AttrProjection>,
+    pub escaped_scalars: HashSet<String>,
 }
 
 /// One projection of a field/attr decl — the entity that encodes group
@@ -2409,6 +2420,7 @@ impl FileAnalysis {
             provisional_dispatches,
             gated_param_types,
             attr_projections,
+            escaped_scalars,
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
@@ -2439,6 +2451,7 @@ impl FileAnalysis {
             provisional_dispatches,
             gated_param_types,
             attr_projections,
+            escaped_scalars,
             scope_starts: Vec::new(),
             symbols_by_name: HashMap::new(),
             symbols_by_scope: HashMap::new(),
@@ -3270,6 +3283,26 @@ impl FileAnalysis {
             }
         }
         out
+    }
+
+    /// True when a closed literal shape on `var_text` is the variable's
+    /// whole story in this file: the scalar is never written after its
+    /// declaration (no reassignment, no `$v->{k} = …` — both surface as
+    /// a `Variable` ref with `Write` access) and its reference never
+    /// escapes into a call / alias / invocant position. Each clause is
+    /// the trust-gate approximation of a lattice widening that isn't
+    /// modeled yet (mutation widening, conditional-reassignment
+    /// disagreement, escape widening — docs/prompt-nested-hashkey.md);
+    /// the unknown-hash-key diagnostic only fires behind it.
+    pub fn closed_shape_is_whole_story(&self, var_text: &str) -> bool {
+        if self.escaped_scalars.contains(var_text) {
+            return false;
+        }
+        !self.refs.iter().any(|r| {
+            matches!(r.kind, RefKind::Variable)
+                && r.access == AccessKind::Write
+                && r.target_name == var_text
+        })
     }
 
     /// Get the return type of a named sub/method (local definitions

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1682,8 +1682,9 @@ pub struct CallBinding {
 /// folds these into the variable's structural shape: an unconditional
 /// static-key write extends a closed `HashWithKeys` (the key joins the
 /// shape, its value typed from `rhs_span`); a dynamic key or a
-/// conditionally-executed write switches the shape open. Persisted so
-/// cross-file enrichment can re-run the pass once imported shapes land.
+/// conditionally-executed write switches the shape open
+/// (docs/adr/structural-shapes.md). Persisted so cross-file
+/// enrichment can re-run the pass once imported shapes land.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyWrite {
     pub var_text: String,
@@ -3337,7 +3338,7 @@ impl FileAnalysis {
     /// closed shape; conditional/dynamic writes switch it open). The
     /// two remaining clauses are trust-gate stand-ins for unmodeled
     /// lattice widenings (conditional-reassignment disagreement, escape
-    /// widening — docs/prompt-nested-hashkey.md); the unknown-hash-key
+    /// widening — docs/adr/structural-shapes.md); the unknown-hash-key
     /// diagnostic only fires behind them.
     pub fn closed_shape_is_whole_story(&self, var_text: &str) -> bool {
         !self.escaped_scalars.contains(var_text)

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -1483,10 +1483,10 @@ my $host = $cfg->{host};
 
     let point = Point { row: 2, column: 20 };
     let t = fa.inferred_type_via_bag("$cfg", point);
-    assert_eq!(
+    assert!(
+        t.as_ref().is_some_and(|t| t.is_hash_shaped() && t.class_name().is_none()),
+        "without class evidence, $cfg is hash-shaped and classless: {:?}",
         t,
-        Some(InferredType::HashRef),
-        "without class evidence, $cfg is plain HashRef"
     );
 }
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 74;
+pub const EXTRACT_VERSION: i64 = 75;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 73;
+pub const EXTRACT_VERSION: i64 = 74;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 75;
+pub const EXTRACT_VERSION: i64 = 76;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 77;
+pub const EXTRACT_VERSION: i64 = 78;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 78;
+pub const EXTRACT_VERSION: i64 = 79;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 76;
+pub const EXTRACT_VERSION: i64 = 77;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 79;
+pub const EXTRACT_VERSION: i64 = 80;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_index_tests.rs
+++ b/src/module_index_tests.rs
@@ -195,9 +195,9 @@ sub make_obj {
         Some(parse_source_to_cached(src, "Config::DB")),
     );
 
-    assert_eq!(
-        idx.get_return_type_cached("get_config"),
-        Some(InferredType::HashRef)
+    assert!(
+        idx.get_return_type_cached("get_config").is_some_and(|t| t.is_hash_shaped()),
+        "hash-shaped",
     );
     assert_eq!(
         idx.get_return_type_cached("make_obj"),

--- a/src/parametric_resultset_tests.rs
+++ b/src/parametric_resultset_tests.rs
@@ -979,3 +979,72 @@ sub action {
     // `greet` is declared on `sub greet` (row 4, 0-based).
     assert_eq!(def.unwrap().start.row, 4);
 }
+
+// ---- Tier 1 nested-hashkey: direct `$row->{col}` deref ----
+
+/// `$row->{name}` on a typed row (DBIC HRI shape): the deref's hash key
+/// resolves to the column def, same as `$row->name` does. The row's
+/// class comes from the RowOf projection (`$rs->find` →
+/// ClassName(Schema::Result::Users)); the key's owner must land on
+/// `Class(row)` so goto-def / references reach the add_columns def.
+#[test]
+fn row_hashref_deref_resolves_column() {
+    let src = format!(
+        "{}{}",
+        USERS_RESULT,
+        "package main;
+my $rs = $schema->resultset('Schema::Result::Users');
+my $row = $rs->find(1);
+my $n = $row->{name};
+"
+    );
+    let (fa, _tree) = parse_with_tree(&src);
+    let key = point_at(&src, "name};");
+    let def = fa.find_definition(key, None);
+    assert!(
+        def.is_some(),
+        "$row->{{name}} resolves to the column def; ref at cursor: {:?}",
+        fa.ref_at(key),
+    );
+    assert_eq!(def.unwrap().start.row, NAME_COL_DEF_ROW, "lands on the name column");
+}
+
+/// The negative space of tier 1: a key that isn't a column resolves to
+/// nothing (no wrong-owner latch), and an untyped variable's deref keeps
+/// its lexical grouping (plain `%config` hashes are untouched by the
+/// post-fold owner upgrade).
+#[test]
+fn row_hashref_deref_negative_space() {
+    let src = format!(
+        "{}{}",
+        USERS_RESULT,
+        "package main;
+my $rs = $schema->resultset('Schema::Result::Users');
+my $row = $rs->find(1);
+my $x = $row->{not_a_column};
+my $plain = { adhoc => 1 };
+my $y = $plain->{adhoc};
+"
+    );
+    let (fa, _tree) = parse_with_tree(&src);
+    let bad = point_at(&src, "not_a_column}");
+    assert!(
+        fa.find_definition(bad, None).is_none(),
+        "non-column key stays unresolved",
+    );
+    // The plain hashref's key still resolves through its own literal
+    // (Variable/Sub-owned path untouched by the upgrade).
+    let adhoc = point_at(&src, "adhoc};");
+    let r = fa.ref_at(adhoc).expect("adhoc key ref");
+    assert!(
+        !matches!(
+            r.kind,
+            crate::file_analysis::RefKind::HashKeyAccess {
+                owner: Some(crate::file_analysis::HashKeyOwner::Class(_)),
+                ..
+            }
+        ),
+        "untyped hashref deref not promoted to a class owner: {:?}",
+        r.kind,
+    );
+}

--- a/src/return_expr_tests.rs
+++ b/src/return_expr_tests.rs
@@ -257,11 +257,10 @@ my $sentinel;
     let fa = parse(src);
     let pt = point_at(src, "my $sentinel");
     let ty = fa.inferred_type_via_bag("$r", pt);
-    assert_eq!(
-        ty,
-        Some(InferredType::ArrayRef),
+    assert!(
+        ty.is_some_and(|t| t.is_array_shaped()),
         "dynamic-method call must chase $cb's CodeRef return_edge — \
          the closure returns an arrayref regardless of receiver, so \
-         the chase resolves through the Symbol's stored return"
+         the chase resolves through the Symbol's stored return",
     );
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -196,30 +196,40 @@ pub fn find_definition(
         }));
     }
 
-    // Deferred constructor-key (`owner: None`): the class lives in another
-    // file, so the build-time gate couldn't pin the owner. Derive it now
-    // (enclosing call's invocant class, index in hand) and jump to the def
-    // the class file carries — `field $x :param` / Moo `has x` synthesize
-    // the HashKeyDef there.
+    // Cross-file hash-key defs. Two shapes share the lookup:
+    //   * deferred ctor key (`owner: None`) — the build-time gate
+    //     couldn't see the class; derive the owner now (enclosing call's
+    //     invocant class, index in hand);
+    //   * resolved Class owner (`$row->{name}` upgraded post-fold to
+    //     `Class(NestedRow)`) whose class — and therefore its
+    //     `add_columns` / `has` / `:param` HashKeyDef — lives elsewhere.
+    // Either way: the class's cached analysis carries the def.
     if let Some(r) = analysis.ref_at(point) {
-        if matches!(r.kind, RefKind::HashKeyAccess { owner: None, .. }) {
-            if let Some(owner) = analysis.deferred_hash_key_owner(r, Some(module_index)) {
-                if let crate::file_analysis::HashKeyOwner::Sub { package: Some(ref class), .. } =
-                    owner
-                {
-                    if let Some(cached) = module_index.get_cached(class) {
-                        if let Some(def) = cached
-                            .analysis
-                            .hash_key_defs_for_owner(&owner)
-                            .into_iter()
-                            .find(|d| d.name == r.target_name)
-                        {
-                            if let Ok(module_uri) = Url::from_file_path(&cached.path) {
-                                return Some(GotoDefinitionResponse::Scalar(Location {
-                                    uri: module_uri,
-                                    range: span_to_range(def.selection_span),
-                                }));
-                            }
+        if let RefKind::HashKeyAccess { ref owner, .. } = r.kind {
+            let owner = match owner {
+                Some(o) => Some(o.clone()),
+                None => analysis.deferred_hash_key_owner(r, Some(module_index)),
+            };
+            let class = match &owner {
+                Some(crate::file_analysis::HashKeyOwner::Sub { package: Some(c), .. }) => {
+                    Some(c.clone())
+                }
+                Some(crate::file_analysis::HashKeyOwner::Class(c)) => Some(c.clone()),
+                _ => None,
+            };
+            if let (Some(owner), Some(class)) = (owner, class) {
+                if let Some(cached) = module_index.get_cached(&class) {
+                    if let Some(def) = cached
+                        .analysis
+                        .hash_key_defs_for_owner(&owner)
+                        .into_iter()
+                        .find(|d| d.name == r.target_name)
+                    {
+                        if let Ok(module_uri) = Url::from_file_path(&cached.path) {
+                            return Some(GotoDefinitionResponse::Scalar(Location {
+                                uri: module_uri,
+                                range: span_to_range(def.selection_span),
+                            }));
                         }
                     }
                 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2762,10 +2762,9 @@ pub fn collect_diagnostics(
     // key) and doesn't define the key. Writes are skipped — assigning a
     // new key extends the shape, it isn't a typo. Open shapes are
     // skipped — the spread may carry the key. The whole-story gate
-    // skips vars that were mutated, reassigned, or escaped (the
-    // trust-gate stand-in for the unmodeled lattice widenings —
-    // docs/prompt-nested-hashkey.md). HINT severity, per the
-    // quiet-by-design diagnostics convention.
+    // skips reassigned/escaped vars (the trust-gate stand-in for the
+    // unmodeled lattice widenings — docs/adr/structural-shapes.md).
+    // HINT severity, per the quiet-by-design diagnostics convention.
     use crate::file_analysis::InferredType;
     for r in &analysis.refs {
         let RefKind::HashKeyAccess { ref var_text, .. } = r.kind else { continue };

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2757,6 +2757,54 @@ pub fn collect_diagnostics(
         }
     }
 
+    // Closed-shape hash-key typo: a READ of `$config->{typo}` where
+    // `$config`'s structural literal is CLOSED (no spread, no dynamic
+    // key) and doesn't define the key. Writes are skipped — assigning a
+    // new key extends the shape, it isn't a typo. Open shapes are
+    // skipped — the spread may carry the key. The whole-story gate
+    // skips vars that were mutated, reassigned, or escaped (the
+    // trust-gate stand-in for the unmodeled lattice widenings —
+    // docs/prompt-nested-hashkey.md). HINT severity, per the
+    // quiet-by-design diagnostics convention.
+    use crate::file_analysis::InferredType;
+    for r in &analysis.refs {
+        let RefKind::HashKeyAccess { ref var_text, .. } = r.kind else { continue };
+        if !var_text.starts_with('$') {
+            continue;
+        }
+        if matches!(r.access, crate::file_analysis::AccessKind::Write) {
+            continue;
+        }
+        let Some(t) =
+            analysis.inferred_type_via_bag_ctx(var_text, r.span.start, Some(module_index))
+        else {
+            continue;
+        };
+        let InferredType::HashWithKeys { ref keys, open: false } = t else { continue };
+        if keys.iter().any(|(k, _)| k == &r.target_name) {
+            continue;
+        }
+        if !analysis.closed_shape_is_whole_story(var_text) {
+            continue;
+        }
+        let mut known: Vec<&str> = keys.iter().map(|(k, _)| k.as_str()).take(5).collect();
+        if keys.len() > 5 {
+            known.push("...");
+        }
+        diagnostics.push(Diagnostic {
+            range: span_to_range(r.span),
+            severity: Some(DiagnosticSeverity::HINT),
+            code: Some(NumberOrString::String("unknown-hash-key".into())),
+            message: format!(
+                "key '{}' is not in {}'s literal shape (keys: {})",
+                r.target_name,
+                var_text,
+                known.join(", "),
+            ),
+            ..Default::default()
+        });
+    }
+
     diagnostics
 }
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2769,7 +2769,10 @@ pub fn collect_diagnostics(
     use crate::file_analysis::InferredType;
     for r in &analysis.refs {
         let RefKind::HashKeyAccess { ref var_text, .. } = r.kind else { continue };
-        if !var_text.starts_with('$') {
+        // `$config->{k}` (scalar holding a hashref) and `$config{k}`
+        // (literal `%config`, canonical var_text) — same model, both
+        // spellings.
+        if !(var_text.starts_with('$') || var_text.starts_with('%')) {
             continue;
         }
         if matches!(r.access, crate::file_analysis::AccessKind::Write) {

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4335,3 +4335,45 @@ class Point {
     );
     assert_eq!(loc.range.start.line, 2, "lands on the field decl line");
 }
+
+/// Closed-shape hash-key typo diagnostic: a READ of a key the closed
+/// literal doesn't define is hinted. Silent when the whole-story gate
+/// fails — a key write extends the shape, a reassignment replaces it,
+/// an escape (call arg / alias / invocant / sigil deref) hands the
+/// reference to code that may mutate it — and for open shapes and
+/// known keys.
+#[test]
+fn test_closed_shape_unknown_key_diagnostic() {
+    let src = "\
+my $config = { host => 'x', port => 1 };
+my $bad = $config->{typo};
+my $ok = $config->{host};
+my $mut = { host => 'x' };
+$mut->{added} = 1;
+my $r1 = $mut->{other};
+my $esc = { host => 'x' };
+process($esc);
+my $r2 = $esc->{anything};
+my $re = { host => 'x' };
+$re = fetch_config() if $ENV{X};
+my $r3 = $re->{whatever};
+my $base = { a => 1 };
+my $open = { %$base, extra => 1 };
+my $maybe = $open->{whatever};
+";
+    let analysis = parse_analysis(src);
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let diags = collect_diagnostics(
+        &analysis,
+        &idx,
+        DiagnosticOptions { unresolved_dispatch: false },
+    );
+    let keys: Vec<&str> = diags
+        .iter()
+        .filter(|d| matches!(&d.code, Some(NumberOrString::String(c)) if c == "unknown-hash-key"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(keys.len(), 1, "exactly the typo is hinted: {:?}", keys);
+    assert!(keys[0].contains("'typo'"), "{:?}", keys);
+    assert!(keys[0].contains("host"), "message names the known keys: {:?}", keys);
+}

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4337,20 +4337,24 @@ class Point {
 }
 
 /// Closed-shape hash-key typo diagnostic: a READ of a key the closed
-/// literal doesn't define is hinted. Silent when the whole-story gate
-/// fails — a key write extends the shape, a reassignment replaces it,
-/// an escape (call arg / alias / invocant / sigil deref) hands the
-/// reference to code that may mutate it — and for open shapes and
-/// known keys.
+/// literal doesn't define is hinted. An unconditional write EXTENDS
+/// the shape (the written key reads silently; other unknowns still
+/// hint); a conditional write opens it. Silent when the whole-story
+/// gate fails — reassignment, escape (call arg / alias / invocant /
+/// sigil deref) — and for open shapes and known keys.
 #[test]
 fn test_closed_shape_unknown_key_diagnostic() {
     let src = "\
 my $config = { host => 'x', port => 1 };
 my $bad = $config->{typo};
 my $ok = $config->{host};
-my $mut = { host => 'x' };
-$mut->{added} = 1;
-my $r1 = $mut->{other};
+my $mutv = { host => 'x' };
+$mutv->{added} = 1;
+my $r0 = $mutv->{added};
+my $r1 = $mutv->{other};
+my $cond = { host => 'x' };
+$cond->{maybe} = 1 if $ENV{X};
+my $rc = $cond->{anything};
 my $esc = { host => 'x' };
 process($esc);
 my $r2 = $esc->{anything};
@@ -4373,7 +4377,13 @@ my $maybe = $open->{whatever};
         .filter(|d| matches!(&d.code, Some(NumberOrString::String(c)) if c == "unknown-hash-key"))
         .map(|d| d.message.as_str())
         .collect();
-    assert_eq!(keys.len(), 1, "exactly the typo is hinted: {:?}", keys);
+    assert_eq!(keys.len(), 2, "the typo and the post-extension unknown: {:?}", keys);
     assert!(keys[0].contains("'typo'"), "{:?}", keys);
     assert!(keys[0].contains("host"), "message names the known keys: {:?}", keys);
+    assert!(keys[1].contains("'other'"), "{:?}", keys);
+    assert!(
+        keys[1].contains("added"),
+        "extended shape names the written key: {:?}",
+        keys,
+    );
 }

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4387,3 +4387,34 @@ my $maybe = $open->{whatever};
         keys,
     );
 }
+
+/// The literal-hash spelling gets the same diagnostic: container-form
+/// reads (`$h{k}`) check against `%h`'s shape. A bare `func(%h)` pass
+/// flattens to copies — the callee can't add keys — so it does NOT
+/// suppress; `\%h` ref-taking does.
+#[test]
+fn test_literal_hash_unknown_key_diagnostic() {
+    let src = "\
+my %config = (host => 'x');
+my $bad = $config{typo};
+func(%config);
+my %taken = (host => 'x');
+my $r = \\%taken;
+my $silent = $taken{anything};
+";
+    let analysis = parse_analysis(src);
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let diags = collect_diagnostics(
+        &analysis,
+        &idx,
+        DiagnosticOptions { unresolved_dispatch: false },
+    );
+    let keys: Vec<&str> = diags
+        .iter()
+        .filter(|d| matches!(&d.code, Some(NumberOrString::String(c)) if c == "unknown-hash-key"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(keys.len(), 1, "only the %config typo: {:?}", keys);
+    assert!(keys[0].contains("'typo'"), "{:?}", keys);
+    assert!(keys[0].contains("%config"), "names the hash variable: {:?}", keys);
+}

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -645,7 +645,18 @@ impl WitnessReducer for FrameworkAwareTypeFold {
                         first_param_class = Some(package.clone())
                     }
                     b @ InferredType::BrandedRoute { .. } => branded = Some(b.clone()),
-                    other => plain_type = Some(other.clone()),
+                    // Latest wins UNLESS the standing answer subsumes the
+                    // newcomer — structure dominates rep (`HashWithKeys` is
+                    // not downgraded by a deref's re-derived `HashRef`),
+                    // mirroring the class-dominates-rep rule below.
+                    other => {
+                        if !plain_type
+                            .as_ref()
+                            .is_some_and(|have| have.subsumes_narrowing(other))
+                        {
+                            plain_type = Some(other.clone());
+                        }
+                    }
                 },
                 WitnessPayload::Observation(obs) => match obs {
                     TypeObservation::ClassAssertion(name) => {

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -1958,6 +1958,111 @@ pub fn query_variable_type(
     reg.query_variable_with_visited(bag, ctx, var, scope, point, &mut state)
 }
 
+/// Fold `KeyWrite`s into variable shape witnesses — the mutation-
+/// extension pass. For each write on a variable whose shape at the
+/// write point is `HashWithKeys`:
+///
+/// - unconditional static-key write → push the EXTENDED shape (key
+///   joins the list, value typed from the RHS expression, `open`
+///   preserved). A write to an already-known key retypes its value.
+/// - dynamic key, syntactically conditional write, or a write whose
+///   scope chain crosses a boundary before reaching the attachment
+///   scope (nested block / closure — execution unknowable) → push the
+///   same keys with `open: true`.
+///
+/// Witnesses attach to the scope the variable's existing witnesses
+/// live on (so the read-side scope walk finds them) with a zero-width
+/// span at the write position — the same temporal contract as TC
+/// mirrors: invisible to reads before the write, latest-wins after
+/// (`HashWithKeys` subsumption is equality-only, so a different shape
+/// legitimately replaces the standing one).
+///
+/// Re-emittable: fold callers pass `clear = true` (clear-and-emit per
+/// iteration, tag `mutation_extension`). Enrichment passes `false` —
+/// post-finalize the bag is append-only (removal would shift the
+/// sealed `base_witness_count`); duplicate pushes are idempotent under
+/// latest-wins and truncated away by the next enrichment cycle.
+pub(crate) fn emit_mutation_extension_witnesses(
+    bag: &mut WitnessBag,
+    ctx: &BagContext,
+    key_writes: &[crate::file_analysis::KeyWrite],
+    clear: bool,
+) {
+    if clear {
+        bag.remove_by_source_tag("mutation_extension");
+    }
+    // Per-var doc order so later writes see earlier extensions.
+    let mut writes: Vec<&crate::file_analysis::KeyWrite> = key_writes.iter().collect();
+    writes.sort_by_key(|w| (&w.var_text, w.span.start));
+    for w in writes {
+        // Attach where the variable's existing witnesses live; note
+        // whether getting there crosses a scope boundary (nested block
+        // or closure — the write may not have executed by read time).
+        let mut attach: Option<(ScopeId, bool)> = None;
+        let mut cur = Some(w.scope);
+        let mut crossed = false;
+        while let Some(sid) = cur {
+            let att = WitnessAttachment::Variable { name: w.var_text.clone(), scope: sid };
+            if !bag.for_attachment(&att).is_empty() {
+                attach = Some((sid, crossed));
+                break;
+            }
+            crossed = true;
+            cur = ctx.scopes[sid.0 as usize].parent;
+        }
+        let Some((attach_sid, scope_crossed)) = attach else { continue };
+        let Some(InferredType::HashWithKeys { mut keys, open }) =
+            query_variable_type(bag, ctx, &w.var_text, w.scope, w.span.start)
+        else {
+            continue;
+        };
+        let widen = w.key.is_none() || w.conditional || scope_crossed;
+        let shape = if widen {
+            if open {
+                continue; // already open — nothing to add
+            }
+            InferredType::HashWithKeys { keys, open: true }
+        } else {
+            let k = w.key.as_deref().unwrap();
+            let vtype = w.rhs_span.and_then(|s| {
+                let reg = ReducerRegistry::with_defaults();
+                let att = WitnessAttachment::Expr(s);
+                let q = ReducerQuery {
+                    attachment: &att,
+                    point: None,
+                    framework: FrameworkFact::Plain,
+                    arity_hint: None,
+                    receiver: None,
+                    context: Some(ctx),
+                };
+                match reg.query(bag, &q) {
+                    ReducedValue::Type(t) => Some(t),
+                    _ => None,
+                }
+            });
+            match keys.iter_mut().find(|(name, _)| name == k) {
+                Some(entry) => {
+                    if vtype.is_none() || entry.1.as_deref() == vtype.as_ref() {
+                        continue; // no new information
+                    }
+                    entry.1 = vtype.map(Box::new);
+                }
+                None => keys.push((k.to_string(), vtype.map(Box::new))),
+            }
+            InferredType::HashWithKeys { keys, open }
+        };
+        bag.push(Witness {
+            attachment: WitnessAttachment::Variable {
+                name: w.var_text.clone(),
+                scope: attach_sid,
+            },
+            source: WitnessSource::Builder("mutation_extension".into()),
+            payload: WitnessPayload::InferredType(shape),
+            span: Span { start: w.span.start, end: w.span.start },
+        });
+    }
+}
+
 // ---------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -189,6 +189,24 @@ pub enum WitnessPayload {
     Derivation,
     /// Escape hatch for plugin-defined payloads that don't fit above.
     Custom { family: String, json: String },
+    /// Edge fact with a projection: "the value at my attachment is the
+    /// `step`-projection of whatever resolves at `base`." Emitted for
+    /// `expr->{key}` / `expr->[N]` expressions so the drill participates
+    /// in the edge graph — the chase materializes `base` at QUERY time
+    /// (when cross-file knowledge like an imported literal's
+    /// `HashWithKeys` is in hand) and narrows through the step. Kept at
+    /// the END for bincode variant-index stability (bump
+    /// `EXTRACT_VERSION`).
+    Projected {
+        base: WitnessAttachment,
+        step: ProjectionStep,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ProjectionStep {
+    HashKey(String),
+    ArrayIndex(i32),
 }
 
 /// A sub's return type as a **deferred computation**, not a value:
@@ -1686,6 +1704,36 @@ impl ReducerRegistry {
                             payload: WitnessPayload::InferredType(t.clone()),
                             span: w.span,
                         });
+                    }
+                }
+                WitnessPayload::Projected { base, step } => {
+                    // Materialize the base, then narrow through the step —
+                    // the value-side mirror of the build-time
+                    // `invocant_type_at_node` drill, run where the index is
+                    // in hand so imported structural types project too.
+                    let sub_q = ReducerQuery {
+                        attachment: base,
+                        point: q.point,
+                        framework: q.framework,
+                        arity_hint: None,
+                        receiver: q.receiver.clone(),
+                        context: q.context,
+                    };
+                    if let ReducedValue::Type(t) = &*self.query_rec(bag, &sub_q, state) {
+                        let projected = match step {
+                            ProjectionStep::HashKey(k) => {
+                                t.key_value_type(k).flatten().cloned()
+                            }
+                            ProjectionStep::ArrayIndex(i) => t.element_at(*i).cloned(),
+                        };
+                        if let Some(t) = projected {
+                            out.push(Witness {
+                                attachment: w.attachment.clone(),
+                                source: w.source.clone(),
+                                payload: WitnessPayload::InferredType(t),
+                                span: w.span,
+                            });
+                        }
                     }
                 }
                 WitnessPayload::QualifiedCallReturn { method_lookup, receiver_class, arity } => {

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -1711,15 +1711,32 @@ impl ReducerRegistry {
                     // the value-side mirror of the build-time
                     // `invocant_type_at_node` drill, run where the index is
                     // in hand so imported structural types project too.
-                    let sub_q = ReducerQuery {
-                        attachment: base,
-                        point: q.point,
-                        framework: q.framework,
-                        arity_hint: None,
-                        receiver: q.receiver.clone(),
-                        context: q.context,
+                    // A Variable base scope-walks like the Edge arm above
+                    // (`$h{k}` projects off `%h`, whose witnesses live on
+                    // the decl scope, not the access scope).
+                    let base_t = match (base, q.context) {
+                        (WitnessAttachment::Variable { name, scope }, Some(ctx)) => {
+                            let point = scope_point(ctx.scopes, *scope);
+                            self.query_variable_with_visited(
+                                bag, ctx, name, *scope, point, state,
+                            )
+                        }
+                        _ => {
+                            let sub_q = ReducerQuery {
+                                attachment: base,
+                                point: q.point,
+                                framework: q.framework,
+                                arity_hint: None,
+                                receiver: q.receiver.clone(),
+                                context: q.context,
+                            };
+                            match &*self.query_rec(bag, &sub_q, state) {
+                                ReducedValue::Type(t) => Some(t.clone()),
+                                _ => None,
+                            }
+                        }
                     };
-                    if let ReducedValue::Type(t) = &*self.query_rec(bag, &sub_q, state) {
+                    if let Some(t) = base_t {
                         let projected = match step {
                             ProjectionStep::HashKey(k) => {
                                 t.key_value_type(k).flatten().cloned()

--- a/test_e2e_cross_file.lua
+++ b/test_e2e_cross_file.lua
@@ -69,9 +69,9 @@ t.test("hover: $cfg shows HashRef from imported get_config", function()
     "$cfg = get_config()", 0, "HashRef")
 end)
 
-t.test("hover: $items shows ArrayRef from imported make_items", function()
-  hover_has("hover: $items shows ArrayRef from imported make_items",
-    "$items = make_items()", 0, "ArrayRef")
+t.test("hover: $items shows the imported tuple type from make_items", function()
+  hover_has("hover: $items shows the imported tuple type from make_items",
+    "$items = make_items()", 0, "Sequence<")
 end)
 
 -- ── 2. Inlay hints show imported return types ────────────────────────
@@ -80,8 +80,8 @@ t.test("inlay hint: $cfg shows HashRef", function()
   hint_has("inlay hint: $cfg shows HashRef", "my %$cfg = get_config", "HashRef")
 end)
 
-t.test("inlay hint: $items shows ArrayRef", function()
-  hint_has("inlay hint: $items shows ArrayRef", "my %$items = make_items", "ArrayRef")
+t.test("inlay hint: $items shows the tuple type", function()
+  hint_has("inlay hint: $items shows the tuple type", "my %$items = make_items", "Sequence<")
 end)
 
 -- ── 3. Hash key completion from imported module ──────────────────────


### PR DESCRIPTION
Implements all three tiers of `docs/prompt-nested-hashkey.md`, plus drill-hop cross-file resolution, the closed-shape typo diagnostic with modeled mutation effects, the literal-`%hash` spelling, and the gold-corpus cost-tracking harness extension.

## Nested hash-key intelligence

- **Tier 1**: `$row->{name}` on a typed row resolves to the column def — a post-fold owner-upgrade pass promotes Variable-owned derefs once the variable's class settles. Untyped variables keep their lexical grouping.
- **Tier 2**: `InferredType::HashWithKeys` — hash literals carry per-key value types with an `open` flag for spreads. `->{key}` narrows through assignment hops, double-drills, and sub-return literals. Lattice rules: all-hash-shaped return arms unify coarse, and **structure dominates rep** (`subsumes_narrowing` + the plain-type fold honor informativeness).
- **Tier 3**: array literals type as per-index `Sequence` tuples; `->[N]` projects, and the mixed drill `$obj->{users}->[0]->{name}` chains end-to-end. Hover shows `Sequence<…>`, visible cross-file through imports.
- **Drill hops resolve cross-file**: `WitnessPayload::Projected { base, step }` — drill expressions emit an edge-with-projection witness; the registry materializes the base at query time and narrows by the step. Both xfail rows XPASSed on landing and were promoted to gold.
- Cross-file goto-def for Class-owned hash keys whose class lives elsewhere.

## Closed-shape unknown-key diagnostic + modeled mutation

A READ of `$config->{typo}` where the literal shape is CLOSED and lacks the key gets a HINT naming the known keys. Mutation effects are **modeled on the type** (the route-branding lesson), not gated away:

- An unconditional `$v->{k} = …` write EXTENDS the closed shape — the key joins it, its value typed from the RHS, so the read drills back typed and the typo beside it still hints.
- A dynamic key, a conditional write (if/postfix/ternary/loop/short-circuit), a scope-crossing write (block/closure), or any slice write switches the shape **open**.
- The whole-story trust gate shrinks to escape + reassignment (`escaped_scalars` / `reassigned_scalars`, builder-recorded).

## Literal `%hash` spelling — same model, every slice form

`my %h = (k => v)` types through the **same** `hash_literal_type` builder (array spreads like `@_` open the shape — the args-with-defaults idiom). Container-form reads (`$h{k}`) key everything by the canonical `%h`. Hash gates are sharper than scalar ones: bare `func(%h)` flattens to copies — not an escape; only `\%h` ref-taking is. All six slice spellings record open-switching writes: `@h{…}`/`%h{k}`, `@$h{…}`/`%$h{k}`, `$h->@{…}`/`$h->%{…}`; slice READS are value copies and don't suppress.

Calibrated against the full 2,293-module substrate at every step: **zero hints outside the deliberate fixture typos** (the 23 pre-gate false positives all fall to modeled shapes or the two gate clauses).

## Gold-corpus cost report + harness fix

Per-capability timing table (n/total/mean/max wall ms), per-root startup latency, child CPU, peak RSS on every suite run; `METRICS_OUT=<file>` writes JSON; `--emit --root <dir>` for per-row-root authoring. Also fixes a latent harness hole: `normalize()` ran `decode_json` on an already-decoded character string, so any non-ASCII response character dropped the row to the raw-text fallback where `none` assertions vacuously pass — five diagnostics xfail rows briefly "XPASSed" exactly this way.

New committed `nested-fixture/` workspace: 11 gold rows (mixed-drill type-at, imported-tuple + drill-hop hover, row-key definition + references, typo hints in both spellings, mutation-extension + literal-hash value type-at) and 1 xfail row pinning the batch-diagnostics enrichment-parity gap (KNOWN-GAPS.md).

**Verification:** 904 unit / 108 e2e / gold **177 PASS, 13 xfail, 0 FAIL, 0 XPASS, 0 CRASH**. EXTRACT_VERSION 73→80 across the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
