### PR TITLE
cleanup: comment + doc sweep after graph walking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Builder          builder.rs                   → produces FileAnalysis
 Data model       file_analysis.rs             → FileAnalysis (serde, bincode-cacheable)
 ```
 
-See `docs/ROADMAP.md` for the forward design corpus entry point. `docs/adr/file-store-and-resolve.md` covers the landed cross-file unification: single role-tagged FileStore + RoleMask + `refs_to`, plus `resolve_symbol` (cursor→`ResolvedTarget`) — the one entry point both LSP handlers (references/rename) and their CLI mirrors use to identify the target before calling `refs_to`. Never map `RenameKind`→`TargetRef` inline in a handler; per-feature policy on a target is a method on `TargetRef` (e.g. `supports_cross_file_rename`). The next architectural pillar (graph walking, which absorbed the unification residuals) is `docs/prompt-graph-walking.md`.
+See `docs/ROADMAP.md` for the forward design corpus entry point. `docs/adr/file-store-and-resolve.md` covers the landed cross-file unification: single role-tagged FileStore + RoleMask + `refs_to`, plus `resolve_symbol` (cursor→`ResolvedTarget`) — the one entry point both LSP handlers (references/rename) and their CLI mirrors use to identify the target before calling `refs_to`. Never map `RenameKind`→`TargetRef` inline in a handler; per-feature policy on a target is a method on `TargetRef` (e.g. `supports_cross_file_rename`). Graph walking — one lazy `walk` over the visibility edges (inheritance / bridges / descendants) — landed: `docs/adr/graph-walking.md` (`GraphView`, the closed `EdgeKind` + exhaustive `edges_from`, the Model-layer placement, the file-role/lexical boundaries). Forward work (branded edges, the deferred Scope-node taxonomy) in `docs/prompt-graph-walking.md`.
 
 ### Rules (read before writing code)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,16 +5,12 @@ This file is only what's NEXT, in order.
 
 ## Now (in order)
 
-1. **Long-distance remainder** — entrypoint-scan helper lint +
-   param typing's framework-mediated case. PR in flight
-   (`long-distance-remainder`). Docs: `prompt-long-distance.md`,
-   `prompt-helper-consumption.md`.
-2. **Graph walking** — the architectural pillar: one typed-edge graph,
-   one walker, replacing six bespoke walk mechanisms. Absorbs the
-   Openness diagnostic, `home_namespace`, the eager `Ref.target`
-   field shape, and per-app Mojo surfaces. Doc:
-   `prompt-graph-walking.md`.
-3. **DBIC out of core** — ungated; phase ladder in
+1. **Graph walking** — the walker + the whole inheritance axis landed
+   (`adr/graph-walking.md`). Next: **branded edges** (`$minion`/`$app`
+   instance identity → multi-app Mojo), then the deferred Scope-node
+   taxonomy (Openness diagnostic, `home_namespace`) when those are
+   built. Forward work: `prompt-graph-walking.md`.
+2. **DBIC out of core** — ungated; phase ladder in
    `prompt-dbic-as-plugin.md`. Ends with core plugin-free except
    generic dispatch.
 

--- a/docs/adr/graph-walking.md
+++ b/docs/adr/graph-walking.md
@@ -1,0 +1,91 @@
+# ADR: Graph walking — one lazy walker over the visibility edges
+
+Several queries answered "what is visible from here" by walking
+conceptually-one graph through different bespoke code: the class MRO
+(`for_each_ancestor_class`), the composer fan-out (`children_index`),
+plugin-namespace bridges (`for_each_entity_bridged_to`). Forgetting one
+was a class of "cross-file feature mysteriously degraded" bug. `walk`
+is the single traversal those collapse into.
+
+## The shape: a lazy derived view, not a built graph
+
+`src/graph.rs::GraphView` holds two borrows — `&FileAnalysis` and
+`Option<&dyn CrossFileLookup>` — and stores nothing. There is no node
+list, no adjacency map, no build step. `walk(origin, mask, visit)`
+DFS-chases edges on demand: `edges_from` derives a node's neighbours at
+the moment the walker asks, by calling the stores that already exist
+(`parents_of`, `direct_children_of`, `for_each_entity_bridged_to`). A
+walk materialises only its transient state (seen-set + per-node
+neighbour vec), discarded on return. "Chasing an edge" *is* a map
+lookup against `package_parents` — the same primitive the ported
+consumers used, so a port is parity by construction.
+
+`walk` is the caching seam: every consumer goes through it and never
+sees how edges are produced, so caching slots in behind `edges_from`
+with zero consumer change. Per-edge-kind, not all-or-nothing —
+`children_index` is the materialised form of the INHERITS_INV edge (the
+reverse walk was expensive, precomputed once), while INHERITS stays a
+lazy `parents_of` lookup. The home for an edge cache is `ModuleIndex`
+(the only `CrossFileLookup` impl), behind the trait method — the view
+never owns cross-query state. Lazy is the default so nothing pays for
+that machinery until a profiler asks.
+
+## `EdgeKind` is a closed enum; `edges_from` is exhaustive
+
+The edge kinds are a closed `enum EdgeKind { Inherits, InheritsInv,
+Bridges }`, and `edges_from` matches it **exhaustively** — adding a
+kind is a compile error until its derivation is written. This is the
+"one match site, never a parallel walker" rule with compiler teeth.
+The `EdgeKindMask` bitflags exists only for set membership + ergonomic
+`|` (a walk traverses several kinds at once); `EdgeKind` is the source
+of truth, and `EdgeKind::ALL` + `flag()` keep the two in lockstep (a
+test pins that the `ALL`-union covers every mask bit, the one hole the
+fixed-length array can't catch at compile time).
+
+## Model layer — why the view sits below the index
+
+`GraphView` imports only `file_analysis` (the `CrossFileLookup` trait +
+`parents_of`) — zero Index-layer deps — so it lives at the Model layer.
+That lets the model-internal walkers (`for_each_ancestor_class` and the
+method/dispatch/bridge resolution that funnels through it) call `walk`
+directly, no up-layer import. The DAG test permits this: graph and
+`file_analysis` mutually reference at the same layer (only a strictly-
+upward import is a violation). The alternative — relocating the
+ancestry query functions up out of the model — is available if the
+model ever gets fat, but is not needed: the view stays pure, and any
+caching lives at the Index layer behind the trait.
+
+## The inheritance axis is one walk
+
+Every inheritance consumer funnels through `for_each_ancestor_class`,
+which is now `visit(self)` then `walk(class, INHERITS)`. Self-handling
+lives in that one wrapper — it runs the consumer's own closure on the
+origin, which is consumer-specific (`class_isa` checks equality,
+`resolve_method_in_ancestors` checks the method) and so cannot move
+into `walk`, which holds no closure for the origin. `SUPER::` — parents
+only, never self — is the bare `walk`; there is no `skip_self` flag,
+because *checking self is not a walk*. The cycle guard is `walk`'s
+path-depth cap (the seen-set already breaks cycles); a class with many
+ancestors is no longer silently truncated the way the old total-node
+cap did.
+
+## Boundaries — what is NOT a walk
+
+Two of the "parallel models" the graph was meant to absorb are not
+edge-following traversals, and forcing them in would be contortion:
+
+- **File roles** (`refs_to`/`references_mask_for` open→workspace→
+  dependency tiers) ENUMERATE every file and scan its analysis — there
+  is no origin and no edge to chase. The completeness this guarantees
+  (re-exports, framework DSL, dynamic dispatch produce refs with no
+  clean import edge) is the whole point of the scan. `RoleMask` is a
+  partition, not a traversal, and stays.
+- **Lexical scope chains** are a single-parent linked-list climb to the
+  file scope — no branching, no cycles, no cross-file. `walk`'s
+  machinery buys nothing. The one parent-climb is `scope_chain_of(&[Scope],
+  start)`, shared by `FileAnalysis::scope_chain` and the witness-bag
+  query path (which holds a `&[Scope]` slice, not a `&FileAnalysis`).
+
+The migration ends when `package_parents` and `PluginNamespace.bridges`
+have no direct consumers — every *reachability* question is a `walk`
+with a mask. `RoleMask` is not in that set.

--- a/docs/prompt-graph-walking.md
+++ b/docs/prompt-graph-walking.md
@@ -1,527 +1,85 @@
-# Graph Walking: One Typed-Edge Graph, One Walker
+# Graph walking — forward work
 
-> **Scheduled NOW (June 2026).** The type-inference arc's remaining
-> items are all explicitly deferred-by-design; meanwhile six bespoke
-> walk mechanisms have accumulated (`parents_of`, `ModuleEdgeIndexes`'
-> three maps, `for_each_descendant_package`, `ReceiverGated`, RoleMask
-> tiers) — each with its own B6-style feed discipline. The strangler-
-> fig consumers exist; this is the next pillar.
->
-> Cross-refs: `adr/file-store-and-resolve.md` (today's `RoleMask` model
-> that this retires); `adr/plugin-system.md` (today's `PluginNamespace`
-> + `Bridge` that becomes typed edges); `adr/role-contracts.md`
-> (children_index — the inverse edge this graph makes first-class).
-> This doc also absorbed the unification residuals (Openness,
-> `home_namespace`, the eager `Ref.target` field) — see the final
-> section.
+The walker landed: `src/graph.rs` (`GraphView` + `walk`), the closed
+`EdgeKind` enum with exhaustive `edges_from`, and the INHERITS /
+INHERITS_INV / BRIDGES edge kinds. The whole inheritance axis routes
+through it; `children_index`'s descendant fan-out and plugin bridges
+too. Landed design + rationale: `docs/adr/graph-walking.md`. This doc
+is what's left.
 
-## The problem
+## Next: branded edges
 
-Several walkers do conceptually-similar work via different code paths:
-
-- `resolve_method_in_ancestors` — class hierarchy walk.
-- `for_each_entity_bridged_to(class, ...)` — plugin namespace bridges.
-- `resolve.rs::resolve_symbol(name, from, RoleMask::VISIBLE)` — file tier.
-- `cursor_context.rs` scope-chain walks — lexical resolution.
-- Import-list resolution scattered across `enrich_*` passes.
-
-Each handles different edge types (parent / role / bridge / import /
-file-tier). Forgetting one is a class of "cross-file feature mysteriously
-degraded" bug. Adding a new edge kind today means touching N walkers.
-
-The string-keyed `package_parents` graph is the core, but it's siloed from
-the lexical `Scope` tree, the plugin `Bridge` enum, and the file-tier
-`RoleMask`. Four parallel models for what's morally one graph.
-
-## The shape
-
-Three node kinds. One walker. Typed edges. Branded edges where identity
-matters.
-
-### Nodes
-
-- **Scope** — lexical block, package, module/file, plugin namespace,
-  builtin. Loose superset of "anything that can contain a binding."
-- **Symbol** — definition. Has a home scope.
-- **Ref** — use site. Resolves to a symbol via the walk.
-
-### Edges
-
-Every "X is visible from Y" relationship in the codebase, typed:
-
-#### Lexical structure
-- **`parent`** — scope → enclosing scope.
-- **`member`** — symbol → scope.
-
-#### Variable binding (sigil-aware)
-- **`binds_lexical`** — `my $x`. Lives in declaring scope.
-- **`binds_persistent`** — `state $x`. Lexical-shaped, init once.
-- **`binds_param`** — sub/method params. Marker for invocant + position.
-- **`binds_dynamic`** — `local $x`. **See open question below.**
-
-`our $x` is **not** a separate edge kind. Instead: every lexical scope
-inside `package Foo` has a `parent` edge to `Foo`'s package scope. `our`
-declarations install the symbol *in* the package scope, and the normal
-walk finds it through the existing parent chain. **Invariant to enforce
-at emission**: lexical scope → package scope `parent` edges are
-mandatory. This is a single path; no second mechanism for `our`.
-
-#### Package structure
-- **`provides_package`** — file → package (multiple files contribute).
-- **`inherits`** — package → package. Subkind: `extends` (use parent /
-  `@ISA` / `class :isa` / `Mojo::Base 'X'`) | `with_role` (`with` /
-  `class :does` / `does => 'Role'`) | `loads_component` (DBIC).
-- DFS walk + kind-mask is the policy. **No MRO/C3 modeling.**
-
-#### Cross-package access
-- **`imports_sub`** — package → symbol. Subkind: `qw_explicit` |
-  `tag_export` | `framework_dsl` (Mojo::Lite suppression entries).
-- **`re_exports`** — package → symbol (`our @EXPORT = qw(bar)`).
-- **`uses_module`** — file → file (the import's source file).
-
-#### Hash key ownership
-- **`owns_hashkey`** — scope → hashkey symbol. Subkind: `Sub(name)` |
-  `Class(name)` | `Variable(scope, name)`.
-- **No `Constructor` subkind.** Today's `HashKeyOwner::Sub("new")` for
-  Moo/Moose `has`-derived constructor keys collapses into a single owner
-  path. Pick whichever (Class is the natural one — the keys belong to
-  the class, not the synthesized `new` sub) and rename-transport
-  through. Two paths is a footgun; one path is correct.
-
-#### Plugin-namespace bridges
-- **`bridges_class`** — plugin_namespace → package. Visible from class
-  and descendants. (Today: `Bridge::Class`.)
-- **`bridges_bareword`** — plugin_namespace → bareword name. (Today:
-  `Bridge::Bareword`.) Used for `app` in Mojolicious::Lite.
-- **`bridges_variable`** — plugin_namespace → branded variable identity.
-  See "Branded edges" below.
-- **`bridges_file`** — plugin_namespace → file. Used for per-file
-  singletons (the Mojolicious::Lite app case).
-
-#### File attribution — `RoleMask` STAYS (the unification thesis's boundary)
-**Correction (graph-walking-1, after porting the inheritance axis):**
-this was an overreach. `refs_to`/`references_mask_for`/`group_refs`
-ENUMERATE file tiers (open → workspace → dependency), collecting
-matching refs from *every* file — a brute-force scan partitioned by
-role. There is no origin and no edge to follow, so it is not a
-`walk(origin, mask)`: forcing it needs a synthetic "root" node with a
-`file_role` edge to every file, which still enumerates everything,
-dressed as a graph. Zero benefit.
-
-The only real graph version is an import-reachability OPTIMIZATION
-(scan only files that transitively import the target via reverse
-`uses_module` edges) — but that trades the completeness `refs_to`
-exists for (re-exports, framework DSL, dynamic dispatch produce refs
-with no clean import edge) for speed. Not a parity strangle.
-
-So `RoleMask` is a PARTITION, not a traversal model, and stays as the
-right abstraction. `walk` unifies the three edge-following models
-(`package_parents`→INHERITS, `bridges`→BRIDGES, the lexical scope
-tree→PARENT); file-role is orthogonal and out of scope. If the three
-tier-iteration sites ever want DRYing, that's a shared
-`for_each_file_in_mask` helper in resolve/file_store — not the graph.
-
-### Branded edges (first-class)
-
-A branded edge fires only when the walker's *context* matches the brand:
+A branded edge fires only when the walker's *context* matches a brand —
+the instance-identity cases the plain class/bridge edges can't express.
 
 ```rust
