### PR TITLE
dbic-as-plugin phase 1: column/relationship synthesis → frameworks/dbic.rhai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,9 +1350,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "ts-parser-perl"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff62b91624001556debd009c28ec603c795df8dce96613705c78a4f691672f4"
+checksum = "720dcad2c9e8445465c98a7117574224bede0ee4168d081a37bfbad9699cd459"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ perf_bench = []
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.25"
-ts-parser-perl = "1.1.2"
+ts-parser-perl = "1.1.3"
 ts-parser-pod = "1"
 dashmap = "6"
 serde = { version = "1", features = ["derive"] }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,6 +32,13 @@ Type intelligence:
 - A4 v2: cross-FILE slot writes (`$self->{k} = Obj->new` in another
   file) — the `MethodOnClass` bridge pattern.
 
+Plugin genericity:
+- `has_options` final dissolution: move the `isa`-string→`InferredType`
+  mapping out of core (it's the last Moo-semantic field there) onto the
+  `type_constraint_names()` / `type_constraint_inner()` plugin seam.
+  Once it lands, `HasOptions` collapses into `arg_names` + `arg_pairs`
+  (the generic keyval primitive that already carries the options).
+
 Hardening:
 - Fold safety net: `eprintln!` → `tracing::error!` (builder.rs
   ~12061) + a synthetic-oscillator test so the release-mode

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,6 +53,23 @@ Hardening:
 - `return_via_edge` chases lack `TypeProvenance` (stamp
   `Delegation{kind: "callable_return_edge"}` on the chase).
 - cst/conventions migration backlog — `prompt-cst-migration.md`.
+- Unify autoquoted-key-as-literal into `cst::string_list`. Today
+  `string_list` routes `autoquoted_bareword` through the caller's
+  `fold` (const resolution), so the DSL-arg callers (`extract_arg_name_list`)
+  carry a per-caller fold that special-cases autoquoted→literal. An
+  autoquoted bareword is a grammar-certified literal for *every* caller,
+  so the right home for the rule is `string_list` itself — then
+  `extract_arg_name_list` deletes and the DBIC/keyval paths just use
+  `extract_string_list`. **Blocked on** a latent use-import bug it
+  unmasks: `use constant NAME => v`'s autoquoted key gets emitted as a
+  spurious `FunctionCall` import ref (resolved_package `"constant"`) by
+  the use-list walker — the old fold hid it by dropping non-constant
+  barewords. Regression-guarded by `const_call_form_not_double_reffed`.
+  Fix the use-`constant` path to not feed its declared names to the
+  generic import-ref emitter (it already routes them to
+  `accumulate_use_constant`), THEN move the autoquoted arm into
+  `string_list` and drop the per-caller fold. Proper unification; not
+  urgent (the per-caller fold is correct, just not DRY).
 
 QA tail:
 - MAIN-1 (`main::` across `require`) and H1 (duplicate packages) —

--- a/docs/prompt-dbic-as-plugin.md
+++ b/docs/prompt-dbic-as-plugin.md
@@ -11,12 +11,18 @@ synthesis out. Only phase 3 below still touches the axis question.
 
 ## Phase ladder
 
-1. **Accessor/relationship synthesis → `frameworks/dbic.rhai`.** Move
-   the `visit_dbic_add_columns` / `visit_dbic_relationship` family the
-   way moo.rhai took the accessor-option vocabulary: core walks the
-   call into decision-ready context (rule #1), the plugin owns
-   keyword → method-name + typed-return rules. `load_components`
-   parent registration stays core (it's generic parent machinery).
+1. **Accessor/relationship synthesis → `frameworks/dbic.rhai`.** ✅
+   LANDED. The `visit_dbic_*` family is gone; `frameworks/dbic.rhai`
+   (trigger `ClassIsa("DBIx::Class")`) synthesizes column accessors +
+   HashKeyDefs and relationship accessors (typed return: ResultSet for
+   has_many/many_to_many, row class for belongs_to/has_one/might_have).
+   The decision-ready context is the generic `CallContext.arg_names`
+   (the call's args as a flat `(name, span)` string list via the shared
+   `cst::string_list`), populated only for verbs a plugin registers via
+   the `arg_name_verbs()` manifest — core hardcodes no DSL verb. moo was
+   moved onto the same registration gate. `load_components` parent
+   registration stays core (generic parent machinery). Custom-resultset
+   discovery + per-column `data_type` typing are deferred to phase 3.
 2. **Meta-method suppression → manifest.** The DBIC entries in
    `symbols.rs`' `universal_methods` (comment-flagged debt) become a
    plugin manifest field; core's diagnostic consults the registry.

--- a/frameworks/dbic.rhai
+++ b/frameworks/dbic.rhai
@@ -1,0 +1,132 @@
+// dbic: DBIx::Class result-class DSL → column + relationship accessors.
+//
+// A DBIC Result class declares its table shape with class-method calls:
+//
+//     __PACKAGE__->add_columns(qw/id name email/);
+//     __PACKAGE__->add_columns(id => { data_type => 'integer' }, ...);
+//     __PACKAGE__->has_many(comments => 'Schema::Result::Comment', 'post_id');
+//     __PACKAGE__->belongs_to(author => 'Schema::Result::User', 'author_id');
+//
+// Each column installs an accessor method (and a HashKeyDef so
+// `$rs->search({ name => ... })` / `$row->{name}` resolve the column).
+// Each relationship installs an accessor whose RETURN names the related
+// shape: a `has_many` / `many_to_many` yields a `DBIx::Class::ResultSet`,
+// a `belongs_to` / `has_one` / `might_have` yields the row class.
+//
+// Core walks the call args into `ctx.arg_names` (rule #1 — the shared
+// `cst::string_list`: qw-expanded, fat-comma-key + positional strings,
+// each with its tight span, separator-agnostic). This plugin owns the
+// verb vocabulary: which name is a column vs an accessor+target-class,
+// and the typed return. The trigger (`ClassIsa("DBIx::Class")`) scopes
+// synthesis to result classes at any inheritance depth.
+//
+// `load_components` parent registration stays in core — it's generic
+// component-mixin machinery, not DBIC-specific. Parametric ResultSet
+// typing (per-method projection: `find` → row, `search` → resultset)
+// is deliberate follow-up; the accessor + plain typed return is the
+// load-bearing 80%.
+
+fn id() { "dbic" }
+
+fn triggers() {
+    [ #{ ClassIsa: "DBIx::Class" } ]
+}
+
+// The verbs whose args core should flatten into `ctx.arg_names`.
+fn arg_name_verbs() {
+    ["add_columns", "add_column", "has_many", "many_to_many",
+     "belongs_to", "has_one", "might_have"]
+}
+
+fn is_resultset_rel(verb) {
+    verb == "has_many" || verb == "many_to_many"
+}
+
+fn is_row_rel(verb) {
+    verb == "belongs_to" || verb == "has_one" || verb == "might_have"
+}
+
+// A column accessor: a get/set Method plus the HashKeyDef owned by the
+// result class (constructor / search / direct-deref key resolution).
+fn column_actions(name, span, pkg) {
+    let out = [];
+    out += #{
+        Method: #{
+            name: name,
+            span: span,
+            selection_span: span,
+            params: [ #{ name: "$val", "default": (), is_slurpy: false, is_invocant: false } ],
+            is_method: true,
+            return_type: (),
+            doc: (),
+            on_class: (),
+            display: (),
+            hide_in_outline: false,
+            opaque_return: false,
+        }
+    };
+    if pkg != () {
+        out += #{
+            HashKeyDef: #{
+                name: name,
+                owner: #{ Class: pkg },
+                span: span,
+                selection_span: span,
+            }
+        };
+    }
+    out
+}
+
+// A relationship accessor: a no-arg Method whose return names the
+// related shape. `ret` is the InferredType (ResultSet class or row class).
+fn relationship_method(name, span, ret) {
+    #{
+        Method: #{
+            name: name,
+            span: span,
+            selection_span: span,
+            params: [],
+            is_method: true,
+            return_type: ret,
+            doc: (),
+            on_class: (),
+            display: (),
+            hide_in_outline: false,
+            opaque_return: false,
+        }
+    }
+}
+
+fn on_method_call(ctx) {
+    let out = [];
+    let verb = ctx.method_name;
+    if verb == () { return out; }
+
+    let names = ctx.arg_names;
+    if names == () || names.len() < 1 { return out; }
+
+    if verb == "add_columns" || verb == "add_column" {
+        // Every flattened name is a column (the hashref option values
+        // carry no name and never reach `arg_names`).
+        for pair in names {
+            out += column_actions(pair[0], pair[1], ctx.current_package);
+        }
+        return out;
+    }
+
+    if is_resultset_rel(verb) || is_row_rel(verb) {
+        // names[0] is the accessor, names[1] (if present) the related class.
+        let acc = names[0];
+        let ret = ();
+        if is_resultset_rel(verb) {
+            ret = #{ ClassName: "DBIx::Class::ResultSet" };
+        } else if names.len() >= 2 {
+            ret = #{ ClassName: names[1][0] };
+        }
+        out += relationship_method(acc[0], acc[1], ret);
+        return out;
+    }
+
+    out
+}

--- a/frameworks/dbic.rhai
+++ b/frameworks/dbic.rhai
@@ -1,30 +1,20 @@
 // dbic: DBIx::Class result-class DSL → column + relationship accessors.
 //
-// A DBIC Result class declares its table shape with class-method calls:
-//
-//     __PACKAGE__->add_columns(qw/id name email/);
-//     __PACKAGE__->add_columns(id => { data_type => 'integer' }, ...);
+// A Result class declares its table shape with class-method calls:
+//     __PACKAGE__->add_columns(qw/id name/);   # or  id => { data_type => ... }
 //     __PACKAGE__->has_many(comments => 'Schema::Result::Comment', 'post_id');
-//     __PACKAGE__->belongs_to(author => 'Schema::Result::User', 'author_id');
+//     __PACKAGE__->belongs_to(author => 'Schema::Result::User');
 //
-// Each column installs an accessor method (and a HashKeyDef so
-// `$rs->search({ name => ... })` / `$row->{name}` resolve the column).
-// Each relationship installs an accessor whose RETURN names the related
-// shape: a `has_many` / `many_to_many` yields a `DBIx::Class::ResultSet`,
-// a `belongs_to` / `has_one` / `might_have` yields the row class.
+// A column installs an accessor + a HashKeyDef (so `$rs->search({ name => ... })`
+// and `$row->{name}` resolve it). A relationship installs an accessor whose
+// return names the related shape: has_many / many_to_many → a ResultSet,
+// belongs_to / has_one / might_have → the row class.
 //
