### PR TITLE
feat(narrowing): place subjects (v1b) — stacked on #82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base filter: every PR runs, whatever its base — so a PR stacked on
+  # another feature branch is covered (the reason the default `[main]`
+  # filter was dropped). Runs on PRs; doesn't *require* a green check —
+  # that's branch protection, separate from this file.
   pull_request:
-    branches: [main]
+
+# Cancel superseded runs when a PR branch is re-pushed.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/prompt-flow-narrowing.md
+++ b/docs/prompt-flow-narrowing.md
@@ -181,6 +181,16 @@ place's writes can hide behind **aliasing**: `$self->reset` or
 
 ### v1a — variables · v1b — places (one feature, two flowing increments)
 
+**Status:** v1a landed; v1b landed for single-hop places — a constant
+hash/array projection off a scalar root (`$self->{x}`, `$self->[0]`).
+Multi-hop chains (`$self->{a}{b}`) and zero-arg accessor projections
+(`$self->name`) are the remaining follow-up. A place is keyed by its
+source spelling on the existing `Variable` attachment (the doc's "a
+`Place` witness is *just* a span-scoped slot witness" — so the engine,
+narrow-filter, and scope-walk are untouched); the place-vs-variable
+distinction lives only in the truncation rule and the one
+`method_call_invocant_class` query seam.
+
 The narrowing soundness lives **entirely on the emit side**, so places
 are *additive*, not a query-path rewrite — provided v1a's seams admit
 them from day one:

--- a/src/builder/narrowing.rs
+++ b/src/builder/narrowing.rs
@@ -14,10 +14,21 @@ use crate::file_analysis::{InferredType, Span};
 
 use super::{connector_keyword_between, point_lt, raw_leading_op, raw_mid_op, Builder};
 
-/// The subject a guard narrows. v1a recognizes plain scalars; the
-/// `Place` arm (`$self->{x}`) lands with the access-path canonicalizer.
+/// The subject a guard narrows — a plain scalar, or a constant
+/// hash/array place (`$self->{x}`) keyed by its source spelling.
 pub(super) enum NarrowSubject {
     Variable(String),
+    Place { key: String, root: String },
+}
+
+/// Classify a guard's operand into the subject it narrows: a plain
+/// scalar (`Variable`), else a constant place path (`Place`).
+fn narrow_subject_of(node: Node, src: &[u8]) -> Option<NarrowSubject> {
+    if let Some(v) = crate::cst::canonical_var_name(node, src) {
+        return Some(NarrowSubject::Variable(v));
+    }
+    let (key, root) = crate::cst::canonical_place_path(node, src)?;
+    Some(NarrowSubject::Place { key, root })
 }
 
 /// A recognized guard fact: the subject, the type it proves, and whether
@@ -62,12 +73,15 @@ fn string_literal_text(node: Node, source: &[u8]) -> Option<String> {
     content.filter(|s| !s.is_empty())
 }
 
