### PR TITLE
Long-distance remainder: entrypoint-scan lint, cross-file slot typing, loader-config param typing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Inspect any snippet's CST with `perl-lsp --parse <file>` (or `echo '...' | perl-
 
 ## Workspace indexing
 
-- `workspace_index` indexed at startup (Rayon `par_iter`, `.gitignore`-aware via `ignore` crate, 1MB cap, `catch_unwind` per file).
+- `workspace_index` indexed at startup (Rayon `par_iter`, `.gitignore`-aware via `ignore` crate, 1MB cap, `catch_unwind` per file). Standard extensions (`*.pm`/`*.pl`/`*.t`) are type-pruned at the walk; extensionless ENTRYPOINT scripts (`#!/usr/bin/env perl` — Mojo::Lite apps where `plugin 'X'` loads live) are found by a SHALLOW shebang scan over root + `bin/` + `script/` (`scan_entrypoint_scripts`; its `extra: &[String]` param is the seam for a future workspace-config `entrypoint_dirs` — callers pass `&[]` today). Don't broaden the entrypoint scan to a recursive walk — it would enumerate non-Perl source trees.
 - File watcher via `workspace/didChangeWatchedFiles` for incremental updates (`spawn_blocking`).
 - Query priority: `documents` (open, freshest) → `workspace_index` (all project files) → `module_index` (external @INC).
 

--- a/docs/prompt-helper-consumption.md
+++ b/docs/prompt-helper-consumption.md
@@ -10,7 +10,7 @@ from that round:
   intend to use it" — resolve generously; PRECISION is the
   diagnostic's job, not the resolver's.
 
-## Phase 2 — entrypoint-scan diagnostic (in flight: long-distance PR)
+## Phase 2 — entrypoint-scan diagnostic (LANDED: long-distance-remainder)
 
 At the USAGE site: "`$c->was_loaded` is provided by
 Clove::App::Plugin::WasLoaded, which no entrypoint loads

--- a/docs/prompt-long-distance.md
+++ b/docs/prompt-long-distance.md
@@ -1,24 +1,37 @@
-# Long-distance intelligence — remaining members
+# Long-distance intelligence — epic record
 
 The epic's shape: information a position needs lives in files that
-REFERENCE this one; resolution flows use → definition. The shared
-primitive (`children_index`) and members 1–2 (requires →
-implementations; composer-mismatch diagnostic) landed — record in
-`adr/role-contracts.md`. Members 3–4 are in flight on the
-`long-distance-remainder` PR.
+REFERENCE this one; resolution flows use → definition. ALL FOUR
+members + the shared primitive are landed (PRs #56 +
+`long-distance-remainder`):
 
-## Entrypoint-scan helper lint
+1. **children_index** + goto-implementation + composer-mismatch —
+   `adr/role-contracts.md`.
+2. **Entrypoint-scan helper lint** (`helper-not-loaded`) — loaded
+   facts from imports + the `PluginLoad`/SyntheticUse both plugin
+   arms emit; exact-or-tail matching (loose only toward silence);
+   workspace providers only. House kits with custom loaders
+   (Clove::Test) declare ONE SyntheticUse/PluginLoad arm in their own
+   `.perl-lsp` plugin — the BYO principle.
+3. **Loader-config param typing** (the framework-mediated case of
+   #25): `plugin 'X', {...}` → `register`'s `$conf` types as the
+   gathered config shape. Manifest declares the contract
+   (`param_types` + `from_loader_config`), callers record the value
+   (`PluginLoad{name, config_span}`), enrichment joins with
+   agreement: all equal → the shape; keyed disagreement → OPEN key
+   union; otherwise decline. Static `type_class` is the no-caller
+   fallback; structure-dominates-rep prefers the gathered shape.
+4. **A4 v2** (joined the epic mid-flight): `$self->{k}` reads narrow
+   through slot writes in OTHER files and up the ancestry — Projected
+   falls back to `SlotType{class,key}`, which gained the
+   MethodOnClass-style cross-file + parents recursion.
 
-See `prompt-helper-consumption.md` phase 2 — a read-only miniature of
-the arg-shape gather below; its first muscle.
+## What stays open (the epic's honest boundary)
 
-## Long-distance param typing (task #25)
-
-`plugin 'CloveApp', { minion => 1, … }` → `$conf:
-HashWithKeys{minion, …}` inside the plugin's `register`. Generalizes
-to any sub with enumerable callers: gather call-site arg shapes, fold
-with the existing agreement rules (all agree → the type; disagree →
-widen; ANY un-enumerable caller → decline — the honesty gate, the
-non-negotiable). The framework-mediated case (plugin registration:
-callers enumerable by construction) lands first; the open-world
-gather stays declined until enumerability has a witness.
+**Open-world caller gather** — typing params of an ordinary sub from
+arbitrary call sites. The honesty gate stands: ANY un-enumerable
+caller (dynamic dispatch, exported surface) poisons the claim. The
+loader-config machinery is the template — what's missing is a
+WITNESS of enumerability for plain subs, which the graph rework's
+unresolved bucket (`prompt-graph-walking.md`) could provide. Revisit
+then.

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -219,6 +219,9 @@ fn on_function_call(ctx) {
                 if !name.contains("::") {
                     out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::" + name, "args": [], "imports": [], "span": span }};
                 }
+                let cfg = ();
+                if args.len() >= 2 { cfg = args[1].span; }
+                out += #{ "PluginLoad": #{ "name": name, "config_span": cfg }};
             }
         }
         return out;

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -219,9 +219,14 @@ fn on_function_call(ctx) {
                 if !name.contains("::") {
                     out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::" + name, "args": [], "imports": [], "span": span }};
                 }
+                // Multi-value: a lite `plugin($_) for qw/A B/` and a
+                // folded constant both surface in `string_values`
+                // (the const-folding machinery), so record every name.
                 let cfg = ();
                 if args.len() >= 2 { cfg = args[1].span; }
-                out += #{ "PluginLoad": #{ "name": name, "config_span": cfg }};
+                for nm in args[0].string_values {
+                    out += #{ "PluginLoad": #{ "name": nm, "config_span": cfg }};
+                }
             }
         }
         return out;

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -127,6 +127,12 @@ fn param_types() {
     [
         #{ method: "register", in_role: "Mojolicious::Plugin", param: 1,
            type_class: "Mojolicious" },
+        // $conf: typed from whatever the loader call passed
+        // (`plugin 'X', {...}` — the PluginLoad fact carries the arg
+        // span). HashRef is the no-caller static fallback;
+        // structure-dominates-rep prefers the gathered shape.
+        #{ method: "register", in_role: "Mojolicious::Plugin", param: 2,
+           type_class: "HashRef", from_loader_config: true },
     ]
 }
 
@@ -334,6 +340,11 @@ fn on_method_call(ctx) {
                 } else {
                     out += #{ "SyntheticUse": #{ "module": name, "args": [], "imports": [], "span": span }};
                 }
+                // the loader fact: which module, and where its config
+                // value sits — the caller half of $conf typing
+                let cfg = ();
+                if args.len() >= 2 { cfg = args[1].span; }
+                out += #{ "PluginLoad": #{ "name": name, "config_span": cfg }};
             }
         }
         return out;

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -323,6 +323,17 @@ fn on_method_call(ctx) {
                         invocant_span: (),
                     }
                 };
+                // "You loaded it" — same as the lite arm: record the
+                // load so the resolver pulls the plugin AND the
+                // entrypoint-scan lint sees the load fact. Default
+                // namespace guess for short names; the lint
+                // tail-matches, so app-custom namespaces
+                // (Clove::App::Plugin::*) count as loaded too.
+                if !name.contains("::") {
+                    out += #{ "SyntheticUse": #{ "module": "Mojolicious::Plugin::" + name, "args": [], "imports": [], "span": span }};
+                } else {
+                    out += #{ "SyntheticUse": #{ "module": name, "args": [], "imports": [], "span": span }};
+                }
             }
         }
         return out;

