### PR TITLE
crm QA sweep: roles, barewords, and the Mojo quartet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ hangs).
   type — drills narrow per key, mutation extends or opens the shape, and the
   `unknown-hash-key` hint catches key typos at **zero false positives** across
   the 2,293-module substrate.
+- **Role contracts.** `requires` declares what a role demands: calls on those
+  methods resolve inside the role, and a method a role uses WITHOUT declaring
+  it gets a hint — surfacing years-old undeclared contracts in real codebases.
 - **Bundled plugins + a plugin system.** Ships plugins for Catalyst, Dancer2,
   Mojolicious (helpers, events, Minion tasks), and DBIx::Class ResultDDL; you can
   drop your own `.rhai` plugins in a repo-local `.perl-lsp/`, or generate one from
@@ -52,6 +55,20 @@ hangs).
 - Refs reach into more places: chained hash-ref keys at any depth, `use constant`
   usages, `s///e` replacement code, forward-reference calls (call above its sub),
   and sigil-deref spellings.
+- **Roles connect both ways**: references from a role method find every
+  composing class's call sites, and map-built role lists
+  (`with map "My::Roles::$_", qw/CSV DB/`) fold statically — goto-def lands on
+  each role from its own qw word.
+- **Barewords naming an in-scope sub are calls** (Perl's own reading): hover,
+  goto-def, references, rename, and semantic tokens all work on
+  `my $x = get_config;` and the `get_config->{host}` base — and `sub INFINITY ()`
+  prototype constants link their usages.
+- Interpolated code is code: `${\ $self->filetype }` inside a string OR a
+  regex pattern carries real refs — rename and references reach into
+  `s/_to_${\ $self->filetype }$//`.
+- **Mojolicious plugin names** goto-def: `plugin 'Thing'` lands on the plugin
+  class's `register`, whatever namespace it lives in (`Mojolicious::Plugin::*`
+  and app-specific trees both work).
 
 ### Field & attribute projection groups
 
@@ -84,6 +101,24 @@ hangs).
 - `$self` / `$c` controller typing for Mojolicious and Catalyst actions.
 - Parameters declared as `my ($self, $name) = (shift, shift)` are recognized for
   signature help
+- **Framework-assigned Mojo attrs type**: `$c->app`, `$c->tx`, `$c->ua`,
+  `$c->req`/`res` (and the `$tx->req`/`res` delegations) chain without an
+  indexed Mojo tree, and a plugin's `register($self, $app, $conf)` knows
+  `$app` is the application.
+
+### Mojolicious routing & helpers
+
+- **Lite apps inherit route targets**: `under('/notifications')->to('notifications#under')`
+  sets the controller the following `get(...)->to('#action')` partials use,
+  `group { }` scopes it — goto-def works on nested route groups, and the
+  base restores after the group.
+- **Default helpers are discovered from source** — no hardcoded list:
+  DefaultHelpers/TagHelpers' own registration loops
+  (`$app->helper($_ => …) for qw(...)`) expand, so all ~50 built-in helpers
+  resolve, including dotted chains (`$c->proxy->get_p`). Framework-loaded
+  plugins resolve unconditionally; `plugin 'X'` pulls X in — "you loaded it".
+- Helpers registered the lite way (`helper name => sub {…}`, no `$app->`)
+  resolve like the method spelling.
 
 ### Structural hash & array shapes
 
@@ -160,6 +195,9 @@ hangs).
   severity, since dynamic Perl (AUTOLOAD, runtime glob installs, uninstalled
   deps) is common and shouldn't flood the Problems panel. This is frequently
   solvable by using a custom plugin.
+- **Role-contract hints**: a role calling `$self->fetch_raw` without
+  `requires 'fetch_raw'` keeps its hint — the diagnostic teaches the contract
+  the role should declare (declared requirements resolve silently).
 
 ### Editors & CLI
 
@@ -168,6 +206,10 @@ hangs).
 - New CLI query modes for scripting/CI: `--batch` (one startup, many queries on
   stdin), plus `--completion`, `--signature-help`, `--semantic-tokens`,
   `--document-highlight`, `--linked-editing`, and `--timings`.
+- **One-shot CLI sessions resolve @INC modules themselves** (headless
+  resolver: same scan, project-local libs, and SQLite cache as the editor) —
+  CLI answers match the editor instead of depending on what an editor session
+  happened to cache. Workspace-symbol search no longer lists anonymous subs.
 
 ### Under the hood
 

