### PR TITLE
Body-enclosing outline extents for inline-sub registrations (sticky scroll / breadcrumb)

### DIFF
--- a/frameworks/minion.rhai
+++ b/frameworks/minion.rhai
@@ -200,7 +200,10 @@ fn on_method_call(ctx) {
                     "foreground",
                 ],
                 params: params,
-                span: task.name_span,
+                // Extent covers the whole `add_task(name => sub {…})` so the
+                // outline node encloses the task body — editor sticky-scroll /
+                // breadcrumb pin the task while the cursor is inside it.
+                span: ctx.call_span,
                 selection_span: task.name_span,
                 // Tasks render as Function, not Event — you don't
                 // subscribe to them, you enqueue calls. Matches how

--- a/frameworks/mojo-events.rhai
+++ b/frameworks/mojo-events.rhai
@@ -102,7 +102,10 @@ fn on_method_call(ctx) {
                 owner: ev.owner,
                 dispatchers: ["emit"],
                 params: params,
-                span: ev.name_span,
+                // Extent covers the whole `on(name => sub {…})` so the outline
+                // node encloses the handler body — editor sticky-scroll /
+                // breadcrumb pin the event while the cursor is inside it.
+                span: ctx.call_span,
                 selection_span: ev.name_span,
             }
         };

--- a/frameworks/mojo-helpers.rhai
+++ b/frameworks/mojo-helpers.rhai
@@ -177,7 +177,12 @@ fn helper_emissions(ctx, name, params, name_span, ret_edge) {
         out += #{
             Method: #{
                 name: name,
-                span: name_span,
+                // Extent spans the whole `helper(name => sub {…})` call so
+                // the outline node encloses the callback body — that's what
+                // lets editor sticky-scroll / breadcrumb pin the helper while
+                // the cursor is inside it. `selection_span` stays the name so
+                // goto-def / highlight anchor precisely.
+                span: ctx.call_span,
                 selection_span: name_span,
                 params: params,
                 is_method: true,
@@ -284,7 +289,9 @@ fn helper_emissions(ctx, name, params, name_span, ret_edge) {
     out += #{
         Method: #{
             name: leaf,
-            span: name_span,
+            // Body-enclosing extent for sticky-scroll / breadcrumb (see the
+            // single-segment helper above); name stays the goto anchor.
+            span: ctx.call_span,
             selection_span: name_span,
             params: params,
             is_method: true,

--- a/frameworks/mojo-lite.rhai
+++ b/frameworks/mojo-lite.rhai
@@ -286,7 +286,11 @@ fn on_function_call(ctx) {
             owner: #{ Class: "Mojolicious::Controller" },
             dispatchers: ["url_for", "redirect_to"],
             params: params,
-            span: args[0].span,
+            // Extent covers the whole `get '/path' => sub {…}` so the outline
+            // node encloses the route body — editor sticky-scroll / breadcrumb
+            // pin the route while the cursor is inside it. Selection stays the
+            // path string for a precise goto anchor.
+            span: ctx.call_span,
             selection_span: args[0].span,
             display: "Route",
             hide_in_outline: false,

--- a/src/file_analysis_tests.rs
+++ b/src/file_analysis_tests.rs
@@ -915,6 +915,45 @@ sub three {}
     );
 }
 
+/// A Mojo helper registered inside `startup` nests under it AND its outline
+/// extent encloses the callback body — the LSP containment the editor's
+/// sticky-scroll / breadcrumb rely on to pin the helper while the cursor is
+/// in its body. `selection_span` stays the name so goto-def anchors precisely.
+#[test]
+fn mojo_helper_outline_extent_covers_callback_body() {
+    let src = "\
+package MyApp;
+use Mojo::Base 'Mojolicious', -signatures;
+sub startup ($self) {
+  $self->helper(format_money => sub ($c, $cents) {
+    my $dollars = $cents / 100;
+    return sprintf '$%.2f', $dollars;
+  });
+}
+1;
+";
+    let fa = build_fa_from_source(src);
+    let outline = fa.document_symbols();
+    let myapp = outline.iter().find(|s| s.name == "MyApp").expect("MyApp container");
+    let startup = myapp
+        .children
+        .iter()
+        .find(|s| s.name == "startup")
+        .expect("startup nested under MyApp");
+    let helper = startup
+        .children
+        .iter()
+        .find(|s| s.name.contains("format_money"))
+        .expect("helper nested under startup");
+    // Name line is L3; the callback body runs through L5.
+    assert_eq!(helper.selection_span.start.row, 3, "selection anchors the name");
+    assert!(
+        helper.span.end.row >= 5,
+        "outline extent must enclose the callback body, got end {:?}",
+        helper.span.end,
+    );
+}
+
 /// #61: goto-def on the module name in `use Foo::Bar;` must resolve as a
 /// package reference (→ external `.pm`), not fall back to the use statement's
 /// own Module symbol (the self-reference bug). The builder emits a PackageRef


### PR DESCRIPTION
Plugin-synthesized registrations that wrap an inline `sub {…}` body emitted their outline symbol with a **name/path-only `span`**, so the `DocumentSymbol.range` didn't enclose the callback body. The editor's **sticky scroll** (and breadcrumb) pin a symbol while the viewport is inside its `range` — with a name-only range there was nothing to pin while scrolling a helper/task/route/event body.

Fix: widen the outline **extent** to `ctx.call_span` (the whole `verb(name => sub {…})` call) for these registrations, keeping `selection_span` on the name/path so goto-def / highlight stay precise. Each symbol already nests under its enclosing scope (a helper registered inside `startup` nests under it), and now also encloses the body — the containment the LSP requires for sticky scroll.

## Swept
- `mojo-helpers.rhai` — `helper name => sub {…}` (single + dotted-leaf)
- `minion.rhai` — `add_task(name => sub {…})`
- `mojo-events.rhai` — `on(name => sub {…})`
- `mojo-lite.rhai` — `get '/path' => sub {…}` (and the other route verbs)

## Left as-is (no local body to enclose)
- `mojo-routes.rhai` `->to('Ctrl#action')` / `->name(...)` — the action body lives in the controller (a native `sub`, already body-covering there); the route declaration is a one-liner.
- Accessor/column synthesis (Moo `has`, DBIC) — no callback.
- Catalyst — emits refs/dispatch, not outline symbols; its actions are native `sub`s.
- Dancer — emits no route Handlers today (a separate gap, not this change).

## Validation
- New test `mojo_helper_outline_extent_covers_callback_body`: a helper inside `startup` nests under it (`MyApp > startup > format_money`) and its extent reaches the callback body while `selection_span` stays the name.
- 947 unit + 187 gold green; the existing `plugin_mojo_demo_outline_pinned` snapshot is unchanged (registrations start on the name line, so `@L` is stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)