### PR TITLE
Branded edges: accessor-chain instance brands ($app->minion)

### DIFF
--- a/docs/adr/branded-edges.md
+++ b/docs/adr/branded-edges.md
@@ -100,12 +100,30 @@ brand key is same-FILE (a lexical decl's location), so cross-file
 handlers are left unfiltered — instance identity doesn't cross the file
 boundary, and same-file row:col keys would otherwise risk a collision.
 
+## Accessor chains (landed) — keyed on the accessor identity
+
+`$app->minion->add_task(t); $app->minion->enqueue(t)` scopes by accessor,
+and `$app->other_minion` is a distinct instance. The brand keys on the
+**leaf accessor** (`conventions::accessor_chain_brand` → `acc:minion`),
+NOT the base expression — a singleton accessor returns ONE instance, so
+`$app->minion` (registered in a plugin) and `$c->minion` (enqueued in a
+controller) name the same minion and MUST share a brand. Keying on the
+base variable would break that extremely common registers-here /
+enqueues-there split — the receiver expressions differ while the instance
+is one.
+
+The brand is **pure text** (the accessor name), so build
+(`assign_task_instance_brands`) and query (`instance_brand_at`) compute it
+identically with no inference — the lazy-at-query-time resolution the
+bake-off called for, without an enrichment pass (which, being
+open-documents-only, would have re-merged on workspace/dependency files).
+Only a bare-identifier leaf qualifies; `$app->minion('x')` / deref shapes
+stay global. Known coarseness: two *different* apps' `->minion` in one
+workspace share `acc:minion` (a home-brand prefix would separate them — a
+further tier).
+
 ## Boundaries — what this does NOT do yet
 
-- **Accessor chains** (`$app->minion`) need the brand derived from what
-  the accessor returns — lazy-at-query-time from the resolved invocant,
-  NOT a cross-file enrichment post-pass (enrichment is open-documents-
-  only and would re-merge on workspace/dependency files).
 - **Full Mojo multi-app** (helpers on an app class, consumed by separate
   controller files) stays merged — the consumer file can't carry the
   app's brand. Documented degradation, not a regression.

--- a/docs/adr/branded-edges.md
+++ b/docs/adr/branded-edges.md
@@ -122,6 +122,24 @@ stay global. Known coarseness: two *different* apps' `->minion` in one
 workspace share `acc:minion` (a home-brand prefix would separate them — a
 further tier).
 
+**Variable aliases inherit the accessor brand.** `my $m = $app->minion`
+makes `$m` the SAME instance as the accessor, so `$m->enqueue` reaches
+`$app->minion`'s tasks regardless of which form registered vs enqueued —
+the common register-in-plugin (`$app->minion->add_task`) /
+enqueue-via-local (`my $m = $app->minion; $m->enqueue`) split. The builder
+records `var_accessor_brands` (decl symbol → `acc:leaf`) for a single
+scalar initialized by a non-constructor method-call chain;
+`instance_brand_at` reads it before the per-variable brand, the build side
+does the identical lookup. `Class->new` is excluded — a fresh instance
+keyed per-variable, not an alias. Without this, the accessor tier would
+*regress* the mixed-form pattern (the chains were global before).
+
+Because an accessor brand is a singleton that DOES cross files, completion
+filters cross-file handlers by the receiver brand too (a cross-file
+`acc:other` task is hidden on `$app->minion`); a per-variable `inst:…` is
+same-file and never matches a foreign receiver, so it's filtered there by
+the same rule.
+
 ## Boundaries — what this does NOT do yet
 
 - **Full Mojo multi-app** (helpers on an app class, consumed by separate

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12045,8 +12045,15 @@ impl<'a> Builder<'a> {
         let receivers = std::mem::take(&mut self.task_handler_receivers);
         let mut assignments: Vec<(crate::file_analysis::SymbolId, String)> = Vec::new();
         for (hsid, receiver) in &receivers {
-            // Only a plain lexical scalar is an instance we can key on —
-            // not `$self`/`$class` (the package), not a chain/bareword.
+            // Accessor chain (`$app->minion`) — brand on the accessor
+            // identity, base-independent, pure text (so it matches the
+            // query side exactly). Handled before the lexical-scalar path.
+            if let Some(brand) = crate::conventions::accessor_chain_brand(receiver) {
+                assignments.push((*hsid, brand));
+                continue;
+            }
+            // Otherwise only a plain lexical scalar is an instance we can
+            // key on — not `$self`/`$class` (the package), not a bareword.
             if !receiver.starts_with('$')
                 || crate::conventions::is_conventional_invocant_name(receiver)
             {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -241,6 +241,7 @@ fn build_with_plugins_inner(
         reexport_modules: Vec::new(),
         plugin_namespaces: Vec::new(),
         task_handler_receivers: Vec::new(),
+        var_accessor_brands: std::collections::HashMap::new(),
         type_provenance: std::collections::HashMap::new(),
         bag: crate::witnesses::WitnessBag::new(),
         unresolved_expr_nodes: Vec::new(),
@@ -556,6 +557,7 @@ fn build_with_plugins_inner(
         role_packages: b.role_packages,
         plugin_loads: b.plugin_loads,
         loader_config_params: b.loader_config_params,
+        var_accessor_brands: b.var_accessor_brands,
     });
     // Finalize: run the legacy text-based MCB resolver as a fallback.
     // For every assignment the unified typer (run before
@@ -1392,6 +1394,12 @@ struct Builder<'a> {
     /// Resolved to per-instance brands post-construction once the
     /// scope/symbol tables settle (`FileAnalysis::assign_instance_brands`).
     task_handler_receivers: Vec<(crate::file_analysis::SymbolId, String)>,
+    /// Variable decl symbol → the accessor brand it aliases
+    /// (`my $m = $app->minion` → `$m` is `acc:minion`). So a variable that
+    /// aliases an accessor dispatches to the SAME instance as the accessor
+    /// chain — `$m->enqueue` reaches `$app->minion`'s tasks. See
+    /// `docs/adr/branded-edges.md`.
+    var_accessor_brands: std::collections::HashMap<crate::file_analysis::SymbolId, String>,
     /// Per-symbol provenance for return types. Populated by plugin
     /// `overrides()` (PluginOverride) and by reducer-driven folds
     /// (ReducerFold). Empty entry == `TypeProvenance::Inferred`.
@@ -4575,6 +4583,33 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// The accessor brand a `my $x = <rhs>` decl aliases, if its RHS is a
+    /// method-call chain naming an accessor (`$app->minion` → `acc:minion`).
+    /// `None` for a constructor (`Class->new` — a FRESH instance, keyed
+    /// per-variable), a non-method RHS, or no initializer. Matches
+    /// `conventions::accessor_chain_brand`'s leaf rule so the aliased
+    /// variable and the accessor chain agree. See `docs/adr/branded-edges.md`.
+    fn decl_accessor_alias_brand(&self, decl: Node<'a>) -> Option<String> {
+        let parent = decl.parent()?;
+        if parent.kind() != "assignment_expression" {
+            return None;
+        }
+        if parent.child_by_field_name("left").map(|n| n.id()) != Some(decl.id()) {
+            return None;
+        }
+        let rhs = parent.child_by_field_name("right")?;
+        if rhs.kind() != "method_call_expression" {
+            return None;
+        }
+        let method = rhs.child_by_field_name("method")?;
+        let name = method.utf8_text(self.source).ok()?;
+        if crate::conventions::is_constructor_name(name) {
+            return None; // `->new` is a fresh instance, not an alias
+        }
+        (!name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+            .then(|| format!("acc:{name}"))
+    }
+
     fn visit_variable_decl(&mut self, node: Node<'a>) {
         let keyword = self.get_decl_keyword(node, );
         let decl_kind = match keyword.as_deref() {
@@ -4587,6 +4622,12 @@ impl<'a> Builder<'a> {
 
         // Collect all declared variables
         let vars = self.collect_vars_from_decl(node);
+        // `my $m = $app->minion` — record `$m` as an alias of the accessor
+        // instance so it shares the accessor's brand. Only a single scalar
+        // decl initialized by a (non-constructor) method-call chain.
+        let alias_brand = (vars.len() == 1 && vars[0].0.starts_with('$'))
+            .then(|| self.decl_accessor_alias_brand(node))
+            .flatten();
         for (name, var_span) in &vars {
             let sigil = name.chars().next().unwrap_or('$');
             let sym_kind = if decl_kind == DeclKind::Field { SymKind::Field } else { SymKind::Variable };
@@ -4596,13 +4637,16 @@ impl<'a> Builder<'a> {
             } else {
                 SymbolDetail::Variable { sigil, decl_kind }
             };
-            self.add_symbol(
+            let sid = self.add_symbol(
                 name.clone(),
                 sym_kind,
                 node_to_span(node),
                 *var_span,
                 detail,
             );
+            if let Some(brand) = &alias_brand {
+                self.var_accessor_brands.insert(sid, brand.clone());
+            }
             self.add_ref(
                 RefKind::Variable,
                 *var_span,
@@ -12030,16 +12074,18 @@ impl<'a> Builder<'a> {
         if self.task_handler_receivers.is_empty() {
             return;
         }
-        // scope -> declared scalars/fields (name, decl point), the same
-        // shape `resolve_variable_refs` walks.
-        let mut scope_vars: std::collections::HashMap<ScopeId, Vec<(String, Point)>> =
-            std::collections::HashMap::new();
+        // scope -> declared scalars/fields (name, decl point, sym id), the
+        // same shape `resolve_variable_refs` walks.
+        let mut scope_vars: std::collections::HashMap<
+            ScopeId,
+            Vec<(String, Point, crate::file_analysis::SymbolId)>,
+        > = std::collections::HashMap::new();
         for sym in &self.symbols {
             if matches!(sym.kind, SymKind::Variable | SymKind::Field) {
                 scope_vars
                     .entry(sym.scope)
                     .or_default()
-                    .push((sym.name.clone(), sym.span.start));
+                    .push((sym.name.clone(), sym.span.start, sym.id));
             }
         }
         let receivers = std::mem::take(&mut self.task_handler_receivers);
@@ -12068,15 +12114,22 @@ impl<'a> Builder<'a> {
                     // the identical max-by-position selection the
                     // query side (`FileAnalysis::latest_lexical_decl`)
                     // makes, so brands never disagree.
-                    if let Some((_, decl_point)) = vars
+                    if let Some((_, decl_point, decl_id)) = vars
                         .iter()
-                        .filter(|(n, p)| n == receiver && le_point(*p, before))
-                        .max_by_key(|(_, p)| (p.row, p.column))
+                        .filter(|(n, p, _)| n == receiver && le_point(*p, before))
+                        .max_by_key(|(_, p, _)| (p.row, p.column))
                     {
-                        assignments.push((
-                            *hsid,
-                            format!("inst:{}@{}:{}", receiver, decl_point.row, decl_point.column),
-                        ));
+                        // A variable aliasing an accessor inherits the
+                        // accessor brand (identical lookup to the query
+                        // side's `var_accessor_brands`).
+                        let brand = self
+                            .var_accessor_brands
+                            .get(decl_id)
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                format!("inst:{}@{}:{}", receiver, decl_point.row, decl_point.column)
+                            });
+                        assignments.push((*hsid, brand));
                         break;
                     }
                 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4603,11 +4603,9 @@ impl<'a> Builder<'a> {
         }
         let method = rhs.child_by_field_name("method")?;
         let name = method.utf8_text(self.source).ok()?;
-        if crate::conventions::is_constructor_name(name) {
-            return None; // `->new` is a fresh instance, not an alias
-        }
-        (!name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
-            .then(|| format!("acc:{name}"))
+        // Same leaf rule as the receiver-side `accessor_chain_brand`
+        // (excludes `->new`, the constructor) — one helper, no drift.
+        crate::conventions::accessor_brand_for_leaf(name)
     }
 
     fn visit_variable_decl(&mut self, node: Node<'a>) {

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -30,6 +30,34 @@ pub fn is_constructor_name(name: &str) -> bool {
     name == "new"
 }
 
+/// The per-INSTANCE brand for an accessor-chain receiver
+/// (`$app->minion`), or `None` if `receiver` isn't a clean chain.
+///
+/// The brand keys on the LEAF accessor — the method that produces the
+/// receiver — NOT the base expression, because a singleton accessor
+/// returns one instance: `$app->minion` (in a plugin) and `$c->minion`
+/// (in a controller) name the SAME minion and must share a brand, while
+/// `$app->other_minion` is a different instance. Computed identically at
+/// the `add_task` and `enqueue` sites (it's pure text), so build and
+/// query never disagree. Used for the accessor-chain tier of
+/// `instance_brand_at`. See `docs/adr/branded-edges.md`.
+///
+/// Only a bare-identifier leaf qualifies (`$app->minion`), not a call
+/// with args or a sigil — `$app->minion('x')` / deref shapes stay global
+/// (`None`), the conservative default.
+pub fn accessor_chain_brand(receiver: &str) -> Option<String> {
+    let leaf = receiver.rsplit("->").next()?.trim();
+    // a chain at all? (`rsplit` always yields the whole string when there
+    // is no `->`, so require the separator was actually present)
+    if leaf == receiver {
+        return None;
+    }
+    let is_ident = !leaf.is_empty()
+        && leaf.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !leaf.chars().next().unwrap().is_ascii_digit();
+    is_ident.then(|| format!("acc:{leaf}"))
+}
+
 /// `__PACKAGE__` — the compile-time token for the enclosing package.
 pub fn is_current_package_token(text: &str) -> bool {
     text == "__PACKAGE__"
@@ -185,7 +213,23 @@ impl<'a> MethodToken<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{InvocantText, MethodToken};
+    use super::{accessor_chain_brand, InvocantText, MethodToken};
+
+    #[test]
+    fn accessor_chain_brand_keys_on_leaf() {
+        // base-independent: same accessor → same brand.
+        assert_eq!(accessor_chain_brand("$app->minion").as_deref(), Some("acc:minion"));
+        assert_eq!(accessor_chain_brand("$c->minion").as_deref(), Some("acc:minion"));
+        assert_eq!(accessor_chain_brand("$self->minion").as_deref(), Some("acc:minion"));
+        // different accessor → different brand.
+        assert_eq!(accessor_chain_brand("$app->other_minion").as_deref(), Some("acc:other_minion"));
+        // deeper chain keys on the leaf.
+        assert_eq!(accessor_chain_brand("$app->svc->minion").as_deref(), Some("acc:minion"));
+        // not a chain, or not a clean identifier leaf → None (stays global).
+        assert_eq!(accessor_chain_brand("$minion"), None);
+        assert_eq!(accessor_chain_brand("$app->minion('x')"), None);
+        assert_eq!(accessor_chain_brand("$Foo::bar"), None);
+    }
 
     #[test]
     fn invocant_text_variants() {

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -46,16 +46,27 @@ pub fn is_constructor_name(name: &str) -> bool {
 /// with args or a sigil — `$app->minion('x')` / deref shapes stay global
 /// (`None`), the conservative default.
 pub fn accessor_chain_brand(receiver: &str) -> Option<String> {
-    let leaf = receiver.rsplit("->").next()?.trim();
+    let leaf = receiver.rsplit("->").next()?;
     // a chain at all? (`rsplit` always yields the whole string when there
     // is no `->`, so require the separator was actually present)
     if leaf == receiver {
         return None;
     }
+    accessor_brand_for_leaf(leaf)
+}
+
+/// The brand for an accessor whose leaf method is `leaf`, or `None` if
+/// `leaf` isn't a singleton-accessor identity. The ONE leaf rule, shared
+/// by `accessor_chain_brand` (receiver text) and the builder's
+/// `decl_accessor_alias_brand` (assignment RHS) so they can't drift: a
+/// bare Perl identifier that ISN'T a constructor (`->new` returns a fresh
+/// instance, not a singleton). See `docs/adr/branded-edges.md`.
+pub fn accessor_brand_for_leaf(leaf: &str) -> Option<String> {
+    let leaf = leaf.trim();
     let is_ident = !leaf.is_empty()
         && leaf.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
         && !leaf.chars().next().unwrap().is_ascii_digit();
-    is_ident.then(|| format!("acc:{leaf}"))
+    (is_ident && !is_constructor_name(leaf)).then(|| format!("acc:{leaf}"))
 }
 
 /// `__PACKAGE__` — the compile-time token for the enclosing package.
@@ -229,6 +240,9 @@ mod tests {
         assert_eq!(accessor_chain_brand("$minion"), None);
         assert_eq!(accessor_chain_brand("$app->minion('x')"), None);
         assert_eq!(accessor_chain_brand("$Foo::bar"), None);
+        // a constructor leaf is a FRESH instance, not a singleton accessor.
+        assert_eq!(accessor_chain_brand("$app->new"), None);
+        assert_eq!(accessor_chain_brand("Minion->new"), None);
     }
 
     #[test]

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -6636,18 +6636,21 @@ impl FileAnalysis {
     /// (scoping the dispatch). See `docs/adr/branded-edges.md`.
     pub(crate) fn instance_brand_at(&self, receiver: &str, point: Point) -> Option<String> {
         use crate::conventions::InvocantText;
-        // Only a plain lexical scalar is an "instance" we can key on.
+        // Accessor chain (`$app->minion`) — brand on the accessor identity
+        // (singleton-accessor semantics); base-independent, so `$c->minion`
+        // matches `$app->minion`. Pure text, identical at build and query.
+        if let Some(brand) = crate::conventions::accessor_chain_brand(receiver) {
+            return Some(brand);
+        }
+        // Otherwise only a plain lexical scalar is an instance we can key on.
         let InvocantText::Scalar(_) = InvocantText::parse(receiver) else {
             return None;
         };
         if crate::conventions::is_conventional_invocant_name(receiver) {
             return None; // $self / $class — the package, not an instance
         }
-        // A chain (`$app->minion`) or qualified name (`$pkg::var`) is not
-        // a plain lexical scalar we can key an instance on — reject it
-        // up front rather than leaning on a failed symbol lookup. (The
-        // accessor-chain brand is the deferred tier — branded-edges ADR.)
-        if receiver.contains("->") || receiver.contains("::") {
+        // A qualified name (`$pkg::var`) isn't a plain lexical scalar.
+        if receiver.contains("::") {
             return None;
         }
         // Key on the LATEST decl before `point` (Perl shadowing), the

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2345,6 +2345,14 @@ pub struct FileAnalysis {
     #[serde(default)]
     pub home_brand: Option<String>,
 
+    /// Variable decl symbol → the accessor brand it aliases
+    /// (`my $m = $app->minion` → `acc:minion`). So a variable holding an
+    /// accessor's result dispatches to the SAME instance as the accessor
+    /// chain itself; `instance_brand_at` reads it before the per-variable
+    /// brand. See `docs/adr/branded-edges.md`.
+    #[serde(default)]
+    pub var_accessor_brands: HashMap<SymbolId, String>,
+
     /// Per-symbol provenance for return types. Populated for plugin
     /// `overrides()` and for reducer-driven folds over the witness bag.
     /// Missing entry == `TypeProvenance::Inferred`.
@@ -2529,6 +2537,7 @@ pub struct FileAnalysisParts {
     pub role_packages: HashSet<String>,
     pub plugin_loads: Vec<PluginLoadFact>,
     pub loader_config_params: Vec<LoaderConfigParam>,
+    pub var_accessor_brands: HashMap<SymbolId, String>,
 }
 
 /// "This file loads plugin `name`, passing the config value at
@@ -2677,6 +2686,7 @@ impl FileAnalysis {
             role_packages,
             plugin_loads,
             loader_config_params,
+            var_accessor_brands,
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
@@ -2700,6 +2710,7 @@ impl FileAnalysis {
             plugin_namespaces,
             // Set at registration (`apply_home_brand`), not build.
             home_brand: None,
+            var_accessor_brands,
             type_provenance,
             witnesses,
             package_framework,
@@ -6658,15 +6669,23 @@ impl FileAnalysis {
         // at build time — `resolve_variable` returns the FIRST in-scope
         // match and would disagree under shadowing, splitting one
         // instance's identity. See `docs/adr/branded-edges.md`.
-        let decl = self.latest_lexical_decl(receiver, point)?;
-        Some(format!("inst:{}@{}:{}", receiver, decl.row, decl.column))
+        let decl_id = self.latest_lexical_decl(receiver, point)?;
+        // A variable that aliases an accessor (`my $m = $app->minion`)
+        // shares the ACCESSOR's brand, so `$m->enqueue` reaches the same
+        // tasks as `$app->minion->enqueue`. Checked before the per-variable
+        // brand. Build side does the identical lookup.
+        if let Some(brand) = self.var_accessor_brands.get(&decl_id) {
+            return Some(brand.clone());
+        }
+        let p = self.symbols[decl_id.0 as usize].span.start;
+        Some(format!("inst:{}@{}:{}", receiver, p.row, p.column))
     }
 
-    /// Location of the LATEST declaration of scalar/field `name` before
-    /// `point`: scope chain innermost-first, first scope with a match
-    /// wins (its latest decl). The shared decl-selection rule for
-    /// instance brands — build time runs the same selection.
-    fn latest_lexical_decl(&self, name: &str, point: Point) -> Option<Point> {
+    /// The LATEST declaration of scalar/field `name` before `point`: scope
+    /// chain innermost-first, first scope with a match wins (its latest
+    /// decl). The shared decl-selection rule for instance brands — build
+    /// time runs the same selection.
+    fn latest_lexical_decl(&self, name: &str, point: Point) -> Option<SymbolId> {
         let scope = self.scope_at(point)?;
         for scope_id in self.scope_chain(scope) {
             let latest = self
@@ -6680,8 +6699,8 @@ impl FileAnalysis {
                         && matches!(s.kind, SymKind::Variable | SymKind::Field)
                         && le_point(s.span.start, point)
                 })
-                .map(|s| s.span.start)
-                .max_by_key(|p| (p.row, p.column));
+                .max_by_key(|s| (s.span.start.row, s.span.start.column))
+                .map(|s| s.id);
             if latest.is_some() {
                 return latest;
             }

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -2153,6 +2153,40 @@ fn minion_tasks_are_scoped_per_instance() {
         "$a->enqueue('task_b') must NOT reach $b's task (the leak)");
 }
 
+/// Accessor-chain instance brands (`$app->minion`): the brand keys on the
+/// LEAF ACCESSOR (singleton-accessor semantics), not the base expression.
+/// So `$app->minion` and `$c->minion` (same accessor, different base —
+/// the common plugin-registers / controller-enqueues split) share an
+/// instance, while `$app->other_minion` is a distinct one. See
+/// `docs/adr/branded-edges.md`.
+#[test]
+fn accessor_chain_tasks_scoped_by_accessor() {
+    let src = "use Minion;\n\
+        $app->minion->add_task(only_minion => sub { 1 });\n\
+        $app->other_minion->add_task(only_other => sub { 2 });\n\
+        $app->minion->enqueue('only_minion');\n\
+        $app->minion->enqueue('only_other');\n\
+        $c->minion->enqueue('only_minion');\n";
+    let mut parser = crate::builder::create_parser();
+    let tree = parser.parse(src, None).unwrap();
+    let fa = crate::builder::build(&tree, src.as_bytes());
+    let resolved_at = |row: usize, task: &str| -> bool {
+        fa.refs.iter().any(|r| {
+            matches!(&r.kind, crate::file_analysis::RefKind::DispatchCall { dispatcher, .. } if dispatcher == "enqueue")
+                && r.target_name == task
+                && r.span.start.row == row
+                && r.resolves_to.is_some()
+        })
+    };
+    // $app->minion->enqueue('only_minion') resolves (same accessor).
+    assert!(resolved_at(3, "only_minion"), "own accessor's task must resolve");
+    // $app->minion->enqueue('only_other') must NOT — other_minion's task.
+    assert!(!resolved_at(4, "only_other"), "a different accessor's task must NOT resolve (the leak)");
+    // $c->minion->enqueue('only_minion') resolves — different base, SAME
+    // accessor is the same singleton instance (must not regress).
+    assert!(resolved_at(5, "only_minion"), "same accessor on a different base must still resolve");
+}
+
 /// F1 regression: a re-`my` of the receiver (Perl shadowing) must brand
 /// build-side and resolve query-side on the SAME (latest) declaration —
 /// otherwise the brands disagree and the own task silently fails to

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -2187,6 +2187,43 @@ fn accessor_chain_tasks_scoped_by_accessor() {
     assert!(resolved_at(5, "only_minion"), "same accessor on a different base must still resolve");
 }
 
+/// A variable initialized from an accessor chain (`my $m = $app->minion`)
+/// ALIASES that accessor's instance — so it dispatches to the SAME tasks,
+/// whichever form (accessor or alias) registers vs enqueues. A
+/// constructor (`Class->new`) stays a fresh per-variable instance. Closes
+/// the mixed-form regression the accessor-chain tier introduced. See
+/// `docs/adr/branded-edges.md`.
+#[test]
+fn accessor_alias_variable_shares_the_accessor_instance() {
+    use crate::file_analysis::RefKind;
+    let enqueue_resolves = |src: &str, task: &str| -> bool {
+        let mut parser = crate::builder::create_parser();
+        let tree = parser.parse(src, None).unwrap();
+        let fa = crate::builder::build(&tree, src.as_bytes());
+        fa.refs.iter().any(|r| {
+            matches!(&r.kind, RefKind::DispatchCall { dispatcher, .. } if dispatcher == "enqueue")
+                && r.target_name == task
+                && r.resolves_to.is_some()
+        })
+    };
+    // accessor registers, alias enqueues — same instance, resolves.
+    assert!(enqueue_resolves(
+        "use Minion;\n$app->minion->add_task(t => sub {1});\nmy $m = $app->minion;\n$m->enqueue('t');\n", "t"),
+        "alias of $app->minion must reach $app->minion's task");
+    // alias registers, accessor enqueues — same instance, resolves.
+    assert!(enqueue_resolves(
+        "use Minion;\nmy $m = $app->minion;\n$m->add_task(t => sub {1});\n$app->minion->enqueue('t');\n", "t"),
+        "$app->minion must reach its alias's task");
+    // a DIFFERENT accessor aliased — distinct instance, must NOT resolve.
+    assert!(!enqueue_resolves(
+        "use Minion;\n$app->other->add_task(t => sub {1});\nmy $m = $app->minion;\n$m->enqueue('t');\n", "t"),
+        "alias of ->minion must NOT reach ->other's task");
+    // constructor stays per-variable: $a can't reach $b's task.
+    assert!(!enqueue_resolves(
+        "use Minion;\nmy $a = Minion->new;\nmy $b = Minion->new;\n$b->add_task(t => sub {1});\n$a->enqueue('t');\n", "t"),
+        "Minion->new is a fresh instance, not an accessor alias");
+}
+
 /// F1 regression: a re-`my` of the receiver (Perl shadowing) must brand
 /// build-side and resolve query-side on the SAME (latest) declaration —
 /// otherwise the brands disagree and the own task silently fails to

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 95;
+pub const EXTRACT_VERSION: i64 = 96;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1503,19 +1503,23 @@ fn dispatch_target_items_for(
     module_index: &ModuleIndex,
     owner_class: &str,
     dispatcher_names: &[String],
-    // The receiver's per-instance brand at the cursor — local handlers
-    // are filtered to those visible to this instance, so completing
-    // `$a->enqueue('|')` offers only `$a`'s tasks, not `$b`'s. `None`
-    // (non-instance receiver) keeps the pre-brand behavior. Cross-file
-    // handlers stay unfiltered: instance brands key on a same-file
-    // declaration, so they don't carry across the file boundary.
+    // The receiver's per-instance brand at the cursor. Handlers are
+    // filtered to those visible to this instance — completing
+    // `$a->enqueue('|')` offers only `$a`'s tasks. Applied to LOCAL AND
+    // CROSS-FILE handlers: an accessor brand (`acc:minion`) is a singleton
+    // that carries across files, so a cross-file `acc:other` task must be
+    // filtered out too; a per-variable brand (`inst:…`) keys on a same-file
+    // decl, so a cross-file `inst:…` never matches this receiver and is
+    // (correctly) filtered. `None` (non-instance receiver) keeps the
+    // pre-brand "see everything" behavior via `brand_visible`.
     receiver_brand: Option<&str>,
 ) -> Vec<CompletionItem> {
     use crate::file_analysis::{brand_visible, SymbolDetail};
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut out: Vec<CompletionItem> = Vec::new();
     let mut emit = |sym: &crate::file_analysis::Symbol| {
-        let SymbolDetail::Handler { display, .. } = &sym.detail else { return };
+        let SymbolDetail::Handler { display, instance_brand, .. } = &sym.detail else { return };
+        if !brand_visible(instance_brand.as_deref(), receiver_brand) { return; }
         if !seen.insert(sym.name.clone()) { return; }
         let detail = display.outline_word().map(|s| s.to_string());
         out.push(CompletionItem {
@@ -1529,11 +1533,6 @@ fn dispatch_target_items_for(
         });
     };
     for sym in analysis.handlers_for_owner(owner_class, dispatcher_names) {
-        if let SymbolDetail::Handler { instance_brand, .. } = &sym.detail {
-            if !brand_visible(instance_brand.as_deref(), receiver_brand) {
-                continue;
-            }
-        }
         emit(sym);
     }
     module_index.for_each_cached(|_, cached| {

--- a/test_e2e_branded_minion.lua
+++ b/test_e2e_branded_minion.lua
@@ -42,4 +42,27 @@ t.test("branded edges: $a->enqueue does NOT offer $b's task", function()
   end
 end)
 
+-- Accessor-chain: cursor between the quotes of `$app->minion->enqueue('')`.
+local function accessor_completions()
+  local line, col = b.find_pos(buf, "$app->minion->enqueue('')")
+  if not line then return {} end
+  return lsp.completion_labels(buf, line, col + 23) -- inside the ''
+end
+
+t.test("branded edges: $app->minion->enqueue offers its accessor's task", function()
+  local N = "branded edges: $app->minion->enqueue offers its accessor's task"
+  if t.contains(N, accessor_completions(), "acc_minion_task", "accessor tasks") then
+    t.pass(N)
+  end
+end)
+
+t.test("branded edges: $app->minion does NOT offer $app->other_minion's task", function()
+  local N = "branded edges: $app->minion does NOT offer $app->other_minion's task"
+  local labels = accessor_completions()
+  if t.ok(N, not has(labels, "acc_other_task"),
+      "other_minion's task must NOT leak onto ->minion; got: [" .. table.concat(labels, ", ") .. "]") then
+    t.pass(N)
+  end
+end)
+
 t.finish()

--- a/test_files/branded_minion.pl
+++ b/test_files/branded_minion.pl
@@ -12,3 +12,11 @@ $b->add_task(beta_task => sub { my $job = shift; });
 
 # Completion inside the quotes here must offer alpha_task, NOT beta_task.
 $a->enqueue('');
+
+# Accessor-chain instances: tasks scoped by the ACCESSOR name, not the
+# base. `$app->minion` and `$app->other_minion` are distinct instances.
+$app->minion->add_task(acc_minion_task => sub { my $job = shift; });
+$app->other_minion->add_task(acc_other_task => sub { my $job = shift; });
+
+# Completion here must offer acc_minion_task, NOT acc_other_task.
+$app->minion->enqueue('');


### PR DESCRIPTION
**Stacked on #65** (base = `branded-edges`). The accessor-chain tier the ADR deferred — `$app->minion` / `$app->other_minion`.

### What's stopping us was a design fork, not review velocity

A probe of the current behavior:
```
$app->minion->enqueue('only_minion')  → resolves ✓
$app->minion->enqueue('only_other')   → resolves to other_minion's task  ✗ (leak)
$c->minion->enqueue('only_minion')    → resolves to $app->minion's task  ← MUST preserve
```

That last line is the crux: the common Minion pattern **registers** via `$app->minion` (in a plugin's `register`) and **enqueues** via `$c->minion` (in a controller) — different base expressions, same logical instance. So keying the brand on the base variable (like the per-variable tier) would *regress* it.

### The fix: key on the accessor identity

A singleton accessor returns one instance, so the brand is the **leaf accessor** (`conventions::accessor_chain_brand` → `acc:minion`), base-independent:
- `$app->minion` and `$c->minion` → `acc:minion` (share — preserved)
- `$app->other_minion` → `acc:other_minion` (distinct — leak fixed)

It's **pure text** (the accessor name), so build (`assign_task_instance_brands`) and query (`instance_brand_at`) compute it identically — the lazy-at-query-time resolution the bake-off called for, with **no enrichment pass** (which, being open-documents-only, would re-merge on workspace/dependency files). Only a bare-identifier leaf qualifies; `$app->minion('x')` / deref stay global. Known coarseness (documented): two different apps' `->minion` in one workspace share `acc:minion` — a home-brand prefix is a further tier.

### Verification
- Unit: accessor-scoped resolution (leak fixed + cross-base preserved) + `conventions::accessor_chain_brand` table.
- E2E: `$app->minion->enqueue('` completion offers its accessor's task, not the other accessor's.
- Nets: cargo 953 · e2e 118 · gold 187 PASS / 0 FAIL.

Adversarial review pass to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)