-// Core walks the call args into `ctx.arg_names` (rule #1 — the shared
-// `cst::string_list`: qw-expanded, fat-comma-key + positional strings,
-// each with its tight span, separator-agnostic). This plugin owns the
-// verb vocabulary: which name is a column vs an accessor+target-class,
-// and the typed return. The trigger (`ClassIsa("DBIx::Class")`) scopes
-// synthesis to result classes at any inheritance depth.
-//
-// `load_components` parent registration stays in core — it's generic
-// component-mixin machinery, not DBIC-specific. Parametric ResultSet
-// typing (per-method projection: `find` → row, `search` → resultset)
-// is deliberate follow-up; the accessor + plain typed return is the
-// load-bearing 80%.
+// Core feeds the flat arg names in `ctx.arg_names`; this plugin owns the verb
+// vocabulary. `ClassIsa("DBIx::Class")` scopes synthesis to result classes at
+// any depth. `load_components` parent registration stays core (generic mixin
+// machinery). Parametric ResultSet typing (per-method `find` → row) is
+// follow-up; accessor + plain typed return is the load-bearing 80%.
 
 fn id() { "dbic" }
 

--- a/frameworks/dbic.rhai
+++ b/frameworks/dbic.rhai
@@ -103,6 +103,10 @@ fn on_method_call(ctx) {
     let verb = ctx.method_name;
     if verb == () { return out; }
 
+    // Class-level declaration only: `__PACKAGE__->add_columns(...)`, never a
+    // runtime `$rs->add_columns({...})` (a query op, not a column decl).
+    if !ctx.receiver_is_package { return out; }
+
     let names = ctx.arg_names;
     if names == () || names.len() < 1 { return out; }
 

--- a/frameworks/moo.rhai
+++ b/frameworks/moo.rhai
@@ -36,6 +36,15 @@ fn role_makers() {
     ["Moo::Role", "Moose::Role", "Mouse::Role", "Role::Tiny"]
 }
 
+// The verbs whose args core flattens into `ctx.arg_names` — and, since
+// these are Moo's accessor declarators, the gate behind which core also
+// builds the richer `has_options` (classified shorthand/handles options a
+// flat name list can't carry). Declaring them here is what keeps core from
+// hardcoding `has`/`option`; the vocabulary lives with the plugin.
+fn arg_name_verbs() {
+    ["has", "option"]
+}
+
 fn triggers() {
     [
         #{ UsesModule: "Moo" },

--- a/frameworks/moo.rhai
+++ b/frameworks/moo.rhai
@@ -12,15 +12,13 @@
 //                       a class, the delegated method's return edges to the
 //                       remote method on that class
 //
-// The core walks the `has` CST and hands this plugin EVERY fat-comma option
-// key→value as a value-shape-classified `ctx.has_options` entry (rule #1 —
-// only the builder touches tree-sitter; no keyword allowlist in core, so a
-// new keyword needs no core edit). What lives HERE is the vocabulary: which
-// keyword maps to which name pattern and return behavior; arms below ignore
-// keywords/shapes they don't act on. New Moo accessor behavior is a new arm
-// in this file, not a branch in the builder. The default accessor / isa /
-// constructor-key synthesis is still native in `visit_has_call` (a larger
-// move left as future work); this plugin is the seam for everything beyond it.
+// The core walks the `has` CST and hands this plugin every fat-comma option
+// as a value-shape-classified `ctx.arg_pairs` entry (rule #1 — only the
+// builder touches tree-sitter; no keyword allowlist in core, so a new keyword
+// needs no core edit). What lives HERE is the vocabulary: which keyword maps
+// to which name pattern and return behavior; arms below ignore keywords/shapes
+// they don't act on. The default accessor / isa / constructor-key synthesis is
+// still native in `visit_has_call`; this plugin is the seam beyond it.
 
 fn id() { "moo" }
 
@@ -36,11 +34,10 @@ fn role_makers() {
     ["Moo::Role", "Moose::Role", "Mouse::Role", "Role::Tiny"]
 }
 
-// The verbs whose args core flattens into `ctx.arg_names` — and, since
-// these are Moo's accessor declarators, the gate behind which core also
-// builds the richer `has_options` (classified shorthand/handles options a
-// flat name list can't carry). Declaring them here is what keeps core from
-// hardcoding `has`/`option`; the vocabulary lives with the plugin.
+// The verbs whose args core flattens into `ctx.arg_pairs` (the accessor
+// options) and `has_options` (the attr-name + isa head). Declaring them
+// here keeps core from hardcoding `has`/`option` — the vocabulary lives
+// with the plugin.
 fn arg_name_verbs() {
     ["has", "option"]
 }

--- a/frameworks/moo.rhai
+++ b/frameworks/moo.rhai
@@ -118,6 +118,23 @@ fn isa_class(isa_type) {
     ()
 }
 
+// The `=> 1` shorthand: the generic value-shape is `Num("1")`.
+fn is_shorthand(val) {
+    val.Num == "1"
+}
+
+// `handles => {l => r}` / `[qw/m/]` as `[local, remote]` pairs. The
+// "arrayref entry is its own remote" rule is Moo's, so it lives here:
+// the generic primitive just hands us `HashPairs` / `ArrayItems`.
+fn handles_pairs(val) {
+    if val.HashPairs != () { return val.HashPairs; }
+    let out = [];
+    if val.ArrayItems != () {
+        for n in val.ArrayItems { out.push([n, n]); }
+    }
+    out
+}
+
 fn on_function_call(ctx) {
     let out = [];
     // `option` (MooX::Options) shares `has`'s accessor-option vocabulary.
@@ -126,17 +143,20 @@ fn on_function_call(ctx) {
     if opts == () { return out; }
 
     let cls = isa_class(opts.isa_type);
+    // The accessor options are the generic value-shape-classified pairs.
+    let pairs = ctx.arg_pairs;
 
     for attr_pair in opts.attr_names {
         let attr = attr_pair[0];
         let span = attr_pair[1];
 
-        for opt in opts.options {
-            let kw = opt.keyword;
+        for opt in pairs {
+            let kw = opt.key;
+            let val = opt.value;
 
             // `lazy_build => 1` (Moose) implies a builder/clearer/predicate
             // trio at runtime; expand it to the three companion methods.
-            if kw == "lazy_build" && opt.shorthand {
+            if kw == "lazy_build" && is_shorthand(val) {
                 out += plain_method("_build_" + attr, span, [], attr);
                 out += plain_method(derive_name("clear_", attr), span, [], attr);
                 out += plain_method(derive_name("has_", attr), span, [], attr);
@@ -151,7 +171,7 @@ fn on_function_call(ctx) {
                 // One method per delegated name. With a class-typed isa, edge
                 // the method's return through MethodOnClass{class, remote} so
                 // `$self->log(...)` chains to the remote method's return.
-                for pair in opt.handles {
+                for pair in handles_pairs(val) {
                     let local = pair[0];
                     let remote = pair[1];
                     let edge = ();
@@ -183,13 +203,13 @@ fn on_function_call(ctx) {
             // Resolve the method name: shorthand derives from the attr, an
             // explicit string is used verbatim.
             let name = ();
-            if opt.shorthand {
+            if is_shorthand(val) {
                 if kw == "predicate" { name = derive_name("has_", attr); }
                 else if kw == "clearer" { name = derive_name("clear_", attr); }
                 else if kw == "builder" { name = "_build_" + attr; }
                 // writer/reader have no `=> 1` shorthand in Moo.
-            } else if opt.explicit_name != () {
-                name = opt.explicit_name;
+            } else if val.Str != () {
+                name = val.Str;
             }
             if name == () { continue; }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2689,6 +2689,7 @@ impl<'a> Builder<'a> {
             current_package_parents: parents,
             current_package_uses: uses,
             has_options: None,
+            arg_names: Vec::new(),
         }
     }
 
@@ -5534,6 +5535,29 @@ impl<'a> Builder<'a> {
         })
     }
 
+    /// Flatten a DSL call's args to `(name, span)` for a plugin's
+    /// `CallContext::arg_names`. Shares `cst::string_list` (qw / string /
+    /// nested-list / fat-comma handling) but with a DSL-arg fold: a
+    /// bareword is its own LITERAL text. Fat-comma autoquoting means a
+    /// key/name bareword is that name, never a constant lookup — and the
+    /// parser labels fat-comma keys as `bareword` OR `autoquoted_bareword`
+    /// interchangeably, so both resolve to text here. `@array` elements
+    /// still fold through the constant table.
+    fn extract_arg_name_list(&self, node: Node<'a>) -> Vec<(String, Span)> {
+        crate::cst::string_list(node, self.source, &mut |n| {
+            if n.kind() == "array" {
+                let Ok(text) = n.utf8_text(self.source) else { return vec![] };
+                let Some(values) = self.resolve_constant_strings(text, 0) else { return vec![] };
+                let span = node_to_span(n);
+                return values.into_iter().map(|v| (v, span)).collect();
+            }
+            match n.utf8_text(self.source) {
+                Ok(text) => vec![(text.to_string(), node_to_span(n))],
+                Err(_) => vec![],
+            }
+        })
+    }
+
     /// Extract strings without spans. Convenience for callers that don't need positions.
     fn extract_string_names(&self, node: Node<'a>) -> Vec<String> {
         self.extract_string_list(node).into_iter().map(|(s, _)| s).collect()
@@ -7502,11 +7526,25 @@ impl<'a> Builder<'a> {
                     );
                     ctx.call_kind = plugin::CallKind::Function;
                     ctx.function_name = Some(name.to_string());
-                    // The accessor-option vocabulary (predicate/clearer/writer/
-                    // reader/builder/handles) lives in the moo plugin. Core does
-                    // the node walk (rule #1) and hands over the decision-ready
-                    // option shape; the plugin maps keywords to method names.
-                    if name == "has" || name == "option" {
+                    // The verb vocabulary is the plugin's (`arg_name_verbs`),
+                    // not core's: when an applicable plugin registered this
+                    // name, hand over the flat `cst::string_list` of args.
+                    let wants_names = {
+                        let query = plugin::TriggerQuery {
+                            package_uses: &ctx.current_package_uses,
+                            package_parents: &ctx.current_package_parents,
+                        };
+                        self.plugins.wants_arg_names(&query, name)
+                    };
+                    if wants_names {
+                        ctx.arg_names = self.extract_arg_name_list(node
+                            .child_by_field_name("arguments")
+                            .unwrap_or(node));
+                        // Moo/Moose `has`/`option` additionally needs the
+                        // classified option shape (shorthand `=> 1`, `handles`
+                        // hashref) a flat name list can't carry — the moo
+                        // plugin reads it from `has_options`. Built behind the
+                        // same registration gate, scoped by framework mode.
                         if let Some(mode) = self.current_package.as_ref()
                             .and_then(|pkg| self.framework_modes.get(pkg).copied())
                         {
@@ -10396,10 +10434,9 @@ impl<'a> Builder<'a> {
                 if name == "load_components" {
                     self.visit_load_components(node);
                 }
-                // DBIC accessor synthesis
-                if self.is_dbic_class() {
-                    self.visit_dbic_class_method(node, name);
-                }
+                // DBIC column/relationship accessor synthesis lives in the
+                // `dbic` plugin (`ClassIsa("DBIx::Class")`); core hands it
+                // `ctx.arg_names` below via the `arg_name_verbs` registration.
                 // Class::Accessor::Grouped accessor synthesis. Not DBIC-gated:
                 // any package can `use parent 'Class::Accessor::Grouped'`. The
                 // call shape is the signal — `mk_*_accessors('group', @names)`
@@ -10472,6 +10509,23 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
+                // Flat arg-name extraction for verbs a plugin registered
+                // (`arg_name_verbs`) — the shared `cst::string_list`, run
+                // only when an applicable plugin asked for it. Core knows
+                // no DSL verb; the DBIC plugin reads columns/relationship
+                // names off `ctx.arg_names`.
+                let wants_names = {
+                    let query = plugin::TriggerQuery {
+                        package_uses: &ctx.current_package_uses,
+                        package_parents: &ctx.current_package_parents,
+                    };
+                    self.plugins.wants_arg_names(&query, name)
+                };
+                if wants_names {
+                    if let Some(args_node) = node.child_by_field_name("arguments") {
+                        ctx.arg_names = self.extract_arg_name_list(args_node);
+                    }
+                }
                 self.record_provisional_dispatch(name, &ctx);
                 self.record_plugin_loads(name, &ctx);
                 self.dispatch_method_call_plugins(ctx);
@@ -10479,39 +10533,6 @@ impl<'a> Builder<'a> {
         }
 
         self.visit_children(node);
-    }
-
-    /// Check if the current package inherits from a DBIx::Class package,
-    /// at any depth. Walks the full local ancestry (`package_parents`),
-    /// so multi-level chains (`Result → BaseResult → DBIx::Class::Core`)
-    /// still get column/relationship synthesis — not just direct parents.
-    /// The builder has no `module_index` during the live walk, but the
-    /// resolver re-runs the full builder per file, so each file's own
-    /// `package_parents` carries the edges it declares.
-    fn is_dbic_class(&self) -> bool {
-        let Some(ref pkg) = self.current_package else { return false };
-        crate::file_analysis::any_ancestor(
-            pkg,
-            &self.package_parents,
-            None,
-            |c| c.starts_with("DBIx::Class"),
-        )
-    }
-
-    /// Synthesize accessor methods from DBIC class method calls.
-    fn visit_dbic_class_method(&mut self, node: Node<'a>, method_name: &str) {
-        match method_name {
-            "add_columns" | "add_column" => {
-                self.visit_dbic_add_columns(node);
-            }
-            "has_many" | "many_to_many" => {
-                self.visit_dbic_relationship(node, true);
-            }
-            "belongs_to" | "has_one" | "might_have" => {
-                self.visit_dbic_relationship(node, false);
-            }
-            _ => {}
-        }
     }
 
     /// Class::Accessor::Grouped accessor synthesis. The `mk_group_*_accessors`
@@ -10590,217 +10611,6 @@ impl<'a> Builder<'a> {
                     lexical: false,
                 },
             );
-        }
-    }
-
-    /// Synthesize column accessor methods from __PACKAGE__->add_columns(...).
-    fn visit_dbic_add_columns(&mut self, node: Node<'a>) {
-        // Arguments from method_call_expression:
-        //   qw(id name email)
-        //   id => { data_type => 'integer' }, name => { data_type => 'varchar' }
-        let args = match node.child_by_field_name("arguments") {
-            Some(a) => a,
-            None => return,
-        };
-
-        let mut col_names: Vec<(String, Span)> = Vec::new();
-
-        match args.kind() {
-            "quoted_word_list" => {
-                self.extract_array_attr_names(args, &mut col_names);
-            }
-            "parenthesized_expression" | "list_expression" => {
-                self.extract_dbic_column_names(args, &mut col_names);
-            }
-            _ => {}
-        }
-
-        for (name, sel_span) in &col_names {
-            self.add_symbol(
-                name.clone(),
-                SymKind::Method,
-                node_to_span(node),
-                *sel_span,
-                SymbolDetail::Sub {
-                    params: vec![ParamInfo {
-                        name: "$val".into(),
-                        default: None,
-                        is_slurpy: false,
-                    is_invocant: false,
-                    }],
-                    is_method: true,
-                    doc: None,
-                    display: None,
-                    hide_in_outline: false,
-                    opaque_return: false,
-                    is_constant: false,
-                    lexical: false,
-                },
-            );
-        }
-
-        // Also synthesize HashKeyDef symbols owned by the row class so
-        // `$rs->search({ name => … })` and `$row->{name}` find their column
-        // def (same shape Mojo `has` emits for constructor args).
-        if let Some(ref pkg) = self.current_package {
-            let owner = HashKeyOwner::Class(pkg.clone());
-            for (name, sel_span) in &col_names {
-                self.add_symbol(
-                    name.clone(),
-                    SymKind::HashKeyDef,
-                    node_to_span(node),
-                    *sel_span,
-                    SymbolDetail::HashKeyDef {
-                        owner: owner.clone(),
-                        is_dynamic: false,
-                    },
-                );
-            }
-        }
-    }
-
-    /// Extract column names from DBIC add_columns argument list.
-    /// In `id => { ... }, name => { ... }`, the column names are the fat-comma keys.
-    fn extract_dbic_column_names(&self, node: Node<'a>, names: &mut Vec<(String, Span)>) {
-        let mut expect_key = true;
-        for i in 0..node.child_count() {
-            let child = match node.child(i) {
-                Some(c) => c,
-                None => continue,
-            };
-
-            if !child.is_named() {
-                if child.kind() == "=>" {
-                    expect_key = false; // next named node is a value
-                }
-                continue;
-            }
-
-            if expect_key {
-                match child.kind() {
-                    "bareword" | "autoquoted_bareword" => {
-                        if let Ok(text) = child.utf8_text(self.source) {
-                            names.push((text.to_string(), node_to_span(child)));
-                        }
-                        expect_key = true; // will flip on =>
-                    }
-                    "string_literal" | "interpolated_string_literal" => {
-                        if let Some(text) = self.extract_string_content(child) {
-                            names.push((text, self.string_content_span(child)));
-                        }
-                        expect_key = true;
-                    }
-                    "quoted_word_list" => {
-                        // qw(id name email) — simple form
-                        self.extract_array_attr_names(child, names);
-                        return;
-                    }
-                    _ => {}
-                }
-            } else {
-                // Skip the value (hash_ref, string, etc.)
-                expect_key = true;
-            }
-        }
-    }
-
-    /// Synthesize relationship accessor from __PACKAGE__->has_many/belongs_to/etc.
-    fn visit_dbic_relationship(&mut self, node: Node<'a>, is_resultset: bool) {
-        // First arg: accessor name, second arg: related class
-        let mut accessor_name: Option<(String, Span)> = None;
-        let mut related_class: Option<String> = None;
-
-        let args = match node.child_by_field_name("arguments") {
-            Some(a) => a,
-            None => return,
-        };
-
-        match args.kind() {
-            "parenthesized_expression" | "list_expression" => {
-                self.extract_relationship_args(args, &mut accessor_name, &mut related_class);
-            }
-            _ => {}
-        }
-
-        if let Some((name, sel_span)) = accessor_name {
-            let return_type = if is_resultset {
-                Some(InferredType::ClassName("DBIx::Class::ResultSet".to_string()))
-            } else {
-                related_class.map(|c| InferredType::ClassName(c))
-            };
-
-            let sym_id = self.add_symbol(
-                name.clone(),
-                SymKind::Method,
-                node_to_span(node),
-                sel_span,
-                SymbolDetail::Sub {
-                    params: vec![],
-                    is_method: true,
-                    doc: None,
-                    display: None,
-                    hide_in_outline: false,
-                    opaque_return: false,
-                    is_constant: false,
-                    lexical: false,
-                },
-            );
-            // DBIC relationship accessor — arity 0 (no arg form is
-            // the standard call shape; with-arg variants exist but
-            // surface via different code paths). Encode as Empty +
-            // Concrete; multi-row vs single-row representation is
-            // already in `return_type` (a `Parametric(ResultSet)`
-            // for has_many, a `ClassName(row)` for belongs_to /
-            // has_one / might_have).
-            let arm = return_type.map(|t| {
-                (
-                    crate::witnesses::ArgGuard::Empty,
-                    crate::witnesses::ReturnExpr::Concrete(t),
-                )
-            });
-            self.record_framework_accessor_witness(
-                sym_id,
-                &name,
-                arm,
-                "DBIx::Class",
-                if is_resultset {
-                    format!("DBIx::Class resultset relationship `{}`", name)
-                } else {
-                    format!("DBIx::Class row relationship `{}`", name)
-                },
-            );
-        }
-    }
-
-    /// Extract accessor name and related class from relationship call arguments.
-    fn extract_relationship_args(&self, node: Node<'a>, accessor: &mut Option<(String, Span)>, related: &mut Option<String>) {
-        let mut arg_idx = 0;
-        for i in 0..node.child_count() {
-            let child = match node.child(i) {
-                Some(c) if c.is_named() => c,
-                _ => continue,
-            };
-            match child.kind() {
-                "string_literal" | "interpolated_string_literal" => {
-                    if let Some(text) = self.extract_string_content(child) {
-                        if arg_idx == 0 {
-                            *accessor = Some((text, self.string_content_span(child)));
-                        } else if arg_idx == 1 {
-                            *related = Some(text);
-                        }
-                        arg_idx += 1;
-                    }
-                }
-                "bareword" | "autoquoted_bareword" => {
-                    if let Ok(text) = child.utf8_text(self.source) {
-                        if arg_idx == 0 {
-                            *accessor = Some((text.to_string(), node_to_span(child)));
-                        }
-                        arg_idx += 1;
-                    }
-                }
-                _ => { arg_idx += 1; }
-            }
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5539,15 +5539,12 @@ impl<'a> Builder<'a> {
         })
     }
 
-    /// Flatten a DSL call's args to `(name, span)` for a plugin's
-    /// `CallContext::arg_names`. Shares `cst::string_list` but with a
-    /// DSL-arg fold: an `autoquoted_bareword` is a grammar-certified
-    /// fat-comma key — its value IS its text, never a constant lookup. A
-    /// plain `bareword` / `@array` is a genuine value and routes through
-    /// the constant table. (`cst::string_list` hands both kinds to the
-    /// fold, so the distinction is drawn here rather than in the shared
-    /// helper — keeping its const-folding contract intact for the
-    /// use-import / export-list callers.)
+    /// Flatten a DSL call's args to `(name, span)` for `CallContext::arg_names`.
+    /// Like `cst::string_list` but with a DSL-arg fold: an `autoquoted_bareword`
+    /// is a grammar-certified fat-comma key (its value IS its text, never a
+    /// constant lookup); a plain `bareword` / `@array` is a genuine value and
+    /// folds through the constant table. The autoquoted rule isn't pushed into
+    /// `string_list` itself — that unmasks a use-import bug; see ROADMAP.
     fn extract_arg_name_list(&self, node: Node<'a>) -> Vec<(String, Span)> {
         crate::cst::string_list(node, self.source, &mut |n| {
             if n.kind() == "autoquoted_bareword" {
@@ -7546,11 +7543,9 @@ impl<'a> Builder<'a> {
                         ctx.arg_names = self.extract_arg_name_list(node
                             .child_by_field_name("arguments")
                             .unwrap_or(node));
-                        // Moo/Moose `has`/`option`: the accessor options are
-                        // the generic value-shape pairs (`arg_pairs`); the
-                        // non-pair head (attr name(s) + resolved isa) rides
-                        // `has_options`. Built behind the same registration
-                        // gate, scoped by framework mode.
+                        // Moo/Moose `has`/`option`: options ride `arg_pairs`;
+                        // `has_options` carries only the non-pair head (attr
+                        // names + isa). Scoped by framework mode.
                         if let Some(mode) = self.current_package.as_ref()
                             .and_then(|pkg| self.framework_modes.get(pkg).copied())
                         {
@@ -9451,20 +9446,13 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Walk a `has` call's CST into the decision-ready `HasOptions` the moo
-    /// plugin reads. The split is deliberate: core owns the node walk
-    /// (rule #1) and value *classification* (shorthand `=> 1` vs explicit
-    /// string vs `handles` delegation pairs); the plugin owns the accessor
-    /// *vocabulary* (which keyword → which method-name pattern). Only the
-    /// non-default options live here — the default accessor / isa /
-    /// constructor-key synthesis stays native in `visit_has_call`. New Moo
-    /// behavior wants the plugin; this seam is where structured option data
-    /// crosses over.
-    /// `has` decomposes into a non-pair head (attr name(s) + the resolved
-    /// `isa` type) and a tail of accessor options. The head is returned in
-    /// `HasOptions`; the options are the generic value-shape-classified
-    /// `arg_pairs` the caller sets on the context. `isa` is the one
-    /// type-semantic field core still resolves (roadmapped to move out).
+    /// Walk a `has` call into its non-pair head — the `HasOptions` the moo
+    /// plugin reads (attr name(s) + resolved `isa` type). The accessor
+    /// options are the generic `arg_pairs` the caller sets alongside. Core
+    /// owns the node walk (rule #1); the plugin owns the keyword vocabulary.
+    /// `isa` is the one type-semantic field core still resolves (roadmapped
+    /// to move out); the default accessor / isa / constructor-key synthesis
+    /// stays native in `visit_has_call`.
     fn extract_has_options(
         &mut self,
         node: Node<'a>,
@@ -10373,9 +10361,8 @@ impl<'a> Builder<'a> {
                 if name == "load_components" {
                     self.visit_load_components(node);
                 }
-                // DBIC column/relationship accessor synthesis lives in the
-                // `dbic` plugin (`ClassIsa("DBIx::Class")`); core hands it
-                // `ctx.arg_names` below via the `arg_name_verbs` registration.
+                // DBIC column/relationship synthesis lives in the `dbic`
+                // plugin (`ClassIsa("DBIx::Class")`), fed `ctx.arg_names`.
                 // Class::Accessor::Grouped accessor synthesis. Not DBIC-gated:
                 // any package can `use parent 'Class::Accessor::Grouped'`. The
                 // call shape is the signal — `mk_*_accessors('group', @names)`
@@ -10409,10 +10396,7 @@ impl<'a> Builder<'a> {
                 );
                 ctx.call_kind = plugin::CallKind::Method;
                 ctx.method_name = Some(name.clone());
-                // `__PACKAGE__->m(...)` / `CurrentClass->m(...)` — a
-                // class-level call. Class-declaration DSLs (DBIC columns,
-                // load_components) gate on this so a runtime instance call
-                // (`$rs->add_columns(...)`) isn't read as a declaration.
+                // The class-level-call fact declaration DSLs gate on.
                 ctx.receiver_is_package = is_pkg_call;
                 ctx.receiver_text = invocant_text.clone();
                 ctx.receiver_type = self.receiver_type_for(invocant_node);
@@ -10453,11 +10437,8 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
-                // Flat arg-name extraction for verbs a plugin registered
-                // (`arg_name_verbs`) — the shared `cst::string_list`, run
-                // only when an applicable plugin asked for it. Core knows
-                // no DSL verb; the DBIC plugin reads columns/relationship
-                // names off `ctx.arg_names`.
+                // Flat arg-names for registered verbs (the DBIC plugin
+                // reads columns/relationship names off `ctx.arg_names`).
                 let wants_names = {
                     let query = plugin::TriggerQuery {
                         package_uses: &ctx.current_package_uses,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5540,31 +5540,27 @@ impl<'a> Builder<'a> {
     }
 
     /// Flatten a DSL call's args to `(name, span)` for a plugin's
-    /// `CallContext::arg_names`. Shares `cst::string_list` (qw / string /
-    /// nested-list / fat-comma handling) but with a DSL-arg fold: a
-    /// bareword is its own LITERAL text. Fat-comma autoquoting means a
-    /// key/name bareword is that name, never a constant lookup. `@array`
-    /// elements still fold through the constant table.
-    ///
-    /// KLUDGE (tree-sitter-perl grammar): a fat-comma key is *normally*
-    /// lexed as `autoquoted_bareword` (a grammar-certified literal), but on
-    /// continuation lines of a multi-line list certain words (`name`,
-    /// `status`) come through as plain `bareword`. Treating every bareword
-    /// as literal text here papers over that until the grammar is fixed
-    /// upstream; once it is, this can defer to the autoquoted classification
-    /// (and constant barewords could route back through the fold).
+    /// `CallContext::arg_names`. Shares `cst::string_list` but with a
+    /// DSL-arg fold: an `autoquoted_bareword` is a grammar-certified
+    /// fat-comma key — its value IS its text, never a constant lookup. A
+    /// plain `bareword` / `@array` is a genuine value and routes through
+    /// the constant table. (`cst::string_list` hands both kinds to the
+    /// fold, so the distinction is drawn here rather than in the shared
+    /// helper — keeping its const-folding contract intact for the
+    /// use-import / export-list callers.)
     fn extract_arg_name_list(&self, node: Node<'a>) -> Vec<(String, Span)> {
         crate::cst::string_list(node, self.source, &mut |n| {
-            if n.kind() == "array" {
-                let Ok(text) = n.utf8_text(self.source) else { return vec![] };
-                let Some(values) = self.resolve_constant_strings(text, 0) else { return vec![] };
-                let span = node_to_span(n);
-                return values.into_iter().map(|v| (v, span)).collect();
+            if n.kind() == "autoquoted_bareword" {
+                return match n.utf8_text(self.source) {
+                    Ok(text) => vec![(text.to_string(), node_to_span(n))],
+                    Err(_) => vec![],
+                };
             }
-            match n.utf8_text(self.source) {
-                Ok(text) => vec![(text.to_string(), node_to_span(n))],
-                Err(_) => vec![],
-            }
+            // plain bareword / @array: a genuine value — fold via constants.
+            let Ok(text) = n.utf8_text(self.source) else { return vec![] };
+            let Some(values) = self.resolve_constant_strings(text, 0) else { return vec![] };
+            let span = node_to_span(n);
+            values.into_iter().map(|v| (v, span)).collect()
         })
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2686,6 +2686,7 @@ impl<'a> Builder<'a> {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         }
     }
 
@@ -10412,6 +10413,11 @@ impl<'a> Builder<'a> {
                 );
                 ctx.call_kind = plugin::CallKind::Method;
                 ctx.method_name = Some(name.clone());
+                // `__PACKAGE__->m(...)` / `CurrentClass->m(...)` — a
+                // class-level call. Class-declaration DSLs (DBIC columns,
+                // load_components) gate on this so a runtime instance call
+                // (`$rs->add_columns(...)`) isn't read as a declaration.
+                ctx.receiver_is_package = is_pkg_call;
                 ctx.receiver_text = invocant_text.clone();
                 ctx.receiver_type = self.receiver_type_for(invocant_node);
                 // The receiver's call name is a generic syntax fact —

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2690,6 +2690,7 @@ impl<'a> Builder<'a> {
             current_package_uses: uses,
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         }
     }
 
@@ -5539,10 +5540,16 @@ impl<'a> Builder<'a> {
     /// `CallContext::arg_names`. Shares `cst::string_list` (qw / string /
     /// nested-list / fat-comma handling) but with a DSL-arg fold: a
     /// bareword is its own LITERAL text. Fat-comma autoquoting means a
-    /// key/name bareword is that name, never a constant lookup — and the
-    /// parser labels fat-comma keys as `bareword` OR `autoquoted_bareword`
-    /// interchangeably, so both resolve to text here. `@array` elements
-    /// still fold through the constant table.
+    /// key/name bareword is that name, never a constant lookup. `@array`
+    /// elements still fold through the constant table.
+    ///
+    /// KLUDGE (tree-sitter-perl grammar): a fat-comma key is *normally*
+    /// lexed as `autoquoted_bareword` (a grammar-certified literal), but on
+    /// continuation lines of a multi-line list certain words (`name`,
+    /// `status`) come through as plain `bareword`. Treating every bareword
+    /// as literal text here papers over that until the grammar is fixed
+    /// upstream; once it is, this can defer to the autoquoted classification
+    /// (and constant barewords could route back through the fold).
     fn extract_arg_name_list(&self, node: Node<'a>) -> Vec<(String, Span)> {
         crate::cst::string_list(node, self.source, &mut |n| {
             if n.kind() == "array" {
@@ -7540,15 +7547,18 @@ impl<'a> Builder<'a> {
                         ctx.arg_names = self.extract_arg_name_list(node
                             .child_by_field_name("arguments")
                             .unwrap_or(node));
-                        // Moo/Moose `has`/`option` additionally needs the
-                        // classified option shape (shorthand `=> 1`, `handles`
-                        // hashref) a flat name list can't carry — the moo
-                        // plugin reads it from `has_options`. Built behind the
-                        // same registration gate, scoped by framework mode.
+                        // Moo/Moose `has`/`option`: the accessor options are
+                        // the generic value-shape pairs (`arg_pairs`); the
+                        // non-pair head (attr name(s) + resolved isa) rides
+                        // `has_options`. Built behind the same registration
+                        // gate, scoped by framework mode.
                         if let Some(mode) = self.current_package.as_ref()
                             .and_then(|pkg| self.framework_modes.get(pkg).copied())
                         {
-                            ctx.has_options = self.extract_has_options(node, mode);
+                            if let Some((opts, pairs)) = self.extract_has_options(node, mode) {
+                                ctx.has_options = Some(opts);
+                                ctx.arg_pairs = pairs;
+                            }
                         }
                     }
                     self.dispatch_function_call_plugins(ctx);
@@ -9078,21 +9088,21 @@ impl<'a> Builder<'a> {
 
         // After first arg: options (Moo/Moose) or default value (Mojo::Base).
         // Both the nested `=> (is => ...)` and the flat `, is => ...` forms
-        // route through `for_each_has_option_pair`.
+        // route through `has_option_pair_nodes`.
         let rest: Vec<Node> = first_named_idx
             .map(|first| args_children[first + 1..].to_vec())
             .unwrap_or_default();
         if mode == FrameworkMode::MojoBase {
             mojo_default_node = rest.iter().copied().find(|c| c.is_named());
         } else {
-            self.for_each_has_option_pair(&rest, |key, val_node| {
-                match key {
-                    "is" => {
+            for (k_node, val_node) in self.has_option_pair_nodes(&rest) {
+                match self.extract_node_string(k_node).as_deref() {
+                    Some("is") => {
                         if is_value.is_none() {
                             is_value = self.extract_node_string(val_node);
                         }
                     }
-                    "isa" => {
+                    Some("isa") => {
                         if isa_value.is_none() {
                             isa_value = self.extract_node_string(val_node);
                         }
@@ -9102,8 +9112,7 @@ impl<'a> Builder<'a> {
                     }
                     _ => {}
                 }
-                true
-            });
+            }
         }
 
         // Map isa value to InferredType
@@ -9452,7 +9461,16 @@ impl<'a> Builder<'a> {
     /// constructor-key synthesis stays native in `visit_has_call`. New Moo
     /// behavior wants the plugin; this seam is where structured option data
     /// crosses over.
-    fn extract_has_options(&mut self, node: Node<'a>, mode: FrameworkMode) -> Option<plugin::HasOptions> {
+    /// `has` decomposes into a non-pair head (attr name(s) + the resolved
+    /// `isa` type) and a tail of accessor options. The head is returned in
+    /// `HasOptions`; the options are the generic value-shape-classified
+    /// `arg_pairs` the caller sets on the context. `isa` is the one
+    /// type-semantic field core still resolves (roadmapped to move out).
+    fn extract_has_options(
+        &mut self,
+        node: Node<'a>,
+        mode: FrameworkMode,
+    ) -> Option<(plugin::HasOptions, Vec<plugin::ArgPair>)> {
         // Mojo::Base has no accessor-option vocabulary — its `has` is just
         // getter/setter + default value, all native.
         if mode == FrameworkMode::MojoBase {
@@ -9466,10 +9484,6 @@ impl<'a> Builder<'a> {
         };
 
         let mut attr_names: Vec<(String, Span)> = Vec::new();
-        let mut isa_value: Option<String> = None;
-        let mut isa_value_node: Option<Node<'a>> = None;
-        let mut option_nodes: Vec<(String, Node<'a>)> = Vec::new();
-
         let mut first_named_idx: Option<usize> = None;
         for (idx, child) in args_children.iter().enumerate() {
             if !child.is_named() { continue; }
@@ -9497,12 +9511,26 @@ impl<'a> Builder<'a> {
 
         if attr_names.is_empty() { return None; }
 
+        // Option tail → generic classified pairs. `isa` rides the pairs like
+        // any other keyword (the plugin ignores keywords it doesn't act on)
+        // AND is captured here for the type resolution core still owns.
+        let mut arg_pairs: Vec<plugin::ArgPair> = Vec::new();
+        let mut isa_value: Option<String> = None;
+        let mut isa_value_node: Option<Node<'a>> = None;
         if let Some(first) = first_named_idx {
             let rest = &args_children[first + 1..];
-            self.collect_has_option_value_nodes(
-                rest, &mut isa_value, &mut isa_value_node, &mut option_nodes,
-            );
+            for (k_node, v_node) in self.has_option_pair_nodes(rest) {
+                let Some(key) = self.extract_node_string(k_node) else { continue };
+                if key == "isa" {
+                    if isa_value.is_none() { isa_value = self.extract_node_string(v_node); }
+                    if isa_value_node.is_none() { isa_value_node = Some(v_node); }
+                }
+                let value = self.classify_value_shape(v_node);
+                arg_pairs.push(plugin::ArgPair { key, key_span: node_to_span(k_node), value });
+            }
         }
+
+        if arg_pairs.is_empty() { return None; }
 
         let isa_type = isa_value
             .as_deref()
@@ -9513,90 +9541,55 @@ impl<'a> Builder<'a> {
                 self.bag_query_expr_span(node_to_span(n))?.constrained_inner().cloned()
             });
 
-        // Classify each option by VALUE shape, not by keyword — the keyword
-        // vocabulary is the plugin's (rule #10). `shorthand` (`=> 1`),
-        // `explicit_name` (`=> 'name'`), and `handles` (`=> {..}` / `[..]`)
-        // are mutually exclusive value shapes; an option whose value matches
-        // none still passes through with all fields empty (the plugin's arms
-        // ignore keywords / shapes it doesn't act on).
-        let mut options: Vec<plugin::HasOption> = Vec::new();
-        for (keyword, val_node) in option_nodes {
-            let shorthand = self.node_is_numeric_one(val_node);
-            let explicit_name = if shorthand {
-                None
-            } else {
-                self.extract_node_string(val_node)
-            };
-            let handles = if shorthand || explicit_name.is_some() {
-                Vec::new()
-            } else {
-                self.extract_handles_delegation(val_node)
-            };
-            options.push(plugin::HasOption {
-                keyword,
-                shorthand,
-                explicit_name,
-                handles,
-            });
-        }
-
-        if options.is_empty() { return None; }
-        Some(plugin::HasOptions { attr_names, isa_type, options })
+        Some((plugin::HasOptions { attr_names, isa_type }, arg_pairs))
     }
 
-    /// Walk a `has` options fat-comma list, capturing the `isa` value (its
-    /// string and node) and the value node for *every other* option keyword —
-    /// no allowlist. The accessor-keyword vocabulary lives in `moo.rhai`
-    /// (rule #10); core only does the CST walk (rule #1) and hands the full
-    /// option list to the plugin, which decides which keywords matter. Keeps
-    /// the raw value nodes so the classifier can read the value shape.
-    /// Drive `f(key, value_node)` over a `has` call's option tail, regardless
-    /// of which surface form was written:
-    ///   `has 'name' => (is => 'ro')`  — options live in one nested list node
-    ///   `has 'name', is => 'ro'`      — options are flat siblings of the name
-    /// `rest` is the slice of `arguments` children *after* the first (name)
-    /// arg. A single nested list/paren delegates to the container walker; any
-    /// other shape is read as a flat fat-comma run.
-    fn for_each_has_option_pair<F>(&self, rest: &[Node<'a>], f: F)
-    where
-        F: FnMut(&str, Node<'a>) -> bool,
-    {
+    /// Collect a call's option-tail fat-comma pairs as `(key_node, value_node)`,
+    /// regardless of surface form — `has 'n' => (k => v)` (one nested list) or
+    /// `has 'n', k => v` (flat siblings). Owned Vec so the caller can run
+    /// `&self` classifiers over each pair without a borrow tangle.
+    fn has_option_pair_nodes(&self, rest: &[Node<'a>]) -> Vec<(Node<'a>, Node<'a>)> {
         let named: Vec<Node<'a>> = rest.iter().copied().filter(|n| n.is_named()).collect();
         if let [only] = named.as_slice() {
             if matches!(only.kind(), "list_expression" | "parenthesized_expression") {
-                self.for_each_pair_in_list(*only, f);
-                return;
+                return crate::cst::pair_nodes(*only);
             }
         }
-        self.for_each_pair_in_children(rest, f);
+        crate::cst::pair_nodes_in(rest)
     }
 
-    fn collect_has_option_value_nodes(
-        &self,
-        rest: &[Node<'a>],
-        isa_value: &mut Option<String>,
-        isa_value_node: &mut Option<Node<'a>>,
-        option_nodes: &mut Vec<(String, Node<'a>)>,
-    ) {
-        self.for_each_has_option_pair(rest, |key, val_node| {
-            // `isa` feeds the resolved attribute type, not an accessor option.
-            if key == "isa" {
-                if isa_value.is_none() {
-                    *isa_value = self.extract_node_string(val_node);
-                }
-                if isa_value_node.is_none() {
-                    *isa_value_node = Some(val_node);
-                }
-            } else {
-                option_nodes.push((key.to_string(), val_node));
+    /// Classify a fat-comma value node into the generic [`plugin::ValueShape`]
+    /// — no DSL vocabulary, just the syntactic shape. The plugin maps
+    /// `(keyword, shape)` to behavior.
+    fn classify_value_shape(&self, node: Node<'a>) -> plugin::ValueShape {
+        match node.kind() {
+            "number" => plugin::ValueShape::Num(
+                node.utf8_text(self.source).unwrap_or("").to_string(),
+            ),
+            "string_literal" | "interpolated_string_literal" => {
+                plugin::ValueShape::Str(self.extract_string_content(node).unwrap_or_default())
             }
-            true
-        });
-    }
-
-    /// `true` when the node is the integer literal `1` (the `=> 1` shorthand).
-    fn node_is_numeric_one(&self, node: Node<'_>) -> bool {
-        node.kind() == "number" && matches!(node.utf8_text(self.source), Ok("1"))
+            "bareword" | "autoquoted_bareword" => {
+                plugin::ValueShape::Str(node.utf8_text(self.source).unwrap_or("").to_string())
+            }
+            "anonymous_hash_expression" => {
+                let mut tokens: Vec<String> = Vec::new();
+                self.collect_hash_tokens(node, &mut tokens);
+                let mut pairs = Vec::new();
+                let mut i = 0;
+                while i + 1 < tokens.len() {
+                    pairs.push((tokens[i].clone(), tokens[i + 1].clone()));
+                    i += 2;
+                }
+                plugin::ValueShape::HashPairs(pairs)
+            }
+            "array_ref_expression" | "anonymous_array_expression" => {
+                plugin::ValueShape::ArrayItems(
+                    self.extract_string_list(node).into_iter().map(|(s, _)| s).collect(),
+                )
+            }
+            other => plugin::ValueShape::Other(other.to_string()),
+        }
     }
 
     /// Extract a string from a bareword or string-literal node.
@@ -9606,40 +9599,6 @@ impl<'a> Builder<'a> {
             "string_literal" | "interpolated_string_literal" => self.extract_string_content(node),
             _ => None,
         }
-    }
-
-    /// Parse a `handles` value into `(local, remote)` delegation pairs.
-    /// Hashref `{ local => 'remote' }` maps local→remote; arrayref / qw list
-    /// uses the same name for both. tree-sitter-perl nests fat-comma pairs
-    /// right-associatively inside a `list_expression`, so the hashref form
-    /// flattens the token stream and re-pairs.
-    fn extract_handles_delegation(&self, node: Node<'_>) -> Vec<(String, String)> {
-        let mut pairs = Vec::new();
-        match node.kind() {
-            "anonymous_hash_expression" => {
-                let mut tokens: Vec<String> = Vec::new();
-                self.collect_hash_tokens(node, &mut tokens);
-                let mut i = 0;
-                while i + 1 < tokens.len() {
-                    pairs.push((tokens[i].clone(), tokens[i + 1].clone()));
-                    i += 2;
-                }
-            }
-            "array_ref_expression" | "anonymous_array_expression" => {
-                for (name, _span) in self.extract_string_list(node) {
-                    pairs.push((name.clone(), name));
-                }
-            }
-            "quoted_word_list" => {
-                let mut names = Vec::new();
-                self.extract_qw_word_spans(node, &mut names);
-                for (name, _span) in names {
-                    pairs.push((name.clone(), name));
-                }
-            }
-            _ => {}
-        }
-        pairs
     }
 
     /// Flatten a fat-comma hash node into alternating key/value strings,
@@ -9835,25 +9794,6 @@ impl<'a> Builder<'a> {
                 }
             }
         }
-    }
-
-    /// Slice variant of `for_each_pair_in_list`: walk a flat sequence of
-    /// sibling nodes (including the inter-token commas / `=>`) as positional
-    /// pairs. Lets callers feed a *sub-range* of a container's children —
-    /// e.g. the option tail of `has 'name', is => 'ro', ...`, where the name
-    /// and the options share one `list_expression` parent and there's no
-    /// nested options node to hand to the container variant. String-key
-    /// projection over `for_each_pair_node_in_children`.
-    fn for_each_pair_in_children<F>(&self, children: &[Node<'a>], mut f: F)
-    where
-        F: FnMut(&str, Node<'a>) -> bool,
-    {
-        self.for_each_pair_node_in_children(children, |k_node, val| {
-            match self.extract_node_string(k_node) {
-                Some(key) => f(&key, val),
-                None => true,
-            }
-        });
     }
 
     /// Node-level pair walker over a flat sibling sequence — see

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -4182,6 +4182,41 @@ __PACKAGE__->belongs_to(author => 'Schema::Result::User', 'author_id');
 }
 
 #[test]
+fn test_dbic_instance_add_columns_does_not_synthesize() {
+    // A runtime `$rs->add_columns('x','y')` (dynamic query building, e.g. crm's
+    // ResultSet joins) is NOT a class declaration — the dbic plugin gates on
+    // `receiver_is_package`, so no column accessors are minted from it. Only
+    // `__PACKAGE__->add_columns` (class-level) declares columns.
+    let fa = build_fa(
+        "
+package My::RS;
+use base 'DBIx::Class::ResultSet';
+__PACKAGE__->add_columns('decl_col');
+sub widen {
+    my $self = shift;
+    $self->add_columns('runtime_col');
+}
+",
+    );
+    let decl: Vec<_> = fa
+        .symbols
+        .iter()
+        .filter(|s| s.name == "decl_col" && s.kind == SymKind::Method)
+        .collect();
+    let runtime: Vec<_> = fa
+        .symbols
+        .iter()
+        .filter(|s| s.name == "runtime_col" && s.kind == SymKind::Method)
+        .collect();
+    assert_eq!(decl.len(), 1, "class-level __PACKAGE__->add_columns declares");
+    assert_eq!(
+        runtime.len(),
+        0,
+        "instance $rs->add_columns is a runtime op, not a declaration"
+    );
+}
+
+#[test]
 fn test_accessor_return_type_propagation() {
     let src = r#"
 package Moo::Config;

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1536,48 +1536,6 @@ pub fn class_isa(
     false
 }
 
-/// Walk `class`'s full MRO (local `package_parents` ∪ cross-file graph) and
-/// return `true` as soon as any class in the chain (including `class` itself)
-/// satisfies `pred`. The predicate-variant of [`class_isa`] — for "does any
-/// ancestor look like a DBIC base class" where the target isn't a single
-/// fixed name. Same cycle-guard + budget as `class_isa`.
-pub fn any_ancestor<F>(
-    class: &str,
-    package_parents: &HashMap<String, Vec<String>>,
-    module_index: Option<&dyn CrossFileLookup>,
-    mut pred: F,
-) -> bool
-where
-    F: FnMut(&str) -> bool,
-{
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut stack: Vec<String> = vec![class.to_string()];
-    let mut budget = 0;
-    while let Some(cur) = stack.pop() {
-        if budget > 200 {
-            break;
-        }
-        budget += 1;
-        if !seen.insert(cur.clone()) {
-            continue;
-        }
-        if pred(&cur) {
-            return true;
-        }
-        if let Some(parents) = package_parents.get(&cur) {
-            for p in parents {
-                stack.push(p.clone());
-            }
-        }
-        if let Some(idx) = module_index {
-            for p in idx.parents_cached(&cur) {
-                stack.push(p);
-            }
-        }
-    }
-    false
-}
-
 /// Three-way outcome of resolving a [`ReceiverGated`] value against a
 /// concrete receiver class. Splitting "doesn't apply" from "can't tell"
 /// is load-bearing: `DoesNotApply` is a settled negative (the receiver

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 94;
+pub const EXTRACT_VERSION: i64 = 95;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -160,6 +160,19 @@ pub struct CallContext {
     /// `frameworks/moo.rhai`. `None` for every other call.
     #[serde(default)]
     pub has_options: Option<HasOptions>,
+    /// The call's positional args read as a flat string list — every
+    /// string-ish token (string-literal content, barewords, autoquoted
+    /// fat-comma keys, `qw(...)` words, foldable constants), each with
+    /// its tight selection span, in source order, separator-agnostic
+    /// (the fat-comma gotcha: never gate on `=>`). Non-string args
+    /// (hashrefs, coderefs) carry no name and are dropped. Produced by
+    /// `cst::string_list` (rule #1) so a list-DSL plugin reads its
+    /// accessor / column / export names without touching the tree.
+    /// Populated ONLY for calls whose verb a plugin registered via
+    /// [`FrameworkPlugin::arg_name_verbs`]; empty otherwise. See
+    /// `frameworks/dbic.rhai`.
+    #[serde(default)]
+    pub arg_names: Vec<(String, Span)>,
 }
 
 /// Decision-ready snapshot of a Moo/Moose `has` declaration's accessor
@@ -831,6 +844,18 @@ pub trait FrameworkPlugin: Send + Sync {
         &[]
     }
 
+    /// Call verbs (method or function names) for which this plugin wants
+    /// the args pre-flattened into `CallContext::arg_names` — the shared
+    /// `cst::string_list` extraction, run by core only when an APPLICABLE
+    /// plugin registered the verb. Keeps tree access in the builder
+    /// (rule #1) while leaving the "which calls, which names" vocabulary
+    /// with the plugin (rule #8/#10): core hardcodes no DSL verb. Default
+    /// empty; list-DSL plugins (DBIC columns/relationships, exporters)
+    /// declare theirs. See `frameworks/dbic.rhai`.
+    fn arg_name_verbs(&self) -> &[String] {
+        &[]
+    }
+
     /// Static role-contract parameter-type manifest — see `ParamType`.
     /// Applied at the sub-declaration walk. Default empty.
     fn param_types(&self) -> &[ParamType] {
@@ -1207,6 +1232,16 @@ impl PluginRegistry {
                 None
             }
         })
+    }
+
+    /// Does an APPLICABLE plugin want `verb`'s args pre-flattened into
+    /// `CallContext::arg_names`? Gates the builder's shared
+    /// `cst::string_list` extraction so it runs only for registered
+    /// verbs in packages where the declaring plugin actually fires —
+    /// no DSL verb is hardcoded in core.
+    pub fn wants_arg_names(&self, query: &TriggerQuery<'_>, verb: &str) -> bool {
+        self.applicable(query)
+            .any(|p| p.arg_name_verbs().iter().any(|v| v == verb))
     }
 
     /// Return plugins whose triggers match the current package context.

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -160,17 +160,12 @@ pub struct CallContext {
     /// `frameworks/moo.rhai`. `None` for every other call.
     #[serde(default)]
     pub has_options: Option<HasOptions>,
-    /// The call's positional args read as a flat string list — every
-    /// string-ish token (string-literal content, barewords, autoquoted
-    /// fat-comma keys, `qw(...)` words, foldable constants), each with
-    /// its tight selection span, in source order, separator-agnostic
-    /// (the fat-comma gotcha: never gate on `=>`). Non-string args
-    /// (hashrefs, coderefs) carry no name and are dropped. Produced by
-    /// `cst::string_list` (rule #1) so a list-DSL plugin reads its
-    /// accessor / column / export names without touching the tree.
-    /// Populated ONLY for calls whose verb a plugin registered via
-    /// [`FrameworkPlugin::arg_name_verbs`]; empty otherwise. See
-    /// `frameworks/dbic.rhai`.
+    /// The call's positional args as a flat `(name, span)` string list —
+    /// string-literal content, barewords, autoquoted keys, `qw(...)`
+    /// words, foldable constants; non-string args (hashrefs, coderefs)
+    /// carry no name. Via `cst::string_list` (rule #1), so a list-DSL
+    /// plugin reads its column / export names tree-free. Populated only
+    /// for verbs a plugin registered via [`FrameworkPlugin::arg_name_verbs`].
     #[serde(default)]
     pub arg_names: Vec<(String, Span)>,
     /// The call's fat-comma pairs, value-shape classified — the generic
@@ -179,29 +174,23 @@ pub struct CallContext {
     /// from here. Empty otherwise.
     #[serde(default)]
     pub arg_pairs: Vec<ArgPair>,
-    /// True when this is a method call whose receiver is the current
-    /// package itself — `__PACKAGE__->m(...)` or `CurrentClass->m(...)`,
-    /// i.e. a class-level call, not an instance one. The distinguishing
-    /// fact for framework DSLs that declare on the class (`add_columns`,
-    /// `load_components`, `mk_*_accessors`): a class-level call mutates the
-    /// class, an instance call (`$rs->add_columns(...)`) is a runtime
-    /// query/op and must NOT be read as a declaration. Always false for
-    /// function calls. See `frameworks/dbic.rhai`.
+    /// True when a method call's receiver is the current package itself
+    /// (`__PACKAGE__->m(...)` / `CurrentClass->m(...)`) — a class-level
+    /// call. Class-declaration DSLs (`add_columns`, `load_components`)
+    /// gate on it: an instance call (`$rs->add_columns(...)`) is a runtime
+    /// op, not a declaration. False for function calls.
     #[serde(default)]
     pub receiver_is_package: bool,
 }
 
-/// Decision-ready snapshot of a Moo/Moose `has` declaration's
-/// non-pair head: the attribute name(s) and the resolved `isa` type.
-/// The accessor *options* are carried generically in
-/// [`CallContext::arg_pairs`]. The builder fills this from the CST; the
-/// plugin reads it.
+/// A Moo/Moose `has` declaration's non-pair head: the attribute name(s)
+/// and the resolved `isa` type. The accessor *options* ride
+/// [`CallContext::arg_pairs`] generically.
 ///
-/// `isa_type` is the one remaining Moo-semantic field core resolves
-/// (`'Str'` → `String`, `"InstanceOf['X']"` → `InstanceOf`, …). Moving
-/// that mapping out to a plugin — leaning on the `type_constraint_*`
-/// seam — is roadmapped; once it lands, this whole struct dissolves into
-/// `arg_names` + `arg_pairs`.
+/// `isa_type` is the one Moo-semantic field core resolves (`'Str'` →
+/// `String`, `"InstanceOf['X']"` → `InstanceOf`). Moving it onto the
+/// `type_constraint_*` seam — after which this struct dissolves into
+/// `arg_names` + `arg_pairs` — is roadmapped.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HasOptions {
     /// `(attribute_name, name_token_span)` — one per attr (`has [qw/a b/]`
@@ -228,13 +217,10 @@ pub struct ArgPair {
     pub value: ValueShape,
 }
 
-/// The classified shape of a fat-comma pair's value. Generic — no DSL
-/// vocabulary. The plugin maps `(keyword, shape)` to behavior: a Moo
-/// `predicate => 1` is `Num("1")`, `predicate => 'has_x'` is `Str`,
-/// `handles => { l => r }` is `HashPairs`, `handles => [qw/m/]` is
-/// `ArrayItems`. Every variant carries data so it serializes to a
-/// single-key map (Rhai reads `value.Str` / `value.HashPairs` / … as
-/// `()` when absent).
+/// The classified shape of a fat-comma pair's value — generic, no DSL
+/// vocabulary; the plugin maps `(keyword, shape)` to behavior. Every
+/// variant carries data so it serializes to a single-key map: Rhai reads
+/// `value.Str` / `value.HashPairs` / … as `()` when absent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ValueShape {
     /// A string literal's content or a bareword's text.
@@ -881,14 +867,11 @@ pub trait FrameworkPlugin: Send + Sync {
         &[]
     }
 
-    /// Call verbs (method or function names) for which this plugin wants
-    /// the args pre-flattened into `CallContext::arg_names` — the shared
-    /// `cst::string_list` extraction, run by core only when an APPLICABLE
-    /// plugin registered the verb. Keeps tree access in the builder
-    /// (rule #1) while leaving the "which calls, which names" vocabulary
-    /// with the plugin (rule #8/#10): core hardcodes no DSL verb. Default
-    /// empty; list-DSL plugins (DBIC columns/relationships, exporters)
-    /// declare theirs. See `frameworks/dbic.rhai`.
+    /// Call verbs (method or function names) whose args this plugin wants
+    /// pre-flattened into `CallContext::arg_names` / `arg_pairs`. Core runs
+    /// the `cst::string_list` extraction only for verbs an applicable
+    /// plugin registered, so no DSL verb is hardcoded in core (rule #10).
+    /// Default empty. See `frameworks/dbic.rhai`.
     fn arg_name_verbs(&self) -> &[String] {
         &[]
     }
@@ -1271,11 +1254,9 @@ impl PluginRegistry {
         })
     }
 
-    /// Does an APPLICABLE plugin want `verb`'s args pre-flattened into
-    /// `CallContext::arg_names`? Gates the builder's shared
-    /// `cst::string_list` extraction so it runs only for registered
-    /// verbs in packages where the declaring plugin actually fires —
-    /// no DSL verb is hardcoded in core.
+    /// Does an applicable plugin want `verb`'s args pre-flattened? Gates
+    /// the builder's `cst::string_list` extraction to registered verbs in
+    /// packages where the declaring plugin actually fires.
     pub fn wants_arg_names(&self, query: &TriggerQuery<'_>, verb: &str) -> bool {
         self.applicable(query)
             .any(|p| p.arg_name_verbs().iter().any(|v| v == verb))

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -173,10 +173,25 @@ pub struct CallContext {
     /// `frameworks/dbic.rhai`.
     #[serde(default)]
     pub arg_names: Vec<(String, Span)>,
+    /// The call's fat-comma pairs, value-shape classified — the generic
+    /// keyval primitive (see [`ArgPair`]). Populated alongside `arg_names`
+    /// for registered verbs; the moo plugin reads its accessor options
+    /// from here. Empty otherwise.
+    #[serde(default)]
+    pub arg_pairs: Vec<ArgPair>,
 }
 
-/// Decision-ready snapshot of a Moo/Moose `has` declaration's accessor
-/// options. The builder fills it from the CST; the plugin reads it.
+/// Decision-ready snapshot of a Moo/Moose `has` declaration's
+/// non-pair head: the attribute name(s) and the resolved `isa` type.
+/// The accessor *options* are carried generically in
+/// [`CallContext::arg_pairs`]. The builder fills this from the CST; the
+/// plugin reads it.
+///
+/// `isa_type` is the one remaining Moo-semantic field core resolves
+/// (`'Str'` → `String`, `"InstanceOf['X']"` → `InstanceOf`, …). Moving
+/// that mapping out to a plugin — leaning on the `type_constraint_*`
+/// seam — is roadmapped; once it lands, this whole struct dissolves into
+/// `arg_names` + `arg_pairs`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HasOptions {
     /// `(attribute_name, name_token_span)` — one per attr (`has [qw/a b/]`
@@ -188,29 +203,41 @@ pub struct HasOptions {
     /// return to the remote method on that class.
     #[serde(default)]
     pub isa_type: Option<InferredType>,
-    pub options: Vec<HasOption>,
 }
 
-/// One Moo/Moose `has` accessor option (`predicate`, `clearer`, `writer`,
-/// `reader`, `builder`, `handles`). The builder classifies the value
-/// shape; the plugin maps the keyword to a method-name pattern.
+/// One fat-comma pair of a call's argument list, value-shape classified —
+/// the generic keyval primitive. `key` is the autoquoted/string LHS; the
+/// builder walks the value node (rule #1) into a [`ValueShape`] so the
+/// plugin reads its meaning without touching the tree. Separator-agnostic
+/// (the LHS is a key whether written `k => v` or `'k', v`). Populated for
+/// the verbs a plugin registers (`arg_name_verbs`); see `frameworks/moo.rhai`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HasOption {
-    /// `"predicate"`, `"clearer"`, `"writer"`, `"reader"`, `"builder"`,
-    /// `"handles"`.
-    pub keyword: String,
-    /// The value was `=> 1` — the plugin derives the method name from the
-    /// attribute (`has_<attr>`, `clear_<attr>`, `_build_<attr>`, …).
-    #[serde(default)]
-    pub shorthand: bool,
-    /// The value was an explicit string — use it verbatim as the method name.
-    #[serde(default)]
-    pub explicit_name: Option<String>,
-    /// For `handles => {local => remote}` / `[qw/m.../]`: the
-    /// `(local_name, remote_name)` delegation pairs (local == remote for
-    /// the arrayref form). Empty for the non-`handles` keywords.
-    #[serde(default)]
-    pub handles: Vec<(String, String)>,
+pub struct ArgPair {
+    pub key: String,
+    pub key_span: Span,
+    pub value: ValueShape,
+}
+
+/// The classified shape of a fat-comma pair's value. Generic — no DSL
+/// vocabulary. The plugin maps `(keyword, shape)` to behavior: a Moo
+/// `predicate => 1` is `Num("1")`, `predicate => 'has_x'` is `Str`,
+/// `handles => { l => r }` is `HashPairs`, `handles => [qw/m/]` is
+/// `ArrayItems`. Every variant carries data so it serializes to a
+/// single-key map (Rhai reads `value.Str` / `value.HashPairs` / … as
+/// `()` when absent).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ValueShape {
+    /// A string literal's content or a bareword's text.
+    Str(String),
+    /// A numeric literal's text (`1` is the Moo `=> 1` shorthand).
+    Num(String),
+    /// `{ k => v, ... }` flattened to `(key, value)` string pairs.
+    HashPairs(Vec<(String, String)>),
+    /// `[ a, b ]` / `[qw/a b/]` flattened to its string items.
+    ArrayItems(Vec<String>),
+    /// A value we don't classify (coderef, scalar var, nested expr);
+    /// carries the node kind for debugging.
+    Other(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -179,6 +179,16 @@ pub struct CallContext {
     /// from here. Empty otherwise.
     #[serde(default)]
     pub arg_pairs: Vec<ArgPair>,
+    /// True when this is a method call whose receiver is the current
+    /// package itself — `__PACKAGE__->m(...)` or `CurrentClass->m(...)`,
+    /// i.e. a class-level call, not an instance one. The distinguishing
+    /// fact for framework DSLs that declare on the class (`add_columns`,
+    /// `load_components`, `mk_*_accessors`): a class-level call mutates the
+    /// class, an instance call (`$rs->add_columns(...)`) is a runtime
+    /// query/op and must NOT be read as a declaration. Always false for
+    /// function calls. See `frameworks/dbic.rhai`.
+    #[serde(default)]
+    pub receiver_is_package: bool,
 }
 
 /// Decision-ready snapshot of a Moo/Moose `has` declaration's

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -139,6 +139,7 @@ pub struct RhaiPlugin {
     type_constraint_names: Vec<String>,
     app_surface_consumers: Vec<String>,
     role_makers: Vec<String>,
+    arg_name_verbs: Vec<String>,
     topic_route_dsl: Option<crate::plugin::TopicRouteDsl>,
     engine: Arc<Engine>,
     ast: Arc<AST>,
@@ -326,6 +327,27 @@ impl RhaiPlugin {
             }
         }
 
+        // `arg_name_verbs()` — call verbs wanting flat-arg-name
+        // extraction; same optional, fail-safe array-of-strings shape.
+        let mut arg_name_verbs: Vec<String> = Vec::new();
+        if signatures.iter().any(|n| n == "arg_name_verbs") {
+            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "arg_name_verbs", ()) {
+                Ok(arr) => {
+                    for d in arr {
+                        match from_dynamic::<String>(&d) {
+                            Ok(s) => arg_name_verbs.push(s),
+                            Err(e) => log::error!(
+                                "plugin `{}` arg_name_verbs() bad entry: {}",
+                                id,
+                                e
+                            ),
+                        }
+                    }
+                }
+                Err(e) => log::error!("plugin `{}` arg_name_verbs() failed: {}", id, e),
+            }
+        }
+
         // `topic_route_dsl()` — optional manifest map; bad shapes log
         // and disable rather than fail the plugin.
         let mut topic_route_dsl: Option<crate::plugin::TopicRouteDsl> = None;
@@ -355,6 +377,7 @@ impl RhaiPlugin {
             type_constraint_names,
             app_surface_consumers,
             role_makers,
+            arg_name_verbs,
             topic_route_dsl,
             engine,
             ast: Arc::new(ast),
@@ -452,6 +475,10 @@ impl FrameworkPlugin for RhaiPlugin {
 
     fn role_makers(&self) -> &[String] {
         &self.role_makers
+    }
+
+    fn arg_name_verbs(&self) -> &[String] {
+        &self.arg_name_verbs
     }
 
     fn topic_route_dsl(&self) -> Option<crate::plugin::TopicRouteDsl> {
@@ -560,6 +587,7 @@ const BUNDLED: &[(&str, &str)] = &[
     ("minion", include_str!("../../frameworks/minion.rhai")),
     ("data-printer", include_str!("../../frameworks/data-printer.rhai")),
     ("dbic-resultddl", include_str!("../../frameworks/dbic-resultddl.rhai")),
+    ("dbic", include_str!("../../frameworks/dbic.rhai")),
     ("type-tiny", include_str!("../../frameworks/type-tiny.rhai")),
     ("dancer", include_str!("../../frameworks/dancer.rhai")),
     ("moo", include_str!("../../frameworks/moo.rhai")),
@@ -777,6 +805,7 @@ mod tests {
             current_package_parents: vec![],
             current_package_uses: vec!["Demo".into()],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_function_call(&ctx);
@@ -850,6 +879,7 @@ mod tests {
             ("minion", include_str!("../../frameworks/minion.rhai")),
             ("data-printer", include_str!("../../frameworks/data-printer.rhai")),
             ("dbic-resultddl", include_str!("../../frameworks/dbic-resultddl.rhai")),
+            ("dbic", include_str!("../../frameworks/dbic.rhai")),
             ("type-tiny", include_str!("../../frameworks/type-tiny.rhai")),
             ("dancer", include_str!("../../frameworks/dancer.rhai")),
             ("moo", include_str!("../../frameworks/moo.rhai")),
@@ -905,6 +935,7 @@ mod tests {
             current_package_parents: vec!["Mojo::EventEmitter".into()],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -974,6 +1005,7 @@ mod tests {
                 current_package_parents: vec![],
                 current_package_uses: vec!["DBIx::Class::ResultDDL".into()],
                 has_options: None,
+                arg_names: Vec::new(),
             };
 
             let emissions = plugin.on_function_call(&ctx);
@@ -1019,6 +1051,7 @@ mod tests {
             current_package_parents: vec![],
             current_package_uses: vec!["DBIx::Class::ResultDDL".into()],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         // Dynamic column name (`col $field => ...`) — nothing to synthesize.
@@ -1073,6 +1106,7 @@ mod tests {
             current_package_parents: vec!["Mojo::EventEmitter".into()],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1213,6 +1247,7 @@ mod tests {
             current_package_parents: vec!["Catalyst::Controller".into()],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1264,6 +1299,7 @@ mod tests {
             current_package_parents: vec!["Catalyst::Controller".into()],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1315,6 +1351,7 @@ mod tests {
             current_package_parents: vec!["Catalyst::Controller".into()],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1350,6 +1387,7 @@ mod tests {
             current_package_parents: vec![],
             current_package_uses: vec![],
             has_options: None,
+            arg_names: Vec::new(),
         };
         assert!(plugin.on_function_call(&ctx).is_empty());
     }

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -806,6 +806,7 @@ mod tests {
             current_package_uses: vec!["Demo".into()],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_function_call(&ctx);
@@ -936,6 +937,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1006,6 +1008,7 @@ mod tests {
                 current_package_uses: vec!["DBIx::Class::ResultDDL".into()],
                 has_options: None,
                 arg_names: Vec::new(),
+                arg_pairs: Vec::new(),
             };
 
             let emissions = plugin.on_function_call(&ctx);
@@ -1052,6 +1055,7 @@ mod tests {
             current_package_uses: vec!["DBIx::Class::ResultDDL".into()],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         // Dynamic column name (`col $field => ...`) — nothing to synthesize.
@@ -1107,6 +1111,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1248,6 +1253,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1300,6 +1306,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1352,6 +1359,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1388,6 +1396,7 @@ mod tests {
             current_package_uses: vec![],
             has_options: None,
             arg_names: Vec::new(),
+            arg_pairs: Vec::new(),
         };
         assert!(plugin.on_function_call(&ctx).is_empty());
     }

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -807,6 +807,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_function_call(&ctx);
@@ -938,6 +939,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1009,6 +1011,7 @@ mod tests {
                 has_options: None,
                 arg_names: Vec::new(),
                 arg_pairs: Vec::new(),
+                receiver_is_package: false,
             };
 
             let emissions = plugin.on_function_call(&ctx);
@@ -1056,6 +1059,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         // Dynamic column name (`col $field => ...`) — nothing to synthesize.
@@ -1112,6 +1116,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1254,6 +1259,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1307,6 +1313,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1360,6 +1367,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
 
         let emissions = plugin.on_method_call(&ctx);
@@ -1397,6 +1405,7 @@ mod tests {
             has_options: None,
             arg_names: Vec::new(),
             arg_pairs: Vec::new(),
+            receiver_is_package: false,
         };
         assert!(plugin.on_function_call(&ctx).is_empty());
     }


### PR DESCRIPTION
Roadmap "Now" item 2 (DBIC out of core), phase 1. Moves the DBIC result-class DSL synthesis out of the builder into a bundled Rhai plugin, the way `moo.rhai` took the `has`-option vocabulary.

## What moved
`frameworks/dbic.rhai` (trigger `ClassIsa("DBIx::Class")`) now synthesizes:
- **columns** (`add_columns` / `add_column`) → accessor `Method` + `HashKeyDef` owned by the result class.
- **relationships** (`has_many` / `many_to_many` → `DBIx::Class::ResultSet` return; `belongs_to` / `has_one` / `might_have` → row-class return).

Removed from `builder.rs`: `is_dbic_class`, `visit_dbic_class_method`, `visit_dbic_add_columns`, `extract_dbic_column_names`, `visit_dbic_relationship`, `extract_relationship_args`, plus the now-dead `file_analysis::any_ancestor`. `load_components` parent registration stays core (generic component machinery). Net ~150 fewer lines in `builder.rs`.

## Mechanism — registration-driven, no DSL verb in core
- New `CallContext.arg_names` — the call's args as a flat `(name, span)` string list via the shared `cst::string_list`. Named for the data shape, not a DSL.
- New `FrameworkPlugin::arg_name_verbs()` manifest (mirrored in the Rhai host like `role_makers` / `dispatch_verbs`): the verbs whose args core should flatten. Core populates `arg_names` **only** when an applicable plugin registered the verb (`PluginRegistry::wants_arg_names`).
- **moo** now declares `arg_name_verbs ["has","option"]`; the `has_options` gate is driven by that registration instead of a hardcoded `name == "has"`.

## Verification
`cargo test` 943 + 4 green (migrated DBIC tests + the parametric ResultSet suite unchanged). e2e + gold not runnable in the dev sandbox (no nvim; CPAN substrate not installable) — relying on CI here.

⚠️ Open question under review with the maintainer: the fold used for `arg_names`. Multi-line fat-comma keys for certain words (`name`, `status`) parse as plain `bareword` (not `autoquoted_bareword`), which the const-folding `extract_string_list` would drop; this PR uses a literal-fallback fold. May change pending the grammar discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxDsDEmcBGyJX4489PtdTt)_