### PR TITLE
Bare-statement drills get their Projected witness

### DIFF
--- a/gold-corpus/fixtures/nested-diagnostics.json
+++ b/gold-corpus/fixtures/nested-diagnostics.json
@@ -106,6 +106,25 @@
       },
       "status": "gold",
       "note": "Call-base drill (local_cfg()->{retrys}) hints off the producer's closed return shape via the Projected witness; no variable in hand."
+    },
+    {
+      "id": "nested-bare-statement-drill-typo",
+      "difficulty": "simple",
+      "semantic_area": "structural-shapes",
+      "root": "gold-corpus/nested-fixture",
+      "file": "main.pl",
+      "line": 48,
+      "col": 13,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "key 'tiemout' is not in this expression's literal shape"
+        ],
+        "none": []
+      },
+      "status": "gold",
+      "note": "Bare-statement drill (local_cfg()->{tiemout};) \u2014 read elements get their Projected witness in visit_hash_element, not only under an assignment emitter."
     }
   ]
 }

--- a/gold-corpus/nested-fixture/main.pl
+++ b/gold-corpus/nested-fixture/main.pl
@@ -46,5 +46,6 @@ my $pt = $plain{retrys};
 # Expression-base spelling: the drill's own witness carries the pair.
 sub local_cfg { return { retries => 3, timeout => 10 } }
 my $et = local_cfg()->{retrys};
+local_cfg()->{tiemout};
 
 print "$host $port $first $uname $uid $n\n";

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6590,6 +6590,18 @@ impl<'a> Builder<'a> {
             });
             return;
         }
+        // Idempotent per span: the walk reaches many expressions twice
+        // (child visit first, then the enclosing assignment/invocant
+        // emitter). One "expression"-source witness per Expr(span) is
+        // the contract; identical duplicates only bloat the bag.
+        let already = self
+            .bag
+            .for_attachment(&WitnessAttachment::Expr(span))
+            .iter()
+            .any(|w| matches!(&w.source, WitnessSource::Builder(t) if t == "expression"));
+        if already {
+            return;
+        }
         if let Some(payload) = self.expr_payload(node) {
             self.bag.push(Witness {
                 attachment: WitnessAttachment::Expr(span),
@@ -10516,6 +10528,16 @@ impl<'a> Builder<'a> {
         // the LHS of an assignment, so the grandparent check returns
         // Write. Needed for invocant mutations.
         let element_access = self.determine_access(node);
+
+        // READ drills get their Projected witness here, not only when
+        // an enclosing assignment/invocant emitter happens to reach
+        // them — a bare-statement `cfg()->{k};` is still a drill the
+        // expression-base diagnostic must see. Writes stay
+        // witness-less: a write extends the producer's shape, it isn't
+        // a typo to hint on.
+        if element_access != AccessKind::Write {
+            self.emit_expr_witness(node);
+        }
 
         // A method-call container (`$obj->get_config->{host}`) has no
         // variable identity to anchor the key on — its owner is the

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 83;
+pub const EXTRACT_VERSION: i64 = 84;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4441,6 +4441,7 @@ fn test_expression_base_unknown_key_diagnostic() {
 sub cfg { return { host => 'x', port => 1 } }
 my $ok = cfg()->{host};
 my $bad = cfg()->{hsot};
+cfg()->{hsot2};
 ";
     let analysis = parse_analysis(src);
     let idx = crate::module_index::ModuleIndex::new_for_test();
@@ -4454,11 +4455,21 @@ my $bad = cfg()->{hsot};
         .filter(|d| matches!(&d.code, Some(NumberOrString::String(c)) if c == "unknown-hash-key"))
         .map(|d| d.message.as_str())
         .collect();
-    assert_eq!(keys.len(), 1, "only the call-base typo: {:?}", keys);
+    assert_eq!(
+        keys.len(),
+        2,
+        "assignment-position and bare-statement call-base typos: {:?}",
+        keys,
+    );
     assert!(keys[0].contains("'hsot'"), "{:?}", keys);
     assert!(
         keys[0].contains("this expression's"),
         "expression-base message form: {:?}",
+        keys,
+    );
+    assert!(
+        keys[1].contains("'hsot2'"),
+        "bare-statement drill is witnessed too: {:?}",
         keys,
     );
 }

--- a/test_e2e.lua
+++ b/test_e2e.lua
@@ -356,7 +356,31 @@ end)
 
 -- ── diagnostics ──────────────────────────────────────────────────────
 
-lsp.assert_no_diagnostics(t, buf)
+-- The deliberate shape typos in sample.pl ($sner->{pot} + the two
+-- call-base ->{prot} drills, bare-statement included): pinned
+-- positively here, then allowed through the no-unexpected sweep.
+t.test("unknown-hash-key hints on the deliberate typos", function()
+  local N = "unknown-hash-key hints on the deliberate typos"
+  local found = 0
+  for _ = 1, 20 do
+    found = 0
+    for _, d in ipairs(vim.diagnostic.get(buf)) do
+      if d.message:find("literal shape", 1, true) then found = found + 1 end
+    end
+    if found >= 3 then break end
+    vim.wait(250)
+  end
+  if found == 3 then
+    t.pass(N)
+  else
+    t.fail(N, "expected 3 unknown-hash-key hints, saw " .. found)
+  end
+end)
+
+lsp.assert_no_diagnostics(t, buf, {
+  "key 'pot' is not in $sner's literal shape",
+  "key 'prot' is not in this expression's literal shape",
+})
 
 -- ── done ─────────────────────────────────────────────────────────────
 

--- a/test_files/sample.pl
+++ b/test_files/sample.pl
@@ -53,6 +53,11 @@ sub get_self {
     return $self;
 }
 
+my $sner = get_config();
+get_config()->{prot};
+get_config->{prot};
+$sner->{pot};
+
 package main;
 
 my $calc = Calculator->new(verbose => 1);


### PR DESCRIPTION
`cfg()->{kye};` as a bare statement never passed through an assignment/invocant emitter, so no `Projected` witness existed — the expression-base diagnostic was blind to exactly the spelling you'd write while probing. Found by veesh in sample.pl: the variable form hinted, both call-base forms didn't.

- `visit_hash_element` emits the expr witness for READ elements directly (statement position included); writes stay witness-less — the chained-write guard holds.
- `emit_expr_witness` gains an idempotence guard (one `expression`-source witness per `Expr(span)`), which also stops the pre-existing child-then-wrapper double emission from bloating the bag.
- sample.pl's probe lines are now permanent fixture content with pinned e2e coverage (3 hints asserted positively, then allowed through the no-unexpected sweep); gold gains the bare-statement row.

**Verification:** 910 unit / 109 e2e (+1) / gold **180 PASS** (+1), 12 xfail, 0 FAIL/XPASS/CRASH; substrate still **zero unknown-hash-key** with every statement-position read drill across 2,293 modules now witnessed. EXTRACT 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)