--- a/frameworks/mojo-routes.rhai
+++ b/frameworks/mojo-routes.rhai
@@ -123,6 +123,14 @@ fn overrides() {
 // `register($self, $app, $conf)` — the contract method every
 // Mojolicious plugin implements; the framework passes the app. $conf's
 // call-site shape is future work (long-distance param typing).
+// `$app->plugin('X')` LOADS X — recognized core-side, trigger-
+// independently (the cascade is in Mojolicious::Plugin files no Mojo
+// trigger matches). receiver_class is the honest app type; the load
+// fact is a lint-suppression signal, recorded liberally.
+fn load_verbs() {
+    [ #{ verb: "plugin", receiver_class: "Mojolicious", name_arg_index: 0 } ]
+}
+
 fn param_types() {
     [
         #{ method: "register", in_role: "Mojolicious::Plugin", param: 1,
@@ -340,11 +348,10 @@ fn on_method_call(ctx) {
                 } else {
                     out += #{ "SyntheticUse": #{ "module": name, "args": [], "imports": [], "span": span }};
                 }
-                // the loader fact: which module, and where its config
-                // value sits — the caller half of $conf typing
-                let cfg = ();
-                if args.len() >= 2 { cfg = args[1].span; }
-                out += #{ "PluginLoad": #{ "name": name, "config_span": cfg }};
+                // The load FACT (PluginLoad) is recorded core-side,
+                // trigger-independently: the nested-plugin cascade runs
+                // in Mojolicious::Plugin files this hook never sees. See
+                // `load_verbs()` + `Builder::record_plugin_loads`.
             }
         }
         return out;

--- a/gold-corpus/fixtures/longdist-diagnostics.json
+++ b/gold-corpus/fixtures/longdist-diagnostics.json
@@ -10,14 +10,15 @@
       "expect": {
         "all": [
           "helper-not-loaded",
-          "'widget_count' is provided by My::Plugin::Widgets, which no workspace entrypoint loads"
+          "'orphan_h' is provided by My::Plugin::Orphan, which no workspace entrypoint loads"
         ],
         "none": [
+          "'widget_count'",
           "'confy_thing'"
         ]
       },
       "status": "gold",
-      "note": "Widgets is a workspace plugin nothing loads — the lint fires at the usage site. Confy IS loaded (app.pl `plugin 'Confy'`), so its helper stays silent: both directions of the entrypoint scan in one sweep."
+      "note": "Orphan is a workspace plugin nothing loads \u2014 the lint fires. widget_count stays silent because the EXTENSIONLESS `jobs` entrypoint (`#!.../perl`, `plugin Widgets => {...}` bareword form) is indexed by shebang and records the load; confy_thing likewise. Pins entrypoint-script indexing + the bareword load form in one sweep."
     },
     {
       "id": "loader-config-conf-shape-closed",

--- a/gold-corpus/fixtures/longdist-diagnostics.json
+++ b/gold-corpus/fixtures/longdist-diagnostics.json
@@ -1,0 +1,38 @@
+{
+  "capability": "diagnostics",
+  "rows": [
+    {
+      "id": "helper-not-loaded-workspace-plugin",
+      "difficulty": "tricky",
+      "semantic_area": "long-distance",
+      "root": "gold-corpus/longdist-fixture",
+      "file": "",
+      "expect": {
+        "all": [
+          "helper-not-loaded",
+          "'widget_count' is provided by My::Plugin::Widgets, which no workspace entrypoint loads"
+        ],
+        "none": [
+          "'confy_thing'"
+        ]
+      },
+      "status": "gold",
+      "note": "Widgets is a workspace plugin nothing loads — the lint fires at the usage site. Confy IS loaded (app.pl `plugin 'Confy'`), so its helper stays silent: both directions of the entrypoint scan in one sweep."
+    },
+    {
+      "id": "loader-config-conf-shape-closed",
+      "difficulty": "tricky",
+      "semantic_area": "long-distance",
+      "root": "gold-corpus/longdist-fixture",
+      "file": "",
+      "expect": {
+        "all": [
+          "key 'alpa' is not in $conf's literal shape (keys: alpha, beta)"
+        ],
+        "none": []
+      },
+      "status": "gold",
+      "note": "The $conf typo hint proves the whole loader-config chain: the PluginLoad fact from a PACKAGELESS lite entrypoint, the registration-time shape projection, the enrichment join, and the resulting CLOSED HashWithKeys{alpha, beta} feeding the unknown-hash-key diagnostic."
+    }
+  ]
+}

--- a/gold-corpus/fixtures/longdist-hover.json
+++ b/gold-corpus/fixtures/longdist-hover.json
@@ -1,0 +1,17 @@
+{
+  "capability": "hover",
+  "rows": [
+    {
+      "id": "a4v2-cross-file-slot-read",
+      "difficulty": "tricky",
+      "semantic_area": "long-distance",
+      "root": "gold-corpus/longdist-fixture",
+      "file": "lib/My/Child.pm",
+      "line": 6,
+      "col": 8,
+      "expect": { "all": ["My::Conn"], "none": [] },
+      "status": "gold",
+      "note": "my $x = $self->{conn} where the typed slot write lives in the PARENT class's file — the SlotType cross-file + ancestor recursion (A4 v2)."
+    }
+  ]
+}

--- a/gold-corpus/longdist-fixture/app.pl
+++ b/gold-corpus/longdist-fixture/app.pl
@@ -1,0 +1,5 @@
+use Mojolicious::Lite;
+
+plugin 'Confy', { alpha => 1, beta => 'x' };
+
+app->start;

--- a/gold-corpus/longdist-fixture/jobs
+++ b/gold-corpus/longdist-fixture/jobs
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+use Mojolicious::Lite;
+
+plugin 'Confy', { alpha => 1, beta => 'x' };
+plugin Widgets => { opt => 1 };
+
+app->start;

--- a/gold-corpus/longdist-fixture/lib/Mojolicious/Plugin/Confy.pm
+++ b/gold-corpus/longdist-fixture/lib/Mojolicious/Plugin/Confy.pm
@@ -1,0 +1,11 @@
+package Mojolicious::Plugin::Confy;
+use Mojo::Base 'Mojolicious::Plugin';
+
+sub register {
+    my ($self, $app, $conf) = @_;
+    my $a = $conf->{alpha};
+    my $oops = $conf->{alpa};
+    $app->helper(confy_thing => sub { 1 });
+}
+
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Base.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Base.pm
@@ -1,0 +1,9 @@
+package My::Base;
+use Moo;
+
+sub init {
+    my ($self) = @_;
+    $self->{conn} = My::Conn->new;
+}
+
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Child.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Child.pm
@@ -1,0 +1,11 @@
+package My::Child;
+use Moo;
+extends 'My::Base';
+
+sub go {
+    my ($self) = @_;
+    my $x = $self->{conn};
+    return $x;
+}
+
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Consumer.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Consumer.pm
@@ -7,3 +7,8 @@ sub act {
 }
 
 1;
+
+package My::Consumer2;
+use Mojo::Base 'Mojolicious::Controller';
+sub act2 { my $self = shift; return $self->orphan_h; }
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Consumer.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Consumer.pm
@@ -1,0 +1,9 @@
+package My::Consumer;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub act {
+    my $self = shift;
+    return $self->widget_count;
+}
+
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Plugin/Orphan.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Plugin/Orphan.pm
@@ -1,0 +1,4 @@
+package My::Plugin::Orphan;
+use Mojo::Base 'Mojolicious::Plugin';
+sub register { my ($self,$app)=@_; $app->helper(orphan_h => sub {1}); }
+1;

--- a/gold-corpus/longdist-fixture/lib/My/Plugin/Widgets.pm
+++ b/gold-corpus/longdist-fixture/lib/My/Plugin/Widgets.pm
@@ -1,0 +1,9 @@
+package My::Plugin::Widgets;
+use Mojo::Base 'Mojolicious::Plugin';
+
+sub register {
+    my ($self, $app, $conf) = @_;
+    $app->helper(widget_count => sub { 42 });
+}
+
+1;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -260,6 +260,8 @@ fn build_with_plugins_inner(
         app_surface_consumers: Vec::new(),
         param_type_manifest: std::collections::HashMap::new(),
         param_type_wildcards: Vec::new(),
+        plugin_loads: Vec::new(),
+        loader_config_params: Vec::new(),
         any_requires_action_attr: false,
         provisional_dispatches: Vec::new(),
         gated_param_types: Vec::new(),
@@ -534,6 +536,8 @@ fn build_with_plugins_inner(
         contract_symbols: b.contract_symbols,
         dynamic_parent_packages: b.dynamic_parent_packages,
         role_packages: b.role_packages,
+        plugin_loads: b.plugin_loads,
+        loader_config_params: b.loader_config_params,
     });
     // Finalize: run the legacy text-based MCB resolver as a fallback.
     // For every assignment the unified typer (run before
@@ -1448,6 +1452,14 @@ struct Builder<'a> {
     /// Plugin `param_types()` manifest, grouped by method name. At a matching
     /// sub declaration in a role-doer, the named param gets a typed TC.
     param_type_manifest: std::collections::HashMap<String, Vec<plugin::ParamType>>,
+
+    /// Caller-side loader facts (`plugin 'X', {...}`) — flushed into
+    /// `FileAnalysis.plugin_loads`.
+    plugin_loads: Vec<crate::file_analysis::PluginLoadFact>,
+    /// Callee-side markers: params whose type arrives from loader
+    /// config at enrichment. Flushed into
+    /// `FileAnalysis.loader_config_params`.
+    loader_config_params: Vec<crate::file_analysis::LoaderConfigParam>,
     /// Rules from `param_types()` with `method: None` — applied to every sub
     /// declaration in a matching class, regardless of method name. The
     /// "every action in a controller" case (Catalyst `$c`).
@@ -2949,6 +2961,12 @@ impl<'a> Builder<'a> {
                     }
                 }
             }
