### PR TITLE
Add Claude Code plugin (LSP integration)

### DIFF
--- a/editors/claude-code/.claude-plugin/plugin.json
+++ b/editors/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "perl-lsp",
+  "displayName": "Perl (perl-lsp)",
+  "version": "0.1.0",
+  "description": "Perl language intelligence for Claude Code: type inference without annotations, cross-file navigation, and framework awareness for Moo/Moose, Mojolicious, and DBIx::Class. Requires the perl-lsp binary on PATH (cargo install perl-lsp).",
+  "author": {
+    "name": "tree-sitter-perl",
+    "url": "https://github.com/tree-sitter-perl"
+  },
+  "homepage": "https://github.com/tree-sitter-perl/perl-tree-sitter-lsp",
+  "repository": "https://github.com/tree-sitter-perl/perl-tree-sitter-lsp",
+  "license": "Artistic-2.0",
+  "keywords": ["perl", "lsp", "language-server", "type-inference", "mojolicious", "moo", "moose", "dbix-class"]
+}

--- a/editors/claude-code/.lsp.json
+++ b/editors/claude-code/.lsp.json
@@ -1,0 +1,11 @@
+{
+  "perl": {
+    "command": "perl-lsp",
+    "extensionToLanguage": {
+      ".pl": "perl",
+      ".pm": "perl",
+      ".t": "perl"
+    },
+    "diagnostics": true
+  }
+}

--- a/editors/claude-code/README.md
+++ b/editors/claude-code/README.md
@@ -1,0 +1,68 @@
+# perl-lsp for Claude Code
+
+Gives Claude Code real-time Perl intelligence — type inference, cross-file
+navigation, and framework awareness — by wiring up the
+[perl-lsp](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp) language
+server over LSP.
+
+## Prerequisite: install the language server
+
+This plugin is **configuration only**. It tells Claude Code how to talk to
+`perl-lsp`; it does **not** download or run anything on its own. Install the
+binary yourself first so it's on your `PATH`:
+
+```bash
+cargo install perl-lsp
+```
+
+Verify it's reachable:
+
+```bash
+perl-lsp --version
+```
+
+If the binary is missing, Claude Code reports `Executable not found in $PATH`
+in the `/plugin` **Errors** tab and Perl features stay off until you install it.
+
+## Install the plugin
+
+`perl-lsp` is distributed through the public Claude Code plugin marketplaces.
+Once you've added one of them, install it by name:
+
+```
+/plugin install perl-lsp@<marketplace>
+```
+
+The server starts lazily — the first time you open a `.pl`, `.pm`, or `.t`
+file in a session — and speaks stdio. No flags, no configuration.
+
+### Try it before it's published (local)
+
+The plugin needs no marketplace to run locally. Copy this directory into your
+skills directory and Claude Code auto-loads it on the next session:
+
+```bash
+cp -r editors/claude-code ~/.claude/skills/perl-lsp
+```
+
+It loads as `perl-lsp@skills-dir` with no install step. (Still requires the
+`perl-lsp` binary on `PATH`.)
+
+## What you get
+
+- **Type inference, no annotations** — types are inferred from how values are
+  used, and flow across files and through method chains.
+- **Navigation** — go-to-definition and find-references, scope-aware and
+  cross-file (including through inheritance).
+- **Framework awareness** — Moo/Moose `has`, Mojolicious, and DBIx::Class
+  contribute real symbols, so completion and goto-def understand them.
+- **Diagnostics** — unresolved function/method hints, deliberately
+  low-severity (dynamic Perl is normal). Set `"diagnostics": false` in
+  `.lsp.json` if you want navigation without diagnostic injection.
+
+## Trust note
+
+The only Perl that ever runs is `perl-lsp`'s short `@INC` probe at startup;
+everything else is static analysis over the parse tree. This plugin adds no
+hooks and downloads nothing — you stay in control of what lands on your
+machine.


### PR DESCRIPTION
Adds a config-only Claude Code plugin under `editors/claude-code/` so Claude Code can drive `perl-lsp` over LSP — type inference, navigation, framework awareness — natively in-session.

## What's here
- `.claude-plugin/plugin.json` — manifest (`perl-lsp`, Artistic-2.0)
- `.lsp.json` — names the bare `perl-lsp` binary, maps `.pl`/`.pm`/`.t` → `perl`, `diagnostics: true`
- `README.md` — prerequisite (`cargo install perl-lsp`), lazy stdio launch, marketplace-free skills-dir test path, trust note

## Design
Config only: no hooks, no binary download. It names the `perl-lsp` the user installs themselves, matching the consent model of every other LSP plugin and preserving the "only Perl that runs is the @INC probe" story. We deliberately rejected a SessionStart auto-fetch hook on consent grounds.

No own `marketplace.json` — the public marketplaces (Piebald LSP catalog, Anthropic community) own the catalog and reference this directory as a source. Merging to `main` gives them a stable path to point at.

## Verification
- Passes `claude plugin validate --strict`.
- Dogfooded live: installed via skills-dir, confirmed the LSP launches and drives goto-def / hover / documentSymbol / findReferences against real Perl in `test_files/` (DBIC row-type chains, cross-file Mojo route targets, Minion task resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)