### PR TITLE
Fix release-notes extraction + sync vscode download version (pre-0.5.0 tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,17 +87,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Extract CHANGELOG section for this tag
-        run: |
-          # Pull the block under `## <tag>` (e.g. `## v0.4.0`) up to the next `## `.
-          awk -v hdr="## ${GITHUB_REF_NAME}" '
-            $0 == hdr {f=1; next}
-            /^## / && f {exit}
-            f
-          ' CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "Release ${GITHUB_REF_NAME}." > RELEASE_NOTES.md
-            echo "::warning::No CHANGELOG.md section for ${GITHUB_REF_NAME}; using a stub body."
-          fi
+        # Shared with the local preview (`scripts/release-notes.sh v0.5.0`) so
+        # what you see locally is exactly what the release publishes. The
+        # script prefix-matches the dated `## <tag> — <date>` header and falls
+        # back to a stub body when no section exists.
+        run: scripts/release-notes.sh "${GITHUB_REF_NAME}" > RELEASE_NOTES.md
 
       - name: Create release
         uses: softprops/action-gh-release@v3

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import {
 } from "vscode-languageclient/node";
 
 const REPO = "tree-sitter-perl/perl-tree-sitter-lsp";
-const VERSION = "0.4.0";
+const VERSION = "0.5.0";
 
 let client: LanguageClient | undefined;
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/release-notes.sh v0.5.0 [CHANGELOG.md]
+#
+# Prints the CHANGELOG.md section for a release tag — the exact body the
+# GitHub Release uses (see .github/workflows/release.yml). Run it to preview
+# what a `git push origin v<x.y.z>` will publish.
+set -euo pipefail
+
+TAG="${1:?Usage: $0 <tag> [changelog]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+# Section = the lines under `## <tag>` up to the next `## ` header. Headers
+# are dated (`## v0.5.0 — 2026-06-18`), so match the tag as a PREFIX — an
+# exact-line match misses the date suffix and silently yields nothing.
+section=$(awk -v hdr="## ${TAG}" '
+  $0 == hdr || index($0, hdr " ") == 1 { found = 1; next }
+  /^## / && found { exit }
+  found
+' "$CHANGELOG" | awk 'NF { seen = 1 } seen')   # drop leading blank lines
+
+if [ -z "$section" ]; then
+  echo "Release ${TAG}."
+  echo "::warning::No ${CHANGELOG} section for ${TAG}; using a stub body." >&2
+  exit 0
+fi
+
+printf '%s\n' "$section"


### PR DESCRIPTION
Found while double-checking that pushing `v0.5.0` would produce a correct release. Two blockers, both pre-existing:

1. **Release notes never extracted.** The `release-notes` job matched the CHANGELOG header with `awk '$0 == hdr'` (exact), but headers are dated (`## v0.5.0 — 2026-06-18`), so it always fell back to the stub body. v0.4.2's GitHub Release shows it (stub + auto commit list, no curated notes). Moved the logic into `scripts/release-notes.sh` (prefix-matches the dated header) and call it from the workflow — runnable locally to preview: `scripts/release-notes.sh v0.5.0`.
2. **Stale binary-download version.** `extension.ts` builds the download URL from a hardcoded `VERSION`, stuck at `0.4.0` — the published extension fetched the 0.4.0 binary. The manual bump missed it (`scripts/bump-version.sh` handles this file). Synced to 0.5.0.

After this merges, `main` has everything at 0.5.0 with a working notes pipeline; then the `v0.5.0` tag can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)