-/// The scalar argument of a `func1op_call_expression` (`ref($x)` /
-/// `ref $x`), if its argument is a plain scalar.
-fn func1op_scalar_arg<'a>(node: Node<'a>) -> Option<Node<'a>> {
+/// The subject argument of a `func1op_call_expression` (`ref($x)` /
+/// `ref $self->{x}`) — a plain scalar or a place element.
+fn func1op_subject_arg<'a>(node: Node<'a>) -> Option<Node<'a>> {
     for i in 0..node.named_child_count() {
         let c = node.named_child(i)?;
-        if c.kind() == "scalar" {
+        if matches!(
+            c.kind(),
+            "scalar" | "hash_element_expression" | "array_element_expression"
+        ) {
             return Some(c);
         }
     }
@@ -118,10 +132,10 @@ fn recognize_isa_guard(call: Node, source: &[u8]) -> Option<GuardFact> {
     if method != "isa" && method != "DOES" {
         return None;
     }
-    let var = crate::cst::canonical_var_name(mc.invocant()?, source)?;
+    let subject = narrow_subject_of(mc.invocant()?, source)?;
     let class = string_literal_text(call.child_by_field_name("arguments")?, source)?;
     Some(GuardFact {
-        subject: NarrowSubject::Variable(var),
+        subject,
         narrowed: InferredType::ClassName(class),
         asserts_when_true: true,
     })
@@ -146,10 +160,10 @@ fn recognize_ref_eq_guard(eq: Node, source: &[u8]) -> Option<GuardFact> {
     if fname != "ref" && fname != "reftype" {
         return None;
     }
-    let var = crate::cst::canonical_var_name(func1op_scalar_arg(ref_call)?, source)?;
+    let subject = narrow_subject_of(func1op_subject_arg(ref_call)?, source)?;
     let ty = ref_string_to_type(&string_literal_text(lit, source)?)?;
     Some(GuardFact {
-        subject: NarrowSubject::Variable(var),
+        subject,
         narrowed: ty,
         asserts_when_true: true,
     })
@@ -270,19 +284,79 @@ impl<'a> Builder<'a> {
     /// truncating the region at the first reassignment of the subject.
     fn emit_narrowing_fact(&mut self, fact: GuardFact, region: Span, container: Node<'a>) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        let NarrowSubject::Variable(var) = fact.subject;
-        let end = self
-            .first_subject_write(&var, region, container)
-            .unwrap_or(region.end);
+        let (name, end) = match fact.subject {
+            NarrowSubject::Variable(var) => {
+                let end = self.first_subject_write(&var, region, container);
+                (var, end)
+            }
+            NarrowSubject::Place { key, root } => {
+                let end = self.first_place_invalidation(&key, &root, region, container);
+                (key, end)
+            }
+        };
+        let end = end.unwrap_or(region.end);
         if !point_lt(region.start, end) {
             return; // truncated to nothing
         }
         self.bag.push(Witness {
-            attachment: WitnessAttachment::Variable { name: var, scope: self.current_scope() },
+            attachment: WitnessAttachment::Variable { name, scope: self.current_scope() },
             source: WitnessSource::Builder("narrowing".into()),
             payload: WitnessPayload::InferredType(fact.narrowed),
             span: Span { start: region.start, end },
         });
+    }
+
+    /// Point of the first operation in `container` (at or after
+    /// `region.start`) that could disturb place `key` rooted at `root`:
+    /// a write to the slot, or any non-place-access use of `root` (a root
+    /// write, a method call on `root`, `root` passed as an argument). A
+    /// place READ keeps `root` as the base of a `->{…}` access, so it
+    /// doesn't trip the root rule. Conservative — it under-narrows.
+    fn first_place_invalidation(
+        &self,
+        key: &str,
+        root: &str,
+        region: Span,
+        container: Node<'a>,
+    ) -> Option<Point> {
+        fn consider(node: Node, after: Point, best: &mut Option<Point>) {
+            let p = node.start_position();
+            if !point_lt(p, after) && best.map_or(true, |b| point_lt(p, b)) {
+                *best = Some(p);
+            }
+        }
+        fn scan(node: Node, key: &str, root: &str, after: Point, src: &[u8], best: &mut Option<Point>) {
+            if node.kind() == "assignment_expression" {
+                if let Some(left) = node.child_by_field_name("left") {
+                    if crate::cst::canonical_place_path(left, src).map(|(k, _)| k).as_deref()
+                        == Some(key)
+                    {
+                        consider(node, after, best);
+                    }
+                }
+            }
+            if node.kind() == "scalar"
+                && crate::cst::canonical_var_name(node, src).as_deref() == Some(root)
+            {
+                // Guarded = `root` is the base of a place access (`$self->{…}`),
+                // i.e. a read of some slot — not an opaque use.
+                let guarded = node.parent().map_or(false, |p| {
+                    matches!(p.kind(), "hash_element_expression" | "array_element_expression")
+                        && p.named_child(0) == Some(node)
+                });
+                if !guarded {
+                    consider(node, after, best);
+                }
+            }
+            for i in 0..node.named_child_count() {
+                if let Some(c) = node.named_child(i) {
+                    scan(c, key, root, after, src, best);
+                }
+            }
+        }
+        let mut best = None;
+        scan(container, key, root, region.start, self.source, &mut best);
+        best
     }
 
     /// Point of the first reassignment of `$var` inside `container` at or

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15185,3 +15185,97 @@ fn narrow_conjunction_intersects() {
         "&&-chain narrows on the isa conjunct",
     );
 }
+
+// ── Place narrowing (v1b): `$self->{x}` ──
+
+/// Class an invocant resolves to for the method-call ref named `method`.
+fn invocant_class_of(fa: &FileAnalysis, method: &str) -> Option<String> {
+    let r = fa
+        .refs
+        .iter()
+        .find(|r| r.target_name == method && matches!(r.kind, RefKind::MethodCall { .. }))
+        .unwrap_or_else(|| panic!("no method-call ref for {method}"));
+    fa.method_call_invocant_class(r, None)
+}
+
+#[test]
+fn narrow_place_block_if_isa() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    if ($self->{h}->isa('Foo')) {\n        $self->{h}->go;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$self->{h}", Point::new(4, 8)),
+        Some(InferredType::ClassName("Foo".into())),
+        "place isa guard narrows the slot inside the block",
+    );
+    assert_eq!(invocant_class_of(&fa, "go").as_deref(), Some("Foo"));
+}
+
+#[test]
+fn narrow_place_early_return() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    return unless $self->{cfg}->isa('Cfg');\n    $self->{cfg}->load;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "load").as_deref(), Some("Cfg"));
+}
+
+#[test]
+fn narrow_place_method_on_value_keeps_slot() {
+    // A method call on the slot's VALUE doesn't disturb the slot, so both
+    // uses stay narrowed.
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    return unless $self->{db}->isa('Schema');\n    $self->{db}->connect;\n    $self->{db}->disconnect;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "connect").as_deref(), Some("Schema"));
+    assert_eq!(invocant_class_of(&fa, "disconnect").as_deref(), Some("Schema"));
+}
+
+#[test]
+fn narrow_place_truncated_by_slot_write() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    return unless $self->{x}->isa('Foo');\n    $self->{x}->before;\n    $self->{x} = other();\n    $self->{x}->after;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "before").as_deref(), Some("Foo"));
+    assert_ne!(
+        invocant_class_of(&fa, "after").as_deref(),
+        Some("Foo"),
+        "writing the slot truncates the narrowing",
+    );
+}
+
+#[test]
+fn narrow_place_truncated_by_opaque_root_op() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    return unless $self->{x}->isa('Foo');\n    $self->{x}->before;\n    $self->reset;\n    $self->{x}->after;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "before").as_deref(), Some("Foo"));
+    assert_ne!(
+        invocant_class_of(&fa, "after").as_deref(),
+        Some("Foo"),
+        "an opaque op on the root ($self->reset) truncates the narrowing",
+    );
+}
+
+#[test]
+fn narrow_place_dynamic_key_skipped() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self, $k) = @_;\n    return unless $self->{$k}->isa('Foo');\n    $self->{$k}->go;\n}",
+    );
+    assert_ne!(
+        invocant_class_of(&fa, "go").as_deref(),
+        Some("Foo"),
+        "a dynamic key is not a stable place — no narrowing",
+    );
+}
+
+#[test]
+fn narrow_place_ref_eq() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($self) = @_;\n    return unless ref($self->{cfg}) eq 'HASH';\n    my $v = $self->{cfg};\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$self->{cfg}", Point::new(4, 12)),
+        Some(InferredType::HashRef),
+        "ref(place) eq 'HASH' narrows the slot",
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -296,6 +296,38 @@ pub(crate) fn canonical_container_name<'a>(node: Node<'a>, src: &'a [u8]) -> Opt
     Some(format!("{}{}", target_sigil, bare))
 }
 
