### PR TITLE
feat(narrowing): flow-sensitive guard narrowing (v1a, variables)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,17 +5,23 @@ This file is only what's NEXT, in order.
 
 ## Now (in order)
 
-1. **Graph walking** — the walker + the whole inheritance axis landed
-   (`adr/graph-walking.md`). The deferred Scope-node taxonomy (Openness
-   diagnostic, `home_namespace`) is forward work in
-   `prompt-graph-walking.md`. **Instance brands** (`$minion`/`$app`
-   instance identity, multi-app Mojo) were spiked and PARKED — they're a
-   consumer of the long-distance value-provenance tier (see Queued), not
-   a standalone feature; rationale + the birth-site design in
-   `prompt-graph-walking.md`.
-2. **DBIC out of core** — ungated; phase ladder in
-   `prompt-dbic-as-plugin.md`. Ends with core plugin-free except
-   generic dispatch.
+1. **Flow-sensitive narrowing** — active workstream; design doc first
+   (none yet). Guard recognition (`$x->isa('Foo')` / `ref($x) eq` /
+   `blessed`) emits span-scoped narrowing witnesses; the existing
+   temporal + narrowest-span query path in `witnesses.rs` is the
+   engine, so "un-narrowing at block exit" reduces to span computation,
+   not witness removal. Open: early-return / postfix-guard spans, and
+   else-branch negative narrowing (the one non-monotone case — likely
+   deferred in v1). Type::Tiny guards land later as
+   `type_constraint_names()` manifest entries — not a blocker (build
+   against native guards first; they're dependency-free).
+2. **DBIC out of core — phases 2–3.** Phase 1 landed (`visit_dbic_*`
+   gone; `frameworks/dbic.rhai`, trigger `ClassIsa("DBIx::Class")`).
+   Remaining: meta-method suppression → manifest (the `universal_methods`
+   rule-#10 debt still hardcoded in `symbols.rs`) and parametric
+   emission + per-method return projection (the one axis-shaped piece).
+   Ladder in `prompt-dbic-as-plugin.md`. Ends with core plugin-free
+   except generic dispatch.
 
 ## Queued (pull-driven — QA findings decide order)
 
@@ -23,14 +29,17 @@ Type intelligence:
 - Residual fact classes Parts 1–5 (invocant mutations, hash-key
   unions, method loops, functional operators, value-indexed returns)
   — `prompt-type-inference-residual.md`.
-- Flow-sensitive narrowing (`$x->isa('Foo')` / `ref($x) eq` /
-  Type::Tiny guards). Needs its own design doc first; the open
-  question is un-narrowing at block exit against monotone witnesses.
 - Conditional-reassignment disagreement-to-widen (`$spec = {...}
   unless ref $spec`) — replaces the `reassigned_scalars` trust-gate
   clause with a real lattice fold.
 - A4 v2: cross-FILE slot writes (`$self->{k} = Obj->new` in another
   file) — the `MethodOnClass` bridge pattern.
+
+Graph / diagnostics (graph-walking pillar landed; residual only):
+- Scope-node taxonomy + Openness diagnostic (`home_namespace`,
+  "when is an unresolved call real?") — forward work in
+  `prompt-graph-walking.md`; subsumes the coarse qualified-name
+  suppression noted in `open-problems.md`.
 
 Plugin genericity:
 - `has_options` final dissolution: the option pairing already moved out
@@ -83,6 +92,13 @@ QA tail:
 
 ## Parked (explicit unblock conditions)
 
+- **Instance brands** — per-object dispatch scoping (`$app->minion`
+  vs `$app->other_minion`, two Mojo::Lite apps in one workspace).
+  Spiked and closed (PRs #65/#66, branches `branded-edges` /
+  `branded-edges-accessor`); MUST NOT be rebuilt the syntactic-name
+  way (rule #10 — aliasing breaks it). A downstream consumer of the
+  long-distance value-provenance tier (`prompt-type-inference-residual.md`
+  Parts 1–5); the birth-site design lives in `prompt-graph-walking.md`.
 - **Re-export chains** — branch `worktree-agent-aae99d42f4d5d74bc`
   (correct in isolation; design in `adr/reexport-surface.md` on the
   branch). Blocked on the ts-parser-perl X1 scanner thread-safety fix

--- a/docs/prompt-flow-narrowing.md
+++ b/docs/prompt-flow-narrowing.md
@@ -146,7 +146,91 @@ imprecise.
 the *intersection* — emit one narrowing per recognized conjunct
 (`if ($x->isa('Foo') && $x->can('m'))` narrows on the `isa` conjunct,
 ignores `can`). A top-level `||`/`or` chain narrows nothing (neither
-disjunct is guaranteed). v1: walk top-level `&&`, skip `||`.
+disjunct is guaranteed) — intentionally punted, no union to express it.
+
+## Subjects: variables, expressions, places
+
+A guard's subject is one of **three** kinds, and only two have existing
+machinery. The narrowing must compose with both.
+
+| Subject | identity | machinery |
+| --- | --- | --- |
+| `$x` — **variable** | a named slot with a lifetime | flow-sensitive span-scoped witnesses (exists) |
+| `$obj->thing` — **expression** | functional derivation from receiver type | edge chase (exists) |
+| `$self->{x}` — **place** | slot-like identity, *spelled* as an expression | the gap |
+
+**The edge chase structurally cannot narrow.** Point-narrowing is gated
+to `Variable` attachments on purpose (`witnesses.rs:582–589`): Expression
+attachments fold *every* witness with no point filter, because a method
+call's return type doesn't depend on where you ask. That referential
+transparency is the feature for dispatch — and the exact opposite of
+narrowing, whose whole job is that `$self->{x}` is `Foo` *here* and
+`Unknown` *there*. Expressing narrowing as an edge chase is a category
+error: you'd have to break the point-independence that makes the chase
+correct. A **place** is slot-like (narrowable) but spelled as an
+expression (the chase re-derives it functionally on each occurrence,
+ignoring the narrowing) — so it falls between the two mechanisms. That
+gap is the hardness.
+
+**Why variables narrow for free but places don't — soundness.** A
+variable's writes are *syntactically attributable*: `$x = …` names `$x`,
+pushes a later-starting witness, temporal ordering picks the live one. A
+place's writes can hide behind **aliasing**: `$self->reset` or
+`frob($self)` can replace the `{x}` slot without ever naming
+`$self->{x}`. A narrowing that silently survives such a mutation lies.
+
+### v1a — variables · v1b — places (one feature, two flowing increments)
+
+The narrowing soundness lives **entirely on the emit side**, so places
+are *additive*, not a query-path rewrite — provided v1a's seams admit
+them from day one:
+
+- `emit_narrowing` takes a `NarrowSubject { Variable | Place(AccessPath) }`,
+  never a bare `&str` variable.
+- the reducer narrow-filter (`witnesses.rs:590`) reads `Variable | Place`
+  from the start; the narrowest-span / temporal / scoped-exclusion logic
+  is shared — at query time a `Place` witness is *just* a span-scoped
+  slot witness, the reducer needn't know it's a place.
+- the use-site query forms a `NarrowSubject` key generically.
+
+**v1b adds three pieces, zero engine churn:**
+
+1. **Access-path canonicalization (`cst.rs`).** Extend
+   `canonical_container_name` (today single-container, sigil-normalizing)
+   to a multi-hop path: a root (`$self` / `$x`) + projections, where a
+   projection is a *constant* key/index or a *zero-arg pure accessor*
+   (`->{x}`, `->[0]`, `->name`). Dynamic key `$self->{$k}` is not a
+   stable place — no narrowing. Two occurrences of `$self->{x}`
+   canonicalize identically.
+
+2. **Emit-time invalidation truncation — the soundness model.** When
+   emitting a place narrowing over `[guard-end .. block-end]`, scan the
+   region (the builder is already walking it) and truncate the span at
+   the first operation that could disturb the slot:
+   - an assignment to the place or a **proper prefix** (`$self->{x} =`,
+     `$self =`, `%$self =`);
+   - an **opaque op on a prefix** — a method call whose receiver is a
+     prefix (`$self->reset`), or a prefix passed as an argument
+     (`frob($self)`).
+   - **Not** invalidating: reads of the place, or method calls on the
+     place *value* (`$self->{x}->render` mutates the Foo, not the slot).
+
+   The witness carries `[guard-end .. min(block-end, first-invalidation)]`.
+   Static, monotone, computed once. It **under-narrows** (conservative)
+   rather than lies — past anything unprovable the place re-widens via
+   the same scoped-exclusion rule.
+
+3. **One query seam.** At a deref / method-call use site, form the place
+   key for the receiver and check `Place(path)` for a live narrowing
+   *before* the functional chase (`key_value_type` / `MethodOnClass`).
+   Live narrowing wins; else fall through. Additive.
+
+**The escape hatch that already works in v1a:** `my $x = $self->{x};
+return unless $x->isa('Foo'); $x->render` narrows — it's a `Variable`.
+Idiomatic Perl already binds slots to lexicals to avoid re-derefing, so
+much real-world slot-narrowing is captured the moment v1a lands. v1b is
+the "don't force the user to bind first" upgrade, on top of a flowing
+v1a — not the thing that unblocks the idiom.
 
 ## Sum / optional types — the user's question
 
@@ -196,11 +280,13 @@ demands them.
 
 ## Open questions
 
-1. **Non-variable guard subjects** — `ref($self->{x}) eq 'Foo'`,
-   `if ($obj->thing->isa(...))`. The narrowing subject isn't a
-   `Variable` attachment; it needs `Expr(span)`-keyed narrowing (the
-   query path narrows on `Variable` only — `witnesses.rs:590`) or it's
-   the untyped-boundary problem (`open-problems.md`). v1: variables only.
+1. **Place subjects** — `ref($self->{x}) eq 'Foo'`,
+   `$self->{x}->render`. Designed in §"Subjects" as v1b (canonical
+   access paths + emit-time invalidation truncation + one query seam).
+   Not punted — v1a's seams (`NarrowSubject`, the `Variable | Place`
+   filter) admit it additively. A *method-return* subject
+   (`$obj->thing->isa`) with no backing slot stays out — that's the
+   untyped-boundary problem (`open-problems.md`), not a place.
 2. **Loop-condition narrowing** — `while (my $x = shift) { ... }` (defined
    in body). Ties to Optional; defer with it.
 3. **Reassignment inside the region** — sound for free: the reassignment

--- a/docs/prompt-flow-narrowing.md
+++ b/docs/prompt-flow-narrowing.md
@@ -1,0 +1,225 @@
+# Flow-sensitive narrowing — design
+
+**Status: design, not built.** Active workstream (ROADMAP "Now" #1).
+Playground / executable spec: `test_files/narrowing_playground.pl`.
+
+The feature: a guard expression (`$x->isa('Foo')`, `ref($x) eq 'HASH'`,
+`return unless blessed $x`) refines a variable's type for the region of
+code that the guard dominates, then the type widens back at the region's
+exit.
+
+## The engine already exists — this is an emission feature
+
+The query path already does flow-sensitive lookup. `ReducerRegistry`'s
+`reduce` (`witnesses.rs:581`) on a `Variable` attachment with a `point`:
+
+- **Narrowest-span-containing-point wins** (`witnesses.rs:596–613`): of
+  the non-zero-extent `InferredType` witnesses whose span contains the
+  query point, the smallest-area one is returned.
+- **Temporal ordering** (`witnesses.rs:640–644`): a witness whose span
+  *starts after* the point is skipped (a later reassignment can't poison
+  an earlier read).
+- **Scoped-witness exclusion** (`witnesses.rs:648–651`): a non-zero
+  `InferredType` witness whose span does **not** contain the point is
+  skipped entirely.
+
+That third rule **is the un-narrowing**. There is nothing to remove or
+widen at block exit — a narrowing witness scoped to the guarded region
+simply stops containing the point past the region, so the outer (wide,
+zero-extent) witness wins again. Monotone bag, no retraction. This is
+why `prompt-flow-narrowing`'s old "un-narrowing at block exit against
+monotone witnesses" worry dissolves: it was never a retraction problem,
+it's a **span-computation** problem.
+
+Proof the substrate works today: `witnesses_tests.rs::
+narrowed_span_wins_over_outer_witness_at_inside_point` pushes a
+`HashRef` zero-extent outer witness and an `ArrayRef` span-extent
+witness over rows 4..8, then asserts `ArrayRef` inside and `HashRef`
+before. That test is exactly one hand-built narrowing; this feature
+makes the builder emit those witnesses from guard syntax.
+
+### The one trap: do NOT route through `push_type_constraint`
+
+`push_type_constraint` (`file_analysis.rs:3819`) **zero-extents** the
+primary `InferredType` witness (`span.start..span.start`,
+`file_analysis.rs:3828`) — by design, because an assignment's type holds
+from that point forward via temporal ordering, not over a bounded span.
+A narrowing witness is the opposite: it must carry the **full region
+span** so narrowest-span-wins picks it inside and scoped-exclusion drops
+it outside.
+
+So narrowing gets a dedicated emission helper, not the TC path:
+
+```rust
+// builder.rs — pushes a SPAN-EXTENT InferredType witness on the
+// variable's home scope. Span = the dominated region; the span does the
+// lifetime slicing, the scope stays the variable's (mirrors the proven
+// test, which keeps ScopeId(0) for both outer and narrowing witnesses).
+fn emit_narrowing(&mut self, var: &str, scope: ScopeId,
+                  ty: InferredType, region: Span)
+```
+
+Source tag `Builder("narrowing")`. Emitted during the **live walk**
+(rule #1), so it lands before `finalize_post_walk` seals
+`base_witness_count` and therefore survives enrichment truncation
+(enrichment truncates to the base and re-derives only enrichment
+witnesses). It is **not** re-emittable — it's a once-derived syntactic
+fact, monotone — so it needs no clear-and-emit (worklist invariants).
+
+## Guard catalog (v1 — native, dependency-free)
+
+Each guard recognizes a `(variable, narrowed_type, polarity)` triple
+from the condition CST. The variable must be a plain scalar (`Variable`
+attachment); guards on hash elements / method returns are deferred (see
+Open questions). Name→type mapping is pure `&str` and belongs in
+`conventions.rs`; the CST recognition (which call shape) is builder-side
+via `cst.rs` accessors.
+
+| Guard syntax | narrows `$x` to |
+| --- | --- |
+| `$x->isa('Foo')`, `$x->isa(Foo::)` | `ClassName("Foo")` |
+| `$x->DOES('Role')` | `ClassName("Role")` |
+| `ref($x) eq 'Foo'` (Foo a class) | `ClassName("Foo")` |
+| `ref($x) eq 'HASH'` | `HashRef` |
+| `ref($x) eq 'ARRAY'` | `ArrayRef` |
+| `ref($x) eq 'CODE'` | `CodeRef { return_edge: None }` |
+| `ref($x) eq 'Regexp'` | `Regexp` |
+| `blessed($x)` | *(object, class unknown)* — weak, see below |
+| `defined($x)` | *(removes undef)* — weak, see below |
+
+**`ref` reftype-token vs class** is a *closed grammar constant*, not an
+open behavior set — the reftype strings are a fixed Perl language list
+(`HASH ARRAY CODE SCALAR REF GLOB LVALUE FORMAT IO Regexp`). Classifying
+`ref($x) eq S` by "is `S` in that constant set → rep variant, else →
+`ClassName(S)`" is therefore *not* a rule-#10 shape-table (which is about
+open sets of behaviors); it's reading a language constant. Put the
+constant in `conventions.rs` with a comment saying so.
+
+**`blessed` / `defined` are recognized-but-weak in v1.** Neither has a
+refinement target in today's lattice — there is no "some object" type
+and no undef/Optional. Recognize them (compute their variable + polarity
++ span) but emit nothing, OR emit only the negative-space removal once
+the lattice can express it. They become load-bearing the moment Optional
+lands (next section): `defined $x` / `blessed $x` then narrow
+`Optional<T> → T`. Wiring the recognition now means the refinement is a
+one-line target swap later, not new guard plumbing.
+
+## Span + polarity — the actual design content
+
+Two guard **positions**, two span rules:
+
+**A. Block guard** — `if (G) { BODY }`, `unless`, `elsif`. Narrowing
+span = the **BODY block span**. The narrowing asserts G over BODY.
+
+**B. Early-exit guard** — a statement-level exit (`return` / `die` /
+`croak` / `next` / `last` / `goto`) gated by a postfix/`or`/`and`
+condition. Narrowing span = **[guard-statement-end .. enclosing-block
+-end]** — the "rest of the block" after the guard. This is the assert
+idiom and the user-confirmed shape: *scope the witness to the remainder
+of the block.*
+
+**Polarity** — does the span assert G-true or G-false?
+
+| Form | dominated region | asserts |
+| --- | --- | --- |
+| `if (G) { T }` | T | **G true** ✅ |
+| `if (G) { } else { E }` | E | G false ✘ |
+| `unless (G) { T }` | T | G false ✘ |
+| `return unless G;` | remainder | **G true** ✅ |
+| `G or return;` | remainder | **G true** ✅ |
+| `return if G;` | remainder | G false ✘ |
+| `G and return;` | remainder | G false ✘ |
+
+A guard-internal negation (`if (!G)`, `return unless !G`) flips the row.
+
+**v1 ships only the G-true (✅) rows** — the guarded block and the
+early-return assert, the two dominant idioms. They yield a *positive*
+refinement (`$x` IS Foo), expressible in today's lattice.
+
+The G-false (✘) rows need a **negation / union** the lattice lacks ("`$x`
+is anything-but-Foo"). Deferred with the same dependency as the else
+branch — they light up when Optional/union lands. Skipping them is
+sound: emitting nothing leaves the wide outer type, which is correct if
+imprecise.
+
+**Compound conditions:** a top-level `&&`/`and` chain narrows the body by
+the *intersection* — emit one narrowing per recognized conjunct
+(`if ($x->isa('Foo') && $x->can('m'))` narrows on the `isa` conjunct,
+ignores `can`). A top-level `||`/`or` chain narrows nothing (neither
+disjunct is guaranteed). v1: walk top-level `&&`, skip `||`.
+
+## Sum / optional types — the user's question
+
+**Not scope creep — it's the complement of narrowing — but it is a
+separate, sequenced lattice change, and I'd scope it to Optional/Maybe
+first, not arbitrary unions.**
+
+Why it pairs with narrowing: a function that early-returns undef
+(`return undef unless $ok; return Foo->new`) produces `Foo | undef`.
+Today `SymbolReturnArmFold` / `BranchArmFold` collapse arm *disagreement*
+to `None` (the "1+ arms agree → Some, disagree → None" rule in
+`witnesses.rs`). An `Optional(Box<InferredType>)` variant captures it
+precisely instead of dropping it — and then `defined $r` / `blessed $r`
+at the call site has something to bite on: `Optional<Foo> → Foo`. So the
+two features are two halves of one story: **optionals create the
+imprecision that narrowing resolves.** The `defined`/`blessed` guards in
+the catalog above are wired *for* this.
+
+Why it's separate and *after* narrowing v1:
+
+- It's a **lattice-wide** change. New variant (appended at the enum END
+  for bincode index stability, bump `EXTRACT_VERSION` — same discipline
+  as `Sequence`/`TypeConstraintOf`/`BrandedRoute`). Every reducer fold
+  that today does "agree → T, disagree → None" must instead **join** into
+  `Optional`. `subsumes_narrowing` gains a meet. That's a type-system
+  commit, not a narrowing rider — bundling them makes narrowing
+  un-shippable until the join is right.
+- Narrowing v1 stands alone against the existing lattice (ClassName /
+  HashRef / ArrayRef / CodeRef / Regexp) and ships small. The weak
+  guards no-op until Optional arrives, then flip their target in one
+  line.
+
+Why **Optional, not full unions**: arbitrary `Foo | Bar` is a bigger
+lift (n-ary join, method dispatch over a union receiver) and is YAGNI
+until a non-undef union has a motivating case. `Maybe<T>` (value-or
+-undef) covers the dominant Perl idiom and maps 1:1 onto Type::Tiny's
+`Maybe[T]` / `Optional[T]`, so it also feeds the `type_constraint_names()`
+seam the Type::Tiny guards will use. It also *is* the join for the
+already-queued "Conditional-reassignment disagreement-to-widen" item and
+for the arm-disagreement `None` — all three are the same missing-join
+gap.
+
+**Recommendation:** land narrowing v1 against the current lattice; open a
+sibling roadmap entry for `Optional<T>` (its own design doc) as the
+immediate follow-on; park arbitrary sum types until a `Foo|Bar` case
+demands them.
+
+## Open questions
+
+1. **Non-variable guard subjects** — `ref($self->{x}) eq 'Foo'`,
+   `if ($obj->thing->isa(...))`. The narrowing subject isn't a
+   `Variable` attachment; it needs `Expr(span)`-keyed narrowing (the
+   query path narrows on `Variable` only — `witnesses.rs:590`) or it's
+   the untyped-boundary problem (`open-problems.md`). v1: variables only.
+2. **Loop-condition narrowing** — `while (my $x = shift) { ... }` (defined
+   in body). Ties to Optional; defer with it.
+3. **Reassignment inside the region** — sound for free: the reassignment
+   pushes a later-starting witness; temporal + narrowest-span pick the
+   live one at each point. Worth a playground row to pin.
+4. **Negative / else / `return if`** — deferred to Optional/union (above).
+5. **Postfix-on-block-exit precision** — does the early-exit span end at
+   the lexical block, or follow `last`/`next` semantics into the loop?
+   v1: lexical enclosing block (the conservative, common case).
+
+## Test plan
+
+- Substrate is proven: `narrowed_span_wins_over_outer_witness_at_inside
+  _point` (keep as the engine regression).
+- `test_files/narrowing_playground.pl` is the authoring source — every
+  row carries a `# => Type` annotation at a point. Drive with
+  `perl-lsp --dump-package` / the gold harness `--emit`.
+- Per-row unit tests in `builder_tests.rs`, red-pinned `#[ignore]` until
+  v1 lands (repo precedent: the cross-file ClassIsa probe), unignored as
+  each row goes green. A row that should NOT narrow (the ✘ polarity
+  rows, the `||` case) gets a negative-space test asserting the wide
+  type still wins — these are the guardrails against over-narrowing.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -25,6 +25,11 @@ use crate::plugin::{self, PluginRegistry};
 
 pub use crate::plugin::default_plugin_registry;
 
+/// Flow-sensitive narrowing: guard recognition + span-scoped emission.
+/// A child module so its `impl Builder` methods keep private-field access
+/// while the code lives in its own file (rule #1: still driven by `build()`).
+mod narrowing;
+
 /// Single CST walk that powers the post-walk `ChainTypingReducer`.
 /// Indexes the node sets the reducer needs:
 ///
@@ -613,168 +618,6 @@ impl<'a> Builder<'a> {
         }
     }
 
-    // ── Flow-sensitive narrowing (docs/prompt-flow-narrowing.md) ──
-    //
-    // The query path already does the lookup (narrowest-span witness
-    // containing the point wins; scoped-exclusion un-narrows past the
-    // region). These emit the span-extent `InferredType` witnesses on the
-    // subject's home scope. Soundness against a later reassignment lives
-    // here: the region is truncated at the first write, so the narrowing
-    // never shadows a reassignment's temporal witness.
-
-    /// `if/unless (G) { BODY }` — narrow the then-block where the guard's
-    /// polarity is positive (`if`-body when G true, `unless`-body when
-    /// false; only the positive case is expressible in today's lattice).
-    fn narrow_block_guard(&mut self, cond_stmt: Node<'a>) {
-        let Some(condition) = cond_stmt.child_by_field_name("condition") else { return };
-        let Some(block) = cond_stmt.child_by_field_name("block") else { return };
-        let Some(holds_when_true) = self.block_guard_polarity(cond_stmt, condition) else { return };
-        let region = node_to_span(block);
-        for fact in recognize_guards(condition, self.source) {
-            if fact.asserts_when_true == holds_when_true {
-                self.emit_narrowing_fact(fact, region, block);
-            }
-        }
-    }
-
-    /// `if` → body holds where the guard is TRUE; `unless` → where FALSE.
-    /// `None` for any other leading keyword (`elsif` / `while` / `until`).
-    fn block_guard_polarity(&self, cond_stmt: Node<'a>, condition: Node<'a>) -> Option<bool> {
-        let between =
-            std::str::from_utf8(&self.source[cond_stmt.start_byte()..condition.start_byte()])
-                .ok()?;
-        match between.split_whitespace().next()? {
-            "if" => Some(true),
-            "unless" => Some(false),
-            _ => None,
-        }
-    }
-
-    /// `STMT if/unless G;` where STMT is a control-flow exit — narrow the
-    /// rest of the enclosing block (the guard holds for the fall-through).
-    fn narrow_postfix_exit(&mut self, postfix: Node<'a>) {
-        let Some(condition) = postfix.child_by_field_name("condition") else { return };
-        let Some(modified) = postfix.named_child(0) else { return };
-        if !is_exit_expression(modified, self.source) {
-            return;
-        }
-        let Some(kw) = connector_keyword_between(modified, condition, self.source) else { return };
-        // `return unless G` → fall-through holds when G TRUE; `if G` → FALSE.
-        let holds_when_true = match kw.as_str() {
-            "unless" => true,
-            "if" => false,
-            _ => return,
-        };
-        self.narrow_block_remainder(postfix, condition, holds_when_true);
-    }
-
-    /// `G or EXIT;` / `G and EXIT;` — the bare-logical early-exit idiom.
-    fn narrow_logical_exit(&mut self, expr: Node<'a>) {
-        let Some(left) = expr.child_by_field_name("left") else { return };
-        let Some(right) = expr.child_by_field_name("right") else { return };
-        if !is_exit_expression(right, self.source) {
-            return;
-        }
-        // `G or EXIT` → fall-through holds when G TRUE; `G and EXIT` → FALSE.
-        let holds_when_true = match raw_mid_op(expr, self.source).as_str() {
-            "or" | "||" => true,
-            "and" | "&&" => false,
-            _ => return,
-        };
-        self.narrow_block_remainder(expr, left, holds_when_true);
-    }
-
-    /// Narrow `[statement end .. enclosing-block end]` for a statement-level
-    /// guard.
-    fn narrow_block_remainder(
-        &mut self,
-        stmt_expr: Node<'a>,
-        condition: Node<'a>,
-        holds_when_true: bool,
-    ) {
-        let mut stmt = stmt_expr;
-        while stmt.kind() != "expression_statement" {
-            let Some(p) = stmt.parent() else { return };
-            stmt = p;
-        }
-        let Some(block) = stmt.parent() else { return };
-        if block.kind() != "block" {
-            return;
-        }
-        let region = Span { start: stmt.end_position(), end: block.end_position() };
-        for fact in recognize_guards(condition, self.source) {
-            if fact.asserts_when_true == holds_when_true {
-                self.emit_narrowing_fact(fact, region, block);
-            }
-        }
-    }
-
-    /// Push the span-extent narrowing witness on the subject's home scope,
-    /// truncating the region at the first reassignment of the subject.
-    fn emit_narrowing_fact(&mut self, fact: GuardFact, region: Span, container: Node<'a>) {
-        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        let NarrowSubject::Variable(var) = fact.subject;
-        let end = self
-            .first_subject_write(&var, region, container)
-            .unwrap_or(region.end);
-        if !point_lt(region.start, end) {
-            return; // truncated to nothing
-        }
-        self.bag.push(Witness {
-            attachment: WitnessAttachment::Variable { name: var, scope: self.current_scope() },
-            source: WitnessSource::Builder("narrowing".into()),
-            payload: WitnessPayload::InferredType(fact.narrowed),
-            span: Span { start: region.start, end },
-        });
-    }
-
-    /// Point of the first reassignment of `$var` inside `container` at or
-    /// after `region.start` — the narrowing region's truncation bound.
-    fn first_subject_write(&self, var: &str, region: Span, container: Node<'a>) -> Option<Point> {
-        fn writes_var(left: Node, var: &str, src: &[u8]) -> bool {
-            match left.kind() {
-                "scalar" => crate::cst::canonical_var_name(left, src).as_deref() == Some(var),
-                // `my $x = ...` / `my ($x) = ...` rebinds → also truncates.
-                "variable_declaration" => {
-                    let mut stack = vec![left];
-                    while let Some(n) = stack.pop() {
-                        if n.kind() == "scalar"
-                            && crate::cst::canonical_var_name(n, src).as_deref() == Some(var)
-                        {
-                            return true;
-                        }
-                        for i in 0..n.named_child_count() {
-                            if let Some(c) = n.named_child(i) {
-                                stack.push(c);
-                            }
-                        }
-                    }
-                    false
-                }
-                _ => false,
-            }
-        }
-        fn scan(node: Node, var: &str, after: Point, src: &[u8], best: &mut Option<Point>) {
-            if node.kind() == "assignment_expression" {
-                if let Some(left) = node.child_by_field_name("left") {
-                    if writes_var(left, var, src) {
-                        let p = node.start_position();
-                        if !point_lt(p, after) && best.map_or(true, |b| point_lt(p, b)) {
-                            *best = Some(p);
-                        }
-                    }
-                }
-            }
-            for i in 0..node.named_child_count() {
-                if let Some(c) = node.named_child(i) {
-                    scan(c, var, after, src, best);
-                }
-            }
-        }
-        let mut best = None;
-        scan(container, var, region.start, self.source, &mut best);
-        best
-    }
 
     /// Post-walk pass: ref-derived facts that don't need walk-time
     /// visibility — `HashRefAccess` observations from `$v->{k}` refs
@@ -1091,6 +934,7 @@ fn extract_numeric(node: tree_sitter::Node, source: &[u8]) -> Option<u32> {
     node.utf8_text(source).ok()?.trim().parse::<u32>().ok()
 }
 
+
 /// Read the raw bytes between two sibling nodes to recover the
 /// postfix keyword (`if` / `unless` / `while` / …). Used because
 /// tree-sitter-perl shares one node kind for both `if` and `unless`.
@@ -1105,12 +949,10 @@ fn connector_keyword_between(
         return None;
     }
     let between = std::str::from_utf8(&source[start..end]).ok()?.trim();
-    // Expect exactly one keyword in between.
     for kw in ["unless", "if", "while", "until"] {
         if between == kw || between.starts_with(kw) && between.trim() == kw {
             return Some(kw.to_string());
         }
-        // tolerate extra whitespace (e.g. newlines)
         if between.split_whitespace().next() == Some(kw) {
             return Some(kw.to_string());
         }
@@ -1147,180 +989,10 @@ fn raw_mid_op(node: tree_sitter::Node, source: &[u8]) -> String {
         .to_string()
 }
 
-// ── Flow-sensitive narrowing — guard recognition ──────────────
-//
-// A guard (`$x->isa('Foo')`, `ref($x) eq 'HASH'`) proves a variable's
-// type over the region it dominates. Recognition is pure CST inspection
-// here; emission + span/truncation lives on `Builder`. Design + the
-// span/polarity table: docs/prompt-flow-narrowing.md.
-
 fn point_lt(a: tree_sitter::Point, b: tree_sitter::Point) -> bool {
     (a.row, a.column) < (b.row, b.column)
 }
 
-/// The subject a guard narrows. v1a recognizes plain scalars; the
-/// `Place` arm (`$self->{x}`) lands with the access-path canonicalizer.
-enum NarrowSubject {
-    Variable(String),
-}
-
-/// A recognized guard fact: the subject, the type it proves, and whether
-/// the proof holds where the guard *expression* is TRUE (`!` flips it).
-struct GuardFact {
-    subject: NarrowSubject,
-    narrowed: InferredType,
-    asserts_when_true: bool,
-}
-
-/// Map a `ref(...) eq STRING` right-hand string to the type it proves.
-/// The builtin reftype tokens are a fixed Perl language constant (reading
-/// a grammar constant, not a rule-#10 shape-table over an open behavior
-/// set); tokens with no lattice variant yield `None` (recognized, not
-/// narrowable). Anything else is a class name (a blessed ref).
-fn ref_string_to_type(s: &str) -> Option<InferredType> {
-    Some(match s {
-        "HASH" => InferredType::HashRef,
-        "ARRAY" => InferredType::ArrayRef,
-        "CODE" => InferredType::CodeRef { return_edge: None },
-        "Regexp" => InferredType::Regexp,
-        "SCALAR" | "REF" | "GLOB" | "LVALUE" | "FORMAT" | "IO" | "VSTRING" => return None,
-        other => InferredType::ClassName(other.to_string()),
-    })
-}
-
-/// Literal content of a `string_literal` node — the class name in
-/// `isa('Foo')` / `ref($x) eq 'HASH'`. Rejects interpolated forms (a
-/// class-name guard is a plain literal).
-fn string_literal_text(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
-    if !matches!(node.kind(), "string_literal" | "interpolated_string_literal") {
-        return None;
-    }
-    let mut content: Option<String> = None;
-    for i in 0..node.named_child_count() {
-        let c = node.named_child(i)?;
-        if c.kind() != "string_content" || content.is_some() {
-            return None; // interpolation or multiple fragments
-        }
-        content = c.utf8_text(source).ok().map(|s| s.to_string());
-    }
-    content.filter(|s| !s.is_empty())
-}
-
-/// The scalar argument of a `func1op_call_expression` (`ref($x)` /
-/// `ref $x`), if its argument is a plain scalar.
-fn func1op_scalar_arg<'a>(node: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
-    for i in 0..node.named_child_count() {
-        let c = node.named_child(i)?;
-        if c.kind() == "scalar" {
-            return Some(c);
-        }
-    }
-    None
-}
-
-/// Recognize the narrowing facts a condition proves. One fact per
-/// recognized conjunct (`&&`/`and` intersect the region); a disjunctive
-/// (`||`/`or`) or unrecognized condition yields none.
-fn recognize_guards(cond: tree_sitter::Node, source: &[u8]) -> Vec<GuardFact> {
-    match cond.kind() {
-        "parenthesized_expression" => cond
-            .named_child(0)
-            .map(|c| recognize_guards(c, source))
-            .unwrap_or_default(),
-        "unary_expression" if raw_leading_op(cond, source) == "!" => cond
-            .child_by_field_name("operand")
-            .map(|op| {
-                recognize_guards(op, source)
-                    .into_iter()
-                    .map(|mut f| {
-                        f.asserts_when_true = !f.asserts_when_true;
-                        f
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
-        "binary_expression" if matches!(raw_mid_op(cond, source).as_str(), "&&" | "and") => {
-            let mut out = Vec::new();
-            if let Some(l) = cond.child_by_field_name("left") {
-                out.extend(recognize_guards(l, source));
-            }
-            if let Some(r) = cond.child_by_field_name("right") {
-                out.extend(recognize_guards(r, source));
-            }
-            out
-        }
-        "method_call_expression" => recognize_isa_guard(cond, source).into_iter().collect(),
-        "equality_expression" => recognize_ref_eq_guard(cond, source).into_iter().collect(),
-        _ => Vec::new(),
-    }
-}
-
-/// `$x->isa('Foo')` / `$x->DOES('Role')` → narrow `$x` to `ClassName`.
-fn recognize_isa_guard(call: tree_sitter::Node, source: &[u8]) -> Option<GuardFact> {
-    let mc = crate::cst::MethodCall::cast(call)?;
-    let method = mc.method()?.utf8_text(source).ok()?;
-    if method != "isa" && method != "DOES" {
-        return None;
-    }
-    let var = crate::cst::canonical_var_name(mc.invocant()?, source)?;
-    let class = string_literal_text(call.child_by_field_name("arguments")?, source)?;
-    Some(GuardFact {
-        subject: NarrowSubject::Variable(var),
-        narrowed: InferredType::ClassName(class),
-        asserts_when_true: true,
-    })
-}
-
-/// `ref($x) eq 'Foo'` / `reftype($x) eq 'HASH'` (either operand order) →
-/// narrow `$x` to the proven type.
-fn recognize_ref_eq_guard(eq: tree_sitter::Node, source: &[u8]) -> Option<GuardFact> {
-    if raw_mid_op(eq, source) != "eq" {
-        return None;
-    }
-    let left = eq.child_by_field_name("left")?;
-    let right = eq.child_by_field_name("right")?;
-    let (ref_call, lit) = if left.kind() == "func1op_call_expression" {
-        (left, right)
-    } else if right.kind() == "func1op_call_expression" {
-        (right, left)
-    } else {
-        return None;
-    };
-    let fname = ref_call.child(0)?.utf8_text(source).ok()?;
-    if fname != "ref" && fname != "reftype" {
-        return None;
-    }
-    let var = crate::cst::canonical_var_name(func1op_scalar_arg(ref_call)?, source)?;
-    let ty = ref_string_to_type(&string_literal_text(lit, source)?)?;
-    Some(GuardFact {
-        subject: NarrowSubject::Variable(var),
-        narrowed: ty,
-        asserts_when_true: true,
-    })
-}
-
-/// True if a statement-level expression is a guaranteed control-flow exit
-/// (`return`/`die`/`croak`/`last`/`next`/`redo`/`goto`) — the shape that
-/// makes `STMT if/unless G` narrow the rest of the enclosing block.
-fn is_exit_expression(node: tree_sitter::Node, source: &[u8]) -> bool {
-    const EXITS: [&str; 7] = ["die", "croak", "confess", "last", "next", "redo", "goto"];
-    match node.kind() {
-        "return_expression" | "last_expression" | "next_expression" | "redo_expression" => true,
-        "function" | "bareword" => node
-            .utf8_text(source)
-            .map(|s| EXITS.contains(&s.trim()))
-            .unwrap_or(false),
-        "func1op_call_expression"
-        | "function_call_expression"
-        | "ambiguous_function_call_expression" => node
-            .child_by_field_name("function")
-            .or_else(|| node.child(0))
-            .and_then(|n| n.utf8_text(source).ok())
-            .map(|s| EXITS.contains(&s.trim()))
-            .unwrap_or(false),
-        _ => false,
-    }
-}
 
 /// Structural index of one return-expression in a sub body. Type
 /// information lives in the bag: the body expression carries its own

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -613,6 +613,169 @@ impl<'a> Builder<'a> {
         }
     }
 
+    // ── Flow-sensitive narrowing (docs/prompt-flow-narrowing.md) ──
+    //
+    // The query path already does the lookup (narrowest-span witness
+    // containing the point wins; scoped-exclusion un-narrows past the
+    // region). These emit the span-extent `InferredType` witnesses on the
+    // subject's home scope. Soundness against a later reassignment lives
+    // here: the region is truncated at the first write, so the narrowing
+    // never shadows a reassignment's temporal witness.
+
+    /// `if/unless (G) { BODY }` — narrow the then-block where the guard's
+    /// polarity is positive (`if`-body when G true, `unless`-body when
+    /// false; only the positive case is expressible in today's lattice).
+    fn narrow_block_guard(&mut self, cond_stmt: Node<'a>) {
+        let Some(condition) = cond_stmt.child_by_field_name("condition") else { return };
+        let Some(block) = cond_stmt.child_by_field_name("block") else { return };
+        let Some(holds_when_true) = self.block_guard_polarity(cond_stmt, condition) else { return };
+        let region = node_to_span(block);
+        for fact in recognize_guards(condition, self.source) {
+            if fact.asserts_when_true == holds_when_true {
+                self.emit_narrowing_fact(fact, region, block);
+            }
+        }
+    }
+
+    /// `if` → body holds where the guard is TRUE; `unless` → where FALSE.
+    /// `None` for any other leading keyword (`elsif` / `while` / `until`).
+    fn block_guard_polarity(&self, cond_stmt: Node<'a>, condition: Node<'a>) -> Option<bool> {
+        let between =
+            std::str::from_utf8(&self.source[cond_stmt.start_byte()..condition.start_byte()])
+                .ok()?;
+        match between.split_whitespace().next()? {
+            "if" => Some(true),
+            "unless" => Some(false),
+            _ => None,
+        }
+    }
+
+    /// `STMT if/unless G;` where STMT is a control-flow exit — narrow the
+    /// rest of the enclosing block (the guard holds for the fall-through).
+    fn narrow_postfix_exit(&mut self, postfix: Node<'a>) {
+        let Some(condition) = postfix.child_by_field_name("condition") else { return };
+        let Some(modified) = postfix.named_child(0) else { return };
+        if !is_exit_expression(modified, self.source) {
+            return;
+        }
+        let Some(kw) = connector_keyword_between(modified, condition, self.source) else { return };
+        // `return unless G` → fall-through holds when G TRUE; `if G` → FALSE.
+        let holds_when_true = match kw.as_str() {
+            "unless" => true,
+            "if" => false,
+            _ => return,
+        };
+        self.narrow_block_remainder(postfix, condition, holds_when_true);
+    }
+
+    /// `G or EXIT;` / `G and EXIT;` — the bare-logical early-exit idiom.
+    fn narrow_logical_exit(&mut self, expr: Node<'a>) {
+        let Some(left) = expr.child_by_field_name("left") else { return };
+        let Some(right) = expr.child_by_field_name("right") else { return };
+        if !is_exit_expression(right, self.source) {
+            return;
+        }
+        // `G or EXIT` → fall-through holds when G TRUE; `G and EXIT` → FALSE.
+        let holds_when_true = match raw_mid_op(expr, self.source).as_str() {
+            "or" | "||" => true,
+            "and" | "&&" => false,
+            _ => return,
+        };
+        self.narrow_block_remainder(expr, left, holds_when_true);
+    }
+
+    /// Narrow `[statement end .. enclosing-block end]` for a statement-level
+    /// guard.
+    fn narrow_block_remainder(
+        &mut self,
+        stmt_expr: Node<'a>,
+        condition: Node<'a>,
+        holds_when_true: bool,
+    ) {
+        let mut stmt = stmt_expr;
+        while stmt.kind() != "expression_statement" {
+            let Some(p) = stmt.parent() else { return };
+            stmt = p;
+        }
+        let Some(block) = stmt.parent() else { return };
+        if block.kind() != "block" {
+            return;
+        }
+        let region = Span { start: stmt.end_position(), end: block.end_position() };
+        for fact in recognize_guards(condition, self.source) {
+            if fact.asserts_when_true == holds_when_true {
+                self.emit_narrowing_fact(fact, region, block);
+            }
+        }
+    }
+
+    /// Push the span-extent narrowing witness on the subject's home scope,
+    /// truncating the region at the first reassignment of the subject.
+    fn emit_narrowing_fact(&mut self, fact: GuardFact, region: Span, container: Node<'a>) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        let NarrowSubject::Variable(var) = fact.subject;
+        let end = self
+            .first_subject_write(&var, region, container)
+            .unwrap_or(region.end);
+        if !point_lt(region.start, end) {
+            return; // truncated to nothing
+        }
+        self.bag.push(Witness {
+            attachment: WitnessAttachment::Variable { name: var, scope: self.current_scope() },
+            source: WitnessSource::Builder("narrowing".into()),
+            payload: WitnessPayload::InferredType(fact.narrowed),
+            span: Span { start: region.start, end },
+        });
+    }
+
+    /// Point of the first reassignment of `$var` inside `container` at or
+    /// after `region.start` — the narrowing region's truncation bound.
+    fn first_subject_write(&self, var: &str, region: Span, container: Node<'a>) -> Option<Point> {
+        fn writes_var(left: Node, var: &str, src: &[u8]) -> bool {
+            match left.kind() {
+                "scalar" => crate::cst::canonical_var_name(left, src).as_deref() == Some(var),
+                // `my $x = ...` / `my ($x) = ...` rebinds → also truncates.
+                "variable_declaration" => {
+                    let mut stack = vec![left];
+                    while let Some(n) = stack.pop() {
+                        if n.kind() == "scalar"
+                            && crate::cst::canonical_var_name(n, src).as_deref() == Some(var)
+                        {
+                            return true;
+                        }
+                        for i in 0..n.named_child_count() {
+                            if let Some(c) = n.named_child(i) {
+                                stack.push(c);
+                            }
+                        }
+                    }
+                    false
+                }
+                _ => false,
+            }
+        }
+        fn scan(node: Node, var: &str, after: Point, src: &[u8], best: &mut Option<Point>) {
+            if node.kind() == "assignment_expression" {
+                if let Some(left) = node.child_by_field_name("left") {
+                    if writes_var(left, var, src) {
+                        let p = node.start_position();
+                        if !point_lt(p, after) && best.map_or(true, |b| point_lt(p, b)) {
+                            *best = Some(p);
+                        }
+                    }
+                }
+            }
+            for i in 0..node.named_child_count() {
+                if let Some(c) = node.named_child(i) {
+                    scan(c, var, after, src, best);
+                }
+            }
+        }
+        let mut best = None;
+        scan(container, var, region.start, self.source, &mut best);
+        best
+    }
+
     /// Post-walk pass: ref-derived facts that don't need walk-time
     /// visibility — `HashRefAccess` observations from `$v->{k}` refs
     /// and invocant-mutation facts on hash-key writes. Variable
@@ -982,6 +1145,181 @@ fn raw_mid_op(node: tree_sitter::Node, source: &[u8]) -> String {
         .unwrap_or("")
         .trim()
         .to_string()
+}
+
+// ── Flow-sensitive narrowing — guard recognition ──────────────
+//
+// A guard (`$x->isa('Foo')`, `ref($x) eq 'HASH'`) proves a variable's
+// type over the region it dominates. Recognition is pure CST inspection
+// here; emission + span/truncation lives on `Builder`. Design + the
+// span/polarity table: docs/prompt-flow-narrowing.md.
+
+fn point_lt(a: tree_sitter::Point, b: tree_sitter::Point) -> bool {
+    (a.row, a.column) < (b.row, b.column)
+}
+
+/// The subject a guard narrows. v1a recognizes plain scalars; the
+/// `Place` arm (`$self->{x}`) lands with the access-path canonicalizer.
+enum NarrowSubject {
+    Variable(String),
+}
+
+/// A recognized guard fact: the subject, the type it proves, and whether
+/// the proof holds where the guard *expression* is TRUE (`!` flips it).
+struct GuardFact {
+    subject: NarrowSubject,
+    narrowed: InferredType,
+    asserts_when_true: bool,
+}
+
+/// Map a `ref(...) eq STRING` right-hand string to the type it proves.
+/// The builtin reftype tokens are a fixed Perl language constant (reading
+/// a grammar constant, not a rule-#10 shape-table over an open behavior
+/// set); tokens with no lattice variant yield `None` (recognized, not
+/// narrowable). Anything else is a class name (a blessed ref).
+fn ref_string_to_type(s: &str) -> Option<InferredType> {
+    Some(match s {
+        "HASH" => InferredType::HashRef,
+        "ARRAY" => InferredType::ArrayRef,
+        "CODE" => InferredType::CodeRef { return_edge: None },
+        "Regexp" => InferredType::Regexp,
+        "SCALAR" | "REF" | "GLOB" | "LVALUE" | "FORMAT" | "IO" | "VSTRING" => return None,
+        other => InferredType::ClassName(other.to_string()),
+    })
+}
+
+/// Literal content of a `string_literal` node — the class name in
+/// `isa('Foo')` / `ref($x) eq 'HASH'`. Rejects interpolated forms (a
+/// class-name guard is a plain literal).
+fn string_literal_text(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string_literal" | "interpolated_string_literal") {
+        return None;
+    }
+    let mut content: Option<String> = None;
+    for i in 0..node.named_child_count() {
+        let c = node.named_child(i)?;
+        if c.kind() != "string_content" || content.is_some() {
+            return None; // interpolation or multiple fragments
+        }
+        content = c.utf8_text(source).ok().map(|s| s.to_string());
+    }
+    content.filter(|s| !s.is_empty())
+}
+
+/// The scalar argument of a `func1op_call_expression` (`ref($x)` /
+/// `ref $x`), if its argument is a plain scalar.
+fn func1op_scalar_arg<'a>(node: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+    for i in 0..node.named_child_count() {
+        let c = node.named_child(i)?;
+        if c.kind() == "scalar" {
+            return Some(c);
+        }
+    }
+    None
+}
+
+/// Recognize the narrowing facts a condition proves. One fact per
+/// recognized conjunct (`&&`/`and` intersect the region); a disjunctive
+/// (`||`/`or`) or unrecognized condition yields none.
+fn recognize_guards(cond: tree_sitter::Node, source: &[u8]) -> Vec<GuardFact> {
+    match cond.kind() {
+        "parenthesized_expression" => cond
+            .named_child(0)
+            .map(|c| recognize_guards(c, source))
+            .unwrap_or_default(),
+        "unary_expression" if raw_leading_op(cond, source) == "!" => cond
+            .child_by_field_name("operand")
+            .map(|op| {
+                recognize_guards(op, source)
+                    .into_iter()
+                    .map(|mut f| {
+                        f.asserts_when_true = !f.asserts_when_true;
+                        f
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        "binary_expression" if matches!(raw_mid_op(cond, source).as_str(), "&&" | "and") => {
+            let mut out = Vec::new();
+            if let Some(l) = cond.child_by_field_name("left") {
+                out.extend(recognize_guards(l, source));
+            }
+            if let Some(r) = cond.child_by_field_name("right") {
+                out.extend(recognize_guards(r, source));
+            }
+            out
+        }
+        "method_call_expression" => recognize_isa_guard(cond, source).into_iter().collect(),
+        "equality_expression" => recognize_ref_eq_guard(cond, source).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// `$x->isa('Foo')` / `$x->DOES('Role')` → narrow `$x` to `ClassName`.
+fn recognize_isa_guard(call: tree_sitter::Node, source: &[u8]) -> Option<GuardFact> {
+    let mc = crate::cst::MethodCall::cast(call)?;
+    let method = mc.method()?.utf8_text(source).ok()?;
+    if method != "isa" && method != "DOES" {
+        return None;
+    }
+    let var = crate::cst::canonical_var_name(mc.invocant()?, source)?;
+    let class = string_literal_text(call.child_by_field_name("arguments")?, source)?;
+    Some(GuardFact {
+        subject: NarrowSubject::Variable(var),
+        narrowed: InferredType::ClassName(class),
+        asserts_when_true: true,
+    })
+}
+
+/// `ref($x) eq 'Foo'` / `reftype($x) eq 'HASH'` (either operand order) →
+/// narrow `$x` to the proven type.
+fn recognize_ref_eq_guard(eq: tree_sitter::Node, source: &[u8]) -> Option<GuardFact> {
+    if raw_mid_op(eq, source) != "eq" {
+        return None;
+    }
+    let left = eq.child_by_field_name("left")?;
+    let right = eq.child_by_field_name("right")?;
+    let (ref_call, lit) = if left.kind() == "func1op_call_expression" {
+        (left, right)
+    } else if right.kind() == "func1op_call_expression" {
+        (right, left)
+    } else {
+        return None;
+    };
+    let fname = ref_call.child(0)?.utf8_text(source).ok()?;
+    if fname != "ref" && fname != "reftype" {
+        return None;
+    }
+    let var = crate::cst::canonical_var_name(func1op_scalar_arg(ref_call)?, source)?;
+    let ty = ref_string_to_type(&string_literal_text(lit, source)?)?;
+    Some(GuardFact {
+        subject: NarrowSubject::Variable(var),
+        narrowed: ty,
+        asserts_when_true: true,
+    })
+}
+
+/// True if a statement-level expression is a guaranteed control-flow exit
+/// (`return`/`die`/`croak`/`last`/`next`/`redo`/`goto`) — the shape that
+/// makes `STMT if/unless G` narrow the rest of the enclosing block.
+fn is_exit_expression(node: tree_sitter::Node, source: &[u8]) -> bool {
+    const EXITS: [&str; 7] = ["die", "croak", "confess", "last", "next", "redo", "goto"];
+    match node.kind() {
+        "return_expression" | "last_expression" | "next_expression" | "redo_expression" => true,
+        "function" | "bareword" => node
+            .utf8_text(source)
+            .map(|s| EXITS.contains(&s.trim()))
+            .unwrap_or(false),
+        "func1op_call_expression"
+        | "function_call_expression"
+        | "ambiguous_function_call_expression" => node
+            .child_by_field_name("function")
+            .or_else(|| node.child(0))
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| EXITS.contains(&s.trim()))
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 /// Structural index of one return-expression in a sub body. Type
@@ -3365,6 +3703,21 @@ impl<'a> Builder<'a> {
             // Foldable statements
             "if_statement" | "unless_statement" | "while_statement" | "until_statement" => {
                 self.add_fold_range(node);
+                self.visit_children(node);
+            }
+
+            // Flow-sensitive narrowing: a block guard refines the then-block;
+            // a statement-level exit guard refines the rest of the block.
+            "conditional_statement" => {
+                self.narrow_block_guard(node);
+                self.visit_children(node);
+            }
+            "postfix_conditional_expression" => {
+                self.narrow_postfix_exit(node);
+                self.visit_children(node);
+            }
+            "lowprec_logical_expression" => {
+                self.narrow_logical_exit(node);
                 self.visit_children(node);
             }
 

--- a/src/builder/narrowing.rs
+++ b/src/builder/narrowing.rs
@@ -1,0 +1,335 @@
+//! Flow-sensitive narrowing — guard recognition + span-scoped emission.
+//!
+//! A child module of `builder` (so it keeps direct access to `Builder`'s
+//! private fields) rather than a sibling: narrowing is still part of the
+//! single tree-sitter consumer (rule #1) — `build()` drives it, it just
+//! lives in its own file. Recognition (`recognize_*`) is pure CST
+//! inspection; emission + span/truncation are `Builder` methods. Design +
+//! the span/polarity table: `docs/prompt-flow-narrowing.md`.
+
+use tree_sitter::{Node, Point};
+
+use crate::cst::node_to_span;
+use crate::file_analysis::{InferredType, Span};
+
+use super::{connector_keyword_between, point_lt, raw_leading_op, raw_mid_op, Builder};
+
+/// The subject a guard narrows. v1a recognizes plain scalars; the
+/// `Place` arm (`$self->{x}`) lands with the access-path canonicalizer.
+pub(super) enum NarrowSubject {
+    Variable(String),
+}
+
+/// A recognized guard fact: the subject, the type it proves, and whether
+/// the proof holds where the guard *expression* is TRUE (`!` flips it).
+pub(super) struct GuardFact {
+    subject: NarrowSubject,
+    narrowed: InferredType,
+    asserts_when_true: bool,
+}
+
+/// Map a `ref(...) eq STRING` right-hand string to the type it proves.
+/// The builtin reftype tokens are a fixed Perl language constant (reading
+/// a grammar constant, not a rule-#10 shape-table over an open behavior
+/// set); tokens with no lattice variant yield `None` (recognized, not
+/// narrowable). Anything else is a class name (a blessed ref).
+fn ref_string_to_type(s: &str) -> Option<InferredType> {
+    Some(match s {
+        "HASH" => InferredType::HashRef,
+        "ARRAY" => InferredType::ArrayRef,
+        "CODE" => InferredType::CodeRef { return_edge: None },
+        "Regexp" => InferredType::Regexp,
+        "SCALAR" | "REF" | "GLOB" | "LVALUE" | "FORMAT" | "IO" | "VSTRING" => return None,
+        other => InferredType::ClassName(other.to_string()),
+    })
+}
+
+/// Literal content of a `string_literal` node — the class name in
+/// `isa('Foo')` / `ref($x) eq 'HASH'`. Rejects interpolated forms (a
+/// class-name guard is a plain literal).
+fn string_literal_text(node: Node, source: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string_literal" | "interpolated_string_literal") {
+        return None;
+    }
+    let mut content: Option<String> = None;
+    for i in 0..node.named_child_count() {
+        let c = node.named_child(i)?;
+        if c.kind() != "string_content" || content.is_some() {
+            return None; // interpolation or multiple fragments
+        }
+        content = c.utf8_text(source).ok().map(|s| s.to_string());
+    }
+    content.filter(|s| !s.is_empty())
+}
+
+/// The scalar argument of a `func1op_call_expression` (`ref($x)` /
+/// `ref $x`), if its argument is a plain scalar.
+fn func1op_scalar_arg<'a>(node: Node<'a>) -> Option<Node<'a>> {
+    for i in 0..node.named_child_count() {
+        let c = node.named_child(i)?;
+        if c.kind() == "scalar" {
+            return Some(c);
+        }
+    }
+    None
+}
+
+/// Recognize the narrowing facts a condition proves. One fact per
+/// recognized conjunct (`&&`/`and` intersect the region); a disjunctive
+/// (`||`/`or`) or unrecognized condition yields none.
+fn recognize_guards(cond: Node, source: &[u8]) -> Vec<GuardFact> {
+    match cond.kind() {
+        "parenthesized_expression" => cond
+            .named_child(0)
+            .map(|c| recognize_guards(c, source))
+            .unwrap_or_default(),
+        "unary_expression" if raw_leading_op(cond, source) == "!" => cond
+            .child_by_field_name("operand")
+            .map(|op| {
+                recognize_guards(op, source)
+                    .into_iter()
+                    .map(|mut f| {
+                        f.asserts_when_true = !f.asserts_when_true;
+                        f
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        "binary_expression" if matches!(raw_mid_op(cond, source).as_str(), "&&" | "and") => {
+            let mut out = Vec::new();
+            if let Some(l) = cond.child_by_field_name("left") {
+                out.extend(recognize_guards(l, source));
+            }
+            if let Some(r) = cond.child_by_field_name("right") {
+                out.extend(recognize_guards(r, source));
+            }
+            out
+        }
+        "method_call_expression" => recognize_isa_guard(cond, source).into_iter().collect(),
+        "equality_expression" => recognize_ref_eq_guard(cond, source).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// `$x->isa('Foo')` / `$x->DOES('Role')` → narrow `$x` to `ClassName`.
+fn recognize_isa_guard(call: Node, source: &[u8]) -> Option<GuardFact> {
+    let mc = crate::cst::MethodCall::cast(call)?;
+    let method = mc.method()?.utf8_text(source).ok()?;
+    if method != "isa" && method != "DOES" {
+        return None;
+    }
+    let var = crate::cst::canonical_var_name(mc.invocant()?, source)?;
+    let class = string_literal_text(call.child_by_field_name("arguments")?, source)?;
+    Some(GuardFact {
+        subject: NarrowSubject::Variable(var),
+        narrowed: InferredType::ClassName(class),
+        asserts_when_true: true,
+    })
+}
+
+/// `ref($x) eq 'Foo'` / `reftype($x) eq 'HASH'` (either operand order) →
+/// narrow `$x` to the proven type.
+fn recognize_ref_eq_guard(eq: Node, source: &[u8]) -> Option<GuardFact> {
+    if raw_mid_op(eq, source) != "eq" {
+        return None;
+    }
+    let left = eq.child_by_field_name("left")?;
+    let right = eq.child_by_field_name("right")?;
+    let (ref_call, lit) = if left.kind() == "func1op_call_expression" {
+        (left, right)
+    } else if right.kind() == "func1op_call_expression" {
+        (right, left)
+    } else {
+        return None;
+    };
+    let fname = ref_call.child(0)?.utf8_text(source).ok()?;
+    if fname != "ref" && fname != "reftype" {
+        return None;
+    }
+    let var = crate::cst::canonical_var_name(func1op_scalar_arg(ref_call)?, source)?;
+    let ty = ref_string_to_type(&string_literal_text(lit, source)?)?;
+    Some(GuardFact {
+        subject: NarrowSubject::Variable(var),
+        narrowed: ty,
+        asserts_when_true: true,
+    })
+}
+
+/// True if a statement-level expression is a guaranteed control-flow exit
+/// (`return`/`die`/`croak`/`last`/`next`/`redo`/`goto`) — the shape that
+/// makes `STMT if/unless G` narrow the rest of the enclosing block.
+fn is_exit_expression(node: Node, source: &[u8]) -> bool {
+    const EXITS: [&str; 7] = ["die", "croak", "confess", "last", "next", "redo", "goto"];
+    match node.kind() {
+        "return_expression" | "last_expression" | "next_expression" | "redo_expression" => true,
+        "function" | "bareword" => node
+            .utf8_text(source)
+            .map(|s| EXITS.contains(&s.trim()))
+            .unwrap_or(false),
+        "func1op_call_expression"
+        | "function_call_expression"
+        | "ambiguous_function_call_expression" => node
+            .child_by_field_name("function")
+            .or_else(|| node.child(0))
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| EXITS.contains(&s.trim()))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+impl<'a> Builder<'a> {
+    /// `if/unless (G) { BODY }` — narrow the then-block where the guard's
+    /// polarity is positive (`if`-body when G true, `unless`-body when
+    /// false; only the positive case is expressible in today's lattice).
+    pub(super) fn narrow_block_guard(&mut self, cond_stmt: Node<'a>) {
+        let Some(condition) = cond_stmt.child_by_field_name("condition") else { return };
+        let Some(block) = cond_stmt.child_by_field_name("block") else { return };
+        let Some(holds_when_true) = self.block_guard_polarity(cond_stmt, condition) else { return };
+        let region = node_to_span(block);
+        for fact in recognize_guards(condition, self.source) {
+            if fact.asserts_when_true == holds_when_true {
+                self.emit_narrowing_fact(fact, region, block);
+            }
+        }
+    }
+
+    /// `if` → body holds where the guard is TRUE; `unless` → where FALSE.
+    /// `None` for any other leading keyword (`elsif` / `while` / `until`).
+    fn block_guard_polarity(&self, cond_stmt: Node<'a>, condition: Node<'a>) -> Option<bool> {
+        let between =
+            std::str::from_utf8(&self.source[cond_stmt.start_byte()..condition.start_byte()])
+                .ok()?;
+        match between.split_whitespace().next()? {
+            "if" => Some(true),
+            "unless" => Some(false),
+            _ => None,
+        }
+    }
+
+    /// `STMT if/unless G;` where STMT is a control-flow exit — narrow the
+    /// rest of the enclosing block (the guard holds for the fall-through).
+    pub(super) fn narrow_postfix_exit(&mut self, postfix: Node<'a>) {
+        let Some(condition) = postfix.child_by_field_name("condition") else { return };
+        let Some(modified) = postfix.named_child(0) else { return };
+        if !is_exit_expression(modified, self.source) {
+            return;
+        }
+        let Some(kw) = connector_keyword_between(modified, condition, self.source) else { return };
+        // `return unless G` → fall-through holds when G TRUE; `if G` → FALSE.
+        let holds_when_true = match kw.as_str() {
+            "unless" => true,
+            "if" => false,
+            _ => return,
+        };
+        self.narrow_block_remainder(postfix, condition, holds_when_true);
+    }
+
+    /// `G or EXIT;` / `G and EXIT;` — the bare-logical early-exit idiom.
+    pub(super) fn narrow_logical_exit(&mut self, expr: Node<'a>) {
+        let Some(left) = expr.child_by_field_name("left") else { return };
+        let Some(right) = expr.child_by_field_name("right") else { return };
+        if !is_exit_expression(right, self.source) {
+            return;
+        }
+        // `G or EXIT` → fall-through holds when G TRUE; `G and EXIT` → FALSE.
+        let holds_when_true = match raw_mid_op(expr, self.source).as_str() {
+            "or" | "||" => true,
+            "and" | "&&" => false,
+            _ => return,
+        };
+        self.narrow_block_remainder(expr, left, holds_when_true);
+    }
+
+    /// Narrow `[statement end .. enclosing-block end]` for a statement-level
+    /// guard.
+    fn narrow_block_remainder(
+        &mut self,
+        stmt_expr: Node<'a>,
+        condition: Node<'a>,
+        holds_when_true: bool,
+    ) {
+        let mut stmt = stmt_expr;
+        while stmt.kind() != "expression_statement" {
+            let Some(p) = stmt.parent() else { return };
+            stmt = p;
+        }
+        let Some(block) = stmt.parent() else { return };
+        if block.kind() != "block" {
+            return;
+        }
+        let region = Span { start: stmt.end_position(), end: block.end_position() };
+        for fact in recognize_guards(condition, self.source) {
+            if fact.asserts_when_true == holds_when_true {
+                self.emit_narrowing_fact(fact, region, block);
+            }
+        }
+    }
+
+    /// Push the span-extent narrowing witness on the subject's home scope,
+    /// truncating the region at the first reassignment of the subject.
+    fn emit_narrowing_fact(&mut self, fact: GuardFact, region: Span, container: Node<'a>) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        let NarrowSubject::Variable(var) = fact.subject;
+        let end = self
+            .first_subject_write(&var, region, container)
+            .unwrap_or(region.end);
+        if !point_lt(region.start, end) {
+            return; // truncated to nothing
+        }
+        self.bag.push(Witness {
+            attachment: WitnessAttachment::Variable { name: var, scope: self.current_scope() },
+            source: WitnessSource::Builder("narrowing".into()),
+            payload: WitnessPayload::InferredType(fact.narrowed),
+            span: Span { start: region.start, end },
+        });
+    }
+
+    /// Point of the first reassignment of `$var` inside `container` at or
+    /// after `region.start` — the narrowing region's truncation bound.
+    fn first_subject_write(&self, var: &str, region: Span, container: Node<'a>) -> Option<Point> {
+        fn writes_var(left: Node, var: &str, src: &[u8]) -> bool {
+            match left.kind() {
+                "scalar" => crate::cst::canonical_var_name(left, src).as_deref() == Some(var),
+                // `my $x = ...` / `my ($x) = ...` rebinds → also truncates.
+                "variable_declaration" => {
+                    let mut stack = vec![left];
+                    while let Some(n) = stack.pop() {
+                        if n.kind() == "scalar"
+                            && crate::cst::canonical_var_name(n, src).as_deref() == Some(var)
+                        {
+                            return true;
+                        }
+                        for i in 0..n.named_child_count() {
+                            if let Some(c) = n.named_child(i) {
+                                stack.push(c);
+                            }
+                        }
+                    }
+                    false
+                }
+                _ => false,
+            }
+        }
+        fn scan(node: Node, var: &str, after: Point, src: &[u8], best: &mut Option<Point>) {
+            if node.kind() == "assignment_expression" {
+                if let Some(left) = node.child_by_field_name("left") {
+                    if writes_var(left, var, src) {
+                        let p = node.start_position();
+                        if !point_lt(p, after) && best.map_or(true, |b| point_lt(p, b)) {
+                            *best = Some(p);
+                        }
+                    }
+                }
+            }
+            for i in 0..node.named_child_count() {
+                if let Some(c) = node.named_child(i) {
+                    scan(c, var, after, src, best);
+                }
+            }
+        }
+        let mut best = None;
+        scan(container, var, region.start, self.source, &mut best);
+        best
+    }
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15049,3 +15049,139 @@ fn plugin_loads_recorded_trigger_independent_and_multivalue() {
     );
     let _ = SymKind::Sub;
 }
+
+// ── Flow-sensitive narrowing (docs/prompt-flow-narrowing.md) ──
+
+#[test]
+fn narrow_block_if_isa() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo')) {\n        $x->go;\n    }\n    $x->go;\n}",
+    );
+    // Inside the then-block: narrowed to Foo.
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "isa guard narrows inside the block",
+    );
+    // After the block: widened back (untyped param → None).
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(6, 4)),
+        None,
+        "narrowing does not leak past the block",
+    );
+}
+
+#[test]
+fn narrow_block_ref_eq_reftype() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if (ref($x) eq 'HASH') {\n        my $v = $x;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 16)),
+        Some(InferredType::HashRef),
+        "ref() eq 'HASH' narrows to HashRef",
+    );
+}
+
+#[test]
+fn narrow_early_return_unless() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    return unless $x->isa('Widget');\n    $x->layout;\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 4)),
+        Some(InferredType::ClassName("Widget".into())),
+        "return-unless asserts the type over the remainder",
+    );
+}
+
+#[test]
+fn narrow_logical_or_exit() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    $x->isa('Session') or die;\n    $x->go;\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 4)),
+        Some(InferredType::ClassName("Session".into())),
+        "`G or die` narrows the remainder",
+    );
+}
+
+#[test]
+fn narrow_observed_through_method_dispatch() {
+    // The invocant of `$x->paint` inside the block resolves to Foo, so a
+    // method call dispatches on the narrowed class (the query seam).
+    let fa = build_fa(
+        "package Foo;\nsub paint { my ($self) = @_; }\npackage P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo')) {\n        $x->paint;\n    }\n}",
+    );
+    let r = fa
+        .refs
+        .iter()
+        .find(|r| r.target_name == "paint" && matches!(r.kind, RefKind::MethodCall { .. }))
+        .expect("paint method-call ref");
+    assert_eq!(
+        fa.method_call_invocant_class(r, None).as_deref(),
+        Some("Foo"),
+        "narrowed invocant dispatches on Foo",
+    );
+}
+
+#[test]
+fn narrow_negative_else_not_applied() {
+    // The else-branch knows `$x` is NOT Foo — no positive type to assert.
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo')) {\n        $x->a;\n    } else {\n        $x->b;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "then-branch still narrows",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(6, 8)),
+        None,
+        "else-branch is not narrowed (negative polarity, deferred)",
+    );
+}
+
+#[test]
+fn narrow_negated_guard_skips_then_block() {
+    // `if (!G) { BODY }` proves NOT-Foo in BODY — negative, so no narrowing.
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if (!$x->isa('Foo')) {\n        $x->a;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 8)),
+        None,
+        "negated guard does not positively narrow its block",
+    );
+}
+
+#[test]
+fn narrow_truncated_at_reassignment() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo')) {\n        $x->before;\n        $x = bar();\n        $x->after;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "narrowed before the reassignment",
+    );
+    assert_ne!(
+        fa.inferred_type_via_bag("$x", Point::new(6, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "reassignment truncates the narrowing region",
+    );
+}
+
+#[test]
+fn narrow_conjunction_intersects() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo') && $x->can('m')) {\n        $x->go;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "&&-chain narrows on the isa conjunct",
+    );
+}

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -65,15 +65,20 @@ fn module_sources() -> Vec<(&'static str, Vec<PathBuf>)> {
             continue;
         };
         if path.is_dir() {
-            if stem == "plugin" {
+            // A module directory (`plugin/`, `builder/`) contributes its
+            // `.rs` files to that module's layer — same enforcement as the
+            // top-level `<module>.rs`, so a submodule can't dodge the DAG.
+            if let Some(name) = map.keys().copied().find(|k| *k == stem) {
                 let files = fs::read_dir(&path)
-                    .expect("read plugin/")
+                    .unwrap_or_else(|_| panic!("read {stem}/"))
                     .filter_map(|e| {
                         let p = e.ok()?.path();
-                        (p.extension()? == "rs").then_some(p)
+                        let s = p.file_stem()?.to_str()?;
+                        (p.extension()? == "rs" && !s.ends_with("_tests") && !s.ends_with("_test"))
+                            .then_some(p)
                     })
                     .collect();
-                out.push(("plugin", files));
+                out.push((name, files));
             }
             continue;
         }

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 95;
+pub const EXTRACT_VERSION: i64 = 96;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -1684,7 +1684,17 @@ impl ReducerRegistry {
                             WitnessAttachment::Variable { name, scope },
                             Some(ctx),
                         ) => {
-                            let point = scope_point(ctx.scopes, *scope);
+                            // Narrowing point: an edge reached FROM a positioned
+                            // expression (a variable read recorded at `Expr(span)`)
+                            // resolves the slot at the read's own location, so a
+                            // flow-sensitive guard refines it only inside the
+                            // guard's region (docs/prompt-flow-narrowing.md). Other
+                            // edge sources have no read position; the scope end is
+                            // the standing temporal approximation.
+                            let point = match q.attachment {
+                                WitnessAttachment::Expr(span) => span.start,
+                                _ => scope_point(ctx.scopes, *scope),
+                            };
                             self.query_variable_with_visited(
                                 bag, ctx, name, *scope, point, state,
                             )

--- a/test_files/narrowing_playground.pl
+++ b/test_files/narrowing_playground.pl
@@ -181,6 +181,63 @@ sub weak_blessed {
     }
 }
 
+# ── P. Place subjects (v1b) — narrow a slot, not a variable ──
+#    Canonical access path = root + constant projections. The
+#    narrowing region is TRUNCATED at the first op that could
+#    disturb the slot (emit-time invalidation scan).
+
+sub place_block_isa {
+    my ($self) = @_;
+    if ($self->{handler}->isa('Foo')) {
+        $self->{handler}->render;       # NARROW $self->{handler} => Foo
+    }
+    $self->{handler}->render;           # WIDE (past block)
+}
+
+sub place_assert_remainder {
+    my ($self) = @_;
+    return unless ref($self->{cfg}) eq 'HASH';
+    my $port = $self->{cfg}->{port};    # NARROW $self->{cfg} => HashRef
+}
+
+sub place_method_on_value_ok {
+    my ($self) = @_;
+    return unless $self->{db}->isa('Schema');
+    $self->{db}->connect;               # NARROW $self->{db} => Schema
+    $self->{db}->query;                 # NARROW still (method on the VALUE
+                                        # doesn't disturb the slot)
+}
+
+sub place_invalidated_by_prefix_write {
+    my ($self) = @_;
+    return unless $self->{x}->isa('Foo');
+    $self->{x}->step;                   # NARROW $self->{x} => Foo
+    $self->{x} = make_other();          # WRITE to the place → truncates here
+    $self->{x}->step;                   # WIDE (re-widened past the write)
+}
+
+sub place_invalidated_by_opaque_prefix {
+    my ($self) = @_;
+    return unless $self->{x}->isa('Foo');
+    $self->{x}->step;                   # NARROW $self->{x} => Foo
+    $self->reset;                       # opaque op on prefix $self → truncates
+    $self->{x}->step;                   # WIDE (couldn't prove slot survived)
+}
+
+sub place_dynamic_key_no_narrow {
+    my ($self, $k) = @_;
+    return unless $self->{$k}->isa('Foo');
+    $self->{$k}->step;                  # NO-NARROW (dynamic key — not a
+                                        # stable place identity)
+}
+
+sub place_bind_to_lexical_already_works {
+    my ($self) = @_;
+    my $h = $self->{handler};           # v1a escape hatch: bind the slot
+    return unless $h->isa('Foo');
+    $h->render;                         # NARROW $h => Foo (plain Variable)
+}
+
 # ── H. The complement: a function whose return WANTS Optional ─
 #    Today this folds to None (arm disagreement). With Optional<Foo>
 #    it returns Foo|undef, and weak_defined above resolves it.

--- a/test_files/narrowing_playground.pl
+++ b/test_files/narrowing_playground.pl
@@ -1,0 +1,195 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Scalar::Util qw(blessed reftype);
+
+# ============================================================
+# Flow-sensitive Narrowing — Playground / Executable Spec
+# ============================================================
+#
+# Design: docs/prompt-flow-narrowing.md
+#
+# A guard expression refines a variable's type for the region it
+# dominates, then the type widens back at the region's exit. This
+# file is the authoring source for the per-row tests.
+#
+# Notation:
+#
+#   # NARROW $x => Foo      inside this region, $x narrows to Foo
+#   # WIDE   $x             back to the outer (un-narrowed) type
+#   # NO-NARROW             guard recognized but v1 emits nothing
+#                           (negative polarity, or no lattice target)
+#
+# "Foo" = ClassName(Foo); HashRef/ArrayRef/CodeRef/Regexp as named.
+# The outer type is whatever the parameter/assignment gave (often
+# Unknown — narrowing's job is to make the inside precise anyway).
+#
+# ✅ rows MUST narrow in v1.  ✘ rows MUST NOT (over-narrow guards).
+# ============================================================
+
+# ── A. Block guard, positive (✅) ────────────────────────────
+
+sub block_isa {
+    my ($x) = @_;                       # WIDE $x (Unknown)
+    if ($x->isa('Foo')) {
+        $x->render;                     # NARROW $x => Foo
+    }
+    $x->render;                         # WIDE $x  (un-narrowed past block)
+}
+
+sub block_ref_eq_class {
+    my ($x) = @_;
+    if (ref($x) eq 'Point') {
+        $x->coords;                     # NARROW $x => Point
+    }
+}
+
+sub block_ref_eq_reftype {
+    my ($x) = @_;
+    if (ref($x) eq 'HASH') {
+        my $v = $x->{key};              # NARROW $x => HashRef
+    }
+    if (ref($x) eq 'ARRAY') {
+        my $v = $x->[0];                # NARROW $x => ArrayRef
+    }
+    if (ref($x) eq 'CODE') {
+        $x->();                         # NARROW $x => CodeRef
+    }
+    if (ref($x) eq 'Regexp') {
+        'str' =~ $x;                    # NARROW $x => Regexp
+    }
+}
+
+sub block_does_role {
+    my ($x) = @_;
+    if ($x->DOES('Drawable')) {
+        $x->draw;                       # NARROW $x => Drawable
+    }
+}
+
+# ── B. Early-exit guard, positive (✅) ───────────────────────
+#    Narrowing region = the REST OF THE BLOCK after the guard.
+
+sub assert_unless {
+    my ($x) = @_;                       # WIDE $x
+    return unless $x->isa('Widget');
+    $x->layout;                         # NARROW $x => Widget (remainder)
+    $x->paint;                          # NARROW $x => Widget
+}
+
+sub assert_or_die {
+    my ($x) = @_;
+    $x->isa('Session') or die "not a session";
+    $x->user;                           # NARROW $x => Session (remainder)
+}
+
+sub assert_ref_unless {
+    my ($cfg) = @_;
+    return unless ref($cfg) eq 'HASH';
+    my $port = $cfg->{port};            # NARROW $cfg => HashRef (remainder)
+}
+
+sub assert_negated {
+    my ($x) = @_;
+    die unless !$x->isa('Banned');      # !G under `unless` => G... careful:
+    # `unless !isa(Banned)` exits when isa is true → remainder: NOT Banned.
+    # NO-NARROW (negative polarity — deferred)
+    $x->go;
+}
+
+# ── C. Negation flips polarity ───────────────────────────────
+
+sub negated_block_else_deferred {
+    my ($x) = @_;
+    if (!$x->isa('Foo')) {
+        warn "nope";                    # NO-NARROW (region asserts NOT Foo)
+    } else {
+        $x->render;                     # else of !G asserts G — ✅ if/when
+                                        # else-region emission lands; v1 may
+                                        # skip else entirely. NARROW $x => Foo
+    }
+}
+
+# ── D. Negative-space guardrails — MUST NOT narrow (✘) ───────
+
+sub else_branch_negative {
+    my ($x) = @_;
+    if ($x->isa('Foo')) {
+        $x->render;                     # NARROW $x => Foo
+    } else {
+        $x->fallback;                   # NO-NARROW ($x is NOT Foo; deferred)
+    }
+}
+
+sub unless_block_negative {
+    my ($x) = @_;
+    unless ($x->isa('Foo')) {
+        $x->fallback;                   # NO-NARROW (region asserts NOT Foo)
+    }
+}
+
+sub return_if_negative {
+    my ($x) = @_;
+    return if $x->isa('Legacy');
+    $x->modern;                         # NO-NARROW (remainder is NOT Legacy)
+}
+
+sub or_disjunction_no_narrow {
+    my ($x) = @_;
+    if ($x->isa('Foo') || $x->isa('Bar')) {
+        $x->common;                     # NO-NARROW (could be Foo OR Bar — no
+                                        # join in v1 lattice; ✘ over-narrow)
+    }
+}
+
+# ── E. Compound conjunction — intersection narrows ───────────
+
+sub and_conjunction {
+    my ($x) = @_;
+    if ($x->isa('Foo') && $x->can('extra')) {
+        $x->extra;                      # NARROW $x => Foo (from the isa
+                                        # conjunct; `can` ignored)
+    }
+}
+
+# ── F. Reassignment inside the region (temporal soundness) ───
+
+sub reassign_in_region {
+    my ($x) = @_;
+    if ($x->isa('Foo')) {
+        $x->before;                     # NARROW $x => Foo
+        $x = Bar->new;                  # later-starting witness
+        $x->after;                      # $x => Bar (reassignment wins by
+                                        # temporal order, NOT Foo)
+    }
+}
+
+# ── G. Weak guards — recognized, no v1 target (Optional dep) ─
+
+sub weak_defined {
+    my ($x) = @_;                       # outer: ideally Optional<T> someday
+    return unless defined $x;
+    $x->use;                            # NO-NARROW in v1; becomes T once
+                                        # Optional<T> lands (defined strips undef)
+}
+
+sub weak_blessed {
+    my ($x) = @_;
+    if (blessed $x) {
+        $x->method;                     # NO-NARROW in v1 (no "object" type);
+                                        # future: narrows undef/non-ref away
+    }
+}
+
+# ── H. The complement: a function whose return WANTS Optional ─
+#    Today this folds to None (arm disagreement). With Optional<Foo>
+#    it returns Foo|undef, and weak_defined above resolves it.
+
+sub maybe_make {
+    my ($ok) = @_;
+    return undef unless $ok;            # arm: undef
+    return Foo->new;                    # arm: Foo
+    # v1 return type: None (disagreement). Future: Optional<Foo>.
+}
+
+1;


### PR DESCRIPTION
## What

Flow-sensitive narrowing v1a: a guard expression refines a **variable** to a more specific type over the region the guard dominates, and the type widens back at the region's exit.

```perl
sub f {
    my ($x) = @_;
    return unless $x->isa('Widget');
    $x->layout;          # $x : Widget here
}
```

Recognized guards (positive polarity only):

| Form | narrows |
| --- | --- |
| `if ($x->isa('Foo')) { … }` / `$x->DOES('Role')` | then-block → `ClassName` |
| `return/die/last/next unless $x->isa('Foo'); …` | block remainder |
| `$x->isa('Foo') or die; …` | block remainder |
| `if (ref($x) eq 'HASH') { … }` (`ARRAY`/`CODE`/`Regexp`/class) | then-block → rep / class |
| `if (G1 && G2) { … }` | intersect — one narrowing per recognized conjunct |
| `!G` | flips polarity (negative → skipped) |

## How

The reducer query path **already** does the lookup — narrowest-span `InferredType` witness containing the point wins, and scoped-exclusion drops a witness whose span doesn't contain the point (`witnesses.rs`). So this is purely an **emission** feature, and block-exit "un-narrowing" is automatic: nothing is retracted, the narrow witness simply stops containing points past its region. Two load-bearing pieces on the emit side:

- **Soundness vs reassignment.** A span-extent narrowing witness would short-circuit the narrow path *over* a later (zero-extent, temporal) reassignment. So the region is **truncated at the first write** of the subject — the same invalidation-truncation the place design (v1b) generalizes.
- **The query seam.** An `Edge(Variable)` reached from a positioned `Expr(span)` now resolves the slot at the **read's own location** instead of the scope end, so a method call on a narrowed variable dispatches on the narrowed class. (The `scope_point` doc comment already flagged scope-end as an approximation.)

Only positive-polarity rows ship. Else-branch / negative narrowing (`$x` is *not*-Foo) waits on a union/`Optional` type — see the design doc.

## Scope

- **v1a (this PR):** variable subjects.
- **v1b (follow-on):** place subjects (`$self->{x}`) — canonical access paths + emit-time invalidation truncation + one query seam. The seams here (`NarrowSubject`, home-scope + span emission) are shaped to admit it additively.

Design + executable spec: `docs/prompt-flow-narrowing.md`, `test_files/narrowing_playground.pl`.

## Testing

- `cargo test`: **956 passed, 0 failed** (full suite, incl. layering tests), with **9 new** narrowing tests in `builder_tests.rs` — block/early-exit/logical-exit/ref-eq/conjunction narrowing, the method-dispatch seam, and the negative-space guardrails (else / negated / past-block / reassignment-truncation must **not** over-narrow).
- `./run_e2e.sh` and `gold-corpus/run.pl` could not run in the dev container (no nvim; gold substrate not installed) — relying on CI for both. The materialize point change is the one to watch on the gold net; it's strictly more position-correct, and all type-inference unit tests pass.

Bumps `EXTRACT_VERSION` (new witnesses → invalidate stale cache blobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_