-struct Edge {
-    from: NodeId,
-    to: NodeId,
-    kind: EdgeKind,
-    brand: Option<Brand>,
-}
-
 enum Brand {
     Variable { file: FileId, scope: ScopeId, name: String },
     File(FileId),
-    Custom { kind: String, payload: serde_json::Value },  // for plugins
+    Custom { kind: String, payload: serde_json::Value },  // plugins
 }
 ```
 
 Concrete cases:
 
 - **`my $minion = Minion->new(...)`** — entities of `$minion`'s plugin
-  namespace bridge to brand `Variable { … "$minion" }`. A different
+  namespace bridge to `Brand::Variable { … "$minion" }`. A second
   Minion instance in the same workspace doesn't collide.
-- **`my $app = Mojolicious::Lite->new`** — the app's plugin namespace
-  bridges to brand `File(file_id)`.
+- **`my $app = Mojolicious::Lite->new`** — the app's namespace bridges
+  to `Brand::File(file_id)` (the multi-app Mojo case).
 
-### Brand resolution likely needs enrichment
+The goal is for brands to fit `walk` cleanly — a brand is walk
+*context* that gates branded edges, not a bolt-on. `walk` already
+carries the origin; brand context rides alongside, and `edges_from`
+consults it for branded edge kinds.
 
-The motivating case isn't `my $minion = Minion->new` — that's static and
-straightforward. It's `$app->minion` returning a specific branded
-instance, vs `$app->other_minion_for_those_jobs` returning a different
-one. The brand isn't visible at the call site; it depends on what
-`minion` returns, which depends on type inference + possibly cross-file
-resolution.
+**The one real decision is brand-resolution timing.** The hard case
+isn't `my $minion = Minion->new` (static, visible at the decl) — it's
+`$app->minion` vs `$app->other_minion`, where the brand depends on what
+the accessor returns (type inference, possibly cross-file). Three
+options:
 
-Three timing options for brand resolution:
-
-1. **Static at emission.** Works for `my $x = Class->new` and
-   per-file singletons. Doesn't cover accessor-returned brands.
-2. **Cross-file enrichment post-pass.** After type inference settles,
-   walk method-call refs whose receiver resolves to a branded namespace
-   type; materialize the branded edges. Same machinery as
+1. **Static at emission** — covers `my $x = Class->new` and per-file
+   singletons; misses accessor-returned brands.
+2. **Cross-file enrichment post-pass** — after inference settles, walk
+   method-call refs whose receiver resolves to a branded namespace and
+   materialise the branded edges. Same machinery as
    `enrich_imported_types_with_keys`.
-3. **Lazy at query time.** Branded edges carry a "compute brand from
-   context" closure. Walker evaluates per-query.
+3. **Lazy at query time** — branded edges carry a compute-brand
+   closure. Reintroduces the query-time logic the unification is
+   trying to remove; avoid.
 
-Plausible: **(1) for the cheap cases, (2) for the accessor-chain
-cases.** (3) is tempting but reintroduces query-time logic that the
-unification refactor is trying to eliminate.
+Plan: **(1) for the cheap cases, (2) for accessor chains.** Land (1)
+first; the accessor-chain case shouldn't block it. Decide the timing
+deliberately when this is picked up — don't defer it into the code.
 
-The accessor-chain case (`$app->minion`) is genuinely hard and shouldn't
-block the rest of the design. Land (1) first; tackle (2) when real
-multi-instance Minion / multi-app cases come up.
+## Deferred: Scope nodes (the future taxonomy)
 
-## Architecture: graph lives in isolation
+`Node::Scope` + a PARENT edge would let the graph model lexical scopes,
+packages, and plugin namespaces as one node space — the foundation for:
 
-**The builder does not build the graph.** The builder stays focused on
-CST → `FileAnalysis`. `src/graph.rs` consumes `&FileAnalysis` (+ the
-`CrossFileLookup` trait) and answers `walk` queries.
+- **Openness diagnostic.** Walk the namespace chain from a ref's site:
+  terminates `Closed` without resolving → warn; hits `Open`
+  (role/plugin/abstract base) first → suppress. Replaces the bespoke
+  `framework_imports` suppression and unifies unresolved
+  function/method/stash-key/route/helper.
+- **`Symbol.home_namespace`.** `Symbol.package: Option<String>` →
+  `Symbol.home_scope: NodeId`; `Bridge::Class(...)` → a bridge to a
+  framework scope node directly.
 
-**As built, the graph is NOT materialized — it is a lazy derived
-view.** `GraphView` holds two borrows (`&FileAnalysis`, `Option<&dyn
-CrossFileLookup>`) and nothing else: no node list, no adjacency map, no
-build step. `walk` DFS-chases edges on demand — `edges_from` derives a
-node's neighbors at the moment the walker asks, by calling the stores
-that already exist (`parents_of`, `direct_children_of`,
-`for_each_entity_bridged_to`). A walk materializes only its transient
-traversal state (seen-set + per-node neighbor vec), discarded on
-return. "Chasing an edge" *is* a map lookup against `package_parents`
-— the same primitive the legacy walkers call, which is why a ported
-consumer is provably parity (same lookups, one walker).
+Deferred deliberately: the scope parent-climb is a linked-list, not a
+walk (`adr/graph-walking.md`), so `Node::Scope` earns its keep only
+when Openness / `home_namespace` are actually built — not to port the
+trivial `scope_chain_of`. Build it when those land, with their needs
+shaping the node.
 
-```
-                  ┌─────────────────────┐
-   CST  ──build──▶│   FileAnalysis      │  (today's data model)
-                  │   scopes, symbols,  │
-                  │   refs, owners,     │
-                  │   plugin namespaces │
-                  └──────────┬──────────┘
-                             │  (borrowed; nothing built)
-                  ┌──────────▼──────────┐
-                  │  GraphView (lazy)   │  walk(origin, mask) →
-                  │  edges chased       │  edges_from derives
-                  │  on demand          │  neighbors per call
-                  └──────────┬──────────┘
-                             │
-                       (queries via `walk`)
-```
+## Out of scope (decided, not deferred)
 
-**`walk` is the caching seam.** Because every consumer goes through
-`walk(origin, mask)` and never sees how edges are produced, caching
-slots in behind `edges_from` with ZERO consumer changes — memoize
-`(node, kind) → neighbors` on the view, or hang a longer-lived edge
-cache off the index. Lazy is the default precisely so you don't pay
-for that machinery until a profiler flags an edge kind. And it's
-per-edge-kind, not all-or-nothing: `children_index` is already the
-materialized form of the INHERITS_INV edge (the reverse walk was
-expensive, so it's precomputed once), while INHERITS stays a cheap
-lazy lookup — each edge kind picks lazy-vs-materialized on its own
-cost, behind the same seam.
-
-Consequences:
-
-- Graph is independently testable: feed in a hand-built `FileAnalysis`,
-  assert on the resulting graph shape.
-- Builder stays the size it is; doesn't grow more responsibilities.
-- Brand-enrichment is a clear secondary phase between graph construction
-  and queries.
-- Queries route through the graph; `FileAnalysis` stays the canonical
-  data model. No bidirectional dependency.
-- Migration is strangler fig: build the graph, port one query at a time,
-  retire each old walker as its consumers move over.
-
-## Open-extension hook
-
-Edge kind enum has a `Custom { kind: String }` variant. Plugins emit
-edges with their own kinds; queries that care match on the string;
-native code paths match on the enum variants. Brand kinds similarly
-extensible (`Brand::Custom`).
-
-This is the same pluggability question the original Namespace enum
-faced — but at the edge level, where it's actually load-bearing.
-Frameworks add new visibility relationships (`Catalyst::Controller →
-Catalyst::App`, etc.) without recompiling the host.
-
-## Query model
-
-```rust
-fn walk(
-    graph: &Graph,
-    origin: NodeId,
-    edge_kinds: EdgeKindMask,
-    brand_ctx: &BrandContext,
-) -> impl Iterator<Item = NodeId>;
-```
-
-`BrandContext` carries everything brand-match needs: type-inference
-results, current file id, the receiver variable for the calling
-expression. Walker invokes the brand-match closure when it encounters a
-branded edge.
-
-Today's resolvers re-implement themselves as `walk` calls with
-different masks:
-
-| Today | Tomorrow |
-|---|---|
-| `resolve_method_in_ancestors` | `walk(class_scope, INHERITS)` |
-| `for_each_entity_bridged_to(class)` | `walk(class_scope, BRIDGES_*)` with brand match |
-| `resolve_symbol(name, from, VISIBLE)` | `walk(from_scope, VISIBILITY \ EDITABLE.invert())` |
-| Cursor-context scope walks | `walk(cursor_scope, PARENT \| BINDS_*)` |
-| `enrich_imported_types_with_keys` | brand-resolution post-pass |
-
-## Migration shape
-
-Strangler fig, lasts a while. Phases:
-
-1. **Stand up `Graph` as a parallel structure.** ~~Populated alongside
-   today's data; not yet queried.~~ **LANDED (graph-walking-1)** as a
-   DERIVED view, not parallel storage: `src/graph.rs` `GraphView` +
-   `walk(origin, EdgeKindMask, visit)` — visit-at-pop DFS preserving
-   @ISA order, seen-set, the legacy depth cap. Edge derivation is one
-   function (`edges_from`): INHERITS via `parents_of` (the shared
-   injection site, so graph and legacy walkers cannot disagree),
-   INHERITS_INV via the children index (`direct_children_of`, depth 1
-   — the walker supplies transitivity), BRIDGES via
-   `for_each_entity_bridged_to` (terminal Module nodes; composes with
-   INHERITS through the synthetic app-surface edge, replacing the
-   ancestor+bridge two-step). First ported consumer:
-   `resolve.rs::implementations_of` (the requires→composers fan-out)
-   — its gold rows are the parity net.
-2. **Port one query at a time**, retiring old data structures as their
-   last consumer moves over:
-   - `resolve_method_in_ancestors` first (simplest, smallest blast
-     radius).
-   - Then `for_each_entity_bridged_to` (needs branded edges working).
-   - Then cross-file `resolve_symbol` (needs file-role edges).
-   - Then cursor-context scope walks (needs full lexical edges).
-   - Then enrichment becomes brand-resolution.
-3. **Retire `package_parents`, `RoleMask`-as-separate-concept,
-   `PluginNamespace.bridges`, `imports`/`framework_imports`/
-   `imported_hash_keys` field-by-field** as they become unused.
-
-Type-inference work doesn't pause. Witness reducers that need scope info
-can keep using today's helpers until their query path is ported; the
-graph-walk version is a drop-in replacement when ready.
-
-## What this retires
-
-- `package_parents: HashMap<String, Vec<String>>` → typed `inherits`
-  edges.
-- `PluginNamespace.bridges: Vec<Bridge>` → typed `bridges_*` edges.
-- `RoleMask` (as a separate concept) → file-edge-kind mask.
-- `imports`, `framework_imports`, `imported_hash_keys` → typed edges.
-- The bespoke walkers in `resolve_method_in_ancestors`,
-  `for_each_entity_bridged_to`, `cursor_context.rs` scope chains,
-  `resolve.rs` tier walking → one `walk` call.
-
-## What this unblocks
-
-- **Openness diagnostic** (absorbed residuals, below).
-  Walking the namespace chain to ask "does this terminate Closed?"
-  becomes one `walk` call with an `inherits | imports | bridges` mask.
-- **Multi-app Mojo support** (from `prompt-mojo-todo.md`). Two
-  Mojolicious::Lite apps in one workspace stop colliding once branded
-  edges work.
-- **`home_namespace` move** (absorbed residuals, below).
-  Once nodes are typed, `Symbol.package: Option<String>` becomes
-  `Symbol.home_scope: NodeId`.
-- **Cleaner type-inference scope queries.** `query_variable_type`'s
-  scope chain walk goes through `walk` instead of duplicating logic.
-
-## `stack-graphs` upstream — evaluate, don't auto-adopt
-
-`stack-graphs` (the GitHub Rust crate) is the closest existing
-implementation of this model. Pros: proven path semantics, well-tested,
-tooling. Cons: their model is general; some Perl-specific semantics
-(plugin namespaces, framework synthesis) require restating builder
-emission rules in their pipeline.
-
-Decision deferred until the edge taxonomy here stabilizes against real
-code. Adopting the model is the load-bearing decision; using their
-crate vs rolling our own typed-edge graph + walker is a tactical call.
-A custom impl is ~few-hundred-lines and integrates cleanly with the
-existing builder + witness/reducer pipeline. The crate buys path
-semantics + tooling at the cost of a TSG-shaped emission boundary.
-
-> Note: TSG (the tree-sitter graph DSL stack-graphs originally used) is
-> dead. If we go with `stack-graphs`, the Rust-API construction path is
-> what we'd use, not TSG.
-
-## Open questions
-
-### `local` semantics + async boundaries
-
-`local $x = ...` masks the package binding for the *dynamic extent* of
-the lexical block. For static analysis we approximate as lexical
-shadowing — close enough for navigation; type-inference inside the
-block sees the new binding.
-
-The async-boundary case is real: `local` across `await` / event loop
-boundaries doesn't behave intuitively. `Syntax::Keyword::Dynamic`
-solves this at runtime; we'd want to model it for static analysis too.
-
-Plausible shape: an "escape" edge or a `binds_dynamic` subkind that
-flags "this binding crosses async boundaries; assume re-entry from any
-outer dynamic context." Doesn't need to be precise; just needs to not
-silently lie about visibility.
-
-**Open for discussion.** Land the rest of the graph first; revisit
-when async-flavored Perl shows up in real workloads.
-
-### Brand resolution for accessor chains
-
-Static-at-emission covers `my $x = Class->new`. Cross-file enrichment
-covers `$app->minion` once type inference resolves the accessor's
-return type to a branded namespace. The enrichment pass needs to be
-careful about ordering: type inference must settle before brand
-resolution, but graph queries needed by *intermediate* type-inference
-steps can't yet see branded edges. Shouldn't be a problem in practice
-(type inference doesn't typically resolve through plugin bridges), but
-worth pinning when the implementation lands.
-
-### `Custom` edge / brand kinds — wire format
-
-If plugins emit custom edges via Rhai, we need to define the wire
-format (string kind + serde JSON payload, probably). Same shape as
-`EmitAction::Custom` would be — the existing plugin emission ABI
-extends naturally.
-
-## Out of scope
-
-- MRO/C3 method resolution order.
-- `wantarray` / context-dispatched returns (different layer; lives in
-  type inference).
-- Cross-workspace graph (monorepo multi-root).
-- Effect tracking on edges (which edges mutate state, throw, etc.).
-- Runtime-dynamic graph mutation (e.g. `*Foo::bar = sub { ... }`
-  installing a method at runtime). Static-only.
-
-## Absorbed residuals (from the retired unification doc)
-
-**Openness classification (was phase 6).** Unresolved-* diagnostics
-either over-fire (roles, plugins, abstract bases) or under-fire
-(framework-imported names). One derived-never-stored rule:
-`enum Openness { Closed, Open }` per namespace —
-`use Moo::Role`/`Role::Tiny` → Open; plugin-shaped `Mojo::Base
-'Mojolicious::Plugin'` → Open; an app with `sub startup` → Closed;
-controllers with routes targeting them → Closed; referenced-as-parent
-but never instantiated → Open; scripts → Closed; default Closed.
-Diagnostic rule: walk upward from the ref's namespace via `inherits |
-imports | bridges`; unresolved at a Closed termination → warn; an Open
-node on the way → suppress. Replaces the bespoke `framework_imports`
-suppression and covers unresolved function/method/stash-key/route-
-target/helper uniformly.
-
-**`Symbol.home_namespace` (was phase 7).** Once nodes are typed,
-`Symbol.package: Option<String>` becomes `Symbol.home_scope: NodeId`,
-and `Bridge::Class(...)` becomes a bridge to a framework node directly
-(no more routing app surfaces through a controller class name).
-
-**Eager `Ref.target` (was phase 5, mostly dissolved).** Lazy TREE
-resolution is dead (the one behavior it carried — ctor-key → Corinna
-field — became eager `HashKeyDef` synthesis); MethodCalls carry
-`resolved_method_target`, FunctionCalls `resolved_package`, variables
-`resolves_to`. What remains is the field SHAPE: `resolves_to:
-Option<SymbolId>` → non-optional `target` with an `UNRESOLVED`
-sentinel, which is what the Openness rule's "unresolved bucket" reads.
-Do it as part of this rework — a ref's target is the walk's output.
-
-**The pluggability question (was phase 1's blocker) is this graph's
-node-identity question.** Enum-only nodes (exhaustive, recompile per
-framework) vs `Custom { kind, name }` (open, loses exhaustiveness) vs
-hybrid. The plugin-system's trajectory (manifests over enums —
-`role_makers`, `app_surface_consumers`) argues hybrid with the open
-arm as the default for plugin-declared scopes.
-
-## The ancestry-axis strangle — design space (the #3 decision)
-
-The strangle table above listed "bridges" and "ancestry" as separate
-steps. Porting the real consumers proved that wrong: **they're one
-strangle.** `resolve_method_in_ancestors`, `for_each_dispatch_handler_
-on_class`, `class_isa`, `class_has_unresolved_ancestor`,
-`resolve_super_method`, `method_rename_chain`, `collect_ancestor_
-methods`, `complete_methods_for_class` — all ~8 — funnel through ONE
-function, `for_each_ancestor_class`, and each pulls local symbols +
-bridged entities (the BRIDGES axis) at every class the INHERITS walk
-visits. `for_each_entity_bridged_to` is the bridge *primitive* (the
-graph's BRIDGES edge derivation already calls it), not a consumer to
-strangle. So:
-
-> The ancestry funnel IS the strangle. Port `for_each_ancestor_class`
-> to delegate to `walk(class, INHERITS)` and all 8 consumers come
-> along; their bridge/local pulls stay in their visit closures,
-> untouched.
-
-### The enabler decision (resolved)
-
-Both this and every model-internal walk were gated on a layering
-wall: the consumers live in `file_analysis.rs` (Model); `walk` lived
-in `graph.rs` (Index); Model can't import up. Two ways out:
-
-- **(A) Move the graph DOWN to Model.** `graph.rs` imports only
-  `file_analysis` (the `CrossFileLookup` trait + `parents_of`) — zero
-  Index deps. It was *misfiled* at Index in phase 1. Reassigning it to
-  Model (one line in `layer_map`) lets every model walker call `walk`
-  directly; graph and `file_analysis` mutually reference at the same
-  layer, which the DAG test permits (only `target_layer > my_layer` is
-  a violation). Tiny, no function relocation.
-- **(B) Move the ancestry QUERY functions UP** out of `file_analysis`
-  into a query/Index layer. Aligns with the arch-review note that
-  these `&dyn CrossFileLookup`-taking functions were misfiled in the
-  model — but it's a wide mechanical relocation of ~8 functions + all
-  callers, large risk surface.
-
-**Chosen: (A).** Landed. `class_isa` is the first consumer ported as
-proof (`class_isa_matches_legacy_ancestor_walk` pins parity). (B) stays
-available as an independent later cleanup if the model gets fat.
-
-### What the funnel port still needs
-
-1. **`skip_self` — DECIDED: no such parameter. `walk` is edge-only;
-   callers add the reflexive check.** A walk discovers what you
-   *reach* by following edges; the origin is the thing you already
-   *have*, so yielding it conflates the two. Decisive reason it can't
-   be a `walk` option anyway: the self-handling is CONSUMER-SPECIFIC —
-   `class_isa` checks `self == ancestor`, `resolve_method_in_ancestors`
-   checks `method_resolution_on_class(self)`, `collect_ancestor_
-   methods` gathers self's methods, `class_has_unresolved_ancestor`
-   checks self's parents. `walk` couldn't handle self without calling
-   back into per-consumer logic, which is just the consumer doing it.
-   So: include-self consumers prepend their own one-line check (as
-   `class_isa` did); the old `skip_self=true` variant
-   (`resolve_super_method` — SUPER searches parents only) becomes the
-   BARE `walk(enclosing, INHERITS)`, no flag. The seen-set already
-   seeds the origin (cycle-safe for both shapes), so nothing else
-   changes. `for_each_ancestor_class_opt`'s bool is deleted, not
-   ported.
-2. **Visit signature.** `for_each_ancestor_class` yields `&str` class
-   names. `walk` yields `&Node`. The funnel port maps `Node::Class(c)
-   → c`; Module nodes (from a combined BRIDGES mask) are filtered or
-   handled per consumer. Keep the funnel INHERITS-only; the bridge
-   pull stays in each consumer's closure (no behavior change).
-3. **Parity proof = the existing net.** The 8 consumers drive
-   inheritance/dispatch/SUPER/role e2e + gold rows. Port the funnel,
-   run them; a parity unit test per consumer is cheap insurance for
-   the hot ones (`resolve_method_in_ancestors`).
-
-### Remaining strangles after the funnel
-
-- **lexical scope chains** (`cursor_context`) — needs Scope nodes +
-  `PARENT`/`BINDS_*` edges. New taxonomy. This IS a genuine
-  walk-from-origin (cursor scope → enclosing scopes until a binding),
-  so it fits `walk`; the cost is adding the node/edge kinds.
-- **branded bridges** (`$minion`/`$app` instance identity) — branded
-  edges, the design-heavy finale.
-- ~~file-role tier~~ — REMOVED: enumeration, not a walk (see "File
-  attribution" above). `RoleMask` stays.
-
-Each grows the node/edge set additively. The migration ends when
-`package_parents` and `PluginNamespace.bridges` have no direct
-consumers — every *reachability* question is a `walk` with a mask.
-(`RoleMask` is not in that set; it partitions files, it doesn't
-traverse.) Openness diagnostic + multi-app Mojo fall out then.
+- **File roles** stay `RoleMask` — enumeration, not traversal
+  (`adr/graph-walking.md`).
+- **Stack-graphs upstream** — evaluated, not adopted. The Rust-API
+  construction path would restate Perl-specific emission (plugin
+  namespaces, framework synthesis) in their pipeline; a custom
+  typed-edge view integrates with the existing builder + witness/
+  reducer pipeline at a few hundred lines. Revisit only if their path
+  semantics + tooling become worth that boundary.

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -233,13 +233,6 @@ pub trait CrossFileLookup {
         class_name: &str,
         f: &mut dyn FnMut(&str, &std::sync::Arc<CachedModule>, &Symbol),
     );
-    /// Inverse inheritance/composition walk: every (package, module)
-    /// pair whose package transitively `isa`/composes `class`.
-    fn for_each_descendant_package(
-        &self,
-        class: &str,
-        visit: &mut dyn FnMut(&str, &std::sync::Arc<CachedModule>) -> std::ops::ControlFlow<()>,
-    );
     /// Direct children/composers of `class` as (package, module) pairs
     /// — the `children_index` inverse, depth 1 (the graph walker
     /// supplies transitivity).

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1459,13 +1459,11 @@ pub const APP_SURFACE_CLASS: &str = "Mojolicious::_AppSurface";
 /// The lexical scope chain `[start, parent, …, file]` over a bare
 /// `&[Scope]` slice — the single source of the parent-climb. A free
 /// function (not a `FileAnalysis` method) so the witness-bag query path,
-/// which holds `BagContext.scopes: &[Scope]` and never a `&FileAnalysis`,
-/// shares it instead of re-rolling the `while let Some(p) = …parent`
-/// loop (it had two copies). `FileAnalysis::scope_chain` is the thin
-/// wrapper. The tree has one parent per node and no cycles, so this is a
-/// linked-list climb, not a graph walk — `GraphView` (which needs a
-/// `&FileAnalysis`) deliberately does NOT own it; see
-/// `docs/prompt-graph-walking.md` on why lexical isn't a strangle.
+/// which holds `BagContext.scopes: &[Scope]` and never a
+/// `&FileAnalysis`, shares it. `FileAnalysis::scope_chain` is the thin
+/// wrapper. A scope has one parent and no cycles, so this is a linked-
+/// list climb, not a graph walk — the graph deliberately does not model
+/// it (`docs/adr/graph-walking.md`).
 pub fn scope_chain_of(scopes: &[Scope], start: ScopeId) -> Vec<ScopeId> {
     let mut chain = Vec::new();
     let mut current = Some(start);
@@ -6467,14 +6465,13 @@ impl FileAnalysis {
     /// rules. New ancestor-aware queries should reuse it too rather
     /// than reroll the walk.
     /// The include-self MRO walk: visit `class_name` itself, then every
-    /// proper ancestor in Perl's left-to-right DFS order. The ONE place
-    /// self-handling lives for the ~7 "method on this class or up the
-    /// chain" consumers — running their own closure on self (consumer-
-    /// specific, so it can't move into `walk`, which has no closure for
-    /// the origin). Proper-ancestor traversal IS `walk(class, INHERITS)`
-    /// — same `parents_of` seam, so it cannot diverge from the legacy
-    /// hand-rolled DFS this replaced. The `skip_self=true` variant is
-    /// gone: `SUPER::` is the bare `walk` (see `resolve_super_method`).
+    /// proper ancestor in Perl's left-to-right DFS order. The one place
+    /// self-handling lives for the "method on this class or up the
+    /// chain" consumers — it runs their own closure on self, which is
+    /// consumer-specific (so it can't live in `walk`, which has no
+    /// closure for the origin). Proper-ancestor traversal is
+    /// `walk(class, INHERITS)`. `SUPER::` — parents only, never self —
+    /// is the bare `walk` (see `resolve_super_method`).
     fn for_each_ancestor_class(
         &self,
         class_name: &str,
@@ -6495,8 +6492,7 @@ impl FileAnalysis {
         );
     }
 
-    /// Test-only access to the legacy ancestor walk, for graph-walk
-    /// parity assertions during the strangler migration.
+    /// Test-only access to the include-self ancestor walk.
     #[cfg(test)]
     pub fn for_each_ancestor_class_test(
         &self,
@@ -6515,12 +6511,8 @@ impl FileAnalysis {
         ancestor: &str,
         module_index: Option<&dyn CrossFileLookup>,
     ) -> bool {
-        // First ancestry consumer ported onto the one walker
-        // (`docs/prompt-graph-walking.md`). `walk` excludes the origin,
-        // so the reflexive `X isa X` is a direct check; the rest is an
-        // INHERITS traversal — same `parents_of` seam, same seen-set
-        // and depth cap as the legacy `for_each_ancestor_class`, so the
-        // two cannot disagree during the migration.
+        // `walk` yields reached nodes only, so the reflexive `X isa X`
+        // is a direct check; the rest is an INHERITS traversal.
         if child == ancestor {
             return true;
         }
@@ -6674,8 +6666,7 @@ impl FileAnalysis {
         module_index: Option<&dyn CrossFileLookup>,
     ) -> Option<MethodResolution> {
         // SUPER:: searches the PARENTS, never the enclosing class — so
-        // it is the bare `walk` (origin-excluded by construction). The
-        // old `skip_self=true` variant is exactly this; no flag needed.
+        // it is the bare `walk`, origin-excluded by construction.
         let mut result: Option<MethodResolution> = None;
         let graph = crate::graph::GraphView::new(self, module_index);
         graph.walk(
@@ -7303,9 +7294,8 @@ impl FileAnalysis {
     /// "structural"; a `Sub`/`Method` reached first means "working state".
     /// Both the outline tree builder and the `--outline` CLI ask this.
     pub fn scope_within_sub_body(&self, scope: ScopeId) -> bool {
-        // Climb the shared chain (indexed lookup, not the old O(n)
-        // `.find(|s| s.id == id)` per level); a Sub/Method boundary
-        // before any Class/File answers true.
+        // Climb the scope chain; a Sub/Method boundary reached before
+        // any Class/File answers true.
         for id in self.scope_chain(scope) {
             match self.scopes[id.0 as usize].kind {
                 ScopeKind::Sub { .. } | ScopeKind::Method { .. } => return true,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,22 +1,21 @@
 //! The typed-edge graph — one walker over what is morally one graph.
 //!
-//! Phase 1 of `docs/prompt-graph-walking.md`: a DERIVED view, no new
-//! storage. Edges materialize on demand from the stores that already
-//! exist (`package_parents` ∪ `parents_of`'s synthetic edges, the
-//! ModuleEdgeIndexes children map, plugin-namespace bridges); `walk`
-//! is the single traversal — seen-set, depth cap, edge-kind mask —
-//! that the bespoke walkers collapse into one consumer at a time
-//! (strangler fig).
+//! A DERIVED view, no stored graph. Edges materialize on demand from
+//! the stores that already exist (`package_parents` ∪ `parents_of`'s
+//! synthetic app-surface edge, the `ModuleEdgeIndexes` children map,
+//! plugin-namespace bridges); `walk` is the single traversal — seen-
+//! set, depth cap, edge-kind mask — that the ancestry/bridge/descendant
+//! queries route through. Design: `docs/adr/graph-walking.md`.
 //!
-//! The builder does NOT build this. It consumes `&FileAnalysis` +
-//! the `CrossFileLookup` trait and answers queries; `FileAnalysis`
-//! stays the canonical model (rule #2).
+//! `GraphView` consumes `&FileAnalysis` + the `CrossFileLookup` trait
+//! and answers queries; `FileAnalysis` stays the canonical model (rule
+//! #2), and the builder never touches this.
 //!
-//! MODEL layer: this is a derived view over `&FileAnalysis` and the
-//! model-defined `CrossFileLookup` trait — zero Index-layer deps — so
+//! Model layer: a derived view over `&FileAnalysis` and the model-
+//! defined `CrossFileLookup` trait, with zero Index-layer deps — so the
 //! model-internal walkers (`for_each_ancestor_class` and the dispatch/
-//! method/bridge resolution that funnels through it) can route through
-//! `walk` without an up-layer import. Phase 1 misfiled it at Index.
+//! method/bridge resolution that funnels through it) call `walk`
+//! directly, no up-layer import.
 
 use crate::file_analysis::{CrossFileLookup, FileAnalysis};
 
@@ -29,9 +28,9 @@ use crate::file_analysis::{CrossFileLookup, FileAnalysis};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EdgeKind {
     /// class → parent class/role (`use parent`/`@ISA`/`with`/…, plus
-    /// the synthetic app-surface edge — `parents_of` is the single
-    /// injection site, shared with the legacy walkers so the two
-    /// cannot disagree during the migration).
+    /// the synthetic app-surface edge). `parents_of` is the single
+    /// injection site for this edge — the inheritance consumers share
+    /// it, so they can't disagree on the MRO.
     Inherits,
     /// parent → direct child/composer (the `children_index` inverse;
     /// `walk` supplies the transitivity).
@@ -68,9 +67,8 @@ bitflags::bitflags! {
     }
 }
 
-/// A graph node. Phase 1 carries the class axis (+ terminal Module
-/// nodes for bridges); Scope/Symbol/File nodes join as their walkers
-/// port — see the migration table in the design doc.
+/// A graph node. The class axis + terminal Module nodes for bridges;
+/// Scope/Symbol/File nodes are future taxonomy (`adr/graph-walking.md`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
     Class(String),
@@ -92,9 +90,9 @@ impl<'a> GraphView<'a> {
 
     /// THE walker. DFS from `origin` over edges in `mask`, depth-capped
     /// and cycle-safe; `visit` sees every reached node (origin
-    /// excluded) in traversal order and may stop early. Perl's
-    /// left-to-right DFS order is preserved on INHERITS so method
-    /// resolution semantics survive the port.
+    /// excluded) in traversal order and may stop early. On INHERITS the
+    /// order is Perl's left-to-right DFS MRO, so method resolution sees
+    /// ancestors in the order dispatch demands.
     pub fn walk(
         &self,
         origin: Node,
@@ -104,7 +102,7 @@ impl<'a> GraphView<'a> {
         let mut seen: std::collections::HashSet<Node> = std::collections::HashSet::new();
         seen.insert(origin.clone());
         let mut stack: Vec<(Node, usize)> = vec![(origin, 0)];
-        const MAX_DEPTH: usize = 21; // matches the legacy ancestry guard
+        const MAX_DEPTH: usize = 21; // ancestry-depth backstop (seen-set already breaks cycles)
         while let Some((node, depth)) = stack.pop() {
             // visit at POP — depth-first order, so a left parent's whole
             // ancestry precedes the right parent (the @ISA contract).

--- a/src/graph_tests.rs
+++ b/src/graph_tests.rs
@@ -62,7 +62,6 @@ fn walk_descendants_matches_index_fan_out() {
     // different implementation than the graph walk, so this is a real
     // cross-check, not a tautology.
     let mut index_bfs: Vec<String> = Vec::new();
-    use crate::file_analysis::CrossFileLookup;
     idx.for_each_descendant_package("My::Role", &mut |pkg: &str, _cached: &Arc<crate::file_analysis::CachedModule>| {
         index_bfs.push(pkg.to_string());
         std::ops::ControlFlow::Continue(())

--- a/src/graph_tests.rs
+++ b/src/graph_tests.rs
@@ -40,7 +40,7 @@ fn walk_inherits_preserves_isa_order_and_caps_cycles() {
 }
 
 #[test]
-fn walk_descendants_matches_the_legacy_fan_out() {
+fn walk_descendants_matches_index_fan_out() {
     let idx = crate::module_index::ModuleIndex::new_for_test();
     cache(&idx, "My::Role", "package My::Role;\nuse Moo::Role;\nrequires 'fetch';\n1;\n");
     cache(&idx, "My::Composer", "package My::Composer;\nuse Moo;\nwith 'My::Role';\nsub fetch {1}\n1;\n");
@@ -58,14 +58,17 @@ fn walk_descendants_matches_the_legacy_fan_out() {
     });
     got.sort();
 
-    let mut legacy: Vec<String> = Vec::new();
+    // `for_each_descendant_package` is the ModuleIndex BFS — a
+    // different implementation than the graph walk, so this is a real
+    // cross-check, not a tautology.
+    let mut index_bfs: Vec<String> = Vec::new();
     use crate::file_analysis::CrossFileLookup;
     idx.for_each_descendant_package("My::Role", &mut |pkg: &str, _cached: &Arc<crate::file_analysis::CachedModule>| {
-        legacy.push(pkg.to_string());
+        index_bfs.push(pkg.to_string());
         std::ops::ControlFlow::Continue(())
     });
-    legacy.sort();
-    assert_eq!(got, legacy, "graph fan-out must match the legacy walker");
+    index_bfs.sort();
+    assert_eq!(got, index_bfs, "graph fan-out must match the index BFS");
     assert_eq!(got, vec!["My::Composer", "My::Deep", "My::SubRole"]);
 }
 
@@ -82,7 +85,7 @@ fn walk_bridges_reaches_plugin_modules_terminally() {
     let g = GraphView::new(&fa, Some(&idx));
     // bridges target the synthetic app surface; Controller reaches it
     // through the INHERITS synthetic edge — the masks compose the way
-    // the legacy ancestor+bridge walks did, in ONE walker.
+    // the separate ancestor + bridge walks once did, in ONE walker.
     let mut mods: Vec<String> = Vec::new();
     g.walk(
         Node::Class("Mojolicious::Controller".into()),
@@ -99,9 +102,10 @@ fn walk_bridges_reaches_plugin_modules_terminally() {
 
 
 #[test]
-fn class_isa_matches_legacy_ancestor_walk() {
-    // Parity pin: the ported class_isa (walk INHERITS) must agree with
-    // the legacy for_each_ancestor_class on every shape — reflexive,
+fn class_isa_agrees_with_ancestor_walk() {
+    // class_isa (reflexive check + walk) and for_each_ancestor_class
+    // (self-visit + walk) compose the same INHERITS traversal two
+    // ways; they must answer identically on every shape — reflexive,
     // direct, transitive, role, diamond, and negative.
     let fa = parse(
         "package Base;\n1;\n\
@@ -121,9 +125,9 @@ fn class_isa_matches_legacy_ancestor_walk() {
         ("Base", "Leaf", false),    // wrong direction
     ];
     for (child, ancestor, want) in cases {
-        // ported (walk) answer
+        // class_isa's answer
         let got = fa.class_isa(child, ancestor, None);
-        // independent legacy walk over the same data
+        // the include-self walk over the same data
         let mut legacy = child == ancestor;
         fa.for_each_ancestor_class_test(child, None, |c| {
             if c == ancestor {
@@ -132,7 +136,7 @@ fn class_isa_matches_legacy_ancestor_walk() {
             std::ops::ControlFlow::Continue(())
         });
         assert_eq!(got, want, "class_isa({child}, {ancestor})");
-        assert_eq!(got, legacy, "walk vs legacy disagree on ({child}, {ancestor})");
+        assert_eq!(got, legacy, "class_isa vs ancestor walk disagree on ({child}, {ancestor})");
     }
 }
 

--- a/src/module_index.rs
+++ b/src/module_index.rs
@@ -768,7 +768,8 @@ impl ModuleIndex {
     /// Every cached module containing a package that directly lists
     /// `class_name` as a parent (`isa` or role composition — the
     /// `children` edge map). Direct children only; transitive walks go
-    /// through `for_each_descendant_package`.
+    /// through the graph walk (`walk(INHERITS_INV)`) — this is the
+    /// depth-1 edge it composes.
     pub fn modules_with_parent(&self, class_name: &str) -> Vec<String> {
         match self.edges.children.get(class_name) {
             Some(mods) => {
@@ -782,12 +783,15 @@ impl ModuleIndex {
     }
 
     /// Breadth-first walk over the inverse inheritance/composition
-    /// graph from `class`: visits every (package, module) pair whose
-    /// package transitively `isa`/composes `class`. The role-contracts
-    /// fan-out — "who implements this role's contract" is exactly the
-    /// transitive composer set. Bounded by a package seen-set (cycles,
-    /// diamonds) and a fan-out cap; never does I/O. `visit` returns
-    /// `ControlFlow::Break` to stop early.
+    /// graph from `class`: every (package, module) pair whose package
+    /// transitively `isa`/composes `class`. Bounded by a package
+    /// seen-set (cycles, diamonds) and a fan-out cap; never does I/O.
+    ///
+    /// The independent BFS oracle the graph-walk descendant test
+    /// cross-checks `walk(INHERITS_INV)` against. Production reachability
+    /// goes through the graph walk; this stays test-only so the two
+    /// implementations can disagree loudly.
+    #[cfg(test)]
     pub fn for_each_descendant_package<F>(&self, class: &str, mut visit: F)
     where
         F: FnMut(&str, &Arc<CachedModule>) -> std::ops::ControlFlow<()>,
@@ -962,14 +966,6 @@ impl CrossFileLookup for ModuleIndex {
         f: &mut dyn FnMut(&str, &Arc<CachedModule>, &crate::file_analysis::Symbol),
     ) {
         self.for_each_entity_bridged_to(class_name, f)
-    }
-
-    fn for_each_descendant_package(
-        &self,
-        class: &str,
-        visit: &mut dyn FnMut(&str, &Arc<CachedModule>) -> std::ops::ControlFlow<()>,
-    ) {
-        self.for_each_descendant_package(class, visit)
     }
 
     fn direct_children_of(&self, class: &str) -> Vec<(String, String)> {


### PR DESCRIPTION
Post-merge cleanup sweep over the graph-walking landing (#60). No behavior change — comments, docs, and one dead-code removal.

## Comments & docs
- **graph.rs / file_analysis.rs / graph_tests.rs** — strip migration narration ("strangler fig", "Phase 1 misfiled it at Index", "survive the port", "the legacy walker"). Comments now describe what *is*, not what changed. Tests renamed to say what they assert (`walk_descendants_matches_index_fan_out`, `class_isa_agrees_with_ancestor_walk`).
- **docs/adr/graph-walking.md** (new) — the landed load-bearing design in house voice: lazy derived view, closed `EdgeKind` + exhaustive `edges_from`, Model-layer placement, the caching seam, inheritance-axis-as-one-walk, and the explicit boundaries (file-role is enumeration → `RoleMask` stays; lexical is a linked-list climb → `scope_chain_of`).
- **docs/prompt-graph-walking.md** — rewritten to forward work only: branded edges (next) + deferred Scope-node taxonomy + decided out-of-scope.
- **CLAUDE.md / ROADMAP.md** — repointed at `adr/graph-walking.md`.

## Dead-code removal
- `CrossFileLookup::for_each_descendant_package` had no callers — the descendant fan-out moved to `walk(INHERITS_INV)` (resolve.rs), and even the tests called the inherent `ModuleIndex` method. Removed the trait method + its delegating impl.
- The inherent BFS now survives only as the parity-test oracle the graph-walk descendant test cross-checks against, so it's `#[cfg(test)]`. Refreshed its stale "role-contracts fan-out" production claim.
- Result: **zero build warnings**.

## Verification
- `cargo test` — 943 passed
- `./run_e2e.sh` — 112 passed, 0 failed
- `gold-corpus/run.pl` — 187 PASS, 12 xfail, 0 FAIL, 0 XPASS (peak RSS 633 MB, wall 41s — in line with main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)