+            plugin::EmitAction::PluginLoad { name, config_span } => {
+                self.plugin_loads.push(crate::file_analysis::PluginLoadFact {
+                    name,
+                    config_span,
+                });
+            }
             plugin::EmitAction::MethodCallRef { method_name, invocant, span, invocant_span } => {
                 // Standard MethodCall ref — gd/gr/hover/rename route to
                 // the usual resolution path (inheritance walk + module
@@ -4335,9 +4353,10 @@ impl<'a> Builder<'a> {
                 .child_by_field_name("attributes")
                 .map_or(false, |a| a.named_child_count() > 0);
 
-        // Collect (variable, gate-class, type-class) before mutating self —
-        // can't hold the manifest borrow while pushing into `gated_param_types`.
-        let mut to_gate: Vec<(String, String, String)> = Vec::new();
+        // Collect (variable, gate-class, type-class, from_loader) before
+        // mutating self — can't hold the manifest borrow while pushing
+        // into `gated_param_types`.
+        let mut to_gate: Vec<(String, String, String, bool)> = Vec::new();
 
         // Named rules: only those keyed to exactly this method name.
         if let Some(rules) = self.param_type_manifest.get(method) {
@@ -4351,7 +4370,19 @@ impl<'a> Builder<'a> {
 
         let scope = self.current_scope();
         let span = node_to_span(node);
-        for (variable, in_role, class) in to_gate {
+        for (variable, in_role, class, from_loader) in to_gate {
+            if from_loader {
+                // Callee-side marker: the real type arrives at
+                // enrichment from caller PluginLoad facts. The static
+                // `type_class` still rides the gated path below as the
+                // no-caller fallback — structure-dominates-rep picks
+                // the gathered shape when both land.
+                self.loader_config_params.push(crate::file_analysis::LoaderConfigParam {
+                    variable: variable.clone(),
+                    scope,
+                    in_role: in_role.clone(),
+                });
+            }
             self.gated_param_types.push(crate::file_analysis::ReceiverGated::new(
                 in_role,
                 TypeConstraint {
@@ -4374,7 +4405,7 @@ impl<'a> Builder<'a> {
         params: &[ParamInfo],
         has_action_attr: bool,
         sub_name: &str,
-        out: &mut Vec<(String, String, String)>,
+        out: &mut Vec<(String, String, String, bool)>,
     ) {
         // Catalyst dispatches these private actions by name; over-inclusion of
         // non-action-attributed subs is a documented follow-up.
@@ -4387,7 +4418,12 @@ impl<'a> Builder<'a> {
             }
             if let Some(p) = params.get(r.param) {
                 if p.name.starts_with('$') {
-                    out.push((p.name.clone(), r.in_role.clone(), r.type_class.clone()));
+                    out.push((
+                        p.name.clone(),
+                        r.in_role.clone(),
+                        r.type_class.clone(),
+                        r.from_loader_config,
+                    ));
                 }
             }
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -256,6 +256,7 @@ fn build_with_plugins_inner(
         open_statement_package: None,
         plugins,
         dispatch_manifest: std::collections::HashMap::new(),
+        load_manifest: std::collections::HashMap::new(),
         type_constraint_names: std::collections::HashSet::new(),
         app_surface_consumers: Vec::new(),
         param_type_manifest: std::collections::HashMap::new(),
@@ -287,6 +288,11 @@ fn build_with_plugins_inner(
     b.dispatch_manifest = b
         .plugins
         .dispatch_verbs()
+        .map(|d| (d.verb.clone(), d.clone()))
+        .collect();
+    b.load_manifest = b
+        .plugins
+        .load_verbs()
         .map(|d| (d.verb.clone(), d.clone()))
         .collect();
     b.type_constraint_names = b
@@ -1440,6 +1446,7 @@ struct Builder<'a> {
     /// construction (trigger-independent, like overrides). Drives provisional
     /// dispatch collection in the method-call walk.
     dispatch_manifest: std::collections::HashMap<String, plugin::DispatchVerb>,
+    load_manifest: std::collections::HashMap<String, plugin::LoadVerb>,
     /// Constraint-constructor name gate from plugin `type_constraint_names()`
     /// (`InstanceOf`, …), flattened once. A call to one of these is typed as
     /// `TypeConstraintOf` via the plugin's fold rather than its callee return.
@@ -1915,11 +1922,22 @@ impl<'a> Builder<'a> {
                 }
                 Some(self.extract_string_content(arg).unwrap_or_default())
             }
-            // `autoquoted_bareword` is what the LHS of fat-comma parses
-            // as (`key => value`) — `bareword` never appears there. The
-            // `bareword` branch catches the other contexts (e.g. unquoted
-            // positional args) where the token text IS the string value.
-            "autoquoted_bareword" | "bareword" => Some(text.clone()),
+            // `autoquoted_bareword` is a fat-comma key (`key => value`)
+            // — its text IS the value, never const-folded (a key that
+            // happens to match a constant name is still that key).
+            "autoquoted_bareword" => Some(text.clone()),
+            // A positional `bareword` arg may be a constant — fold it
+            // through the constant table (`$app->plugin(EXTRA)` where
+            // `use constant EXTRA => 'Gizmos'`). Falls back to the raw
+            // token when it names no constant.
+            "bareword" => {
+                if let Some(folded) = self.resolve_constant_strings(&text, 0) {
+                    string_values = folded.clone();
+                    folded.into_iter().next()
+                } else {
+                    Some(text.clone())
+                }
+            }
             "scalar" | "array" | "hash" => {
                 let folded = self.resolve_constant_strings(&text, 0).unwrap_or_default();
                 string_values = folded.clone();
@@ -2785,6 +2803,81 @@ impl<'a> Builder<'a> {
                 call_span: ctx.call_span,
             },
         ));
+    }
+
+    /// Record `PluginLoadFact`s for a method-form load verb
+    /// (`$app->plugin(...)`), TRIGGER-INDEPENDENTLY — the nested-plugin
+    /// cascade runs inside `Mojolicious::Plugin` files that no Mojo
+    /// trigger matches, so gating on the file class loses every load
+    /// past the entrypoint (the receiver-gated dispatch lesson,
+    /// `docs/adr/receiver-gated-dispatch.md`).
+    ///
+    /// Multi-value by construction: `ctx.args[i].string_values` carries
+    /// the full constant-fold — a `qw(...)` loop topic, a `$_` postfix
+    /// fold, OR a folded scalar constant — so `$app->plugin($_) for
+    /// qw/A B C/` records A, B, AND C, and `$app->plugin(SOME_CONST)`
+    /// records the folded name. The load fact is a SUPPRESSION signal
+    /// for the entrypoint lint, so an untyped receiver records (honest-
+    /// silent); the verb-name specificity + workspace-only + tail-match
+    /// bound any false suppression. config_span (arg i+1) rides through
+    /// for loader-config `$conf` typing.
+    fn record_plugin_loads(&mut self, method: &str, ctx: &plugin::CallContext) {
+        let Some(spec) = self.load_manifest.get(method) else { return };
+        let Some(arg) = ctx.args.get(spec.name_arg_index) else { return };
+        let names = arg.string_values.clone();
+        if names.is_empty() {
+            return;
+        }
+        // Skip a load on a receiver KNOWN to be a different concrete
+        // class — the only confident negative we have at walk time
+        // (the app receiver is param-typed, hence None here).
+        if let Some(InferredType::ClassName(c)) = &ctx.receiver_type {
+            if c != &spec.receiver_class
+                && !self.package_isa_local(c, &spec.receiver_class)
+            {
+                // an untyped/None receiver still records; a confirmed
+                // foreign class does not. cross-file isa isn't available
+                // at build, so this only fires on a locally-known class.
+                if self.package_parents.contains_key(c) {
+                    return;
+                }
+            }
+        }
+        let config_span = ctx.args.get(spec.name_arg_index + 1).map(|a| a.span);
+        for n in names {
+            if n.is_empty() {
+                continue;
+            }
+            self.plugin_loads.push(crate::file_analysis::PluginLoadFact {
+                name: n,
+                config_span,
+            });
+        }
+    }
+
+    /// Local-only isa: does `child` reach `ancestor` through this
+    /// file's `package_parents`? (No index at build — `parents_of`'s
+    /// cross-file arm needs one.)
+    fn package_isa_local(&self, child: &str, ancestor: &str) -> bool {
+        if child == ancestor {
+            return true;
+        }
+        let mut stack = vec![child.to_string()];
+        let mut seen = std::collections::HashSet::new();
+        while let Some(c) = stack.pop() {
+            if !seen.insert(c.clone()) {
+                continue;
+            }
+            if let Some(ps) = self.package_parents.get(&c) {
+                for p in ps {
+                    if p == ancestor {
+                        return true;
+                    }
+                    stack.push(p.clone());
+                }
+            }
+        }
+        false
     }
 
     /// Convert a plugin-produced `EmitAction` into real builder state. All
@@ -10380,6 +10473,7 @@ impl<'a> Builder<'a> {
                     }
                 }
                 self.record_provisional_dispatch(name, &ctx);
+                self.record_plugin_loads(name, &ctx);
                 self.dispatch_method_call_plugins(ctx);
             }
         }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -11023,6 +11023,7 @@ mod param_types_manifest {
                     param: 1,
                     type_class: "Mojolicious".into(),
                     requires_action_attr: false,
+                    from_loader_config: false,
                 }]
             })
         }
@@ -11180,6 +11181,7 @@ mod param_types_manifest {
                     // Mirror the real catalyst.rhai: only attribute-carrying
                     // actions get $c, not plain helper subs.
                     requires_action_attr: true,
+                    from_loader_config: false,
                 }]
             })
         }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14985,3 +14985,32 @@ fn test_bundled_moo_manifest_carries_base_role_engines() {
         assert!(!fa.is_role_package(class), "{class} should NOT be a role");
     }
 }
+
+#[test]
+fn plugin_loads_recorded_trigger_independent_and_multivalue() {
+    use crate::file_analysis::SymKind;
+    // A Mojolicious::Plugin file (NO Mojo app trigger) loading other
+    // plugins three ways: literal, qw-loop topic, folded constant.
+    let src = "package My::Plugin::All;\n\
+        use Mojo::Base 'Mojolicious::Plugin';\n\
+        use constant EXTRA => 'Gizmos';\n\
+        sub register {\n\
+          my ($self, $app, $conf) = @_;\n\
+          $app->plugin('FeatureFlags');\n\
+          $app->plugin($_) for qw/SheetReaders ImportTasks ExportTasks/;\n\
+          $app->plugin(EXTRA);\n\
+        }\n\
+        1;\n";
+    let mut parser = create_parser();
+    let tree = parser.parse(src, None).unwrap();
+    let fa = build(&tree, src.as_bytes());
+    let mut loads: Vec<String> = fa.plugin_loads.iter().map(|f| f.name.clone()).collect();
+    loads.sort();
+    assert_eq!(
+        loads,
+        vec!["ExportTasks", "FeatureFlags", "Gizmos", "ImportTasks", "SheetReaders"],
+        "all three forms (literal, qw-loop, folded constant) recorded; got {:?}",
+        fa.plugin_loads,
+    );
+    let _ = SymKind::Sub;
+}

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2318,6 +2318,16 @@ pub struct FileAnalysis {
     #[serde(default)]
     pub role_packages: HashSet<String>,
 
+    /// Caller-side loader facts: this file loads plugin `name` and
+    /// passes the value at `config_span`. Joined at enrichment with
+    /// the loaded module's `loader_config_params` markers.
+    #[serde(default)]
+    pub plugin_loads: Vec<PluginLoadFact>,
+    /// Callee-side markers: params whose type arrives from loader
+    /// config (the `from_loader_config` ParamType flavor).
+    #[serde(default)]
+    pub loader_config_params: Vec<LoaderConfigParam>,
+
     // Indices (built in post-pass — skipped by serde; call rebuild_all_indices() after deserialize)
     #[serde(skip, default)]
     scope_starts: Vec<(Point, ScopeId)>, // sorted by start point
@@ -2383,6 +2393,26 @@ pub struct FileAnalysisParts {
     pub contract_symbols: HashSet<SymbolId>,
     pub dynamic_parent_packages: HashSet<String>,
     pub role_packages: HashSet<String>,
+    pub plugin_loads: Vec<PluginLoadFact>,
+    pub loader_config_params: Vec<LoaderConfigParam>,
+}
+
+/// "This file loads plugin `name`, passing the config value at
+/// `config_span`" — the caller half of loader-config param typing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginLoadFact {
+    pub name: String,
+    pub config_span: Option<Span>,
+}
+
+/// "This param's type arrives from whoever loads me" — the callee
+/// half. `in_role` re-gates at enrichment (the package must still
+/// isa the declaring role/class).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoaderConfigParam {
+    pub variable: String,
+    pub scope: ScopeId,
+    pub in_role: String,
 }
 
 /// One projection of a field/attr decl — the entity that encodes group
