### PR TITLE
release: 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ crate / VS Code extension versions.
 
 ## Unreleased
 
+## v0.4.2 — 2026-06-17
+
+The crate and the VS Code extension are republished together at this version.
+(0.4.1 was a vscode extension-only republish and as such is skipped.)
+
+### Frameworks & plugins
+
+- **tree-sitter-perl 1.1.3.** Fat-comma keys on continuation lines of a
+  multi-line list (`add_columns(\n  name => …,\n  status => …,\n)`, including
+  keyword-like names) now parse as literal keys, so those columns resolve.
+- DBIC support has moved out of core and into a bundled plugin.
+- **New plugin-manifest hooks** (for `.perl-lsp` / `perl-gen` plugins):
+  - `arg_name_verbs()` + `arg_pairs` / `receiver_is_package` — a generic keyval
+    surface, so list/DSL plugins read their columns / options / names without
+    any DSL verb hardcoded in core.
+  - `load_verbs()` — declares which method names load a module (Mojo's
+    `plugin`), so load tracking is trigger-independent: every `$app->plugin(…)`
+    in a nested-plugin cascade is seen, including `for qw/A B C/` loops.
+  - `role_makers()` — declares modules whose `use` makes the consumer a role,
+    so a house role engine is one manifest line in a `.perl-lsp` plugin away.
+
+### Helper-load & cross-file lint
+
+- **`helper-not-loaded` lint** (hint). A method call whose only resolution is a
+  plugin bridge from a workspace module that *no workspace file loads* — the
+  helper exists but nothing pulls it in. Honest-quiet: exact-or-tail load
+  matching (a default-namespace guess never suppresses an app-custom provider),
+  installed CPAN plugins exempt ("downloaded = intended").
+- **Loader-config param typing.** `plugin 'X', { … }` types module `X`'s
+  `register` config param from the config shapes at every call site
+  (agreement-folded across callers; keyed disagreement opens the shape).
+- **Cross-file slot typing.** `$self->{k}` reads narrow through `$self->{k} = …`
+  writes in *other* files and up the ancestry chain.
+- **Extensionless entrypoints indexed.** A shallow shebang scan over the repo
+  root + `bin/` + `script/` finds Perl entrypoint scripts with no `.pl`
+  extension (Mojo::Lite apps), so `plugin 'X'` loads wired only through them are
+  visible.
+
+### Navigation & outline
+
+- **package goto-def.** The module name in `use Foo::Bar;` now jumps to its `.pm`
+  (or the in-file package).
+- **Outline nests under packages.** `documentSymbol` folds each file-scope sub
+  under its owning `package`/`class`, so the outline, sticky-scroll, and
+  breadcrumb nest correctly. Plain scripts stay flat.
+- **Regex semantic token dropped.** `qr//` / regex literals no longer emit a
+  `regexp` token, letting the editor's TextMate `string.regexp` scope keep
+  escape-sequence highlighting.
+
 ### Role contracts, part 2 — long-distance intelligence
 
 - **Go-to-implementation** (`textDocument/implementation`, new capability).
@@ -24,15 +73,10 @@ crate / VS Code extension versions.
   it. Calibrated to zero false positives on the 2,293-module substrate and
   on a large production codebase.
 - **Runtime-generated parents recorded as incomplete ancestry.** `with
-  ReportProxy(type => ...)` — a parent edge that doesn't fold to a literal
+  ParametricRole(type => ...)` — a parent edge that doesn't fold to a literal
   name — now marks the package's ancestry incomplete, suppressing
   inheritance-dependent diagnostics on it (removed 41 false
   `unresolved-method` hints on the calibration codebase).
-- **Plugin-declared role engines** — new `role_makers()` plugin manifest
-  (array of module names whose `use` makes the consumer a role). Core
-  holds no engine list: the base four (Moo::Role, Moose::Role,
-  Mouse::Role, Role::Tiny) ride `frameworks/moo.rhai`'s manifest, and a
-  house role engine is one manifest line in a `.perl-lsp` plugin away.
 - **`children_index`** — new reverse edge in the module index (parent
   class/role → composing/inheriting modules), the shared primitive for the
   long-distance family. All reverse maps now live in one bundle fed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-lsp"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 authors = ["tree-sitter-perl contributors"]
 license = "Artistic-2.0"

--- a/editors/claude-code/README.md
+++ b/editors/claude-code/README.md
@@ -9,7 +9,10 @@ server over LSP.
 
 This plugin is **configuration only**. It tells Claude Code how to talk to
 `perl-lsp`; it does **not** download or run anything on its own. Install the
-binary yourself first so it's on your `PATH`:
+binary yourself first so it's on your `PATH`. Either download a prebuilt binary
+for your platform (macOS, Linux, Windows) from the
+[releases page](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp/releases)
+and put `perl-lsp` on your `PATH`, or build from source with a Rust toolchain:
 
 ```bash
 cargo install perl-lsp

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-perl-lsp",
   "displayName": "Perl (perl-lsp)",
   "description": "Perl language support powered by tree-sitter-perl — type inference, cross-file navigation, framework intelligence",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "tree-sitter-perl",
   "license": "Artistic-2.0",
   "icon": "icon.png",


### PR DESCRIPTION
Release prep for **0.4.2** — no code changes, version + docs only.

- **Version bump**: crate `0.4.0` → `0.4.2`, VS Code extension `0.4.1` → `0.4.2` (shared version). 0.4.1 was a botched extension-only republish, so it's skipped.
- **CHANGELOG**: new `v0.4.2` section covering everything since 0.4.0 — DBIC out of core + the generic plugin-manifest hooks (`arg_name_verbs` / `arg_pairs` / `receiver_is_package` / `load_verbs` / `role_makers`), the helper-load & cross-file lint family, navigation/outline fixes, and role contracts part 2.
- **`editors/claude-code/README.md`**: points users at prebuilt release binaries (macOS/Linux/Windows) as an alternative to building from source.

Does **not** tag or publish — that's a separate manual step once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)