--- a/docs/prompt-helper-consumption.md
+++ b/docs/prompt-helper-consumption.md
@@ -1,0 +1,43 @@
+# Helper consumption — scoping & the phase ladder
+
+**Phase 1 LANDED** (crm-qa-sweep): dependency-registered helpers
+resolve end-to-end. The gap was a four-layer onion, each layer hiding
+the next: (1) the warm-start rebuild fed only the reverse index, never
+`bridges_index` — helpers worked on the cold run that resolved them
+and vanished every warm session after (B6 class); (2) the resolver
+thread never received `bridges_index` at all; (3) nothing literally
+`use`s DefaultHelpers — the framework loads it at runtime — so the
+import-driven resolver never pulled it in: `use Mojolicious::Lite` now
+SyntheticUses DefaultHelpers + TagHelpers, and `plugin 'X'`
+SyntheticUses the default-namespace module; (4) `new_for_cli` spawned
+NO resolver — CLI sessions could only read what editor sessions had
+cached. The headless resolver now serves CLI sessions, and `run_one`
+resolves the query file's imports under a 5s global budget (each
+resolved module persists, so one-shot runs converge to warm).
+
+## Scoping decision (veesh, June 2026)
+
+- **Framework-loaded plugins** (DefaultHelpers, TagHelpers): apply
+  unconditionally — Mojolicious loads them, full stop.
+- **Installed/workspace plugins**: "you downloaded it, you probably
+  intend to use it" — resolve generously; precision is the
+  diagnostic's job, not the resolver's (the exporter-hint pattern).
+- **NOT auto-applied**: nothing. The over-offer risk is bounded by a
+  few phantom completions from installed-but-unloaded plugins.
+
+## Phase 2 — entrypoint-scan diagnostic (open)
+
+At the USAGE site: "`$c->was_loaded` is provided by
+Clove::App::Plugin::WasLoaded, which no entrypoint loads
+(`plugin 'WasLoaded'`)". Hint severity. Scan = workspace lite scripts
++ Mojolicious subclasses' startup for `plugin` registrations. This is
+a read-only miniature of long-distance collection (task #25) — its
+first muscle. Auto-fix code action (insert the `plugin` line) mirrors
+auto-import.
+
+## Phase 3 — per-app surfaces (needs graph walking / multi-app)
+
+mojo-helpers' namespace ids are already per-package; when app
+attribution exists, the generous union narrows to per-app surfaces
+and the phase-2 lint gets exact. Tracked with the graph-walking
+pillar.

--- a/docs/prompt-role-requires.md
+++ b/docs/prompt-role-requires.md
@@ -1,0 +1,63 @@
+# Role `requires` — the composer-mismatch diagnostic (design)
+
+**Status: recorded, not built.** The in-role half LANDED: `requires
+NAMES` synthesizes Method symbols (span = each name's atom) so
+`$self->name` resolves inside the role — no unresolved-method hint,
+goto-def lands on the contract, completion offers it — and the names
+land in `FileAnalysis.role_requires` (per-package `requires` lists,
+serde-default). This doc is the deferred half: telling a COMPOSER it
+doesn't fulfill a contract.
+
+## The diagnostic
+
+For each package P with role parents (the `with` edges already in
+`package_parents`), for each composed role R (cross-file via the
+index), for each name in R's `role_requires`: does P provide it?
+Missing → `role-requires-unfulfilled` on P's `with 'R'` ref span:
+"role R requires 'name'; P does not provide it". Perl dies at
+composition time for this, so WARNING severity is honest (not the
+quiet-by-design HINT tier).
+
+"Provides" must mean what Moo means:
+
+- a local `sub`/`method` in P;
+- an inherited method (full ancestor walk — `parents_of` is the seam);
+- a `has`-synthesized accessor (incl. plugin-enrolled projections);
+- a method provided by ANOTHER role in the same composition — roles
+  satisfy each other's requires at compose time;
+- NOT satisfied by an `around`/`before`/`after` modifier alone
+  (modifiers wrap, they don't provide).
+
+## Role-composing-role
+
+A role that composes a role inherits its unfulfilled requires:
+`role_requires(R) ∪ role_requires(R')` minus what R itself provides.
+This is a query-time walk with a seen-set, NOT baked at build —
+mirrors the inheritance edge-walk discipline (depth stays a
+query-time property).
+
+## Where it runs
+
+`collect_diagnostics`, behind the module index (same enrichment
+parity as the rest: batch/--check get it via the enriched-copy pass).
+The check is ancestry-shaped, so it composes with the `ReceiverGated`
+applicability machinery if gating is ever needed; start without it.
+
+## Calibration
+
+Substrate sweep mandatory before shipping. Known noise sources to
+calibrate against: dynamically-installed methods (`*name = sub` in
+the composer — the codegen recognizers should already cover most),
+`can()`-probed optional contracts (Clove::Sheets probes
+`$self->can('process_row')` — NOT a requires, correctly out of
+scope), and AUTOLOAD composers (suppress when the composer defines
+AUTOLOAD, same rule the unresolved-method hint uses).
+
+## crm finding that motivated this
+
+`Clove::Sheets` calls `$self->fetch_raw` without `requires
+'fetch_raw'` (it's provided by sub-roles like
+`Clove::Sheets::Roles::Source::NamedCSV` that consumers compose) —
+the in-role hint now correctly nudges the contract to be declared.
+The composer-mismatch diagnostic is the other direction of the same
+contract.

--- a/frameworks/mojo-helpers.rhai
+++ b/frameworks/mojo-helpers.rhai
@@ -49,15 +49,37 @@ fn app_surface_consumers() {
 // action. We emit on both entry points; the shared proxy prefix means
 // dotted helpers only pay the fan-out once per leaf.
 
+// Lite scripts register helpers with the bare DSL verb —
+// `helper(frontend_version => sub {…})` — no `$app->` in sight. Same
+// emissions as the method spelling, same fan-out.
+fn on_function_call(ctx) {
+    if ctx.function_name != "helper" { return []; }
+    helper_call_emissions(ctx)
+}
+
 fn on_method_call(ctx) {
+    if ctx.method_name != "helper" { return []; }
+    helper_call_emissions(ctx)
+}
+
+fn helper_call_emissions(ctx) {
     let out = [];
-    if ctx.method_name != "helper" { return out; }
 
     let args = ctx.args;
     if args.len() < 2 { return out; }
 
-    let name = args[0].string_value;
-    if name == () { return out; }
+    // Loop registrations expand: `$app->helper($name => …) for/foreach`
+    // folds the loop variable (or the postfix `$_` topic) over its
+    // literal list, and `string_values` carries every candidate — this
+    // is what discovers DefaultHelpers' own registrations from source,
+    // with no hardcoded helper list anywhere.
+    let names = args[0].string_values;
+    if names == () { names = []; }
+    if names.len() == 0 {
+        let single = args[0].string_value;
+        if single == () { return out; }
+        names = [single];
+    }
 
     // `$app->helper(NAME => sub { my ($c, @rest) = @_; ... })` — the
     // helper's first positional is the Mojolicious controller. Flag
@@ -96,6 +118,19 @@ fn on_method_call(ctx) {
         };
     }
 
+    for name in names {
+        // Unfolded dynamics (`$_` that didn't fold, interpolations)
+        // are honest misses, not helpers named "$_".
+        if name.contains("$") { continue; }
+        out += helper_emissions(ctx, name, params, name_span, args[1].callable_return_edge);
+    }
+    return out;
+}
+
+// Everything one registered helper NAME emits — split out so a loop
+// registration fans out N times over the same callback/spans.
+fn helper_emissions(ctx, name, params, name_span, ret_edge) {
+    let out = [];
     // Split on '.' — single-segment names are the common case and
     // produce exactly one Method. Dotted names chain.
     let segments = name.split(".");
@@ -147,7 +182,7 @@ fn on_method_call(ctx) {
                 params: params,
                 is_method: true,
                 return_type: (),
-                return_via_edge: args[1].callable_return_edge,
+                return_via_edge: ret_edge,
                 doc: (),
                 on_class: app_surface,
                 display: "Helper",

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -93,6 +93,14 @@ fn decamelize(name) {
 fn on_use(ctx) {
     if ctx.module_name != "Mojolicious::Lite" { return []; }
     let out = [];
+    // The framework loads these unconditionally at startup — no `use`
+    // ever names them, so the import-driven resolver would never pull
+    // them in and their helper registrations would stay invisible.
+    // Declaring the implication here (rule #8: the plugin owns
+    // framework behavior) routes them through the normal import →
+    // resolve → bridge pipeline.
+    out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::DefaultHelpers", "args": [], "imports": [], "span": ctx.span }};
+    out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::TagHelpers", "args": [], "imports": [], "span": ctx.span }};
 
     // `app` — no real sub to link to; monkey-patched `sub { $app }`.
     // Typed Sub is the one acknowledged stub; downstream chain flow
@@ -204,6 +212,13 @@ fn on_function_call(ctx) {
                         invocant_span: (),
                     }
                 };
+                // "You loaded it" — make the resolver pull the plugin in
+                // so its helpers register. Default namespace guess only;
+                // app-custom namespaces (Clove::App::Plugin::*) are
+                // workspace modules and already indexed.
+                if !name.contains("::") {
+                    out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::" + name, "args": [], "imports": [], "span": span }};
+                }
             }
         }
         return out;

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -63,6 +63,33 @@ fn topic_route_dsl() {
     }
 }
 
+
+// Mojo::Util decamelize: "FooBar" -> "foo_bar", "Foo::Bar" -> "foo-bar".
+// Plugin names arrive camelized; the core's controller-token search is
+// gated on lowercase-leading tokens (mirroring camelize's /^[A-Z]/
+// early-return), so emitting the decamelized form round-trips through
+// the exact same machinery Mojo's loader uses.
+fn decamelize(name) {
+    let out = "";
+    let parts = name.split("::");
+    let first_part = true;
+    for part in parts {
+        if !first_part { out += "-"; }
+        first_part = false;
+        let first = true;
+        for ch in part {
+            if ch >= 'A' && ch <= 'Z' {
+                if !first { out += "_"; }
+                out += ch.to_lower();
+            } else {
+                out += ch;
+            }
+            first = false;
+        }
+    }
+    out
+}
+
 fn on_use(ctx) {
     if ctx.module_name != "Mojolicious::Lite" { return []; }
     let out = [];
@@ -154,6 +181,33 @@ fn on_use(ctx) {
 
 fn on_function_call(ctx) {
     let out = [];
+
+    // `plugin 'Thing'` — goto-def on the name lands on the plugin
+    // class's `register`. Same machinery as go-to-controller: the
+    // MethodCallRef's invocant token camelizes and tail-matches
+    // workspace modules, with ownership of the action (`register` —
+    // every Mojolicious plugin has one) as the disambiguator.
+    // Namespace-agnostic, so app-specific plugin namespaces
+    // (Clove::App::Plugin::*) resolve the same as Mojolicious::Plugin::*.
+    if ctx.function_name == "plugin" {
+        let args = ctx.args;
+        if args.len() >= 1 {
+            let name = args[0].string_value;
+            if name != () && name != "" {
+                let span = args[0].content_span;
+                if span == () { span = args[0].span; }
+                out += #{
+                    MethodCallRef: #{
+                        method_name: "register",
+                        invocant: decamelize(name),
+                        span: span,
+                        invocant_span: (),
+                    }
+                };
+            }
+        }
+        return out;
+    }
 
     // Route-declaration verbs. `under` is a middleware-ish route
     // wrapper; `websocket` registers a WS handler. Both behave like

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -49,6 +49,20 @@ fn triggers() {
 //     diagnostic skips them regardless of whether the real source module
 //     is resolved cross-file yet.
 
+// The lite topic-route DSL: file-level verbs whose `->to('#action')`
+// partials inherit the controller the nearest `under(...)->to('ctrl#…')`
+// set, scoped by `group { }`. Core keeps the generic frame stack; every
+// NAME in the mechanism is declared right here. The SetRouteBase write
+// itself is emitted by mojo-routes (the plugin that parses to-specs).
+fn topic_route_dsl() {
+    #{
+        "module": "Mojolicious::Lite",
+        "verbs": ["get", "post", "put", "delete", "del", "patch", "options",
+                  "any", "websocket", "under"],
+        "group_fn": "group",
+    }
+}
+
 fn on_use(ctx) {
     if ctx.module_name != "Mojolicious::Lite" { return []; }
     let out = [];

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -86,7 +86,48 @@ fn overrides() {
         "Mojolicious app `routes` accessor returns the top-level router");
     out += route_method_override("Mojolicious::Controller", "routes", "Mojolicious::Routes",
         "Mojolicious controller `routes` accessor returns the top-level router");
+    // Framework-assigned attrs: `has [qw(app tx)]` and friends are
+    // declared with NO default/isa (the framework assigns them at
+    // dispatch), so the synthesized accessors carry no return type and
+    // chains die at the first hop. Declared here as overrides — the
+    // same trick as the route verbs above — so `$c->app->…`,
+    // `$c->tx->…`, `$plugin_app->…` type with or without an indexed
+    // Mojo source tree.
+    let assigned = [
+        ["Mojolicious::Controller", "app", "Mojolicious"],
+        ["Mojolicious::Controller", "tx", "Mojo::Transaction::HTTP"],
+        ["Mojolicious::Plugin", "app", "Mojolicious"],
+        ["Mojo::Server", "app", "Mojolicious"],
+        ["Mojolicious", "ua", "Mojo::UserAgent"],
+        ["Mojolicious::Controller", "ua", "Mojo::UserAgent"],
+        ["Mojo::UserAgent", "transactor", "Mojo::UserAgent::Transactor"],
+        // req/res delegate through $tx in real source (`sub req {
+        // shift->tx->req }`); declared on BOTH the controller and the
+        // transaction (route-verbs pattern) so the chain types without
+        // an indexed Mojo tree, and `$tx->req->…` works wherever a
+        // transaction shows up (ua callbacks, hooks, proxies).
+        ["Mojolicious::Controller", "req", "Mojo::Message::Request"],
+        ["Mojolicious::Controller", "res", "Mojo::Message::Response"],
+        ["Mojo::Transaction", "req", "Mojo::Message::Request"],
+        ["Mojo::Transaction", "res", "Mojo::Message::Response"],
+        ["Mojo::Transaction::HTTP", "req", "Mojo::Message::Request"],
+        ["Mojo::Transaction::HTTP", "res", "Mojo::Message::Response"],
+    ];
+    for a in assigned {
+        out += route_method_override(a[0], a[1], a[2],
+            "framework-assigned attr (has with no default; set at dispatch)");
+    }
     out
+}
+
+// `register($self, $app, $conf)` — the contract method every
+// Mojolicious plugin implements; the framework passes the app. $conf's
+// call-site shape is future work (long-distance param typing).
+fn param_types() {
+    [
+        #{ method: "register", in_role: "Mojolicious::Plugin", param: 1,
+           type_class: "Mojolicious" },
+    ]
 }
 
 // A route is a first-class thing — it has identity (the `Controller#action`

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -295,7 +295,14 @@ fn on_method_call(ctx) {
                 let action_start = lit_controller_len + 1;
                 let action_end   = action_start + action.len();
                 let action_span = subspan_cols(base, action_start, action_end);
-                return route_emissions(controller, action, action_span, ctx.current_package);
+                let ems = route_emissions(controller, action, action_span, ctx.current_package);
+                // Lite `under(...)->to('ctrl#…')` also WRITES the topic
+                // base following sibling routes inherit. The receiver's
+                // call name is a generic core fact; "under" is ours.
+                if ctx.receiver_call_name == "under" && controller != "" {
+                    ems += #{ "SetRouteBase": #{ "controller": controller } };
+                }
+                return ems;
             }
         }
     }

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -235,8 +235,57 @@ fn inherited_controller(ctx) {
     ()
 }
 
+
+// Mojo::Util decamelize: "FooBar" -> "foo_bar", "Foo::Bar" -> "foo-bar".
+// Plugin names arrive camelized; the core's controller-token search is
+// gated on lowercase-leading tokens (mirroring camelize's /^[A-Z]/
+// early-return), so emitting the decamelized form round-trips through
+// the exact same machinery Mojo's loader uses.
+fn decamelize(name) {
+    let out = "";
+    let parts = name.split("::");
+    let first_part = true;
+    for part in parts {
+        if !first_part { out += "-"; }
+        first_part = false;
+        let first = true;
+        for ch in part {
+            if ch >= 'A' && ch <= 'Z' {
+                if !first { out += "_"; }
+                out += ch.to_lower();
+            } else {
+                out += ch;
+            }
+            first = false;
+        }
+    }
+    out
+}
+
 fn on_method_call(ctx) {
     let out = [];
+
+    // `$app->plugin('Thing')` — the OO spelling of the lite `plugin`
+    // verb; same register-anchored resolution (see mojo-lite).
+    if ctx.method_name == "plugin" {
+        let args = ctx.args;
+        if args.len() >= 1 {
+            let name = args[0].string_value;
+            if name != () && name != "" {
+                let span = args[0].content_span;
+                if span == () { span = args[0].span; }
+                out += #{
+                    MethodCallRef: #{
+                        method_name: "register",
+                        invocant: decamelize(name),
+                        span: span,
+                        invocant_span: (),
+                    }
+                };
+            }
+        }
+        return out;
+    }
 
     if ctx.method_name == "name" {
         let args = ctx.args;

--- a/gold-corpus/fixtures/linked-editing.json
+++ b/gold-corpus/fixtures/linked-editing.json
@@ -216,12 +216,15 @@
       "line": 81,
       "col": 4,
       "expect": {
-        "all": [],
-        "none": [
-          "DateTime.pm:"
-        ]
+        "all": [
+          "DateTime.pm:84:26",
+          "DateTime.pm:1823:26",
+          "DateTime.pm:1981:33"
+        ],
+        "none": []
       },
-      "status": "provisional"
+      "status": "gold",
+      "note": "sub INFINITY () constant: bareword usages promote to FunctionCall refs, so linked-editing syncs def + all three usage sites (previously engaged nothing \u2014 the provisional pinned that gap)."
     },
     {
       "id": "le-ppi-logical-file",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -202,6 +202,8 @@ fn build_with_plugins_inner(
     plugins: Arc<PluginRegistry>,
     extra_re_fold: bool,
 ) -> FileAnalysis {
+    let topic_dsls: Vec<plugin::TopicRouteDsl> =
+        plugins.all().filter_map(|pl| pl.topic_route_dsl()).collect();
     let mut b = Builder {
         source,
         scopes: Vec::new(),
@@ -265,6 +267,8 @@ fn build_with_plugins_inner(
         attr_projections: Vec::new(),
         escape_recorded: std::collections::HashSet::new(),
         role_requires: std::collections::HashMap::new(),
+        lite_brand: vec![None],
+        topic_dsls,
         reassigned_scalars: std::collections::HashSet::new(),
         key_writes: Vec::new(),
         method_call_arity: std::collections::HashMap::new(),
@@ -1491,6 +1495,17 @@ struct Builder<'a> {
     /// `FileAnalysis.role_requires`.
     role_requires: std::collections::HashMap<String, Vec<String>>,
 
+    /// Topic-route implicit base — the controller default the current
+    /// base-setter established, scoped by the DSL's group function
+    /// (push on entry, pop on exit). Topic-DSL routes have no variable
+    /// for the brand to ride; this stack IS the receiver for
+    /// `->to('#action')` partials on declared verb calls.
+    lite_brand: Vec<Option<String>>,
+
+    /// Topic-route DSL manifests collected from the plugin registry —
+    /// see `plugin::TopicRouteDsl`.
+    topic_dsls: Vec<plugin::TopicRouteDsl>,
+
     /// Per-MethodCall-ref arg count, keyed by ref index. Lets
     /// `emit_method_call_return_edges` pin the call site's arity onto its
     /// `Expression(refidx)` return edge (`CallReturn`), so a fluent
@@ -2524,6 +2539,32 @@ impl<'a> Builder<'a> {
     /// bareword arms query the local Symbol's return, method-call arms
     /// query Expression(refidx), shift / `$_[0]` / `__PACKAGE__` use
     /// current_package. One function, one dispatch.
+    /// The active topic-route DSL, when a plugin declared one whose
+    /// gating module is in scope. Core knows no names — the plugin
+    /// manifest carries the module, the verbs, and the scope function.
+    fn active_topic_dsl(&self) -> Option<&plugin::TopicRouteDsl> {
+        self.topic_dsls.iter().find(|d| {
+            self.package_uses
+                .values()
+                .any(|ms| ms.iter().any(|m| *m == d.module))
+        })
+    }
+
+    /// The called function's name when `inv` is a call — the generic
+    /// syntax fact `CallContext.receiver_call_name` carries to plugins.
+    fn invocant_call_name(&self, inv: Node<'a>) -> Option<String> {
+        if !matches!(
+            inv.kind(),
+            "function_call_expression" | "ambiguous_function_call_expression"
+        ) {
+            return None;
+        }
+        inv.child_by_field_name("function")?
+            .utf8_text(self.source)
+            .ok()
+            .map(str::to_string)
+    }
+
     fn receiver_type_for(&self, invocant_node: Option<Node<'a>>) -> Option<InferredType> {
         self.invocant_type_at_node(invocant_node?)
     }
@@ -2573,6 +2614,7 @@ impl<'a> Builder<'a> {
             function_name: None,
             method_name: None,
             receiver_text: None,
+            receiver_call_name: None,
             receiver_type: None,
             receiver_route_defaults: Vec::new(),
             args,
@@ -2704,6 +2746,14 @@ impl<'a> Builder<'a> {
     fn apply_emit_action(&mut self, plugin_id: String, action: plugin::EmitAction) {
         let ns = Namespace::framework(plugin_id.clone());
         match action {
+            // Topic-route base write: the plugin parsed its own
+            // `->to('ctrl#…')` on its declared base-setter verb; core
+            // just stores the result on the innermost open frame.
+            plugin::EmitAction::SetRouteBase { controller } => {
+                if let Some(frame) = self.lite_brand.last_mut() {
+                    *frame = Some(controller);
+                }
+            }
             plugin::EmitAction::Method {
                 name,
                 span,
@@ -7252,7 +7302,26 @@ impl<'a> Builder<'a> {
                 }
             }
         }
+        // A topic-route DSL's scope function (`group { … }` in lite)
+        // brackets the implicit base: push a copy of the current frame,
+        // restore after the block — a base set inside applies only
+        // within. The function's NAME comes from the plugin manifest.
+        let lite_group = self
+            .active_topic_dsl()
+            .map(|d| d.group_fn.clone())
+            .is_some_and(|g| {
+                node.child_by_field_name("function")
+                    .and_then(|f| f.utf8_text(self.source).ok())
+                    == Some(g.as_str())
+            });
+        if lite_group {
+            let cur = self.lite_brand.last().cloned().flatten();
+            self.lite_brand.push(cur);
+        }
         self.visit_children(node);
+        if lite_group {
+            self.lite_brand.pop();
+        }
         // If `modifier_invocant_pos` wasn't consumed by a nested `visit_anonymous_sub`
         // (malformed or modifier-without-sub-body code), clear it so it doesn't leak
         // to the next anonymous sub in the file.
@@ -10130,6 +10199,13 @@ impl<'a> Builder<'a> {
                 ctx.method_name = Some(name.clone());
                 ctx.receiver_text = invocant_text.clone();
                 ctx.receiver_type = self.receiver_type_for(invocant_node);
+                // The receiver's call name is a generic syntax fact —
+                // set unconditionally so plugins can match their own
+                // DSL verbs (mojo-routes' base-setter) whatever the
+                // receiver's type resolved to.
+                if let Some(inv) = invocant_node {
+                    ctx.receiver_call_name = self.invocant_call_name(inv);
+                }
                 if let Some(InferredType::BrandedRoute { controller, stash, .. }) =
                     &ctx.receiver_type
                 {
@@ -10138,6 +10214,27 @@ impl<'a> Builder<'a> {
                         defaults.push(("controller".to_string(), c.clone()));
                     }
                     ctx.receiver_route_defaults = defaults;
+                }
+                // Topic-route spelling: the receiver is a DSL verb CALL
+                // (`get('/x')->to('#action')`) — no variable, so the
+                // implicit base lives on the walk's stack. Fills the
+                // controller default only when the brand didn't carry
+                // one; which names count is the plugin manifest's call.
+                if ctx
+                    .receiver_route_defaults
+                    .iter()
+                    .all(|(k, _)| k != "controller")
+                {
+                    if let (Some(dsl), Some(callee)) =
+                        (self.active_topic_dsl(), ctx.receiver_call_name.as_deref())
+                    {
+                        if dsl.verbs.iter().any(|v| v == callee) {
+                            if let Some(c) = self.lite_brand.last().cloned().flatten() {
+                                ctx.receiver_route_defaults
+                                    .push(("controller".to_string(), c));
+                            }
+                        }
+                    }
                 }
                 self.record_provisional_dispatch(name, &ctx);
                 self.dispatch_method_call_plugins(ctx);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2785,6 +2785,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline,
                     opaque_return,
                     is_constant: false,
+                    lexical: false,
                 };
                 let target_pkg = on_class.clone().or_else(|| self.current_package.clone());
                 // Projection-group enrollment: the plugin declared which
@@ -3556,6 +3557,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
         }
@@ -3848,12 +3850,17 @@ impl<'a> Builder<'a> {
         // Extract preceding POD/comment documentation
         let doc = self.extract_preceding_doc(node, &name);
 
+        // `my sub helper { … }` — the grammar's `lexical` field marks a
+        // block-scoped sub: real in-file structure (document symbols
+        // keep it) but not a workspace-addressable entity (workspace
+        // search drops it).
+        let lexical = node.child_by_field_name("lexical").is_some();
         self.add_symbol(
             name.clone(),
             if is_method { SymKind::Method } else { SymKind::Sub },
             node_to_span(node),
             node_to_span(name_node),
-            SymbolDetail::Sub { params: params.clone(), is_method, doc, display: None, hide_in_outline: false, opaque_return: false, is_constant: false },
+            SymbolDetail::Sub { params: params.clone(), is_method, doc, display: None, hide_in_outline: false, opaque_return: false, is_constant: false, lexical },
         );
 
         // Exporter::Extensible method-attribute export form: `sub foo :Export`.
@@ -3996,6 +4003,7 @@ impl<'a> Builder<'a> {
                 hide_in_outline: true,
                 opaque_return: false,
                 is_constant: false,
+                lexical: false,
             },
         );
         self.anon_sub_symbol_by_span.insert(span, sym_id);
@@ -4481,7 +4489,7 @@ impl<'a> Builder<'a> {
                         SymKind::Method,
                         node_to_span(node),
                         bare_span,
-                        SymbolDetail::Sub { params: vec![], is_method: true, doc: None, display: None, hide_in_outline: false, opaque_return: false, is_constant: false },
+                        SymbolDetail::Sub { params: vec![], is_method: true, doc: None, display: None, hide_in_outline: false, opaque_return: false, is_constant: false, lexical: false },
                     );
                 }
                 if has_writer {
@@ -4504,6 +4512,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                         },
                     );
                 }
@@ -4790,6 +4799,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
             self.record_framework_accessor_witness(
@@ -5342,6 +5352,7 @@ impl<'a> Builder<'a> {
                 hide_in_outline: false,
                 opaque_return: false,
                 is_constant: true,
+                lexical: false,
             },
         );
     }
@@ -8325,6 +8336,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
                 Namespace::Language,
                 target_pkg,
@@ -8624,6 +8636,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
         }
@@ -8934,6 +8947,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                         },
                     );
                     // Moo/Moose getter: arity 0 → isa-derived type
