### PR TITLE
feat(types): Optional<T> lattice + return-undef join (phase 1) — stacked on #84

### DIFF
--- a/docs/prompt-optional-types.md
+++ b/docs/prompt-optional-types.md
@@ -1,0 +1,120 @@
+# Optional / Maybe types — design
+
+**Status: Phase 1 implementing.** The complement of flow narrowing
+(`docs/prompt-flow-narrowing.md` §"Sum / optional types"): a function
+that early-returns undef produces `Foo | undef`, which today collapses
+to `None` (arm disagreement). `Optional(Box<InferredType>)` captures it,
+and `defined $x` / `blessed $x` narrowing strips it back to `T` — the
+two features are two halves of one story.
+
+Scoped to **`Optional<T>` (value-or-undef), not arbitrary unions.**
+`Foo | Bar` stays `None` until a motivating case lands. `Maybe<T>` is
+the dominant Perl idiom and maps 1:1 onto Type::Tiny `Maybe[T]` /
+`Optional[T]`.
+
+## The lattice variant
+
+`InferredType::Optional(Box<InferredType>)`, appended at the **END** of
+the enum (`file_analysis.rs`) for bincode variant-index stability — same
+discipline as `Sequence` / `TypeConstraintOf` / `BrandedRoute` /
+`HashWithKeys`. Bump `EXTRACT_VERSION`.
+
+Blast radius is small: exhaustive (`_`-less) matches on `InferredType`
+are confined to `file_analysis.rs` and terminate in `_ =>` wildcards
+(unlike `ParametricType`, which forbids `_`). So adding the variant does
+not cascade compile errors.
+
+**`class_name()` → `None` for `Optional(_)`** (no arm; falls through the
+existing `_`). An `Optional<Foo>` is *not definitely* a `Foo` — letting
+it dispatch as `Foo` is the exact unsoundness the variant exists to
+surface. `is_object()` (`= class_name().is_some()`) is `false`
+automatically; `hash_key_class()` → `None` automatically. The user is
+meant to narrow (`defined`/`blessed`) first; the narrowing yields
+`ClassName(Foo)`, which *does* dispatch. Dispatch-through-optional is a
+deliberate non-feature.
+
+## The join — where {T, undef} becomes Optional<T>
+
+The shared join is `resolve_return_type` (`file_analysis.rs`). Today undef
+arms are **invisible** to it: a `return undef` arm pushes an
+`Edge(Expr(undef_span))` that materializes to nothing (the `undef`
+rvalue has no `Expr` payload — `expr_payload` falls to `_ => None`), and
+a bare `return;` pushes no arm at all. So `{Foo, undef}` looks like just
+`{Foo}` → `Foo`, losing the optionality.
+
+**Fix — make the undef arm legible without adding an `Undef` lattice
+variant:** mark it with a witness **source tag** `Builder("undef_arm")`
+on the existing `SymbolReturnArm(sid)` / `BranchArm(span)` attachment.
+`publish_return_arm_witnesses` detects the bare-`return;` (`None` body)
+and `undef_expression` body cases and pushes the marker. The fold then
+counts undef-marker witnesses separately from typed arms and:
+
+- **≥1 undef-arm AND value-arms resolve to a single non-optional `T`** →
+  `Optional(Box::new(T))`.
+- **no undef-arm** → unchanged (existing behavior; existing tests are a
+  no-op for the new rule).
+- **value-arms genuinely conflict** (`Foo` vs `Bar`) → still `None` (no
+  arbitrary union this phase).
+- **only undef-arms** → `None` (no `Unknown` to wrap; a sub that only
+  `return undef` has no useful value type).
+
+Keeping undef out of the lattice (only `Optional` enters) is the
+load-bearing choice: a private `Undef` variant would leak into every
+consumer.
+
+## `subsumes_narrowing`
+
+- `(Optional(a), Optional(b)) => a.subsumes_narrowing(b)` — recurse.
+- `(a, Optional(b)) => a.subsumes_narrowing(b)` — a concrete `self` is at
+  least as specific as an optional narrowing (narrowing already
+  happened).
+- `(Optional(_), concrete)` — default `false`: the optional does NOT
+  subsume a concrete narrowing, so a `defined`/`blessed` guard's
+  `Optional<T> → T` refinement wins. (No arm; the discriminant fallback
+  is already `false`.)
+
+## Phased plan
+
+**Phase 1 (this doc's target):** `sub f { return undef unless $x;
+return Foo->new }` ⇒ `Optional<ClassName(Foo)>`, all existing tests
+green.
+1. Append `Optional(Box<InferredType>)`; bump `EXTRACT_VERSION`.
+2. `publish_return_arm_witnesses`: push `Builder("undef_arm")` markers
+   for bare `return;` and `return undef`.
+3. `resolve_return_type`: the partition rule above (thread the undef-arm
+   signal in).
+4. `SymbolReturnArmFold`: collect undef-marker count, pass to the join.
+5. `subsumes_narrowing`: the two Optional arms.
+6. `class_name()` untouched (Optional → `None`).
+7. Tests: the target sub; existing arm-fold tests stay green.
+
+**Phase 2 — generalize + light up narrowing:**
+- Route `BranchArmFold` (hand-rolled ternary fold) through the shared
+  join so `$c ? Foo->new : undef` ⇒ `Optional<Foo>` (DRY).
+- `SlotTypeFold` honors Optional (mostly free — undef skips the
+  class-conflict guard, flows into the join).
+- `InferredType::optional_inner()` accessor; wire the **`defined` /
+  `blessed`** guards (today unrecognized) to narrow `Optional<T> → T`.
+  This needs `GuardFact.narrowed` to become a `NarrowOp { To(InferredType),
+  Defined }` enum — `Defined` is a *query* (read the subject's incoming
+  type, strip `Optional`), not a constant type. Emit only when the
+  incoming type is `Optional` (else `defined` is identity).
+
+**Phase 3 — negatives + provenance + Type::Tiny:**
+- Negative-polarity rows (`else` of `if (defined G)`, `return if defined
+  G`) become expressible **for the `defined`/`blessed` family only** —
+  the false arm is the undef side, a concrete element. Needs a bottom
+  (`Undef`) element for the else witness. `isa`/`ref-eq` negatives still
+  need real negation/union (parked).
+- `TypeProvenance::ReducerFold { reducer: "optional_join" }` for
+  `--dump-package`.
+- Map Type::Tiny `Maybe[T]` / `Optional[T]` onto `Optional(Box<T>)` at
+  the `type_constraint_names` seam.
+
+## Sequencing wrinkle (Phase 2+)
+
+A `defined` narrowing whose subject's `Optional` comes from a sub return
+resolved during `fold_to_fixed_point` (phase 6) can't be computed in the
+live walk — the return type isn't in the bag yet. The `defined` emit for
+that case moves to a post-fold pass. The `my ($x) = @_`-typed and
+assignment-typed subjects work in the live walk.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6953,23 +6953,41 @@ impl<'a> Builder<'a> {
     ///   walk through to the arm-fold. Pushed per arm — duplicates
     ///   are idempotent (same target, same materialized result).
     fn publish_return_arm_witnesses(&mut self, return_node: Node<'a>, scope: ScopeId) {
-        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        use crate::witnesses::{
+            FactValue, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
+        };
         let body = match return_node.named_child(0) {
             Some(b) => b,
-            None => return,
+            None => return, // bare `return;` — undef arm deferred (Phase 2)
         };
         let body_span = node_to_span(body);
-        self.emit_expr_witness(body);
 
         let Some(sub_name) = self.enclosing_sub_name() else { return };
         let Some(sym_id) = self.find_sub_symbol_for(&sub_name, scope) else { return };
 
-        self.bag.push(Witness {
-            attachment: WitnessAttachment::SymbolReturnArm(sym_id),
-            source: WitnessSource::Builder("return_arm".into()),
-            payload: WitnessPayload::Edge(WitnessAttachment::Expr(body_span)),
-            span: body_span,
-        });
+        // `return undef` makes the sub's value optional. It has no rvalue
+        // type to ride an `Expr` edge, so mark the arm with a Fact the fold
+        // counts; `join_return_arms` lifts `{T, undef}` to `Optional<T>`.
+        if body.kind() == "undef_expression" {
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
+                source: WitnessSource::Builder("undef_arm".into()),
+                payload: WitnessPayload::Fact {
+                    family: "undef_arm".into(),
+                    key: String::new(),
+                    value: FactValue::Bool(true),
+                },
+                span: body_span,
+            });
+        } else {
+            self.emit_expr_witness(body);
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
+                source: WitnessSource::Builder("return_arm".into()),
+                payload: WitnessPayload::Edge(WitnessAttachment::Expr(body_span)),
+                span: body_span,
+            });
+        }
         self.bag.push(Witness {
             attachment: WitnessAttachment::Symbol(sym_id),
             source: WitnessSource::Builder("return_arm_chain".into()),

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1447,12 +1447,15 @@ fn test_return_type_all_bare_returns() {
 }
 
 #[test]
-fn test_return_type_undef_filtered() {
-    // return undef + typed return → undef is filtered, typed return wins
+fn test_return_type_undef_optional() {
+    // return undef + typed return → Optional<typed>: the sub CAN return undef,
+    // so its value is optional (docs/prompt-optional-types.md). Bare `return;`
+    // is still filtered (Phase 2) — see test_return_type_bare_return_filtered.
     let fa = build_fa("sub maybe {\n    return undef unless 1;\n    return { a => 1 };\n}");
+    let t = fa.sub_return_type_at_arity("maybe", None);
     assert!(
-        fa.sub_return_type_at_arity("maybe", None).is_some_and(|t| t.is_hash_shaped()),
-        "hash-shaped",
+        matches!(&t, Some(InferredType::Optional(inner)) if inner.is_hash_shaped()),
+        "Optional<hash-shaped>, got {t:?}",
     );
 }
 
@@ -15183,6 +15186,32 @@ fn narrow_conjunction_intersects() {
         fa.inferred_type_via_bag("$x", Point::new(4, 8)),
         Some(InferredType::ClassName("Foo".into())),
         "&&-chain narrows on the isa conjunct",
+    );
+}
+
+// ── Optional types (phase 1): `return undef` ──
+
+#[test]
+fn optional_return_undef_or_value() {
+    let fa = build_fa(
+        "package P;\nsub maybe_make {\n    my ($ok) = @_;\n    return undef unless $ok;\n    return Foo->new;\n}",
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("maybe_make", None),
+        Some(InferredType::Optional(Box::new(InferredType::ClassName("Foo".into())))),
+        "return undef + return Foo->new folds to Optional<Foo>",
+    );
+}
+
+#[test]
+fn optional_not_applied_without_undef_arm() {
+    // No undef arm → plain ClassName, not Optional (existing behavior).
+    let fa = build_fa(
+        "package P;\nsub make {\n    my ($ok) = @_;\n    return Foo->new;\n}",
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("make", None),
+        Some(InferredType::ClassName("Foo".into())),
     );
 }
 

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -898,6 +898,15 @@ pub enum InferredType {
         keys: Vec<(String, Option<Box<InferredType>>)>,
         open: bool,
     },
+    /// `Optional(Box<T>)` — value-or-undef (Type::Tiny `Maybe[T]` /
+    /// `Optional[T]`). Produced when an arm/branch fold sees `{T, undef}`:
+    /// the join of a concrete arm with an undef arm. `defined $x` /
+    /// `blessed $x` narrowing strips it back to `T`. NOT a class itself —
+    /// `class_name()` returns `None` (an optional is not *definitely* an
+    /// instance), so it cannot dispatch until narrowed. See
+    /// `docs/prompt-optional-types.md`. Kept at the END for bincode
+    /// variant-index stability (bump `EXTRACT_VERSION`).
+    Optional(Box<InferredType>),
 }
 
 /// Concrete parametric flavors + type-level operators. Each
@@ -1203,6 +1212,14 @@ impl InferredType {
             }
             (InferredType::Sequence(_), InferredType::ArrayRef) => true,
             (a @ InferredType::Sequence(_), b @ InferredType::Sequence(_)) => a == b,
+            // An optional subsumes a narrowing only as specifically as its
+            // inner does; a CONCRETE self is at least as specific as an
+            // optional narrowing (the narrowing already happened). The
+            // reverse — `Optional` vs a concrete narrowing — falls to the
+            // discriminant check below and is `false`, so a `defined` /
+            // `blessed` guard's `Optional<T> → T` refinement wins.
+            (InferredType::Optional(a), InferredType::Optional(b)) => a.subsumes_narrowing(b),
+            (a, InferredType::Optional(b)) => a.subsumes_narrowing(b),
             // Unit-shape variants subsume themselves; mismatched
             // discriminants don't subsume.
             (a, b) => std::mem::discriminant(a) == std::mem::discriminant(b),
@@ -1295,6 +1312,24 @@ pub fn resolve_return_type(return_types: &[InferredType]) -> Option<InferredType
         }
     }
     object
+}
+
+/// Join return/branch arms where some arm may be `undef` (a bare
+/// `return;`, `return undef`, or an `undef` branch). The value arms fold
+/// by [`resolve_return_type`]; if any arm was undef and the value arms
+/// agree on a single non-optional `T`, the result is `Optional<T>` —
+/// `{Foo, undef} → Optional<Foo>`. No undef arm leaves the fold
+/// unchanged; genuinely-conflicting value arms (`Foo` vs `Bar`) stay
+/// `None` (no arbitrary union); only-undef arms stay `None` (no useful
+/// value type). See `docs/prompt-optional-types.md`.
+pub fn join_return_arms(value_types: &[InferredType], has_undef_arm: bool) -> Option<InferredType> {
+    let base = resolve_return_type(value_types);
+    match base {
+        Some(t) if has_undef_arm && !matches!(t, InferredType::Optional(_)) => {
+            Some(InferredType::Optional(Box::new(t)))
+        }
+        other => other,
+    }
 }
 
 // ---- Handler owner ----
@@ -8840,6 +8875,9 @@ pub fn inferred_type_to_tag(ty: &InferredType) -> String {
         InferredType::TypeConstraintOf(_) => "Object:Type::Tiny".to_string(),
         // Method dispatch is against the base; tag like any object.
         InferredType::BrandedRoute { base, .. } => format!("Object:{}", base),
+        // Optional dispatches nowhere until narrowed; tag the inner so the
+        // wire format stays backward-compatible, prefixed Maybe.
+        InferredType::Optional(inner) => format!("Maybe:{}", inferred_type_to_tag(inner)),
     }
 }
 
@@ -8904,6 +8942,7 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
             Some(c) => format!("{}<controller={}>", base, c),
             None => base.clone(),
         },
+        InferredType::Optional(inner) => format!("Maybe<{}>", format_inferred_type(inner)),
     }
 }
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 98;
+pub const EXTRACT_VERSION: i64 = 99;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -845,19 +845,30 @@ impl WitnessReducer for SymbolReturnArmFold {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        matches!(w.attachment, WitnessAttachment::SymbolReturnArm(_))
-            && matches!(w.payload, WitnessPayload::InferredType(_))
+        if !matches!(w.attachment, WitnessAttachment::SymbolReturnArm(_)) {
+            return false;
+        }
+        match &w.payload {
+            WitnessPayload::InferredType(_) => true,
+            // The `return undef` arm marker (no rvalue type to materialize).
+            WitnessPayload::Fact { family, .. } => family == "undef_arm",
+            _ => false,
+        }
     }
 
     fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
-        let arms: Vec<InferredType> = ws
-            .iter()
-            .filter_map(|w| match &w.payload {
-                WitnessPayload::InferredType(t) => Some(t.clone()),
-                _ => None,
-            })
-            .collect();
-        match crate::file_analysis::resolve_return_type(&arms) {
+        let mut arms: Vec<InferredType> = Vec::new();
+        let mut has_undef_arm = false;
+        for w in ws {
+            match &w.payload {
+                WitnessPayload::InferredType(t) => arms.push(t.clone()),
+                WitnessPayload::Fact { family, .. } if family == "undef_arm" => {
+                    has_undef_arm = true
+                }
+                _ => {}
+            }
+        }
+        match crate::file_analysis::join_return_arms(&arms, has_undef_arm) {
             Some(t) => ReducedValue::Type(t),
             None => ReducedValue::None,
         }


### PR DESCRIPTION
**Stacked on #84** (base is the multi-hop branch). The diff here is the Optional Phase 1 only.

## What

Adds `InferredType::Optional(Box<InferredType>)` — value-or-undef (Type::Tiny `Maybe[T]`) — the complement of flow narrowing. A sub that early-returns explicit `return undef` plus a typed return now folds to `Optional<T>` instead of collapsing the arm disagreement to `None`:

```perl
sub maybe_make {
    my ($ok) = @_;
    return undef unless $ok;
    return Foo->new;
}
# return type: Optional<Foo>   (was: Foo, the undef arm silently dropped)
```

## How

- **Append `Optional` at the enum END** (bincode variant-index stability — same discipline as `Sequence`/`BrandedRoute`/`HashWithKeys`); bump `EXTRACT_VERSION`. Blast radius was small (only two exhaustive display matches needed the arm).
- **`join_return_arms(value_arms, has_undef)`** wraps `resolve_return_type`: `{T, undef} → Optional<T>`; no undef arm → unchanged; value conflict (`Foo` vs `Bar`) → still `None` (no arbitrary union this phase); only-undef → `None`.
- **Mark the `return undef` arm** with a `Builder("undef_arm")` Fact witness on `SymbolReturnArm`; `SymbolReturnArmFold` counts it and calls the join. (`undef` has no rvalue type to ride an edge, so a marker is the clean way to keep it legible — no `Undef` lattice variant leaking everywhere.)
- **`class_name()` → `None`** for Optional: an optional is *not definitely* an instance, so it can't dispatch until narrowed — exactly the unsoundness the variant surfaces. Displays as `Maybe<T>`.
- **`subsumes_narrowing`**: a concrete `self` subsumes an optional narrowing; the reverse is `false`, so a future `defined`/`blessed` guard's `Optional<T> → T` refinement wins.

## Scope (deliberately minimal)

- **Phase 1 (this PR):** explicit `return undef`. Bare `return;` stays filtered — it's far more pervasive (`return unless …; return $x`), so making it Optional has wide gold-corpus blast radius; deferred to Phase 2 with gold validation.
- **Phase 2:** route `BranchArmFold` (ternary) + `SlotTypeFold` through the join; wire `defined`/`blessed` guards to narrow `Optional<T> → T` (this is where narrowing and optionals become "two halves of one story").
- **Phase 3:** negative-polarity narrowing rows for the `defined` family, provenance, Type::Tiny `Maybe[T]` mapping.

Design (synthesized from parallel design exploration): `docs/prompt-optional-types.md`.

## Testing

- `cargo test`: **969 passed, 0 failed** (2 new Optional tests; one pre-existing test that encoded the old "undef filtered" rule for explicit `return undef` was updated to the new `Optional` semantics — the bare-`return;` filtered tests still pass, confirming the Phase-1 scoping).
- e2e + gold run in CI. **Gold is the one to watch** — it's the real-CPAN type-inference net, and this changes a fold rule. The change is intentionally narrowed to explicit `return undef` to keep that blast radius small.

Bumps `EXTRACT_VERSION` (99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_