@@ -2511,6 +2541,8 @@ impl FileAnalysis {
             contract_symbols,
             dynamic_parent_packages,
             role_packages,
+            plugin_loads,
+            loader_config_params,
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
@@ -2547,6 +2579,8 @@ impl FileAnalysis {
             contract_symbols,
             dynamic_parent_packages,
             role_packages,
+            plugin_loads,
+            loader_config_params,
             scope_starts: Vec::new(),
             symbols_by_name: HashMap::new(),
             symbols_by_scope: HashMap::new(),
@@ -3437,6 +3471,108 @@ impl FileAnalysis {
     /// hash-key set, reaching cross-file `Symbol(_)` witnesses through
     /// `BagContext.module_index` directly. Call after building, when the
     /// module index is available.
+    /// The enrichment half of loader-config param typing
+    /// (`prompt-long-distance.md`): for each `from_loader_config`
+    /// marker, gather the config-arg shapes from every caller's
+    /// `PluginLoad` facts and push the agreed type as a TC. Honesty
+    /// gate: callers here are ENUMERABLE BY CONSTRUCTION (the loader
+    /// facts name this module); shapes that disagree fold to an OPEN
+    /// key union rather than a guess; zero matching callers pushes
+    /// nothing (the static `type_class` fallback already rode the
+    /// gated path at build).
+    fn apply_loader_config_params(&mut self, module_index: Option<&dyn CrossFileLookup>) {
+        if self.loader_config_params.is_empty() {
+            return;
+        }
+        let Some(idx) = module_index else { return };
+        // every package name this file declares, for FQ + tail matching
+        let my_packages: Vec<String> = self
+            .symbols
+            .iter()
+            .filter(|s| matches!(s.kind, SymKind::Package | SymKind::Class))
+            .map(|s| s.name.clone())
+            .collect();
+        let matches_me = |load_name: &str| -> bool {
+            my_packages.iter().any(|p| {
+                p == load_name || p.rsplit("::").next() == Some(load_name)
+            })
+        };
+
+        let markers = self.loader_config_params.clone();
+        for m in &markers {
+            // re-gate: the marker's package must still isa the
+            // declaring role/class (same condition the static gated
+            // path checks at query time)
+            let pkg = self.scopes.get(m.scope.0 as usize).and_then(|sc| sc.package.clone());
+            let Some(pkg) = pkg else { continue };
+            if !self.class_isa(&pkg, &m.in_role, module_index) {
+                continue;
+            }
+            let mut shapes: Vec<InferredType> = Vec::new();
+            idx.for_each_cached(&mut |_name, cached| {
+                for f in &cached.analysis.plugin_loads {
+                    let Some(span) = f.config_span else { continue };
+                    if !matches_me(&f.name) {
+                        continue;
+                    }
+                    if let Some(t) = cached.analysis.expr_type_at_span(span, Some(idx)) {
+                        shapes.push(t);
+                    }
+                }
+            });
+            if shapes.is_empty() {
+                continue;
+            }
+            let agreed = if shapes.windows(2).all(|w| w[0] == w[1]) {
+                shapes.pop().unwrap()
+            } else {
+                // disagree → widen: union of keys when every shape is
+                // keyed, OPEN (a key any caller passes may arrive);
+                // anything else declines.
+                let mut keys: Vec<(String, Option<Box<InferredType>>)> = Vec::new();
+                let mut all_keyed = true;
+                for sh in &shapes {
+                    match sh {
+                        InferredType::HashWithKeys { keys: ks, .. } => {
+                            for (k, v) in ks {
+                                match keys.iter_mut().find(|(ek, _)| ek == k) {
+                                    None => keys.push((k.clone(), v.clone())),
+                                    Some((_, ev)) => {
+                                        if *ev != *v {
+                                            *ev = None;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            all_keyed = false;
+                            break;
+                        }
+                    }
+                }
+                if !all_keyed {
+                    continue;
+                }
+                InferredType::HashWithKeys { keys, open: true }
+            };
+            let span = self
+                .scopes
+                .get(m.scope.0 as usize)
+                .map(|sc| Span { start: sc.span.start, end: sc.span.start })
+                .unwrap_or(Span {
+                    start: Point { row: 0, column: 0 },
+                    end: Point { row: 0, column: 0 },
+                });
+            self.push_type_constraint(TypeConstraint {
+                variable: m.variable.clone(),
+                scope: m.scope,
+                constraint_span: span,
+                inferred_type: agreed,
+            });
+        }
+    }
+
     pub fn enrich_imported_types_with_keys(
         &mut self,
         module_index: Option<&dyn CrossFileLookup>,
@@ -3453,6 +3589,10 @@ impl FileAnalysis {
         // query time (`applicable_dispatches`), so a `$minion->enqueue('T')`
         // surfaces by the receiver's type whether or not its file is open.
         // See `docs/adr/receiver-gated-dispatch.md`.
+
+        // Loader-config param typing: join my `loader_config_params`
+        // markers with caller-side `PluginLoad` facts across the index.
+        self.apply_loader_config_params(module_index);
 
         // Build the import → exported-name map inline from
         // `self.imports` + `module_index`. `imported_hash_keys` is

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -240,6 +240,11 @@ pub trait CrossFileLookup {
         class: &str,
         visit: &mut dyn FnMut(&str, &std::sync::Arc<CachedModule>) -> std::ops::ControlFlow<()>,
     );
+    /// Registration-time loader-config shapes: every (load_name, shape)
+    /// projected from `PluginLoad` facts across the workspace —
+    /// INCLUDING packageless entrypoint scripts, which never enter the
+    /// module cache.
+    fn for_each_loader_shape(&self, f: &mut dyn FnMut(&str, &InferredType));
 }
 
 // ---- Serde proxy for tree_sitter::Point ----
@@ -3509,15 +3514,9 @@ impl FileAnalysis {
                 continue;
             }
             let mut shapes: Vec<InferredType> = Vec::new();
-            idx.for_each_cached(&mut |_name, cached| {
-                for f in &cached.analysis.plugin_loads {
-                    let Some(span) = f.config_span else { continue };
-                    if !matches_me(&f.name) {
-                        continue;
-                    }
-                    if let Some(t) = cached.analysis.expr_type_at_span(span, Some(idx)) {
-                        shapes.push(t);
-                    }
+            idx.for_each_loader_shape(&mut |load_name, t| {
+                if matches_me(load_name) {
+                    shapes.push(t.clone());
                 }
             });
             if shapes.is_empty() {

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -6591,6 +6591,39 @@ impl FileAnalysis {
         incomplete
     }
 
+    /// The plugin module whose BRIDGE is what resolves `class`->`name`
+    /// — the helper's provider. `None` when a real def resolves first
+    /// (local sub, inherited method, typeglob install) or when nothing
+    /// resolves at all. The entrypoint-scan lint asks this to find
+    /// helpers whose providing plugin no entrypoint loads.
+    pub fn bridged_helper_provider(
+        &self,
+        class: &str,
+        name: &str,
+        module_index: Option<&dyn CrossFileLookup>,
+    ) -> Option<String> {
+        let res = self.resolve_method_in_ancestors(class, name, module_index)?;
+        let MethodResolution::CrossFile { class: on_class, def_module: Some(module) } = res
+        else {
+            return None;
+        };
+        // CrossFile{def_module: Some} covers typeglob installs too —
+        // bridge-classify by the providing module's own declaration.
+        let idx = module_index?;
+        let cached = idx.get_cached(&module)?;
+        let is_bridge = cached.analysis.plugin_namespaces.iter().any(|ns| {
+            ns.bridges
+                .iter()
+                .any(|b| matches!(b, Bridge::Class(c) if c == &on_class))
+                && ns.entities.iter().any(|sid| {
+                    cached.analysis.symbols.get(sid.0 as usize).is_some_and(|s| {
+                        matches!(s.kind, SymKind::Sub | SymKind::Method) && s.name == name
+                    })
+                })
+        });
+        is_bridge.then_some(module)
+    }
+
     /// Is `pkg` a role? Single source of the property — consumers ask
     /// here, never re-derive from use lists. The verdict is baked at
     /// build time from an OPEN maker set (builder `ROLE_MAKERS` base

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -1991,3 +1991,61 @@ fn cross_file_slot_write_types_the_read() {
     assert_eq!(t2, Some(InferredType::ClassName("My::Conn".into())));
 }
 
+
+#[test]
+fn loader_config_types_register_conf_cross_file() {
+    // #25, framework-mediated: `plugin 'CloveApp', {...}` in the app
+    // types `$conf` inside the plugin's register — callers enumerable
+    // by construction (the PluginLoad facts name this module).
+    use std::sync::Arc;
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let app_src = "use Mojolicious::Lite;\nplugin 'CloveApp', { minion => 1, redis => 'r' };\napp->start;\n";
+    {
+        let mut parser = crate::builder::create_parser();
+        let tree = parser.parse(app_src, None).unwrap();
+        let fa = crate::builder::build(&tree, app_src.as_bytes());
+        assert!(
+            fa.plugin_loads.iter().any(|f| f.name == "CloveApp" && f.config_span.is_some()),
+            "the lite plugin arm should record the loader fact: {:?}",
+            fa.plugin_loads,
+        );
+        idx.register_workspace_module(
+            std::path::PathBuf::from("/fake/conf/app.pl.pm-shim"),
+            Arc::new(fa),
+        );
+    }
+    // packageless shim doesn't register; use insert_cache instead
+    let app_src2 = "package MyApp::Boot;\nuse Mojolicious::Lite;\nplugin 'CloveApp', { minion => 1, redis => 'r' };\n1;\n";
+    {
+        let mut parser = crate::builder::create_parser();
+        let tree = parser.parse(app_src2, None).unwrap();
+        let fa = crate::builder::build(&tree, app_src2.as_bytes());
+        idx.insert_cache(
+            "MyApp::Boot",
+            Some(Arc::new(crate::file_analysis::CachedModule::new(
+                std::path::PathBuf::from("/fake/conf/Boot.pm"),
+                Arc::new(fa),
+            ))),
+        );
+    }
+
+    let plugin_src = "package Mojolicious::Plugin::CloveApp;\nuse Mojo::Base 'Mojolicious::Plugin';\n\nsub register {\n    my ($self, $app, $conf) = @_;\n}\n1;\n";
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(plugin_src, None).unwrap();
+    let mut fa = crate::builder::build(&tree, plugin_src.as_bytes());
+    assert!(
+        !fa.loader_config_params.is_empty(),
+        "the param_types from_loader_config rule should mint a marker",
+    );
+    fa.enrich_imported_types_with_keys(Some(&idx));
+
+    let t = fa.inferred_type_via_bag("$conf", Point { row: 5, column: 0 });
+    match t {
+        Some(InferredType::HashWithKeys { keys, .. }) => {
+            let mut names: Vec<&str> = keys.iter().map(|(k, _)| k.as_str()).collect();
+            names.sort();
+            assert_eq!(names, vec!["minion", "redis"]);
+        }
+        other => panic!("expected the gathered config shape, got {other:?}"),
+    }
+}

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -2049,3 +2049,4 @@ fn loader_config_types_register_conf_cross_file() {
         other => panic!("expected the gathered config shape, got {other:?}"),
     }
 }
+

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -1934,3 +1934,60 @@ fn name_in_no_export_or_tag_is_not_exported() {
     assert!(fa.exports_name("foo"));
     assert!(!fa.exports_name("private_helper"), "non-exported sub must stay unexported");
 }
+
+#[test]
+fn cross_file_slot_write_types_the_read() {
+    // A4 v2: the typed slot write lives in the PARENT class's file;
+    // the read in the child file narrows through the registry's
+    // SlotType cross-file + ancestor arm at query time.
+    use std::sync::Arc;
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let parent_src = "package Parent;\nsub init {\n    my ($self) = @_;\n    $self->{conn} = My::Conn->new;\n}\n1;\n";
+    {
+        let mut parser = crate::builder::create_parser();
+        let tree = parser.parse(parent_src, None).unwrap();
+        let fa = crate::builder::build(&tree, parent_src.as_bytes());
+        idx.insert_cache(
+            "Parent",
+            Some(Arc::new(crate::file_analysis::CachedModule::new(
+                std::path::PathBuf::from("/fake/Parent.pm"),
+                Arc::new(fa),
+            ))),
+        );
+    }
+    let child_src = "package Child;\nuse Moo;\nextends 'Parent';\nsub go {\n    my ($self) = @_;\n    my $x = $self->{conn};\n}\n1;\n";
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(child_src, None).unwrap();
+    let fa = crate::builder::build(&tree, child_src.as_bytes());
+
+    // the read expression `$self->{conn}` on line 5 (0-based)
+    let read_span = fa
+        .refs
+        .iter()
+        .find(|r| {
+            matches!(r.kind, RefKind::HashKeyAccess { .. })
+                && r.target_name == "conn"
+                && r.span.start.row == 5
+        })
+        .map(|r| r.span)
+        .expect("read-site hash key ref");
+    // the Expr witness covers the whole `$self->{conn}` element; ask at
+    // the element span — expr_type_at_span finds the narrowest cover.
+    let t = fa.expr_type_at_span(
+        Span { start: Point { row: 5, column: 12 }, end: Point { row: 5, column: 25 } },
+        Some(&idx),
+    );
+    assert_eq!(
+        t,
+        Some(InferredType::ClassName("My::Conn".into())),
+        "read at {read_span:?} should narrow via the parent file's slot write",
+    );
+    // and the variable that received it — `$x` rides Edge(Expr(read))
+    let t2 = fa.inferred_type_via_bag_ctx(
+        "$x",
+        Point { row: 6, column: 0 },
+        Some(&idx),
+    );
+    assert_eq!(t2, Some(InferredType::ClassName("My::Conn".into())));
+}
+

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 91;
+pub const EXTRACT_VERSION: i64 = 92;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 92;
+pub const EXTRACT_VERSION: i64 = 93;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -32,6 +32,8 @@ use crate::module_resolver;
 // index consumers keep one import site.
 pub use crate::file_analysis::{CachedModule, SubInfo};
 
+type InferredTypeOwned = crate::file_analysis::InferredType;
+
 // ---- Internal sync primitives (pub(crate) for resolver thread) ----
 
 /// Thread-safe queue: Mutex<Vec> + Condvar.
@@ -205,6 +207,14 @@ pub struct ModuleIndex {
     /// forgot to load); installed CPAN plugins keep the generous
     /// "downloaded = intended" resolution.
     workspace_modules: Arc<DashMap<String, ()>>,
+    /// Loader-config shapes projected at registration: load-name →
+    /// (contributor, shape) pairs from each file's `PluginLoad` facts.
+    /// Projected HERE because lite entrypoints are PACKAGELESS — they
+    /// never enter the cache, so enrichment can't reach their bags;
+    /// the config value is a literal, so its shape is final at the
+    /// contributor's own build. Fed by register_workspace_module
+    /// (before the packageless early-return) AND insert_cache.
+    loader_config_shapes: Arc<DashMap<String, Vec<(String, InferredTypeOwned)>>>,
     /// Modules loaded from cache with an old extract_version.
     /// Eligible for priority re-resolution when requested.
     stale_modules: Arc<DashMap<String, ()>>,
@@ -264,6 +274,7 @@ impl ModuleIndex {
             edges,
             loaded_modules: Arc::new(DashMap::new()),
             workspace_modules: Arc::new(DashMap::new()),
+            loader_config_shapes: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -545,6 +556,7 @@ impl ModuleIndex {
             edges,
             loaded_modules: Arc::new(DashMap::new()),
             workspace_modules: Arc::new(DashMap::new()),
+            loader_config_shapes: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -593,6 +605,7 @@ impl ModuleIndex {
             edges,
             loaded_modules: Arc::new(DashMap::new()),
             workspace_modules: Arc::new(DashMap::new()),
+            loader_config_shapes: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -620,8 +633,32 @@ impl ModuleIndex {
     pub fn insert_cache(&self, module_name: &str, cached: Option<Arc<CachedModule>>) {
         if let Some(ref m) = cached {
             self.edges.feed(module_name, &m.analysis);
+            self.record_loader_shapes(module_name, &m.analysis);
         }
         self.cache.insert(module_name.to_string(), cached);
+    }
+
+    /// Project each `PluginLoad` fact's config value into a stored
+    /// shape under its load-name. The value is a literal in the
+    /// contributor's file, so `expr_type_at_span` with no index is
+    /// already final — this is a registration-time projection of
+    /// local facts (the same tier as export names), not a cached
+    /// cross-file resolution.
+    fn record_loader_shapes(&self, contributor: &str, analysis: &FileAnalysis) {
+        // re-registration: drop this contributor's old entries
+        self.loader_config_shapes.retain(|_n, v| {
+            v.retain(|(c, _)| c != contributor);
+            !v.is_empty()
+        });
+        for f in &analysis.plugin_loads {
+            let Some(span) = f.config_span else { continue };
+            if let Some(t) = analysis.expr_type_at_span(span, None) {
+                self.loader_config_shapes
+                    .entry(f.name.clone())
+                    .or_default()
+                    .push((contributor.to_string(), t));
+            }
+        }
     }
 
     /// Register a workspace-indexed file under its primary package name
@@ -642,6 +679,7 @@ impl ModuleIndex {
         for imp in &analysis.imports {
             self.loaded_modules.insert(imp.module_name.clone(), ());
         }
+        self.record_loader_shapes(&path.display().to_string(), &analysis);
         let Some(module_name) = first_package_name(&analysis) else { return };
         self.workspace_modules.insert(module_name.clone(), ());
         // Canonicalize the path — `Url::from_file_path` in symbols.rs
@@ -924,6 +962,14 @@ impl CrossFileLookup for ModuleIndex {
         visit: &mut dyn FnMut(&str, &Arc<CachedModule>) -> std::ops::ControlFlow<()>,
     ) {
         self.for_each_descendant_package(class, visit)
+    }
+
+    fn for_each_loader_shape(&self, f: &mut dyn FnMut(&str, &crate::file_analysis::InferredType)) {
+        for entry in self.loader_config_shapes.iter() {
+            for (_contributor, t) in entry.value() {
+                f(entry.key(), t);
+            }
+        }
     }
 }
 

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -679,6 +679,14 @@ impl ModuleIndex {
         for imp in &analysis.imports {
             self.loaded_modules.insert(imp.module_name.clone(), ());
         }
+        // Method-form loads (`$app->plugin('X')`, the nested cascade)
+        // are recorded as `plugin_loads` by the trigger-independent
+        // builder recognizer — feed them too. Names are short
+        // (`FeatureFlags`); `is_module_loaded` tail-matches them to FQ
+        // providers (`Clove::App::Plugin::FeatureFlags`).
+        for f in &analysis.plugin_loads {
+            self.loaded_modules.insert(f.name.clone(), ());
+        }
         self.record_loader_shapes(&path.display().to_string(), &analysis);
         let Some(module_name) = first_package_name(&analysis) else { return };
         self.workspace_modules.insert(module_name.clone(), ());

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -685,8 +685,21 @@ impl ModuleIndex {
     /// Is `module` imported by any workspace file (entrypoint scripts
     /// included)? `false` is honest only after the workspace scan has
     /// run — callers on the diagnostics path are post-startup.
+    ///
+    /// Matching is exact OR last-segment tail: a `plugin 'DataLog'`
+    /// load records the default-namespace guess
+    /// (`Mojolicious::Plugin::DataLog`) while the resolved provider
+    /// may live in an app-custom tree (`Clove::App::Plugin::DataLog`).
+    /// The looseness only SUPPRESSES the lint — the honest-quiet
+    /// direction.
     pub fn is_module_loaded(&self, module: &str) -> bool {
-        self.loaded_modules.contains_key(module)
+        if self.loaded_modules.contains_key(module) {
+            return true;
+        }
+        let tail = module.rsplit("::").next().unwrap_or(module);
+        self.loaded_modules
+            .iter()
+            .any(|e| e.key().rsplit("::").next() == Some(tail))
     }
 
     /// Was `module` registered from the workspace tree (vs @INC)?

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -194,6 +194,17 @@ pub struct ModuleIndex {
     cache: Arc<DashMap<String, Option<Arc<CachedModule>>>>,
     /// See `ModuleEdgeIndexes` — names + bridges + children reverse maps.
     edges: Arc<ModuleEdgeIndexes>,
+    /// Modules imported (literally or via SyntheticUse) by ANY
+    /// workspace file, entrypoint scripts included. Powers the
+    /// entrypoint-scan helper lint's "does anything load M" question.
+    /// Fed by `register_workspace_module` only — the workspace scan
+    /// re-runs every startup, so no warm-rebuild feed is needed.
+    loaded_modules: Arc<DashMap<String, ()>>,
+    /// Primary package names of workspace-registered files. The lint
+    /// fires only for WORKSPACE plugin modules (in-project plugins you
+    /// forgot to load); installed CPAN plugins keep the generous
+    /// "downloaded = intended" resolution.
+    workspace_modules: Arc<DashMap<String, ()>>,
     /// Modules loaded from cache with an old extract_version.
     /// Eligible for priority re-resolution when requested.
     stale_modules: Arc<DashMap<String, ()>>,
@@ -251,6 +262,8 @@ impl ModuleIndex {
         ModuleIndex {
             cache,
             edges,
+            loaded_modules: Arc::new(DashMap::new()),
+            workspace_modules: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -530,6 +543,8 @@ impl ModuleIndex {
         ModuleIndex {
             cache,
             edges,
+            loaded_modules: Arc::new(DashMap::new()),
+            workspace_modules: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -576,6 +591,8 @@ impl ModuleIndex {
         ModuleIndex {
             cache,
             edges,
+            loaded_modules: Arc::new(DashMap::new()),
+            workspace_modules: Arc::new(DashMap::new()),
             stale_modules,
             available_modules,
             builtins,
@@ -616,7 +633,17 @@ impl ModuleIndex {
     ///
     /// No-op for files without a `package` declaration (top-level scripts).
     pub fn register_workspace_module(&self, path: std::path::PathBuf, analysis: Arc<FileAnalysis>) {
+        // Loaded-module tracking feeds the entrypoint-scan lint and must
+        // run BEFORE the packageless early-return: Mojolicious::Lite
+        // scripts (no `package` decl) are exactly the entrypoints whose
+        // `plugin 'X'` loads (via SyntheticUse imports) the lint needs
+        // to see. Workspace scan re-runs every startup, so this set
+        // needs no warm-rebuild feed.
+        for imp in &analysis.imports {
+            self.loaded_modules.insert(imp.module_name.clone(), ());
+        }
         let Some(module_name) = first_package_name(&analysis) else { return };
+        self.workspace_modules.insert(module_name.clone(), ());
         // Canonicalize the path — `Url::from_file_path` in symbols.rs
         // requires absolute paths, so relative workspace paths (e.g.
         // "./test_files/lib/Users.pm" from CLI `.` root) would silently
@@ -655,6 +682,18 @@ impl ModuleIndex {
     /// Callers then pull the namespace's entities from the module's
     /// `FileAnalysis` and iterate. Explicit bridges rather than
     /// symbol-package inference.
+    /// Is `module` imported by any workspace file (entrypoint scripts
+    /// included)? `false` is honest only after the workspace scan has
+    /// run — callers on the diagnostics path are post-startup.
+    pub fn is_module_loaded(&self, module: &str) -> bool {
+        self.loaded_modules.contains_key(module)
+    }
+
+    /// Was `module` registered from the workspace tree (vs @INC)?
+    pub fn is_workspace_module(&self, module: &str) -> bool {
+        self.workspace_modules.contains_key(module)
+    }
+
     pub fn modules_bridging_to(&self, class_name: &str) -> Vec<String> {
         match self.edges.bridges.get(class_name) {
             Some(mods) => {

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -609,6 +609,54 @@ pub fn add_project_lib_paths(inc_paths: &mut Vec<PathBuf>, workspace_root: &std:
 /// resolve. Without this, `->to('Users#list')` couldn't find
 /// `test_files/lib/Users.pm` because nothing ever triggers a
 /// module_index populate for workspace files.
+/// Does this extensionless file start with a Perl shebang
+/// (`#!...perl`)? The entrypoint-script test — `jobs`, `login`,
+/// Mojo::Lite apps. Peeks 64 bytes; never called on extensioned files.
+fn has_perl_shebang(path: &std::path::Path) -> bool {
+    if path.extension().is_some() {
+        return false;
+    }
+    use std::io::Read;
+    let Ok(mut f) = std::fs::File::open(path) else { return false };
+    let mut buf = [0u8; 64];
+    let Ok(n) = f.read(&mut buf) else { return false };
+    let head = String::from_utf8_lossy(&buf[..n]);
+    let first = head.lines().next().unwrap_or("");
+    first.starts_with("#!") && first.contains("perl")
+}
+
+/// Extensionless Perl entrypoint scripts, found by a SHALLOW (depth-1)
+/// shebang scan over the conventional dirs — repo root, `bin/`,
+/// `script/` — plus any `extra` dirs (relative to `root`). Shallow +
+/// dir-scoped on purpose: entrypoints are direct files in known
+/// places, so this never walks a source tree.
+///
+/// `extra` is the SEAM for a future workspace-config `entrypoint_dirs`
+/// knob: today every caller passes `&[]`; wiring config is one line at
+/// the call site, no change here. (The config-file reader itself is
+/// deliberately deferred until there's a real config story to design.)
+fn scan_entrypoint_scripts(root: &std::path::Path, extra: &[String]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> =
+        vec![root.to_path_buf(), root.join("bin"), root.join("script")];
+    dirs.extend(extra.iter().map(|d| root.join(d)));
+    let mut out = Vec::new();
+    for dir in dirs {
+        let Ok(rd) = std::fs::read_dir(&dir) else { continue };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if !p.is_file() {
+                continue;
+            }
+            if std::fs::metadata(&p).map(|m| m.len() < 1_000_000).unwrap_or(false)
+                && has_perl_shebang(&p)
+            {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
 pub fn index_workspace_with_index(
     root: &std::path::Path,
     files: &crate::file_store::FileStore,
@@ -619,6 +667,8 @@ pub fn index_workspace_with_index(
     use rayon::prelude::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    // Extensioned Perl (`*.pm/*.pl/*.t`) — type-pruned at the walk
+    // level (cheap; never descends into a JS tree's files).
     let mut types_builder = TypesBuilder::new();
     types_builder.add("perl", "*.pm").unwrap();
     types_builder.add("perl", "*.pl").unwrap();
@@ -626,7 +676,7 @@ pub fn index_workspace_with_index(
     types_builder.select("perl");
     let types = types_builder.build().unwrap();
 
-    let paths: Vec<PathBuf> = WalkBuilder::new(root)
+    let mut paths: Vec<PathBuf> = WalkBuilder::new(root)
         .types(types)
         .build()
         .filter_map(|e| e.ok())
@@ -634,6 +684,16 @@ pub fn index_workspace_with_index(
         .filter(|e| e.metadata().map(|m| m.len() < 1_000_000).unwrap_or(false))
         .map(|e| e.into_path())
         .collect();
+
+    // Extensionless entrypoint SCRIPTS (`#!/usr/bin/env perl` — crm's
+    // `jobs`/`login`/… Mojo::Lite apps) carry no glob, so a SHALLOW
+    // shebang scan over the conventional entrypoint dirs catches them
+    // without enumerating the whole tree. These scripts are exactly
+    // where `plugin 'X'` loads live; skipping them blinded the
+    // entrypoint-scan lint and goto-def into entrypoint-defined symbols.
+    // `&[]` today; the seam for a future workspace-config
+    // `entrypoint_dirs` (additive to the built-in root/bin/script).
+    paths.extend(scan_entrypoint_scripts(root, &[]));
 
     let count = AtomicUsize::new(0);
 

--- a/src/module_resolver_tests.rs
+++ b/src/module_resolver_tests.rs
@@ -110,3 +110,38 @@ fn test_uri_to_path() {
     );
     assert_eq!(uri_to_path("http://example.com"), None);
 }
+
+#[test]
+fn entrypoint_scan_finds_shebang_scripts_in_conventional_dirs() {
+    let dir = std::env::temp_dir().join(format!("qx-entry-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("bin")).unwrap();
+    std::fs::create_dir_all(dir.join("script")).unwrap();
+    std::fs::create_dir_all(dir.join("lib")).unwrap();
+    // root-level Perl entrypoint (no extension) — found
+    std::fs::write(dir.join("jobs"), "#!/usr/bin/env perl\nuse Mojolicious::Lite;\n").unwrap();
+    // bin/ + script/ entrypoints — found
+    std::fs::write(dir.join("bin/login"), "#! /usr/bin/perl\n").unwrap();
+    std::fs::write(dir.join("script/cron"), "#!/usr/bin/env perl\n").unwrap();
+    // non-Perl shebang — not found
+    std::fs::write(dir.join("deploy"), "#!/bin/bash\n").unwrap();
+    // extensionless script buried in lib/ — NOT scanned by default
+    std::fs::write(dir.join("lib/buried"), "#!/usr/bin/env perl\n").unwrap();
+
+    let mut found: Vec<String> = scan_entrypoint_scripts(&dir, &[])
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    found.sort();
+    assert_eq!(found, vec!["cron", "jobs", "login"]);
+
+    // the config seam: an `extra` dir brings its entrypoints in.
+    std::fs::create_dir_all(dir.join("daemons")).unwrap();
+    std::fs::write(dir.join("daemons/worker"), "#!/usr/bin/env perl\n").unwrap();
+    let mut with_extra: Vec<String> = scan_entrypoint_scripts(&dir, &["daemons".into()])
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    with_extra.sort();
+    assert_eq!(with_extra, vec!["cron", "jobs", "login", "worker"]);
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -442,6 +442,16 @@ pub enum EmitAction {
     /// generic MethodCall ref; from that point on goto-def, references,
     /// rename, and hover work via the standard method-resolution path
     /// (with inheritance walk + workspace index).
+    /// "This call LOADS module `name` and passes it a config value."
+    /// The caller-side half of loader-config param typing: the fact
+    /// rides the calling file's FileAnalysis; enrichment of the LOADED
+    /// module joins it with a `from_loader_config` param marker and
+    /// types the param from the value at `config_span`.
+    PluginLoad {
+        name: String,
+        #[serde(default)]
+        config_span: Option<Span>,
+    },
     MethodCallRef {
         /// The method name (e.g. `"list"` from `"Users#list"`).
         method_name: String,
@@ -754,6 +764,15 @@ pub struct ParamType {
     /// *named* rules that don't set this.
     #[serde(default)]
     pub requires_action_attr: bool,
+    /// The param's REAL type is whatever value the loader call passed
+    /// (`plugin 'X', {...}` → register's `$conf`): enrichment joins
+    /// the callee-side marker this mints with caller-side
+    /// `PluginLoad` facts and pushes the gathered shape. `type_class`
+    /// stays as the static fallback (HashRef for Mojo's `$conf`) —
+    /// the bag's structure-dominates-rep subsumption prefers the
+    /// gathered shape when both land.
+    #[serde(default)]
+    pub from_loader_config: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -713,6 +713,24 @@ pub struct DispatchVerb {
     pub name_arg_index: usize,
 }
 
+/// A method that LOADS a module, naming it in a positional string
+/// argument — `$app->plugin('X')`, `$app->plugin($_) for qw/A B/`.
+/// Recognized TRIGGER-INDEPENDENTLY (like `DispatchVerb`): the load
+/// happens on the receiver app regardless of the enclosing file's
+/// class — a `Mojolicious::Plugin` subclass, never an app, for the
+/// whole nested-plugin cascade. `receiver_class` is the honest intent
+/// (the app type); the load FACT is a suppression signal for the
+/// entrypoint lint, so recording errs toward silence rather than
+/// gating on a receiver type that only resolves at query time (see
+/// `record_plugin_loads`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadVerb {
+    pub verb: String,
+    pub receiver_class: String,
+    #[serde(default)]
+    pub name_arg_index: usize,
+}
+
 /// One extracted parameter of a parametric type-constraint constructor
 /// (`InstanceOf['Foo']` → one param with `string: "Foo"`). The builder
 /// fills exactly one of the two fields per param (rule #1 — it walked the
@@ -805,6 +823,11 @@ pub trait FrameworkPlugin: Send + Sync {
     /// in the enrichment pass (cross-file receiver isa resolution) — see
     /// `DispatchVerb`. Default empty; only dispatch-style plugins declare.
     fn dispatch_verbs(&self) -> &[DispatchVerb] {
+        &[]
+    }
+
+    /// Module-loading verbs — see `LoadVerb`. Default empty.
+    fn load_verbs(&self) -> &[LoadVerb] {
         &[]
     }
 
@@ -1133,6 +1156,10 @@ impl PluginRegistry {
     /// Trigger-independent, same rationale as `overrides`.
     pub fn dispatch_verbs<'a>(&'a self) -> impl Iterator<Item = &'a DispatchVerb> + 'a {
         self.plugins.iter().flat_map(|p| p.dispatch_verbs().iter())
+    }
+
+    pub fn load_verbs<'a>(&'a self) -> impl Iterator<Item = &'a LoadVerb> + 'a {
+        self.plugins.iter().flat_map(|p| p.load_verbs().iter())
     }
 
     /// Yield every role-contract parameter-type rule across the registry.

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -134,6 +134,7 @@ pub struct RhaiPlugin {
     triggers: Vec<Trigger>,
     overrides: Vec<TypeOverride>,
     dispatch_verbs: Vec<DispatchVerb>,
+    load_verbs: Vec<crate::plugin::LoadVerb>,
     param_types: Vec<ParamType>,
     type_constraint_names: Vec<String>,
     app_surface_consumers: Vec<String>,
@@ -220,6 +221,26 @@ impl RhaiPlugin {
                     }
                 }
                 Err(e) => log::error!("plugin `{}` dispatch_verbs() failed: {}", id, e),
+            }
+        }
+
+        // `load_verbs()` — same optional, fail-safe contract.
+        let mut load_verbs: Vec<crate::plugin::LoadVerb> = Vec::new();
+        if signatures.iter().any(|n| n == "load_verbs") {
+            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "load_verbs", ()) {
+                Ok(arr) => {
+                    for d in arr {
+                        match from_dynamic::<crate::plugin::LoadVerb>(&d) {
+                            Ok(v) => load_verbs.push(v),
+                            Err(e) => log::error!(
+                                "plugin `{}` load_verbs() bad entry: {}",
+                                id,
+                                e
+                            ),
+                        }
+                    }
+                }
+                Err(e) => log::error!("plugin `{}` load_verbs() failed: {}", id, e),
             }
         }
 
@@ -329,6 +350,7 @@ impl RhaiPlugin {
             triggers,
             overrides,
             dispatch_verbs,
+            load_verbs,
             param_types,
             type_constraint_names,
             app_surface_consumers,
@@ -410,6 +432,10 @@ impl FrameworkPlugin for RhaiPlugin {
 
     fn dispatch_verbs(&self) -> &[DispatchVerb] {
         &self.dispatch_verbs
+    }
+
+    fn load_verbs(&self) -> &[crate::plugin::LoadVerb] {
+        &self.load_verbs
     }
 
     fn param_types(&self) -> &[ParamType] {

--- a/src/resolve_tests.rs
+++ b/src/resolve_tests.rs
@@ -2953,7 +2953,7 @@ fn test_implementations_of_role_requires_fans_out_to_composers() {
     use std::sync::Arc;
 
     let idx = ModuleIndex::new_for_test();
-    let mut insert = |name: &str, src: &str| {
+    let insert = |name: &str, src: &str| {
         let analysis = Arc::new(parse(src));
         idx.insert_cache(
             name,

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2785,6 +2785,62 @@ pub fn collect_diagnostics(
         });
     }
 
+    // 5h: helper-not-loaded — the entrypoint-scan lint
+    // (docs/prompt-helper-consumption.md phase 2). A method call whose
+    // ONLY resolution is a plugin bridge from a WORKSPACE module that
+    // no workspace file loads (imports literally or via the SyntheticUse
+    // a `plugin 'X'` line emits). Installed CPAN plugins are exempt —
+    // the "downloaded = intended" policy keeps resolution generous and
+    // makes precision this lint's job. HINT severity.
+    {
+        use crate::conventions::{InvocantText, MethodToken};
+        let mut seen: std::collections::HashSet<(String, String)> = Default::default();
+        for r in &analysis.refs {
+            let RefKind::MethodCall { invocant, .. } = &r.kind else { continue };
+            let method_name = &r.target_name;
+            if !matches!(MethodToken::parse(method_name), MethodToken::Bare(_)) {
+                continue;
+            }
+            let class_name = match invocant.classify() {
+                InvocantText::Bareword(b) => Some(b.to_string()),
+                InvocantText::Scalar(_) => analysis
+                    .inferred_type_via_bag(invocant, r.span.start)
+                    .and_then(|ty| ty.class_name().map(|s| s.to_string())),
+                _ => None,
+            };
+            let Some(class_name) = class_name else { continue };
+            if !seen.insert((class_name.clone(), method_name.clone())) {
+                // one hint per (class, helper) per file — the fix is
+                // one `plugin` line, not one per call site
+                continue;
+            }
+            let Some(provider) =
+                analysis.bridged_helper_provider(&class_name, method_name, Some(module_index))
+            else {
+                continue;
+            };
+            if !module_index.is_workspace_module(&provider) {
+                continue;
+            }
+            if analysis.imports.iter().any(|i| i.module_name == provider)
+                || module_index.is_module_loaded(&provider)
+            {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                range: span_to_range(r.span),
+                severity: Some(DiagnosticSeverity::HINT),
+                code: Some(NumberOrString::String("helper-not-loaded".into())),
+                source: Some("perl-lsp".into()),
+                message: format!(
+                    "'{}' is provided by {}, which no workspace entrypoint loads",
+                    method_name, provider,
+                ),
+                ..Default::default()
+            });
+        }
+    }
+
     // Opt-in `unresolved-dispatch`: a known dispatch verb whose receiver
     // couldn't be typed, so we can't tell if the dispatch applies. Fires ONLY
     // on `ReceiverUntyped` (a real typing gap), never on `DoesNotApply` — the

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4681,3 +4681,87 @@ fn test_role_requires_dynamic_parent_honest_silence() {
         role_or_method,
     );
 }
+
+// ---- helper-not-loaded (entrypoint-scan lint) ----
+
+fn helper_lint_setup() -> (crate::module_index::ModuleIndex, String) {
+    // A workspace Mojolicious plugin registering a helper. The bundled
+    // mojo plugins synthesize the helper entity bridged to the
+    // controller surface.
+    let plugin_src = "package My::Plugin::WasLoaded;\nuse Mojo::Base 'Mojolicious::Plugin';\n\
+        sub register {\n    my ($self, $app, $conf) = @_;\n    $app->helper(was_loaded => sub { 1 });\n}\n1;\n";
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(plugin_src, None).unwrap();
+    let fa = crate::builder::build(&tree, plugin_src.as_bytes());
+    idx.register_workspace_module(
+        std::path::PathBuf::from("/fake/lint/My/Plugin/WasLoaded.pm"),
+        std::sync::Arc::new(fa),
+    );
+    let consumer_src = "package MyApp::C;\nuse Mojo::Base 'Mojolicious::Controller';\n\
+        sub act {\n    my $self = shift;\n    $self->was_loaded;\n}\n1;\n"
+        .to_string();
+    (idx, consumer_src)
+}
+
+fn lint_messages(idx: &crate::module_index::ModuleIndex, src: &str) -> Vec<String> {
+    let analysis = parse_analysis(src);
+    collect_diagnostics(&analysis, idx, Default::default())
+        .into_iter()
+        .filter(|d| {
+            matches!(&d.code, Some(tower_lsp::lsp_types::NumberOrString::String(c))
+                if c == "helper-not-loaded")
+        })
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn test_helper_not_loaded_fires_for_unloaded_workspace_plugin() {
+    let (idx, consumer) = helper_lint_setup();
+    let msgs = lint_messages(&idx, &consumer);
+    assert_eq!(
+        msgs,
+        vec!["'was_loaded' is provided by My::Plugin::WasLoaded, which no workspace entrypoint loads"],
+    );
+}
+
+#[test]
+fn test_helper_not_loaded_suppressed_when_an_entrypoint_loads_it() {
+    let (idx, consumer) = helper_lint_setup();
+    // A packageless entrypoint script loading the plugin — exactly the
+    // file shape (lite app) that never enters the module cache; the
+    // loaded-set feed must run before the packageless early-return.
+    let entry_src = "use My::Plugin::WasLoaded;\nprint 1;\n";
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(entry_src, None).unwrap();
+    let fa = crate::builder::build(&tree, entry_src.as_bytes());
+    idx.register_workspace_module(
+        std::path::PathBuf::from("/fake/lint/app.pl"),
+        std::sync::Arc::new(fa),
+    );
+    assert!(lint_messages(&idx, &consumer).is_empty());
+}
+
+#[test]
+fn test_helper_not_loaded_exempts_installed_plugins() {
+    // Same plugin arriving via insert_cache (the @INC path, not
+    // workspace registration): the "downloaded = intended" policy —
+    // no lint.
+    let plugin_src = "package My::Plugin::WasLoaded;\nuse Mojo::Base 'Mojolicious::Plugin';\n\
+        sub register {\n    my ($self, $app, $conf) = @_;\n    $app->helper(was_loaded => sub { 1 });\n}\n1;\n";
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(plugin_src, None).unwrap();
+    let fa = crate::builder::build(&tree, plugin_src.as_bytes());
+    idx.insert_cache(
+        "My::Plugin::WasLoaded",
+        Some(std::sync::Arc::new(crate::file_analysis::CachedModule::new(
+            std::path::PathBuf::from("/inc/My/Plugin/WasLoaded.pm"),
+            std::sync::Arc::new(fa),
+        ))),
+    );
+    let consumer = "package MyApp::C;\nuse Mojo::Base 'Mojolicious::Controller';\n\
+        sub act {\n    my $self = shift;\n    $self->was_loaded;\n}\n1;\n";
+    assert!(lint_messages(&idx, consumer).is_empty());
+}

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -4765,3 +4765,4 @@ fn test_helper_not_loaded_exempts_installed_plugins() {
         sub act {\n    my $self = shift;\n    $self->was_loaded;\n}\n1;\n";
     assert!(lint_messages(&idx, consumer).is_empty());
 }
+

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -1595,6 +1595,66 @@ impl ReducerRegistry {
             }
         }
 
+        // `SlotType{C, k}` the local bag couldn't answer: the typed
+        // slot WRITE may live in C's own file (cross-file primary) or
+        // anywhere up C's ancestry (a base class's BUILD populating
+        // `$self->{conn}`). Hops (1) and (2) of the `MethodOnClass`
+        // fallback above, same shared visited set; no bridge hop —
+        // slot writes are real code, not plugin entities.
+        if let WitnessAttachment::SlotType { class, key } = q.attachment {
+            if let Some(ctx) = q.context {
+                if let Some(idx) = ctx.module_index {
+                    if let Some(cached) = idx.get_cached(class) {
+                        if !std::ptr::eq(bag, &cached.analysis.witnesses) {
+                            let cached_ctx = BagContext {
+                                scopes: &cached.analysis.scopes,
+                                package_framework: &cached.analysis.package_framework,
+                                module_index: Some(idx),
+                                package_parents: &cached.analysis.package_parents,
+                                app_surface_consumers: &cached.analysis.app_surface_consumers,
+                            };
+                            let sub_q = ReducerQuery {
+                                attachment: q.attachment,
+                                point: q.point,
+                                framework: q.framework,
+                                arity_hint: None,
+                                receiver: q.receiver.clone(),
+                                context: Some(&cached_ctx),
+                            };
+                            let v = self.query_rec(&cached.analysis.witnesses, &sub_q, state);
+                            if *v != ReducedValue::None {
+                                return (*v).clone();
+                            }
+                        }
+                    }
+                }
+                let parents = crate::file_analysis::parents_of(
+                    class,
+                    ctx.package_parents,
+                    ctx.module_index,
+                    ctx.app_surface_consumers,
+                );
+                for p in parents {
+                    let parent_att = WitnessAttachment::SlotType {
+                        class: p,
+                        key: key.clone(),
+                    };
+                    let sub_q = ReducerQuery {
+                        attachment: &parent_att,
+                        point: q.point,
+                        framework: q.framework,
+                        arity_hint: None,
+                        receiver: q.receiver.clone(),
+                        context: q.context,
+                    };
+                    let v = self.query_rec(bag, &sub_q, state);
+                    if *v != ReducedValue::None {
+                        return (*v).clone();
+                    }
+                }
+            }
+        }
+
         ReducedValue::None
     }
 
@@ -1739,7 +1799,33 @@ impl ReducerRegistry {
                     if let Some(t) = base_t {
                         let projected = match step {
                             ProjectionStep::HashKey(k) => {
-                                t.key_value_type(k).flatten().cloned()
+                                t.key_value_type(k).flatten().cloned().or_else(|| {
+                                    // Class-typed base: the structural
+                                    // literal can't answer, but a typed
+                                    // slot WRITE can — `SlotType{class,
+                                    // key}`, local or (via the arm in
+                                    // query_rec_body) cross-file and up
+                                    // the ancestry. The read drills
+                                    // through the registry, never a
+                                    // baked value.
+                                    let class = t.class_name()?.to_string();
+                                    let att = WitnessAttachment::SlotType {
+                                        class,
+                                        key: k.clone(),
+                                    };
+                                    let sub_q = ReducerQuery {
+                                        attachment: &att,
+                                        point: q.point,
+                                        framework: q.framework,
+                                        arity_hint: None,
+                                        receiver: q.receiver.clone(),
+                                        context: q.context,
+                                    };
+                                    match &*self.query_rec(bag, &sub_q, state) {
+                                        ReducedValue::Type(t) => Some(t.clone()),
+                                        _ => None,
+                                    }
+                                })
                             }
                             ProjectionStep::ArrayIndex(i) => t.element_at(*i).cloned(),
                         };


### PR DESCRIPTION
Completes the long-distance epic (members 3–4 plus A4 v2, which joined mid-flight). Stacked under the graph-walking PR; QA/review when you're back.

## helper-not-loaded (HINT) — the entrypoint-scan lint

A method call whose only resolution is a plugin bridge from a **workspace** module that no workspace file loads. Loaded facts: imports including the SyntheticUse both plugin arms now emit (`$app->plugin('X')` method form gained it); matching is exact-or-tail so default-namespace guesses suppress app-custom providers — loose only in the honest-quiet direction. Installed CPAN plugins exempt. The loaded-set feeds at workspace registration **before** the packageless early-return, so lite entrypoints count.

## A4 v2 — cross-file `$self->{k}` typing

Reads narrow through slot writes in OTHER files and up the ancestry: `Projected` falls back to `SlotType{class,key}` on class-typed bases; `SlotType` gained the MethodOnClass-style cross-file + parents recursion. The read drills through the registry; nothing baked.

## Loader-config param typing (#25, framework-mediated)

`plugin 'Confy', { alpha => 1, beta => 'x' }` types `$conf: HashWithKeys{alpha: Numeric, beta: String}` (closed!) inside the plugin's `register`. Manifest declares the contract (`param_types` + `from_loader_config`; static `type_class` = no-caller fallback), callers record the value (`PluginLoad{name, config_span}`), and **registration-time shape projection** carries it — the gold fixture caught that lite entrypoints are packageless and never enter the cache, so enrichment scans couldn't reach their bags; shapes are now projected onto the index at registration, before the packageless early-return. Agreement fold: all equal → the shape; keyed disagreement → OPEN key union; else decline. Open-world gather stays declined (`prompt-long-distance.md` records the boundary + graph-rework unblock path).

## Gold diff (the don't-blow-up-the-tings section)

New committed fixture `gold-corpus/longdist-fixture/` + 3 gold rows. **On main, the 2 diagnostics rows FAIL (got: []) and branch passes all 3** — the behavioral diff:

| | main @ 32531fb | this branch |
|---|---|---|
| gold | 184 PASS / **3 FAIL** / 12 xfail | **187 PASS** / 0 FAIL / 12 xfail |
| crashes | 0 | 0 |

The `$conf` row is the whole chain in one assertion: `key 'alpa' is not in $conf's literal shape (keys: alpha, beta)` — packageless-entrypoint fact, projection, enrichment join, closed shape, value types.

## Perf (warm vs warm, same machine, single runs — ±2-3% noise)

| | main | branch | delta |
|---|---|---|---|
| wall | 39.00s | 39.01s | par |
| cpu user / sys | 61.66s / 0.69s | 61.91s / 0.71s | +0.4% |
| peak RSS | 633.6 MB | 631.6 MB | par |
| substrate startup | 3290 ms | 3666 ms | +11% ⚠ single-run; the loader-shape projection runs per registration — watch on re-run |

Per-capability means all within noise (hover 319ms, diagnostics 181ms incl. the two new checks). EXTRACT_VERSION 91→92.

## Verification

935 unit / 112 e2e / 187 gold / substrate lint hits: 0 / crm live: `$app: Mojolicious`, `$conf` HashRef fallback (gathered shape arrives with the kit's loader arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)