### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ crate / VS Code extension versions.
 
 ## Unreleased
 
+## v0.5.0 — 2026-06-18
+
+### Mojolicious
+
+- Multi-arg `->to(...)` route targets resolve — goto-def / references / hover
+  land on the action even with trailing stash key/value pairs, and when the
+  action is supplied as a keyval (`->to('Ctrl#', action => 'x')`).
+- Route values from Mojolicious::Lite *function* verbs (`under` / `get` /
+  `any`) now brand the same way the `$r->under(...)` method form does, so a
+  partial `->to('#action')` on a downstream route variable resolves.
+
+### Outline
+
+- Mojo helpers, Minion tasks, Mojo::EventEmitter handlers, and Lite routes pin
+  in editor sticky-scroll and breadcrumbs while the cursor is inside their
+  body (the outline extent now encloses the callback).
+
+### Plugin authoring (`.perl-lsp` / `perl-gen`)
+
+- New per-arg `value_shape` classification and a shared `classified_pairs`
+  host fn for keyval / argument-shape-polymorphic verbs. Arg lists reach
+  plugins fully flattened.
+- `CallContext.arg_pairs` is removed (breaking for external plugins that read
+  it) — pair the args with `classified_pairs` over `value_shape` instead.
+
+### Distribution
+
+- Static binaries: Linux musl (x86_64 + aarch64) and static-CRT Windows.
+
 ## v0.4.2 — 2026-06-17
 
 The crate and the VS Code extension are republished together at this version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-lsp"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["tree-sitter-perl contributors"]
 license = "Artistic-2.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-perl-lsp",
   "displayName": "Perl (perl-lsp)",
   "description": "Perl IntelliSense — autocomplete, go-to-definition, hover, and project-wide cross-file rename. Type inference and framework intelligence (Moo/Moose, Mojolicious, DBIx::Class), powered by tree-sitter-perl.",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "publisher": "tree-sitter-perl",
   "license": "Artistic-2.0",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump (crate + VS Code extension) 0.4.2 → **0.5.0** and the v0.5.0 `CHANGELOG.md` section.

Highlights since 0.4.2:
- **Mojolicious:** multi-arg `->to(...)` route targets resolve (stash key/vals, keyval action); Lite function-verb route values (`under`/`get`/`any`) now brand like the method form.
- **Outline:** Mojo helpers, Minion tasks, event handlers, and Lite routes pin in sticky scroll / breadcrumbs.
- **Plugin authoring:** per-arg `value_shape` + `classified_pairs` host fn; `CallContext.arg_pairs` removed (breaking for external plugins).
- **Distribution:** static musl Linux (x86_64 + aarch64) + static-CRT Windows binaries.

Chosen **0.5.0** (minor) over 0.4.3 because removing `arg_pairs` is a breaking change for external `.perl-lsp` plugins. Changelog wording is a first pass — editing for accuracy on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)