+/// Canonical access-path key for a place subject — a single constant
+/// hash/array projection off a plain scalar root (`$self->{handler}`,
+/// `$self->[0]`). Returns `(key, root)`: `key` is the place's source text
+/// (the spelling the guard and the use share, so a witness keyed on it
+/// matches the use-site invocant), `root` the base scalar (for the
+/// flow-narrowing invalidation scan). Dynamic keys, deeper chains, and
+/// accessor projections return `None` — not a stable place identity.
+pub(crate) fn canonical_place_path<'a>(
+    node: Node<'a>,
+    src: &'a [u8],
+) -> Option<(String, String)> {
+    let (root_node, constant) = match node.kind() {
+        "hash_element_expression" => {
+            let key = node.child_by_field_name("key")?;
+            let constant =
+                matches!(key.kind(), "autoquoted_bareword" | "string_literal" | "number");
+            (node.named_child(0)?, constant)
+        }
+        "array_element_expression" => {
+            let index = node.child_by_field_name("index")?;
+            (node.named_child(0)?, index.kind() == "number")
+        }
+        _ => return None,
+    };
+    if !constant || root_node.kind() != "scalar" {
+        return None;
+    }
+    let root = canonical_var_name(root_node, src)?;
+    let key = node.text(src)?.to_string();
+    Some((key, root))
+}
+
 /// Per-word `(text, span)` pairs of a `quoted_word_list`, multi-line
 /// aware (rows/cols tracked through internal whitespace).
 pub(crate) fn qw_word_spans(qw_node: Node, src: &[u8], results: &mut Vec<(String, Span)>) {

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -6019,6 +6019,23 @@ impl FileAnalysis {
             return self.enclosing_class_for_scope(r.scope);
         }
 
+        // Flow-narrowing: a place invocant (`$self->{x}`) refined by a guard
+        // resolves at the use-site point, ahead of the functional deref
+        // chase — narrowing is strictly more precise where it applies
+        // (docs/prompt-flow-narrowing.md, v1b). Keyed on the invocant's own
+        // spelling, the place narrowing witness rides the `Variable` query
+        // path like any scalar.
+        if let Some(span) = invocant_span {
+            if invocant.contains("->") {
+                if let Some(cn) = self
+                    .inferred_type_via_bag_ctx(invocant, span.start, module_index)
+                    .and_then(|t| t.class_name().map(|s| s.to_string()))
+                {
+                    return Some(cn);
+                }
+            }
+        }
+
         // The invocant's type, resolved tree-free from the bag at its
         // span. Covers every recorded shape: scalar/array/hash reads,
         // chain receivers (the `Expression(refidx)` axis), function-call

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 96;
+pub const EXTRACT_VERSION: i64 = 97;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.


### PR DESCRIPTION
**Stacked on #82** (base is the v1a branch; review/merge #82 first — the diff here is v1b only).

## What

Extends flow narrowing from variables to **place subjects** — a constant hash/array projection off a scalar root:

```perl
sub f {
    my ($self) = @_;
    return unless $self->{handler}->isa('Foo');
    $self->{handler}->render;     # $self->{handler} : Foo here
}
```

Guards now accept a place invocant/operand: `$self->{x}->isa('Foo')`, `ref($self->{cfg}) eq 'HASH'`, etc.

## How — the place-vs-variable distinction is two spots, nothing else

A place is keyed by its **source spelling** on the existing `Variable` attachment, so the reducer, scope-walk, and narrow-filter are **untouched** (per the design: "a `Place` witness is *just* a span-scoped slot witness"). Only two things know it's a place:

- **Truncation (soundness).** A place narrowing ends at the first op that could disturb the slot: a write to the slot, or any *non-place-access* use of the root — a root write, `$self->reset`, `frob($self)`. A place **read** keeps the root as the base of a `->{…}` access (`p.named_child(0)`), so it doesn't trip the rule. One elegant predicate covers root-write + method-on-root + passed-as-arg; sibling-slot writes and method calls *on the slot value* (`$self->{db}->connect`) correctly don't truncate. Conservative — it under-narrows, never lies.
- **Query seam.** `method_call_invocant_class` resolves a place invocant via the bag at the use-site point, ahead of the functional deref chase.

`cst::canonical_place_path` validates the shape (scalar root + constant key/index, single hop) and yields `(key, root)`.

## Scope

- **Lands:** single-hop hash/array element off a scalar root (`$self->{x}`, `$self->[0]`).
- **Skipped (no narrowing):** dynamic keys (`$self->{$k}`), multi-hop chains (`$self->{a}{b}`), zero-arg accessor projections (`$self->name`) — follow-up.

## Testing

- `cargo test`: **963 passed, 0 failed** (full suite), with **7 new** place tests — block/early-return narrowing, the method-dispatch seam, and the negative-space guardrails: method-on-value keeps the slot, slot-write truncates, opaque-root-op truncates, dynamic key doesn't narrow.
- `./run_e2e.sh` / `gold-corpus/run.pl`: relying on CI (no nvim / gold substrate locally).

Bumps `EXTRACT_VERSION` (97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_