### PR TITLE
ci: ship static musl Linux binaries (x86_64 + aarch64), static Windows CRT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          # Linux ships fully-static musl binaries (no glibc dependency → runs on
+          # any distro, Alpine, scratch containers). aarch64 builds natively on
+          # GitHub's arm runner, so the bundled C deps (SQLite, zstd, grammars)
+          # need no cross toolchain — just musl-gcc from musl-tools.
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
             archive: tar.gz
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -120,9 +127,12 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
+          # crt-static folds the VC runtime into the .exe so it doesn't depend
+          # on vcruntime140.dll being present (UCRT itself ships with Win10+).
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
+            rustflags: "-C target-feature=+crt-static"
 
     runs-on: ${{ matrix.os }}
 
@@ -135,8 +145,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
 
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'

--- a/editors/mason/package.yaml
+++ b/editors/mason/package.yaml
@@ -13,7 +13,10 @@ source:
   id: pkg:github/tree-sitter-perl/perl-tree-sitter-lsp@{{ version }}
   asset:
     - target: linux_x64
-      file: perl-lsp-x86_64-unknown-linux-gnu.tar.gz
+      file: perl-lsp-x86_64-unknown-linux-musl.tar.gz
+      bin: perl-lsp
+    - target: linux_arm64
+      file: perl-lsp-aarch64-unknown-linux-musl.tar.gz
       bin: perl-lsp
     - target: darwin_x64
       file: perl-lsp-x86_64-apple-darwin.tar.gz

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -85,7 +85,8 @@ async function ensureBinary(
 }
 
 const PLATFORM_MAP: Record<string, string> = {
-  "linux-x64": "perl-lsp-x86_64-unknown-linux-gnu.tar.gz",
+  "linux-x64": "perl-lsp-x86_64-unknown-linux-musl.tar.gz",
+  "linux-arm64": "perl-lsp-aarch64-unknown-linux-musl.tar.gz",
   "darwin-x64": "perl-lsp-x86_64-apple-darwin.tar.gz",
   "darwin-arm64": "perl-lsp-aarch64-apple-darwin.tar.gz",
   "win32-x64": "perl-lsp-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
## What

Switches Linux release artifacts from dynamic glibc to **fully-static musl**, and adds an **aarch64 Linux** build (requested by @shoichikaji, author of cpm 🎉).

## Why

The previous `x86_64-unknown-linux-gnu` binary dynamically links glibc, so it breaks on distros with an older glibc than the build runner and won't run on Alpine/musl systems at all. Static musl binaries are zero-dependency — they run on any Linux distro, Alpine, and `scratch` containers.

The crate has no OpenSSL/TLS dependency and all C deps are vendored (bundled SQLite via `rusqlite`, `zstd`, the tree-sitter grammars), so musl builds cleanly.

## Changes

- **Linux → static musl**: replaces `x86_64-unknown-linux-gnu` with `x86_64-unknown-linux-musl`, adds `aarch64-unknown-linux-musl` built **natively** on GitHub's `ubuntu-24.04-arm` runner (no cross toolchain). A `musl-tools` install step (gated on the target) provides `musl-gcc` for the bundled C deps.
- **Windows → self-contained .exe**: adds `-C target-feature=+crt-static` so the binary doesn't depend on `vcruntime140.dll` (UCRT itself ships with Win10+).
- **macOS**: unchanged (Apple disallows fully-static libc; binaries already depend only on OS-guaranteed libraries).
- **Consumers updated**: the VS Code extension (`PLATFORM_MAP`) and Mason manifest now reference the musl asset names and gain `linux-arm64` entries. Since the musl binary is static, it serves glibc users on the existing `linux_x64` target too.

## Validation

x86_64 musl built and validated locally:

- `ldd` → `statically linked`; `file` → `static-pie linked`
- runs (`perl-lsp 0.4.2`)
- tree-sitter C grammar parses correctly
- full server startup (`--dump-package`) runs workspace index + witness-bag type inference
- bundled SQLite (`rusqlite`) initializes without panic

The aarch64-musl variant is the identical recipe building natively on arm; it'll exercise on the first tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)