@@ -8977,6 +8991,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: true,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                             },
                         );
                         let writer_arm = return_type.clone().map(|t| {
@@ -9015,6 +9030,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                             },
                         );
                         let writer_arm = return_type.clone().map(|t| {
@@ -9089,6 +9105,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                         },
                     );
                     let getter_arm = getter_type.clone().map(|t| {
@@ -9125,6 +9142,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: true,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                         },
                     );
                     // Mojo writer: arity ≥ 1 → fluent return
@@ -10390,6 +10408,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
         }
@@ -10436,6 +10455,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
         }
@@ -10543,6 +10563,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
             // DBIC relationship accessor — arity 0 (no arg form is
@@ -11610,6 +11631,7 @@ impl<'a> Builder<'a> {
                     hide_in_outline: false,
                     opaque_return: false,
                     is_constant: false,
+                    lexical: false,
                 },
             );
             synth_names.insert(name.to_string());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6926,6 +6926,21 @@ impl<'a> Builder<'a> {
             return;
         }
 
+        // Interpolation deref: `${ EXPR }` inside a string or regex
+        // parses as `scalar > block` directly — no varname wrapper, so
+        // `is_block_deref` doesn't claim it. The block holds real code
+        // (`"_${\ $self->filetype }_"` carries a method call); visit it
+        // so its refs land, and emit nothing for the outer node — its
+        // text isn't a variable name.
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                if child.kind() == "block" {
+                    self.visit_children(child);
+                    return;
+                }
+            }
+        }
+
         // Sigil-deref of a scalar: `%$x` / `@$x` / `$$x` parses as the outer
         // sigil node (hash/array/scalar) whose varname child wraps an inner
         // `scalar` node naming the dereferenced variable. The inner scalar is

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1855,6 +1855,7 @@ impl<'a> Builder<'a> {
     fn arg_info_for(&mut self, arg: Node<'a>) -> plugin::ArgInfo {
         let text = arg.utf8_text(self.source).unwrap_or("").to_string();
         let mut content_span: Option<Span> = None;
+        let mut string_values: Vec<String> = Vec::new();
         let string_value = match arg.kind() {
             "string_literal" | "interpolated_string_literal" => {
                 // Read the string_content child — quote-flavor-agnostic
@@ -1879,11 +1880,15 @@ impl<'a> Builder<'a> {
             // positional args) where the token text IS the string value.
             "autoquoted_bareword" | "bareword" => Some(text.clone()),
             "scalar" | "array" | "hash" => {
-                self.resolve_constant_strings(&text, 0)
-                    .and_then(|v| v.into_iter().next())
+                let folded = self.resolve_constant_strings(&text, 0).unwrap_or_default();
+                string_values = folded.clone();
+                folded.into_iter().next()
             }
             _ => None,
         };
+        if string_values.is_empty() {
+            string_values.extend(string_value.clone());
+        }
         self.emit_expr_witness(arg);
         let inferred_type = self.bag_query_expr_span(node_to_span(arg));
         let sub_params = if arg.kind() == "anonymous_subroutine_expression" {
@@ -1928,6 +1933,7 @@ impl<'a> Builder<'a> {
         plugin::ArgInfo {
             text,
             string_value,
+            string_values,
             span: node_to_span(arg),
             content_span,
             inferred_type,
@@ -4628,13 +4634,32 @@ impl<'a> Builder<'a> {
         // `... for (LIST)` form (the child_by_field_name paren gotcha), so the
         // list payload is read off the second named child instead — `[call,
         // list]`. `extract_string_list` folds qw / paren-list / constants.
+        let mut topic_values: Vec<String> = Vec::new();
         if let (Some(call), Some(list_node)) = (node.named_child(0), node.named_child(1)) {
             let names = self.extract_string_list(list_node);
             if !names.is_empty() && self.is_class_accessor_loop_body(call) {
                 self.emit_class_accessor_symbols(call, &names);
             }
+            topic_values = names.into_iter().map(|(n, _)| n).collect();
+        }
+        // The statement-modifier topic: `EXPR for qw(...)` runs EXPR once
+        // per element with `$_` bound — fold `$_` over the literal list
+        // for the body visit so registration loops expand
+        // (`$app->helper($_ => …) for qw(a b c)` is N registrations).
+        // Scoped: saved and restored around the children walk.
+        let saved = self.constant_strings.get("$_").cloned();
+        if !topic_values.is_empty() {
+            self.constant_strings.insert("$_".to_string(), topic_values);
         }
         self.visit_children(node);
+        match saved {
+            Some(v) => {
+                self.constant_strings.insert("$_".to_string(), v);
+            }
+            None => {
+                self.constant_strings.remove("$_");
+            }
+        }
     }
 
     /// Is `node` a `mk_classdata`/`mk_classaccessor` call whose single arg is the

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -264,6 +264,7 @@ fn build_with_plugins_inner(
         method_call_invocant: std::collections::HashMap::new(),
         attr_projections: Vec::new(),
         escape_recorded: std::collections::HashSet::new(),
+        role_requires: std::collections::HashMap::new(),
         reassigned_scalars: std::collections::HashSet::new(),
         key_writes: Vec::new(),
         method_call_arity: std::collections::HashMap::new(),
@@ -519,6 +520,7 @@ fn build_with_plugins_inner(
         gated_param_types: b.gated_param_types,
         reassigned_scalars: b.reassigned_scalars,
         key_writes: b.key_writes,
+        role_requires: b.role_requires,
     });
     // Finalize: run the legacy text-based MCB resolver as a fallback.
     // For every assignment the unified typer (run before
@@ -1484,6 +1486,10 @@ struct Builder<'a> {
     /// mutation-extension pass (shape extension / open-widening).
     /// Flushed into `FileAnalysis.key_writes`.
     key_writes: Vec<crate::file_analysis::KeyWrite>,
+
+    /// Per-role `requires` lists. Flushed into
+    /// `FileAnalysis.role_requires`.
+    role_requires: std::collections::HashMap<String, Vec<String>>,
 
     /// Per-MethodCall-ref arg count, keyed by ref index. Lets
     /// `emit_method_call_return_edges` pin the call site's arity onto its
@@ -5233,86 +5239,17 @@ impl<'a> Builder<'a> {
         );
     }
 
-    /// Extract strings from a node's children: qw(), paren lists, bare strings.
-    /// Returns (text, span) pairs where span covers each individual word.
-    /// Also handles the case where the node itself is a string/qw (not just its children).
+    /// Strings of a list-ish node, per-word spans included. Syntax
+    /// (qw / string literals / list recursion) lives in
+    /// `cst::string_list`; this wrapper supplies the constant-folding
+    /// hook for bareword / `@list` elements, which needs builder state.
     fn extract_string_list(&self, node: Node<'a>) -> Vec<(String, Span)> {
-        // Handle the node itself being a leaf string type
-        match node.kind() {
-            "quoted_word_list" => {
-                let mut results = Vec::new();
-                self.extract_qw_word_spans(node, &mut results);
-                return results;
-            }
-            "string_literal" | "interpolated_string_literal" => {
-                if let Some(text) = self.extract_string_content(node) {
-                    return vec![(text, self.string_content_span(node))];
-                }
-                return vec![];
-            }
-            "bareword" | "autoquoted_bareword" => {
-                if let Ok(text) = node.utf8_text(self.source) {
-                    if let Some(values) = self.resolve_constant_strings(text, 0) {
-                        let span = node_to_span(node);
-                        return values.into_iter().map(|v| (v, span)).collect();
-                    }
-                }
-                return vec![];
-            }
-            "array" => {
-                if let Ok(text) = node.utf8_text(self.source) {
-                    if let Some(values) = self.resolve_constant_strings(text, 0) {
-                        let span = node_to_span(node);
-                        return values.into_iter().map(|v| (v, span)).collect();
-                    }
-                }
-                return vec![];
-            }
-            _ => {}
-        }
-        // Walk children
-        let mut results = Vec::new();
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i) {
-                match child.kind() {
-                    "quoted_word_list" => {
-                        self.extract_qw_word_spans(child, &mut results);
-                    }
-                    "string_literal" | "interpolated_string_literal" => {
-                        if let Some(text) = self.extract_string_content(child) {
-                            results.push((text, self.string_content_span(child)));
-                        }
-                    }
-                    "parenthesized_expression" | "list_expression"
-                    | "anonymous_array_expression" => {
-                        results.extend(self.extract_string_list(child));
-                    }
-                    // Constant/variable resolution: barewords and array variables
-                    "bareword" | "autoquoted_bareword" => {
-                        if let Ok(text) = child.utf8_text(self.source) {
-                            if let Some(values) = self.resolve_constant_strings(text, 0) {
-                                let span = node_to_span(child);
-                                for val in values {
-                                    results.push((val, span));
-                                }
-                            }
-                        }
-                    }
-                    "array" => {
-                        if let Ok(text) = child.utf8_text(self.source) {
-                            if let Some(values) = self.resolve_constant_strings(text, 0) {
-                                let span = node_to_span(child);
-                                for val in values {
-                                    results.push((val, span));
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-        results
+        crate::cst::string_list(node, self.source, &mut |n| {
+            let Ok(text) = n.utf8_text(self.source) else { return vec![] };
+            let Some(values) = self.resolve_constant_strings(text, 0) else { return vec![] };
+            let span = node_to_span(n);
+            values.into_iter().map(|v| (v, span)).collect()
+        })
     }
 
     /// Extract strings without spans. Convenience for callers that don't need positions.
@@ -5335,52 +5272,10 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Extract per-word (text, span) pairs from a quoted_word_list node.
-    /// Handles multi-line qw by tracking row/col through whitespace.
     fn extract_qw_word_spans(&self, qw_node: Node<'a>, results: &mut Vec<(String, Span)>) {
-        for j in 0..qw_node.named_child_count() {
-            if let Some(sc) = qw_node.named_child(j) {
-                if sc.kind() == "string_content" {
-                    if let Ok(text) = sc.utf8_text(self.source) {
-                        let sc_start = sc.start_position();
-                        let bytes = text.as_bytes();
-                        let mut row = sc_start.row;
-                        let mut col = sc_start.column;
-                        let mut i = 0;
-                        while i < bytes.len() {
-                            // Skip whitespace, tracking newlines
-                            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                                if bytes[i] == b'\n' {
-                                    row += 1;
-                                    col = 0;
-                                } else {
-                                    col += 1;
-                                }
-                                i += 1;
-                            }
-                            // Collect word
-                            let word_start = (row, col);
-                            let word_begin = i;
-                            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
-                                col += 1;
-                                i += 1;
-                            }
-                            if word_begin < i {
-                                let word = &text[word_begin..i];
-                                let span = Span {
-                                    start: Point::new(word_start.0, word_start.1),
-                                    end: Point::new(row, col),
-                                };
-                                results.push((word.to_string(), span));
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        crate::cst::qw_word_spans(qw_node, self.source, results)
     }
 
-    /// Find the qw close paren position in a use statement (only needed for completion positioning).
     fn find_qw_close_position(&self, node: Node<'a>) -> Option<Point> {
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i) {
@@ -7200,6 +7095,18 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
+                // Moo/Moose role `requires NAMES` — declared method
+                // contracts the composer must fulfill. Gated on the
+                // role sugar actually being in scope (a plain class
+                // never imports `requires`) so a user-defined sub of
+                // the same name doesn't synthesize bogus methods.
+                if name == "requires" && self.framework_imports.contains("requires") {
+                    if let Some(pkg) = self.current_package.clone() {
+                        if self.framework_modes.contains_key(&pkg) {
+                            self.visit_requires_call(node, &pkg);
+                        }
+                    }
+                }
                 // Moose/Moo `with 'Role'` — register roles as parents for method resolution
                 if name == "with" {
                     if let Some(pkg) = self.current_package.clone() {
@@ -8550,6 +8457,41 @@ impl<'a> Builder<'a> {
 
     /// Synthesize accessor methods from `has` calls in Moo/Moose/Mojo::Base classes.
     /// Handle Moose/Moo `extends 'Parent::Class', ...` — register parent classes.
+    /// `requires LIST` in a role — each name is a method CONTRACT the
+    /// composing class must fulfill. Synthesize a Method symbol per
+    /// name (span = the name's own atom, rule #7) so `$self->name`
+    /// resolves inside the role: the unresolved-method hint stays
+    /// quiet, goto-def lands on the contract, completion offers it.
+    /// Names also land in `role_requires` — the input for the future
+    /// composer-mismatch diagnostic.
+    fn visit_requires_call(&mut self, node: Node<'a>, pkg: &str) {
+        let Some(args) = node.child_by_field_name("arguments") else { return };
+        let names = self.extract_string_list(args);
+        for (name, span) in &names {
+            self.add_symbol(
+                name.clone(),
+                SymKind::Method,
+                *span,
+                *span,
+                SymbolDetail::Sub {
+                    params: vec![],
+                    is_method: true,
+                    doc: Some(format!(
+                        "**Required** by role `{pkg}` — the composing class must provide it.",
+                    )),
+                    display: None,
+                    hide_in_outline: false,
+                    opaque_return: false,
+                    is_constant: false,
+                },
+            );
+        }
+        self.role_requires
+            .entry(pkg.to_string())
+            .or_default()
+            .extend(names.into_iter().map(|(n, _)| n));
+    }
+
     fn visit_extends_call(&mut self, node: Node<'a>, pkg: &str) {
         let args = match node.child_by_field_name("arguments") {
             Some(a) => a,
@@ -9414,29 +9356,13 @@ impl<'a> Builder<'a> {
 
     /// Extract string content from a string_literal node (strips quotes).
     fn extract_string_content(&self, node: Node<'a>) -> Option<String> {
-        for i in 0..node.named_child_count() {
-            if let Some(content) = node.named_child(i) {
-                if content.kind() == "string_content" {
-                    return content.utf8_text(self.source).ok().map(|s| s.to_string());
-                }
-            }
-        }
-        None
+        crate::cst::string_content_text(node, self.source)
     }
 
-    /// Get the span of the string_content inside a string_literal (for selection_span).
     fn string_content_span(&self, node: Node<'a>) -> Span {
-        for i in 0..node.named_child_count() {
-            if let Some(content) = node.named_child(i) {
-                if content.kind() == "string_content" {
-                    return node_to_span(content);
-                }
-            }
-        }
-        node_to_span(node)
+        crate::cst::string_content_span(node)
     }
 
-    /// Extract attribute names from an array ref expression: [qw(foo bar)] or ['foo', 'bar']
     fn extract_array_attr_names(&self, node: Node<'a>, names: &mut Vec<(String, Span)>) {
         // Handle bare qw() node directly (e.g. as method arg)
         if node.kind() == "quoted_word_list" {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5159,12 +5159,27 @@ impl<'a> Builder<'a> {
         };
         // A `MAX_RETRIES()` call already gets its FunctionCall ref from
         // `visit_function_call` (the `function` field). Don't double-emit.
+        // Declaration/name slots aren't value-position barewords either:
+        // a sub's own `name`, a package/class/use statement's module —
+        // their refs belong to their visitors.
         if let Some(parent) = node.parent() {
             if matches!(
                 parent.kind(),
                 "function_call_expression" | "ambiguous_function_call_expression"
             ) && parent.child_by_field_name("function").map(|f| f.id()) == Some(node.id())
             {
+                return;
+            }
+            if matches!(
+                parent.kind(),
+                "subroutine_declaration_statement"
+                    | "method_declaration_statement"
+                    | "package_statement"
+                    | "class_statement"
+                    | "use_statement"
+                    | "require_statement"
+                    | "no_statement"
+            ) {
                 return;
             }
         }
@@ -5205,15 +5220,32 @@ impl<'a> Builder<'a> {
             .declared_constants
             .get(&pkg)
             .is_some_and(|set| set.contains(name));
-        if !is_declared {
+        if is_declared {
+            self.add_ref(
+                RefKind::FunctionCall { resolved_package: Some(pkg) },
+                node_to_span(node),
+                name.to_string(),
+                AccessKind::Read,
+            );
             return;
         }
-        self.add_ref(
-            RefKind::FunctionCall { resolved_package: Some(pkg) },
-            node_to_span(node),
-            name.to_string(),
-            AccessKind::Read,
-        );
+        // A bareword naming an in-scope sub IS a call — Perl prefers
+        // the defined sub over the class-name reading (`get_config->`
+        // calls get_config()), so `my $x = get_config;` and the deref
+        // base in `get_config->{host}` deserve the full function
+        // treatment: hover, goto-def, references, rename, semantic
+        // tokens. `resolve_call_package` is the one seam for "whose
+        // sub is this" (enclosing package, then imports) — no pin, no
+        // ref, so unresolvable barewords (filehandles, prototypes'
+        // leftovers) stay untouched.
+        if let Some(owner) = self.resolve_call_package(name) {
+            self.add_ref(
+                RefKind::FunctionCall { resolved_package: Some(owner) },
+                node_to_span(node),
+                name.to_string(),
+                AccessKind::Read,
+            );
+        }
     }
 
     /// Register a single `use constant` name as a parameterless Sub symbol.

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14837,3 +14837,34 @@ get('/y')->to('#after_group');
         "post-group partial inherits the OUTER under — the group frame popped",
     );
 }
+
+/// `plugin 'Thing'` emits a register-anchored MethodCall ref with the
+/// DECAMELIZED token ("WasLoaded" → "was_loaded"), so goto-def rides
+/// the same camelize+tail+ownership search as go-to-controller —
+/// namespace-agnostic (Mojolicious::Plugin::* and app-specific
+/// namespaces both land).
+#[test]
+fn lite_plugin_name_emits_register_ref() {
+    let src = "\
+use Mojolicious::Lite;
+plugin 'WasLoaded';
+plugin 'Foo::BarBaz';
+";
+    let fa = {
+        let mut parser = super::create_parser();
+        let tree = parser.parse(src, None).unwrap();
+        super::build_with_plugins(&tree, src.as_bytes(), super::default_plugin_registry())
+    };
+    let invocants: Vec<String> = fa
+        .refs
+        .iter()
+        .filter(|r| r.target_name == "register")
+        .filter_map(|r| {
+            let RefKind::MethodCall { ref invocant, .. } = r.kind else { return None };
+            Some(format!("{:?}", invocant))
+        })
+        .collect();
+    assert_eq!(invocants.len(), 2, "{:?}", invocants);
+    assert!(invocants[0].contains("was_loaded"), "{:?}", invocants);
+    assert!(invocants[1].contains("foo-bar_baz"), "{:?}", invocants);
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14868,3 +14868,33 @@ plugin 'Foo::BarBaz';
     assert!(invocants[0].contains("was_loaded"), "{:?}", invocants);
     assert!(invocants[1].contains("foo-bar_baz"), "{:?}", invocants);
 }
+
+/// Framework-assigned Mojo attrs (`has [qw(app tx)]` with no default —
+/// the framework sets them at dispatch) type via plugin overrides, and
+/// a plugin's `register($self, $app, $conf)` gets `$app: Mojolicious`
+/// via the param_types manifest — with or without an indexed Mojo
+/// source tree.
+#[test]
+fn mojo_framework_assigned_attrs_type() {
+    let src = "\
+package My::App::Plugin::Demo;
+use Mojo::Base 'Mojolicious::Plugin';
+sub register {
+  my ($self, $app, $conf) = @_;
+  return $app;
+}
+1;
+";
+    let fa = {
+        let mut parser = super::create_parser();
+        let tree = parser.parse(src, None).unwrap();
+        super::build_with_plugins(&tree, src.as_bytes(), super::default_plugin_registry())
+    };
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let t = fa.inferred_type_via_bag_ctx("$app", Point::new(4, 10), Some(&idx));
+    assert_eq!(
+        t,
+        Some(InferredType::ClassName("Mojolicious".into())),
+        "register's $app is the application",
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14793,3 +14793,47 @@ my $f = UNRESOLVED_BAREWORD_FH;
         "unresolvable barewords stay untouched",
     );
 }
+
+/// Mojolicious::Lite topic routes: `under(...)->to('ctrl#…')` sets the
+/// implicit base, `group { }` scopes it (an inner `under` applies only
+/// within, the outer base restores after), and `->to('#action')`
+/// partials on lite verb calls inherit the controller. Every name in
+/// the mechanism comes from the mojo-lite plugin's topic_route_dsl
+/// manifest; the base write is the plugin's SetRouteBase emission.
+#[test]
+fn lite_group_under_route_inheritance() {
+    let src = "\
+use Mojolicious::Lite;
+under('/auth')->to('login#check');
+group {
+  under('/n')->to('notifications#under');
+  get('/x')->to('#missing_fnsku');
+};
+get('/y')->to('#after_group');
+";
+    let fa = {
+        let mut parser = super::create_parser();
+        let tree = parser.parse(src, None).unwrap();
+        super::build_with_plugins(&tree, src.as_bytes(), super::default_plugin_registry())
+    };
+    let invocant_of = |action: &str| -> String {
+        fa.refs
+            .iter()
+            .find_map(|r| {
+                if r.target_name != action {
+                    return None;
+                }
+                let RefKind::MethodCall { ref invocant, .. } = r.kind else { return None };
+                Some(format!("{:?}", invocant))
+            })
+            .unwrap_or_else(|| panic!("no MethodCall ref for {action}"))
+    };
+    assert!(
+        invocant_of("missing_fnsku").contains("notifications"),
+        "in-group partial inherits the group's under",
+    );
+    assert!(
+        invocant_of("after_group").contains("login"),
+        "post-group partial inherits the OUTER under — the group frame popped",
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14898,3 +14898,37 @@ sub register {
         "register's $app is the application",
     );
 }
+
+/// Interpolation deref `${ EXPR }` — `scalar > block` with no varname
+/// wrapper — carries real code in strings AND regex patterns:
+/// `s/_to_${\ $self->filetype }$//` holds a method call that must get
+/// refs (the crm Clove::Converter idiom). The outer scalar emits
+/// nothing (its text is not a variable name).
+#[test]
+fn interpolation_deref_code_gets_refs() {
+    let src = "\
+package T;
+sub filetype { 'csv' }
+sub run {
+  my $self = shift;
+  my @m;
+  grep {s/_to_${\\$self->filetype}$//} @m;
+  my $y = \"x_${\\$self->filetype}_z\";
+  return $y;
+}
+1;
+";
+    let fa = build_fa(src);
+    let calls = fa
+        .refs
+        .iter()
+        .filter(|r| {
+            r.target_name == "filetype" && matches!(r.kind, RefKind::MethodCall { .. })
+        })
+        .count();
+    assert_eq!(calls, 2, "regex-pattern and string interpolations both ref");
+    assert!(
+        !fa.refs.iter().any(|r| r.target_name.contains("${")),
+        "no junk ref for the outer interpolation scalar",
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14760,3 +14760,36 @@ with map \"My::Roles::$_\", qw/Alpha Beta/;
         &["My::Roles::Alpha".to_string(), "My::Roles::Beta".to_string()],
     );
 }
+
+/// A bareword naming an in-scope sub IS a call (Perl prefers the
+/// defined sub over the class-name reading), so value-position
+/// barewords get the full function treatment: a FunctionCall ref per
+/// site — hover/goto-def/references/rename ride it. The declaration
+/// name slot and unresolvable barewords stay untouched.
+#[test]
+fn bareword_promotes_to_function_ref() {
+    let src = "\
+sub get_config { return { host => 1 } }
+my $a = get_config;
+my $b = get_config->{host};
+my @l = (get_config, 1);
+my $f = UNRESOLVED_BAREWORD_FH;
+";
+    let fa = build_fa(src);
+    let call_refs: Vec<_> = fa
+        .refs
+        .iter()
+        .filter(|r| {
+            r.target_name == "get_config" && matches!(r.kind, RefKind::FunctionCall { .. })
+        })
+        .collect();
+    assert_eq!(
+        call_refs.len(),
+        3,
+        "three value-position barewords promote; the decl name does not",
+    );
+    assert!(
+        !fa.refs.iter().any(|r| r.target_name == "UNRESOLVED_BAREWORD_FH"),
+        "unresolvable barewords stay untouched",
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14741,3 +14741,22 @@ my $mixed = [1, some_call()];
     let m = fa.inferred_type_via_bag("$mixed", Point::new(2, 10));
     assert_eq!(m, Some(InferredType::ArrayRef), "untypable element degrades whole literal");
 }
+
+/// `with map "Prefix::$_", qw/A B/` — the string-template map over a
+/// literal list folds statically: role parents land (resolution walks
+/// them) with per-word spans (goto-def on each qw word). The crm
+/// role-graph idiom.
+#[test]
+fn map_built_role_parents() {
+    let src = "\
+package My::Class;
+use Moo;
+with map \"My::Roles::$_\", qw/Alpha Beta/;
+";
+    let fa = build_fa(src);
+    let parents = fa.package_parents.get("My::Class").expect("parents recorded");
+    assert_eq!(
+        parents.as_slice(),
+        &["My::Roles::Alpha".to_string(), "My::Roles::Beta".to_string()],
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -365,6 +365,46 @@ pub(crate) fn string_content_span(node: Node) -> Span {
 /// the qw/string node). Non-literal elements (bareword constants,
 /// `@list` variables) go through `fold`: syntax lives here, constant
 /// resolution stays with the caller that has the state for it.
+/// `map "PREFIX$_", LIST` — the string-template map over a literal
+/// list is statically foldable: each produced string is the template
+/// with `$_` replaced by the list element, and its span is the
+/// ELEMENT's own span, so per-name refs (role parents, package lists)
+/// land on the word that produced them. Exactly one `$_` in the
+/// template and `map` only (`grep` filters, it doesn't transform);
+/// anything fancier is an honest miss. The crm idiom that motivated
+/// it: `with map "Clove::Sheets::Roles::$_", qw/CSV DB/;`.
+fn map_built_strings(
+    node: Node,
+    src: &[u8],
+    fold: &mut dyn FnMut(Node) -> Vec<(String, Span)>,
+) -> Vec<(String, Span)> {
+    let Some(kw) = node.child(0) else { return vec![] };
+    if kw.utf8_text(src).ok() != Some("map") {
+        return vec![];
+    }
+    let Some(cb) = node.child_by_field_name("callback") else { return vec![] };
+    if cb.kind() != "interpolated_string_literal" {
+        return vec![];
+    }
+    let Some(content) = cb.named().find(|c| c.kind() == "string_content") else {
+        return vec![];
+    };
+    let Ok(ctext) = content.utf8_text(src) else { return vec![] };
+    let subs: Vec<Node> = content.named().filter(|c| c.kind() == "scalar").collect();
+    let [topic] = subs.as_slice() else { return vec![] };
+    if topic.utf8_text(src).ok() != Some("$_") {
+        return vec![];
+    }
+    let pre_end = topic.start_byte() - content.start_byte();
+    let post_start = topic.end_byte() - content.start_byte();
+    let (pre, post) = (&ctext[..pre_end], &ctext[post_start..]);
+    let Some(list) = node.child_by_field_name("list") else { return vec![] };
+    string_list(list, src, fold)
+        .into_iter()
+        .map(|(t, sp)| (format!("{pre}{t}{post}"), sp))
+        .collect()
+}
+
 pub(crate) fn string_list(
     node: Node,
     src: &[u8],
@@ -383,6 +423,7 @@ pub(crate) fn string_list(
             return vec![];
         }
         "bareword" | "autoquoted_bareword" | "array" => return fold(node),
+        "map_grep_expression" => return map_built_strings(node, src, fold),
         _ => {}
     }
     let mut results = Vec::new();
@@ -399,6 +440,7 @@ pub(crate) fn string_list(
                 results.extend(string_list(child, src, fold));
             }
             "bareword" | "autoquoted_bareword" | "array" => results.extend(fold(child)),
+            "map_grep_expression" => results.extend(map_built_strings(child, src, fold)),
             _ => {}
         }
     }

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -294,6 +294,117 @@ pub(crate) fn canonical_container_name<'a>(node: Node<'a>, src: &'a [u8]) -> Opt
     Some(format!("{}{}", target_sigil, bare))
 }
 
+/// Per-word `(text, span)` pairs of a `quoted_word_list`, multi-line
+/// aware (rows/cols tracked through internal whitespace).
+pub(crate) fn qw_word_spans(qw_node: Node, src: &[u8], results: &mut Vec<(String, Span)>) {
+    for j in 0..qw_node.named_child_count() {
+        let Some(sc) = qw_node.named_child(j) else { continue };
+        if sc.kind() != "string_content" {
+            continue;
+        }
+        let Ok(text) = sc.utf8_text(src) else { continue };
+        let sc_start = sc.start_position();
+        let bytes = text.as_bytes();
+        let mut row = sc_start.row;
+        let mut col = sc_start.column;
+        let mut i = 0;
+        while i < bytes.len() {
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                if bytes[i] == b'\n' {
+                    row += 1;
+                    col = 0;
+                } else {
+                    col += 1;
+                }
+                i += 1;
+            }
+            let word_start = tree_sitter::Point { row, column: col };
+            let word_begin = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                col += 1;
+                i += 1;
+            }
+            if i > word_begin {
+                results.push((
+                    text[word_begin..i].to_string(),
+                    Span { start: word_start, end: tree_sitter::Point { row, column: col } },
+                ));
+            }
+        }
+    }
+}
+
+/// The `string_content` text of a quoted node — quote-flavor-agnostic.
+pub(crate) fn string_content_text(node: Node, src: &[u8]) -> Option<String> {
+    for i in 0..node.named_child_count() {
+        if let Some(content) = node.named_child(i) {
+            if content.kind() == "string_content" {
+                return content.utf8_text(src).ok().map(|s| s.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Span of the `string_content` inside a quoted node (selection span);
+/// the whole node when there is none (empty string).
+pub(crate) fn string_content_span(node: Node) -> Span {
+    for i in 0..node.named_child_count() {
+        if let Some(content) = node.named_child(i) {
+            if content.kind() == "string_content" {
+                return node_to_span(content);
+            }
+        }
+    }
+    node_to_span(node)
+}
+
+/// Strings of a list-ish node — qw(), paren/comma lists, arrayrefs,
+/// bare string literals — with per-word spans, INCLUDING the case
+/// where `node` itself is the leaf (a parenless call's `arguments` IS
+/// the qw/string node). Non-literal elements (bareword constants,
+/// `@list` variables) go through `fold`: syntax lives here, constant
+/// resolution stays with the caller that has the state for it.
+pub(crate) fn string_list(
+    node: Node,
+    src: &[u8],
+    fold: &mut dyn FnMut(Node) -> Vec<(String, Span)>,
+) -> Vec<(String, Span)> {
+    match node.kind() {
+        "quoted_word_list" => {
+            let mut results = Vec::new();
+            qw_word_spans(node, src, &mut results);
+            return results;
+        }
+        "string_literal" | "interpolated_string_literal" => {
+            if let Some(text) = string_content_text(node, src) {
+                return vec![(text, string_content_span(node))];
+            }
+            return vec![];
+        }
+        "bareword" | "autoquoted_bareword" | "array" => return fold(node),
+        _ => {}
+    }
+    let mut results = Vec::new();
+    for i in 0..node.child_count() {
+        let Some(child) = node.child(i) else { continue };
+        match child.kind() {
+            "quoted_word_list" => qw_word_spans(child, src, &mut results),
+            "string_literal" | "interpolated_string_literal" => {
+                if let Some(text) = string_content_text(child, src) {
+                    results.push((text, string_content_span(child)));
+                }
+            }
+            "parenthesized_expression" | "list_expression" | "anonymous_array_expression" => {
+                results.extend(string_list(child, src, fold));
+            }
+            "bareword" | "autoquoted_bareword" | "array" => results.extend(fold(child)),
+            _ => {}
+        }
+    }
+    results
+}
+
 /// True when `node` sits in a conditionally-executed position within
 /// its enclosing sub: under an if/unless block, a postfix modifier, a
 /// ternary arm, a loop, or a short-circuit chain (`and`/`or`; the

--- a/src/cursor_context.rs
+++ b/src/cursor_context.rs
@@ -1140,6 +1140,7 @@ pub fn build_plugin_query_context(
             Some(s) => vec![crate::plugin::ArgInfo {
                 text: s.clone(),
                 string_value: Some(s.clone()),
+                string_values: vec![s.clone()],
                 span: crate::file_analysis::Span {
                     start: point,
                     end: point,

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,4 +1,4 @@
-use tree_sitter::{InputEdit, Parser, Point, Tree};
+use tree_sitter::{InputEdit, Point, Tree};
 
 use crate::builder;
 use crate::file_analysis::{FileAnalysis, SymKind};

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -499,6 +499,12 @@ pub enum SymbolDetail {
         /// a name set (rule #10).
         #[serde(default)]
         is_constant: bool,
+        /// `my sub helper { … }` — scoped to its enclosing block, not
+        /// callable by name from anywhere else. Document symbols show
+        /// it (it's real in-file structure); workspace-symbol search
+        /// does not (it's not a workspace-addressable entity).
+        #[serde(default)]
+        lexical: bool,
     },
     Class {
         parent: Option<String>,

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2276,6 +2276,13 @@ pub struct FileAnalysis {
     #[serde(default)]
     pub key_writes: Vec<KeyWrite>,
 
+    /// Per-role `requires` lists: the method contracts a composing
+    /// class must fulfill. The synthesized Method symbols carry the
+    /// in-role resolution; this record is the input for the future
+    /// composer-mismatch diagnostic (docs/prompt-role-requires.md).
+    #[serde(default)]
+    pub role_requires: HashMap<String, Vec<String>>,
+
     // Indices (built in post-pass — skipped by serde; call rebuild_all_indices() after deserialize)
     #[serde(skip, default)]
     scope_starts: Vec<(Point, ScopeId)>, // sorted by start point
@@ -2337,6 +2344,7 @@ pub struct FileAnalysisParts {
     pub attr_projections: Vec<AttrProjection>,
     pub reassigned_scalars: HashSet<String>,
     pub key_writes: Vec<KeyWrite>,
+    pub role_requires: HashMap<String, Vec<String>>,
 }
 
 /// One projection of a field/attr decl — the entity that encodes group
@@ -2461,6 +2469,7 @@ impl FileAnalysis {
             attr_projections,
             reassigned_scalars,
             key_writes,
+            role_requires,
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
@@ -2493,6 +2502,7 @@ impl FileAnalysis {
             attr_projections,
             reassigned_scalars,
             key_writes,
+            role_requires,
             scope_starts: Vec::new(),
             symbols_by_name: HashMap::new(),
             symbols_by_scope: HashMap::new(),

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -151,6 +151,7 @@ fn test_resolve_sub_return_type() {
                 hide_in_outline: false,
                 opaque_return: false,
                 is_constant: false,
+                lexical: false,
             },
             namespace: Namespace::Language,
             outline_label: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,9 @@ fn cli_full_startup(root: &str) -> (file_store::FileStore, module_index::ModuleI
     // Indexing without the index (bridge-less) is what forced callers to
     // hand-roll their own `index_workspace_with_index`, and they drifted.
     let module_index = module_index::ModuleIndex::new_for_cli();
+    // Wake the headless resolver: it blocks on this channel for the
+    // @INC scan + SQLite warm.
+    module_index.set_workspace_root(Some(root_uri.as_str()));
     let ws = file_store::FileStore::new();
     let indexed = module_resolver::index_workspace_with_index(&root_path, &ws, Some(&module_index));
     eprintln!("Indexed {} files", indexed);
@@ -674,6 +677,36 @@ impl Drop for ScopedWorkspaceEntry<'_> {
     }
 }
 
+/// Resolve the query file's direct imports before answering. The LSP
+/// backend does this on didOpen (request_resolve per import); a CLI
+/// query is one-shot, so it requests AND waits, bounded per module.
+/// Without it, modules nothing in the workspace literally `use`s —
+/// framework-implied SyntheticUses like Mojolicious::Plugin::
+/// DefaultHelpers — resolve in the editor but stay invisible to CLI
+/// probes and the gold harness.
+fn resolve_imports_blocking(
+    idx: &module_index::ModuleIndex,
+    analysis: &file_analysis::FileAnalysis,
+) {
+    for imp in &analysis.imports {
+        idx.request_resolve(&imp.module_name);
+    }
+    // Global budget, not per-import: a cold cache resolving a
+    // framework's whole dependency tree must not stall the CLI for
+    // minutes. Each resolved module persists to the SQLite cache, so
+    // repeated runs converge to fully warm; within one run we answer
+    // with whatever resolved in time (the editor is eventually-
+    // consistent here too — it refreshes when resolution lands).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    for imp in &analysis.imports {
+        let left = deadline.saturating_duration_since(std::time::Instant::now());
+        if left.is_zero() {
+            break;
+        }
+        let _ = idx.wait_resolved(&imp.module_name, left);
+    }
+}
+
 fn run_one(
     ws: &file_store::FileStore,
     idx: &module_index::ModuleIndex,
@@ -693,6 +726,7 @@ fn run_one(
     match req.q.as_str() {
         "definition" => {
             let (_source, _tree, mut analysis) = parse_file(file);
+            resolve_imports_blocking(idx, &analysis);
             analysis.enrich_imported_types_with_keys(Some(idx));
             let abs = std::fs::canonicalize(file).unwrap_or_else(|_| std::path::PathBuf::from(file));
             let uri = tower_lsp::lsp_types::Url::from_file_path(&abs)
@@ -718,6 +752,7 @@ fn run_one(
         }
         "references" => {
             let (_s, _t, mut analysis) = parse_file(file);
+            resolve_imports_blocking(idx, &analysis);
             analysis.enrich_imported_types_with_keys(Some(idx));
             let file_path = std::path::Path::new(file).canonicalize()
                 .unwrap_or_else(|_| std::path::PathBuf::from(file));
@@ -762,12 +797,14 @@ fn run_one(
         }
         "hover" => {
             let (source, _t, mut analysis) = parse_file(file);
+            resolve_imports_blocking(idx, &analysis);
             analysis.enrich_imported_types_with_keys(Some(idx));
             analysis.hover_info(point, &source, Some(idx))
                 .ok_or_else(|| format!("No hover info at {}:{}", req.line, req.col))
         }
         "type-at" => {
             let (_s, _t, analysis) = parse_file(file);
+            resolve_imports_blocking(idx, &analysis);
             if let Some(r) = analysis.ref_at(point) {
                 if let Some(ty) = analysis.inferred_type_via_bag(&r.target_name, point) {
                     return Ok(file_analysis::format_inferred_type(&ty));
@@ -872,6 +909,7 @@ fn run_one(
         }
         "outline" => {
             let (_s, _t, analysis) = parse_file(file);
+            resolve_imports_blocking(idx, &analysis);
             Ok(outline_json(&analysis))
         }
         "workspace-symbol" => {

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 87;
+pub const EXTRACT_VERSION: i64 = 88;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 88;
+pub const EXTRACT_VERSION: i64 = 89;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 86;
+pub const EXTRACT_VERSION: i64 = 87;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 85;
+pub const EXTRACT_VERSION: i64 = 86;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 84;
+pub const EXTRACT_VERSION: i64 = 85;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -122,12 +122,14 @@ impl ModuleIndex {
             condvar: Condvar::new(),
         });
 
+        let bridges_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
         let refresh = Arc::new(on_diagnostics_refresh);
         let refresh_clone = Arc::clone(&refresh);
 
         module_resolver::spawn_resolver(
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
+            Arc::clone(&bridges_index),
             Arc::clone(&stale_modules),
             Arc::clone(&available_modules),
             Arc::clone(&builtins),
@@ -140,7 +142,8 @@ impl ModuleIndex {
 
         ModuleIndex {
             cache,
-            reverse_index,            bridges_index: Arc::new(DashMap::new()),
+            reverse_index,
+            bridges_index,
             stale_modules,
             available_modules,
             builtins,
@@ -382,35 +385,15 @@ impl ModuleIndex {
 
     /// Create a minimal ModuleIndex for CLI mode (no resolver thread, no @INC scan).
     pub fn new_for_cli() -> Self {
-        ModuleIndex {
-            cache: Arc::new(DashMap::new()),
-            reverse_index: Arc::new(DashMap::new()),            bridges_index: Arc::new(DashMap::new()),
-            stale_modules: Arc::new(DashMap::new()),
-            available_modules: Arc::new(DashMap::new()),
-            builtins: Arc::new(DashMap::new()),
-            queue: Arc::new(ResolveQueue {
-                priority: Mutex::new(Vec::new()),
-                pending: Mutex::new(Vec::new()),
-                condvar: Condvar::new(),
-            }),
-            resolved: Arc::new(ResolveNotify {
-                mu: Mutex::new(()),
-                cv: Condvar::new(),
-            }),
-            workspace_root: Arc::new(WorkspaceRootChannel {
-                root: Mutex::new(None),
-                condvar: Condvar::new(),
-            }),
-            refresh_diagnostics: Arc::new(|| {}),
-        }
-    }
-
-    // ---- Test-only methods ----
-
-    #[cfg(test)]
-    pub fn new_for_test() -> Self {
+        // A real (headless) resolver thread: one-shot CLI sessions used
+        // to carry NO resolver, so they could never resolve a module the
+        // editor hadn't already cached — framework-implied imports
+        // (DefaultHelpers) stayed invisible to every CLI probe and the
+        // gold harness. The thread blocks until `set_workspace_root`
+        // fires in `cli_full_startup`.
         let cache: Arc<DashMap<String, Option<Arc<CachedModule>>>> = Arc::new(DashMap::new());
         let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
+        let bridges_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
         let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
         let available_modules: Arc<DashMap<String, std::path::PathBuf>> = Arc::new(DashMap::new());
         let builtins: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
@@ -431,6 +414,7 @@ impl ModuleIndex {
         module_resolver::spawn_test_resolver(
             Arc::clone(&cache),
             Arc::clone(&reverse_index),
+            Arc::clone(&bridges_index),
             Arc::clone(&stale_modules),
             Arc::clone(&available_modules),
             Arc::clone(&queue),
@@ -440,7 +424,57 @@ impl ModuleIndex {
 
         ModuleIndex {
             cache,
-            reverse_index,            bridges_index: Arc::new(DashMap::new()),
+            reverse_index,
+            bridges_index,
+            stale_modules,
+            available_modules,
+            builtins,
+            queue,
+            resolved,
+            workspace_root,
+            refresh_diagnostics: Arc::new(|| {}),
+        }
+    }
+
+    // ---- Test-only methods ----
+
+    #[cfg(test)]
+    pub fn new_for_test() -> Self {
+        let cache: Arc<DashMap<String, Option<Arc<CachedModule>>>> = Arc::new(DashMap::new());
+        let reverse_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
+        let bridges_index: Arc<DashMap<String, Vec<String>>> = Arc::new(DashMap::new());
+        let stale_modules: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
+        let available_modules: Arc<DashMap<String, std::path::PathBuf>> = Arc::new(DashMap::new());
+        let builtins: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
+        let queue = Arc::new(ResolveQueue {
+            priority: Mutex::new(Vec::new()),
+            pending: Mutex::new(Vec::new()),
+            condvar: Condvar::new(),
+        });
+        let resolved = Arc::new(ResolveNotify {
+            mu: Mutex::new(()),
+            cv: Condvar::new(),
+        });
+        let workspace_root = Arc::new(WorkspaceRootChannel {
+            root: Mutex::new(None),
+            condvar: Condvar::new(),
+        });
+
+        module_resolver::spawn_test_resolver(
+            Arc::clone(&cache),
+            Arc::clone(&reverse_index),
+            Arc::clone(&bridges_index),
+            Arc::clone(&stale_modules),
+            Arc::clone(&available_modules),
+            Arc::clone(&queue),
+            Arc::clone(&resolved),
+            Arc::clone(&workspace_root),
+        );
+
+        ModuleIndex {
+            cache,
+            reverse_index,
+            bridges_index,
             stale_modules,
             available_modules,
             builtins,
@@ -542,6 +576,7 @@ impl ModuleIndex {
     /// calls the equivalent rebuild after its own warm.
     pub fn rebuild_reverse_index_from_cache(&self) {
         self.reverse_index.clear();
+        self.bridges_index.clear();
         for entry in self.cache.iter() {
             if let Some(ref cached) = *entry.value() {
                 for name in crate::module_resolver::reverse_index_names(&cached.analysis) {
@@ -549,6 +584,23 @@ impl ModuleIndex {
                         .entry(name)
                         .or_default()
                         .push(entry.key().clone());
+                }
+                // Bridges too — same cold/warm-attribution class as the
+                // reverse index above: the warm path writes blobs straight
+                // into the cache, so a helper registered in a dependency
+                // (DefaultHelpers) was reachable on the cold run that
+                // resolved it and INVISIBLE on every warm start after.
+                let mut seen: std::collections::HashSet<&str> =
+                    std::collections::HashSet::new();
+                for ns in &cached.analysis.plugin_namespaces {
+                    for crate::file_analysis::Bridge::Class(c) in &ns.bridges {
+                        if seen.insert(c.as_str()) {
+                            self.bridges_index
+                                .entry(c.clone())
+                                .or_default()
+                                .push(entry.key().clone());
+                        }
+                    }
                 }
             }
         }
@@ -630,7 +682,8 @@ impl ModuleIndex {
     }
 
     /// Block until `module_name` appears in the cache, or timeout.
-    #[cfg(test)]
+    /// (Used by tests and the one-shot CLI import resolution.)
+    #[doc(hidden)]
     pub fn wait_resolved(&self, module_name: &str, timeout: std::time::Duration) -> bool {
         let deadline = std::time::Instant::now() + timeout;
         let mut guard = self.resolved.mu.lock().unwrap();

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -28,6 +28,7 @@ pub type OnResolved = Box<dyn Fn() + Send + Sync>;
 pub fn spawn_resolver(
     cache: Arc<DashMap<String, Option<Arc<CachedModule>>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
+    bridges_index: Arc<DashMap<String, Vec<String>>>,
     stale_modules: Arc<DashMap<String, ()>>,
     available_modules: Arc<DashMap<String, PathBuf>>,
     builtins: Arc<DashMap<String, String>>,
@@ -89,7 +90,7 @@ pub fn spawn_resolver(
                     queue.condvar.notify_one();
                 }
                 // Build reverse index from warmed cache.
-                rebuild_reverse_index(&cache, &reverse_index);
+                rebuild_reverse_index(&cache, &reverse_index, &bridges_index);
             }
 
             // Track which extract version each module was resolved at.
@@ -178,6 +179,7 @@ pub fn spawn_resolver(
                     insert_into_cache(
                         &cache,
                         &reverse_index,
+                        &bridges_index,
                         &module_name,
                         result.clone(),
                     );
@@ -319,11 +321,16 @@ fn drain_next_batch(queue: &ResolveQueue) -> Vec<String> {
     }
 }
 
-/// Simplified resolver for tests — no Client, no progress, no cpanfile.
-#[cfg(test)]
+/// Headless resolver — no Client, no LSP progress. Same @INC scan,
+/// project-local lib discovery, SQLite warm/persist, and index feeds
+/// as the full resolver. Serves tests AND one-shot CLI sessions
+/// (`ModuleIndex::new_for_cli`), which previously had NO resolver at
+/// all and could only read what editor sessions had cached.
+#[doc(hidden)]
 pub fn spawn_test_resolver(
     cache: Arc<DashMap<String, Option<Arc<CachedModule>>>>,
     reverse_index: Arc<DashMap<String, Vec<String>>>,
+    bridges_index: Arc<DashMap<String, Vec<String>>>,
     stale_modules: Arc<DashMap<String, ()>>,
     available_modules: Arc<DashMap<String, PathBuf>>,
     queue: Arc<ResolveQueue>,
@@ -355,7 +362,7 @@ pub fn spawn_test_resolver(
                 for name in stale_names {
                     stale_modules.insert(name, ());
                 }
-                rebuild_reverse_index(&cache, &reverse_index);
+                rebuild_reverse_index(&cache, &reverse_index, &bridges_index);
             }
 
             let mut seen: HashMap<String, i64> = HashMap::new();
@@ -375,7 +382,7 @@ pub fn spawn_test_resolver(
                     }
 
                     let result = parse_module(&inc_paths, &module_name, &mut parser, &mut parse_memo);
-                    insert_into_cache(&cache, &reverse_index, &module_name, result.clone());
+                    insert_into_cache(&cache, &reverse_index, &bridges_index, &module_name, result.clone());
                     if let Some(ref conn) = db {
                         module_cache::save_to_db(conn, &module_name, &result, "import");
                     }
@@ -431,6 +438,7 @@ fn indexable_symbol_names(analysis: &crate::file_analysis::FileAnalysis) -> Vec<
 fn insert_into_cache(
     cache: &DashMap<String, Option<Arc<CachedModule>>>,
     reverse_index: &DashMap<String, Vec<String>>,
+    bridges_index: &DashMap<String, Vec<String>>,
     module_name: &str,
     result: Option<Arc<CachedModule>>,
 ) {
@@ -438,6 +446,12 @@ fn insert_into_cache(
         for name in reverse_index_names(&cached.analysis) {
             reverse_index
                 .entry(name)
+                .or_default()
+                .push(module_name.to_string());
+        }
+        for class in bridge_classes(&cached.analysis) {
+            bridges_index
+                .entry(class)
                 .or_default()
                 .push(module_name.to_string());
         }
@@ -466,16 +480,40 @@ pub fn reverse_index_names(analysis: &crate::file_analysis::FileAnalysis) -> Vec
     names.into_iter().collect()
 }
 
+/// The bridge classes an analysis' plugin namespaces declare — the
+/// feed for `bridges_index`, deduped. Shared by every cache-insert and
+/// warm-rebuild site so dependency modules and workspace modules
+/// register bridges identically.
+pub fn bridge_classes(analysis: &crate::file_analysis::FileAnalysis) -> Vec<String> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for ns in &analysis.plugin_namespaces {
+        for crate::file_analysis::Bridge::Class(c) in &ns.bridges {
+            seen.insert(c.clone());
+        }
+    }
+    seen.into_iter().collect()
+}
+
 /// Rebuild reverse index from existing cache (e.g. after warming from SQLite).
 fn rebuild_reverse_index(
     cache: &DashMap<String, Option<Arc<CachedModule>>>,
     reverse_index: &DashMap<String, Vec<String>>,
+    bridges_index: &DashMap<String, Vec<String>>,
 ) {
     for entry in cache.iter() {
         if let Some(ref cached) = *entry.value() {
             for name in reverse_index_names(&cached.analysis) {
                 reverse_index
                     .entry(name)
+                    .or_default()
+                    .push(entry.key().clone());
+            }
+            // Bridges ride the same rebuild — the warm path that made
+            // dependency-registered helpers invisible on every start
+            // after the cold resolve (cold/warm attribution, B6 class).
+            for class in bridge_classes(&cached.analysis) {
+                bridges_index
+                    .entry(class)
                     .or_default()
                     .push(entry.key().clone());
             }

--- a/src/module_resolver_tests.rs
+++ b/src/module_resolver_tests.rs
@@ -77,14 +77,15 @@ sub new {
 
     let cache: DashMap<String, Option<Arc<CachedModule>>> = DashMap::new();
     let reverse_index: DashMap<String, Vec<String>> = DashMap::new();
+    let bridges_index: DashMap<String, Vec<String>> = DashMap::new();
     let cached = Arc::new(CachedModule::new(PathBuf::from("/x/Demo/Has/Event.pm"), analysis));
 
     // Workspace-index style insert: a resolved module.
-    insert_into_cache(&cache, &reverse_index, "Demo::Has::Event", Some(cached));
+    insert_into_cache(&cache, &reverse_index, &bridges_index, "Demo::Has::Event", Some(cached));
     assert!(cache.get("Demo::Has::Event").as_deref().unwrap().is_some());
 
     // On-demand resolver miss: `None`. Must NOT clobber the indexed copy.
-    insert_into_cache(&cache, &reverse_index, "Demo::Has::Event", None);
+    insert_into_cache(&cache, &reverse_index, &bridges_index, "Demo::Has::Event", None);
     assert!(
         cache.get("Demo::Has::Event").as_deref().unwrap().is_some(),
         "a None on-demand miss clobbered an already-indexed module",
@@ -95,7 +96,7 @@ sub new {
     let tree2 = parser.parse(source, None).unwrap();
     let analysis2 = std::sync::Arc::new(crate::builder::build(&tree2, source.as_bytes()));
     let cached2 = Arc::new(CachedModule::new(PathBuf::from("/y/Demo/Has/Event.pm"), analysis2));
-    insert_into_cache(&cache, &reverse_index, "Demo::Has::Event", Some(cached2));
+    insert_into_cache(&cache, &reverse_index, &bridges_index, "Demo::Has::Event", Some(cached2));
     assert_eq!(
         cache.get("Demo::Has::Event").as_deref().unwrap().as_ref().unwrap().path,
         PathBuf::from("/y/Demo/Has/Event.pm"),

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -119,6 +119,11 @@ pub struct CallContext {
     pub method_name: Option<String>,
     /// Raw text of receiver (`$self`, `__PACKAGE__`, etc.). Methods only.
     pub receiver_text: Option<String>,
+    /// When the receiver is itself a CALL (`get('/x')->to(...)`), the
+    /// called function's name — a generic syntax fact, so plugins can
+    /// match their own DSL verbs without core knowing any names.
+    #[serde(default)]
+    pub receiver_call_name: Option<String>,
     /// Resolved receiver type if inference succeeded.
     pub receiver_type: Option<InferredType>,
     /// Route defaults inherited by the receiver value, flattened to a
@@ -241,9 +246,30 @@ impl From<EmittedParam> for ParamInfo {
 /// body's scope doesn't exist yet when `VarType` is emitted), but they
 /// ARE the exceptions — prefer a data emission when you can express the
 /// same thing that way. New side-effect variants need explicit sign-off.
+/// See [`FrameworkPlugin::topic_route_dsl`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicRouteDsl {
+    /// The `use` that puts the DSL in scope (gates the stack).
+    pub module: String,
+    /// Route verbs whose CALL can stand as a `->to` receiver.
+    pub verbs: Vec<String>,
+    /// The block function that scopes the base (push on entry, pop on
+    /// exit).
+    pub group_fn: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EmitAction {
     // ==== Data emissions ====
+
+    /// Set the current topic-route base (the controller following
+    /// sibling routes inherit). Applied to the innermost open scope
+    /// frame of the walk's topic-route stack; the plugin that parses
+    /// `->to('ctrl#…')` emits it when the receiver is its declared
+    /// base-setter verb. Core never parses route specs.
+    SetRouteBase {
+        controller: String,
+    },
 
     /// Emit an accessor-style method. Shorthand for Symbol + SymKind::Method +
     /// SymbolDetail::Sub. The plugin's id becomes the symbol's Namespace tag.
@@ -779,6 +805,16 @@ pub trait FrameworkPlugin: Send + Sync {
     /// consumer set declared once. Default empty.
     fn app_surface_consumers(&self) -> &[String] {
         &[]
+    }
+
+    /// A topic-scoped route DSL this plugin owns (the
+    /// Mojolicious::Lite shape): file-level route verbs whose implicit
+    /// base a [`EmitAction::SetRouteBase`] emission sets and a scope
+    /// function brackets. Core provides only the generic stack — every
+    /// NAME in the mechanism (the gating module, the verb set, the
+    /// scope function) is declared here, never hardcoded in core.
+    fn topic_route_dsl(&self) -> Option<TopicRouteDsl> {
+        None
     }
 
     /// Fold a constraint constructor's extracted params into the

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -55,7 +55,16 @@ pub struct ArgInfo {
     pub text: String,
     /// Constant-folded string if the arg is a literal/bareword or resolves
     /// through `constant_strings`. `None` means "runtime/unknown".
+    /// Multi-valued folds (a loop variable over `qw(...)`, the postfix
+    /// `for` topic) surface their FIRST value here for back-compat;
+    /// `string_values` carries them all.
     pub string_value: Option<String>,
+    /// Every constant-folded candidate for this arg. Single-valued for
+    /// literals; the full list for loop-variable / `$_` folds — a
+    /// registration loop (`$app->helper($_ => …) for qw(a b c)`) is N
+    /// registrations, and plugins fan out over this.
+    #[serde(default)]
+    pub string_values: Vec<String>,
     pub span: Span,
     /// For string-literal args, the span of the INNER content only —
     /// excludes the quote delimiters, heredoc markers, or `q{}`/`qq!!`

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -832,6 +832,7 @@ mod tests {
                 ArgInfo {
                     text: "'connect'".into(),
                     string_value: Some("connect".into()),
+                    string_values: Vec::new(),
                     span: evt_span,
                     content_span: None,
                     inferred_type: Some(InferredType::String), sub_params: vec![], callable_return_edge: None, ref_sub_name: None,
@@ -839,6 +840,7 @@ mod tests {
                 ArgInfo {
                     text: "sub { ... }".into(),
                     string_value: None,
+                    string_values: Vec::new(),
                     span: cb_span,
                     content_span: None,
                     inferred_type: Some(InferredType::CodeRef { return_edge: None }), sub_params: vec![], callable_return_edge: None, ref_sub_name: None,
@@ -905,6 +907,7 @@ mod tests {
                 args: vec![ArgInfo {
                     text: accessor.into(),
                     string_value: Some(accessor.into()),
+                    string_values: Vec::new(),
                     span: name_span,
                     content_span: None,
                     inferred_type: Some(InferredType::String),
@@ -949,6 +952,7 @@ mod tests {
             args: vec![ArgInfo {
                 text: "x".into(),
                 string_value,
+                string_values: Vec::new(),
                 span: sp(1, 4, 1, 8),
                 content_span: None,
                 inferred_type: None,
@@ -996,6 +1000,7 @@ mod tests {
                 ArgInfo {
                     text: "$name".into(),
                     string_value: None,
+                    string_values: Vec::new(),
                     span: sp(0, 0, 0, 5),
                     content_span: None,
                     inferred_type: None, sub_params: vec![], callable_return_edge: None, ref_sub_name: None,
@@ -1003,6 +1008,7 @@ mod tests {
                 ArgInfo {
                     text: "sub {}".into(),
                     string_value: None,
+                    string_values: Vec::new(),
                     span: sp(0, 6, 0, 12),
                     content_span: None,
                     inferred_type: Some(InferredType::CodeRef { return_edge: None }), sub_params: vec![], callable_return_edge: None, ref_sub_name: None,
@@ -1139,6 +1145,7 @@ mod tests {
                 ArgInfo {
                     text: "'Foo'".into(),
                     string_value: Some("Foo".into()),
+                    string_values: Vec::new(),
                     span: name_span,
                     content_span: Some(name_span),
                     inferred_type: Some(InferredType::String),
@@ -1189,6 +1196,7 @@ mod tests {
                 ArgInfo {
                     text: "'/Root/index'".into(),
                     string_value: Some("/Root/index".into()),
+                    string_values: Vec::new(),
                     span: path_span,
                     content_span: Some(path_span),
                     inferred_type: Some(InferredType::String),
@@ -1239,6 +1247,7 @@ mod tests {
                 ArgInfo {
                     text: "'Foo'".into(),
                     string_value: Some("Foo".into()),
+                    string_values: Vec::new(),
                     span: sp(0, 0, 0, 5),
                     content_span: None,
                     inferred_type: Some(InferredType::String),

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -137,6 +137,7 @@ pub struct RhaiPlugin {
     param_types: Vec<ParamType>,
     type_constraint_names: Vec<String>,
     app_surface_consumers: Vec<String>,
+    topic_route_dsl: Option<crate::plugin::TopicRouteDsl>,
     engine: Arc<Engine>,
     ast: Arc<AST>,
     has_on_function_call: bool,
@@ -282,6 +283,19 @@ impl RhaiPlugin {
             }
         }
 
+        // `topic_route_dsl()` — optional manifest map; bad shapes log
+        // and disable rather than fail the plugin.
+        let mut topic_route_dsl: Option<crate::plugin::TopicRouteDsl> = None;
+        if signatures.iter().any(|n| n == "topic_route_dsl") {
+            match engine.call_fn::<Dynamic>(&mut rhai::Scope::new(), &ast, "topic_route_dsl", ()) {
+                Ok(d) => match from_dynamic::<crate::plugin::TopicRouteDsl>(&d) {
+                    Ok(t) => topic_route_dsl = Some(t),
+                    Err(e) => log::error!("plugin `{}` topic_route_dsl() bad shape: {}", id, e),
+                },
+                Err(e) => log::error!("plugin `{}` topic_route_dsl() failed: {}", id, e),
+            }
+        }
+
         Ok(Self {
             has_on_function_call: signatures.iter().any(|n| n == "on_function_call"),
             has_type_constraint_inner: signatures.iter().any(|n| n == "type_constraint_inner"),
@@ -296,6 +310,7 @@ impl RhaiPlugin {
             param_types,
             type_constraint_names,
             app_surface_consumers,
+            topic_route_dsl,
             engine,
             ast: Arc::new(ast),
         })
@@ -384,6 +399,10 @@ impl FrameworkPlugin for RhaiPlugin {
 
     fn app_surface_consumers(&self) -> &[String] {
         &self.app_surface_consumers
+    }
+
+    fn topic_route_dsl(&self) -> Option<crate::plugin::TopicRouteDsl> {
+        self.topic_route_dsl.clone()
     }
 
     fn type_constraint_inner(
@@ -695,6 +714,7 @@ mod tests {
             function_name: Some("greet".into()),
             method_name: None,
             receiver_text: None,
+            receiver_call_name: None,
             receiver_type: None,
             receiver_route_defaults: Vec::new(),
             args: vec![],
@@ -805,6 +825,7 @@ mod tests {
             function_name: None,
             method_name: Some("on".into()),
             receiver_text: Some("$self".into()),
+            receiver_call_name: None,
             receiver_type: Some(InferredType::ClassName("My::Emitter".into())),
             receiver_route_defaults: Vec::new(),
             args: vec![
@@ -878,6 +899,7 @@ mod tests {
                 function_name: Some(func.into()),
                 method_name: None,
                 receiver_text: None,
+                receiver_call_name: None,
                 receiver_type: None,
                 receiver_route_defaults: Vec::new(),
                 args: vec![ArgInfo {
@@ -921,6 +943,7 @@ mod tests {
             function_name: Some(func.into()),
             method_name: None,
             receiver_text: None,
+            receiver_call_name: None,
             receiver_type: None,
             receiver_route_defaults: Vec::new(),
             args: vec![ArgInfo {
@@ -965,6 +988,7 @@ mod tests {
             function_name: None,
             method_name: Some("on".into()),
             receiver_text: Some("$self".into()),
+            receiver_call_name: None,
             receiver_type: Some(InferredType::ClassName("Foo".into())),
             receiver_route_defaults: Vec::new(),
             args: vec![
@@ -1108,6 +1132,7 @@ mod tests {
             function_name: None,
             method_name: Some("model".into()),
             receiver_text: Some("$c".into()),
+            receiver_call_name: None,
             receiver_type: Some(InferredType::ClassName("Catalyst".into())),
             receiver_route_defaults: vec![],
             args: vec![
@@ -1157,6 +1182,7 @@ mod tests {
             function_name: None,
             method_name: Some("forward".into()),
             receiver_text: Some("$c".into()),
+            receiver_call_name: None,
             receiver_type: Some(InferredType::ClassName("Catalyst".into())),
             receiver_route_defaults: vec![],
             args: vec![
@@ -1206,6 +1232,7 @@ mod tests {
             function_name: None,
             method_name: Some("model".into()),
             receiver_text: Some("$schema".into()),
+            receiver_call_name: None,
             receiver_type: Some(InferredType::ClassName("DBIx::Class::Schema".into())),
             receiver_route_defaults: vec![],
             args: vec![
@@ -1251,6 +1278,7 @@ mod tests {
             function_name: Some("unrelated".into()),
             method_name: None,
             receiver_text: None,
+            receiver_call_name: None,
             receiver_type: None,
             receiver_route_defaults: Vec::new(),
             args: vec![],

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -156,8 +156,13 @@ pub fn symbol_to_workspace_info(sym: &crate::file_analysis::Symbol, uri: Url) ->
     }
     // The detail's hide_in_outline covers the workspace list too —
     // anon subs and plugin DSL imports are resolvable, not browsable.
-    if let crate::file_analysis::SymbolDetail::Sub { hide_in_outline: true, .. } = &sym.detail {
-        return None;
+    // Lexical subs likewise: document symbols show them (in-file
+    // structure), workspace search does not (not addressable outside
+    // their block).
+    match &sym.detail {
+        crate::file_analysis::SymbolDetail::Sub { hide_in_outline: true, .. }
+        | crate::file_analysis::SymbolDetail::Sub { lexical: true, .. } => return None,
+        _ => {}
     }
     Some(SymbolInformation {
         name: sym.name.clone(),

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -154,6 +154,11 @@ pub fn symbol_to_workspace_info(sym: &crate::file_analysis::Symbol, uri: Url) ->
         FaSymKind::Sub | FaSymKind::Method | FaSymKind::Package | FaSymKind::Class => {}
         _ => return None,
     }
+    // The detail's hide_in_outline covers the workspace list too —
+    // anon subs and plugin DSL imports are resolvable, not browsable.
+    if let crate::file_analysis::SymbolDetail::Sub { hide_in_outline: true, .. } = &sym.detail {
+        return None;
+    }
     Some(SymbolInformation {
         name: sym.name.clone(),
         kind: fa_sym_kind_to_lsp(&sym.kind),

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4544,3 +4544,28 @@ sub real_sub { 1 }
         names,
     );
 }
+
+/// `my sub helper { … }` — document symbols keep it (real in-file
+/// structure); workspace-symbol search drops it (not addressable
+/// outside its block). Plain subs surface in both.
+#[test]
+fn test_lexical_subs_outline_only() {
+    let src = "\
+my sub helper_fn { 42 }
+sub public_fn { helper_fn() }
+";
+    let analysis = parse_analysis(src);
+    let uri = tower_lsp::lsp_types::Url::parse("file:///t.pl").unwrap();
+    let ws: Vec<String> = analysis
+        .symbols
+        .iter()
+        .filter_map(|s| symbol_to_workspace_info(s, uri.clone()))
+        .map(|i| i.name)
+        .collect();
+    assert!(ws.iter().any(|n| n == "public_fn"), "{:?}", ws);
+    assert!(!ws.iter().any(|n| n == "helper_fn"), "lexical stays out of workspace: {:?}", ws);
+    let outline = analysis.document_symbols();
+    let names: Vec<&str> = outline.iter().map(|d| d.name.as_str()).collect();
+    assert!(names.contains(&"helper_fn"), "outline keeps the lexical sub: {:?}", names);
+    assert!(names.contains(&"public_fn"), "{:?}", names);
+}

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4515,3 +4515,32 @@ sub run {
         "the contract record carries all three names",
     );
 }
+
+/// Anonymous subs are resolvable, not browsable: the synthesized
+/// `(anon)` symbol carries hide_in_outline, and the workspace-symbol
+/// converter honors it (an empty/broad query must not surface them).
+#[test]
+fn test_anon_subs_hidden_from_workspace_symbols() {
+    let src = "\
+my $cb = sub { return 42 };
+sub real_sub { 1 }
+";
+    let analysis = parse_analysis(src);
+    let uri = tower_lsp::lsp_types::Url::parse("file:///t.pl").unwrap();
+    let names: Vec<String> = analysis
+        .symbols
+        .iter()
+        .filter_map(|s| symbol_to_workspace_info(s, uri.clone()))
+        .map(|i| i.name)
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "real_sub"),
+        "real subs surface: {:?}",
+        names,
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("anon")),
+        "anon subs stay out: {:?}",
+        names,
+    );
+}

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4473,3 +4473,45 @@ cfg()->{hsot2};
         keys,
     );
 }
+
+/// Role `requires NAMES` declares method contracts: `$self->name`
+/// inside the role resolves to the synthesized marker (no
+/// unresolved-method hint, goto-def lands on the contract atom); a
+/// genuinely unknown method still hints. Both the qw and
+/// single-string spellings.
+#[test]
+fn test_role_requires_suppresses_unresolved_method() {
+    let src = "\
+package My::Role;
+use Moo::Role;
+requires qw/fetch source/;
+requires 'extra';
+sub run {
+  my ($self) = @_;
+  $self->fetch;
+  $self->source;
+  $self->extra;
+  $self->typo_method;
+}
+1;
+";
+    let analysis = parse_analysis(src);
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let diags = collect_diagnostics(
+        &analysis,
+        &idx,
+        DiagnosticOptions { unresolved_dispatch: false },
+    );
+    let unresolved: Vec<&str> = diags
+        .iter()
+        .filter(|d| matches!(&d.code, Some(NumberOrString::String(c)) if c == "unresolved-method"))
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(unresolved.len(), 1, "only the typo: {:?}", unresolved);
+    assert!(unresolved[0].contains("typo_method"), "{:?}", unresolved);
+    assert_eq!(
+        analysis.role_requires.get("My::Role").map(|v| v.len()),
+        Some(3),
+        "the contract record carries all three names",
+    );
+}


### PR DESCRIPTION
The crm QA sweep — all eight findings from veesh's session, each verified against the crm repo itself plus the full battery and substrate calibration at every step.

## Roles (items 1, 8)

- **`requires NAMES` declares method contracts.** Method symbols synthesize per name (span = the name's atom): `$self->name` resolves inside the role, goto-def lands on the contract, hover names the demanding role. Gated on the requires sugar being in scope — works through crm's `Clove::Role` kit. The composer-mismatch diagnostic is designed (not built) in `docs/prompt-role-requires.md`, with `FileAnalysis.role_requires` recording its input. crm: −61 spurious hints; the survivors (`fetch_raw`, `filename`) are genuine undeclared contracts.
- **The map-built role graph connects.** `with map "Clove::Sheets::Roles::$_", qw/CSV DB/` produced zero parent edges — `cst::string_list` now statically folds single-`$_` string-template maps over literal lists (per-element spans). References from `Clove::Sheets::trim_unpack` finds all 9 composer call sites; goto-def lands from every composer.

## Barewords (item 5)

A bareword naming an in-scope sub IS a call — `my $x = get_config;` and the `get_config->{host}` base get FunctionCall refs (hover/gd/references/rename/semantic tokens ride along); declaration slots excluded; `resolve_call_package` is the gate. Bonus reach: `sub INFINITY ()` prototype constants link their usages — a DateTime linked-editing provisional row went gold.

## Mojo quartet (items 2, 3, 4, 6)

- **Lite topic routes**: `under(...)->to('ctrl#…')` sets an implicit base, `group { }` scopes it, `->to('#action')` partials inherit. Core gains only a generic frame stack; every NAME is plugin-declared (`topic_route_dsl()` manifest, `SetRouteBase` emission from the to-spec parser, generic `receiver_call_name` fact). crm jobs: nested + double-nested group routes goto-def, post-group siblings restore the outer base.
- **Framework-assigned attrs type**: `$c->app`/`tx`/`ua`/`req`/`res` (+ plugin/server `app`, UA `transactor`) via overrides — req/res declared on both controller AND transaction so `$c->tx->res->…` chains without an indexed Mojo tree. `register($self, $app, $conf)`: `$app: Mojolicious` via param_types, ancestry-gated.
- **Default helpers discovered from source**: `ArgInfo.string_values` carries every constant-folded candidate, the postfix `$_` topic folds, and mojo-helpers fans out per name + gains the lite function-form arm. **52 helpers discovered from the real DefaultHelpers.pm — no list anywhere.** Cross-file consumption of dependency-registered helpers remains the known app-surface gap (tracked).
- **Goto-def on plugin names**: `plugin 'Thing'` / `$app->plugin('Thing')` emit register-anchored refs with decamelized tokens — rides the controller camelize+tail+ownership search, namespace-agnostic (crm's `Clove::App::Plugin::*` and `Mojolicious::Plugin::*` both land on `sub register`).

## Workspace symbols (item 7)

Anon subs are resolvable, not browsable — the converter now honors the `hide_in_outline` the `(anon)` symbol already carried.

**Tracked follow-ups:** long-distance param typing (`$conf` from call-site shapes, #25), regex-interpolation intelligence (`${\ $self->filetype }` in s///, #26), cross-file helper consumption.

**Verification:** 917 unit / 109 e2e / gold **181 PASS, 12 xfail, 0 FAIL/XPASS/CRASH**; substrate unresolved-method 1860 → 1839 across the sweep (every removal a modeled fix, zero new noise). EXTRACT 84→87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
