### PR TITLE
feat(narrowing): defined/blessed strip Optional<T> (phase 2) — stacked on #85

### DIFF
--- a/docs/prompt-optional-types.md
+++ b/docs/prompt-optional-types.md
@@ -88,17 +88,23 @@ green.
 6. `class_name()` untouched (Optional → `None`).
 7. Tests: the target sub; existing arm-fold tests stay green.
 
-**Phase 2 — generalize + light up narrowing:**
-- Route `BranchArmFold` (hand-rolled ternary fold) through the shared
-  join so `$c ? Foo->new : undef` ⇒ `Optional<Foo>` (DRY).
-- `SlotTypeFold` honors Optional (mostly free — undef skips the
-  class-conflict guard, flows into the join).
-- `InferredType::optional_inner()` accessor; wire the **`defined` /
-  `blessed`** guards (today unrecognized) to narrow `Optional<T> → T`.
-  This needs `GuardFact.narrowed` to become a `NarrowOp { To(InferredType),
-  Defined }` enum — `Defined` is a *query* (read the subject's incoming
-  type, strip `Optional`), not a constant type. Emit only when the
-  incoming type is `Optional` (else `defined` is identity).
+**Phase 2 — light up narrowing (LANDED for `defined`/`blessed`):**
+- `InferredType::optional_inner()` accessor; `GuardFact` carries a
+  `NarrowOp { To(InferredType), StripOptional { query_point } }`. The
+  `defined`/`blessed` guards (`func1op_call_expression` /
+  `ambiguous_function_call_expression`) recognize their subject and emit
+  `StripOptional`.
+- Because the subject's `Optional` is often a sub return that only
+  converges in the fold, the strip is a **re-emittable fold pass**
+  (`emit_defined_narrowing_witnesses`, tag `defined_narrowing`): each
+  iteration it reads the subject's type at `query_point` — the guard's
+  own location, BEFORE the narrowed region, so the pass's own output is
+  excluded (no oscillation) — and narrows the region to the inner when
+  it's `Optional`. `blessed` ships as `defined`'s strip (the extra
+  is-an-object precision has no lattice target yet).
+- Still deferred: route `BranchArmFold` (ternary `$c ? Foo->new : undef`)
+  and `SlotTypeFold` through the join so they *produce* Optional from a
+  `{T, undef}` pair (needs the same undef-marker on branch/slot arms).
 
 **Phase 3 — negatives + provenance + Type::Tiny:**
 - Negative-polarity rows (`else` of `if (defined G)`, `return if defined

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -286,6 +286,7 @@ fn build_with_plugins_inner(
         parametric_emitted_refs: std::collections::HashSet::new(),
         method_call_ref_dedup: std::collections::HashSet::new(),
         route_branded_refs: std::collections::HashSet::new(),
+        defined_narrowings: Vec::new(),
         anon_sub_symbol_by_span: std::collections::HashMap::new(),
         modifier_invocant_pos: None,
     };
@@ -1591,6 +1592,10 @@ struct Builder<'a> {
     /// as `parametric_emitted_refs`. Cleared+refilled each fold
     /// iteration by `emit_route_brand_witnesses`.
     route_branded_refs: std::collections::HashSet<usize>,
+
+    /// Recorded `defined`/`blessed` guards whose `Optional<T> → T` strip
+    /// is re-derived each fold iteration (`emit_defined_narrowing_witnesses`).
+    defined_narrowings: Vec<narrowing::DefinedNarrowing>,
 
     /// Span (of the `anonymous_subroutine_expression` node) →
     /// SymbolId of the synthesized `(anon)` Sub symbol. Populated by
@@ -12625,6 +12630,7 @@ impl<'a> Builder<'a> {
         // and the bag oscillates (the fold never reaches a fixed point).
         self.emit_route_brand_witnesses(idx, ref_by_span);
         self.emit_method_call_return_edges();
+        self.emit_defined_narrowing_witnesses();
         let (return_types, return_provenance) = self.seed_return_types_from_bag(reg, method_sym_by_name);
         self.write_back_sub_return_types(&return_provenance);
         self.propagate_call_bindings_to_constraints(&return_types);

--- a/src/builder/narrowing.rs
+++ b/src/builder/narrowing.rs
@@ -10,7 +10,7 @@
 use tree_sitter::{Node, Point};
 
 use crate::cst::node_to_span;
-use crate::file_analysis::{InferredType, Span};
+use crate::file_analysis::{InferredType, ScopeId, Span};
 
 use super::{connector_keyword_between, point_lt, raw_leading_op, raw_mid_op, Builder};
 
@@ -31,12 +31,35 @@ fn narrow_subject_of(node: Node, src: &[u8]) -> Option<NarrowSubject> {
     Some(NarrowSubject::Place { key, root })
 }
 
-/// A recognized guard fact: the subject, the type it proves, and whether
-/// the proof holds where the guard *expression* is TRUE (`!` flips it).
+/// What a guard does to the subject's type where it holds.
+pub(super) enum NarrowOp {
+    /// `isa` / `ref…eq` prove a concrete type.
+    To(InferredType),
+    /// `defined` / `blessed` strip `Optional<T>` to `T`. The strip reads
+    /// the subject's incoming type, so it can only run once that type has
+    /// converged (a re-emittable fold pass); `query_point` is the subject's
+    /// location IN THE GUARD — before the narrowed region, so the read
+    /// sees the un-narrowed `Optional`, not the pass's own output.
+    StripOptional { query_point: Point },
+}
+
+/// A recognized guard fact: the subject, what the guard proves, and
+/// whether the proof holds where the guard *expression* is TRUE (`!`
+/// flips it).
 pub(super) struct GuardFact {
     subject: NarrowSubject,
-    narrowed: InferredType,
+    op: NarrowOp,
     asserts_when_true: bool,
+}
+
+/// A pending `defined`/`blessed` narrowing — its `Optional<T> → T` strip
+/// is re-derived each fold iteration once the subject type converges.
+#[derive(Clone)]
+pub(super) struct DefinedNarrowing {
+    name: String,
+    scope: ScopeId,
+    region: Span,
+    query_point: Point,
 }
 
 /// Map a `ref(...) eq STRING` right-hand string to the type it proves.
@@ -121,8 +144,58 @@ fn recognize_guards(cond: Node, source: &[u8]) -> Vec<GuardFact> {
         }
         "method_call_expression" => recognize_isa_guard(cond, source).into_iter().collect(),
         "equality_expression" => recognize_ref_eq_guard(cond, source).into_iter().collect(),
+        "func1op_call_expression" => recognize_defined_guard(cond, source).into_iter().collect(),
+        "ambiguous_function_call_expression" | "function_call_expression" => {
+            recognize_blessed_guard(cond, source).into_iter().collect()
+        }
         _ => Vec::new(),
     }
+}
+
+/// `defined $x` / `defined($x)` → strip `Optional` off the subject.
+fn recognize_defined_guard(call: Node, source: &[u8]) -> Option<GuardFact> {
+    if call.child(0)?.utf8_text(source).ok()? != "defined" {
+        return None;
+    }
+    let arg = func1op_subject_arg(call)?;
+    Some(GuardFact {
+        subject: narrow_subject_of(arg, source)?,
+        op: NarrowOp::StripOptional { query_point: arg.start_position() },
+        asserts_when_true: true,
+    })
+}
+
+/// `blessed $x` / `blessed($x)` → strip `Optional` off the subject (v1
+/// treats `blessed` as `defined`'s strip; the extra "is an object"
+/// precision has no lattice target yet).
+fn recognize_blessed_guard(call: Node, source: &[u8]) -> Option<GuardFact> {
+    let name = call.child_by_field_name("function")?.utf8_text(source).ok()?;
+    if name != "blessed" {
+        return None;
+    }
+    let arg = first_place_or_scalar(call.child_by_field_name("arguments")?)?;
+    Some(GuardFact {
+        subject: narrow_subject_of(arg, source)?,
+        op: NarrowOp::StripOptional { query_point: arg.start_position() },
+        asserts_when_true: true,
+    })
+}
+
+/// First scalar / place-element node at or under `node` — the argument
+/// subject of a `blessed(...)` call.
+fn first_place_or_scalar<'a>(node: Node<'a>) -> Option<Node<'a>> {
+    if matches!(
+        node.kind(),
+        "scalar" | "hash_element_expression" | "array_element_expression"
+    ) {
+        return Some(node);
+    }
+    for i in 0..node.named_child_count() {
+        if let Some(found) = node.named_child(i).and_then(first_place_or_scalar) {
+            return Some(found);
+        }
+    }
+    None
 }
 
 /// `$x->isa('Foo')` / `$x->DOES('Role')` → narrow `$x` to `ClassName`.
@@ -136,7 +209,7 @@ fn recognize_isa_guard(call: Node, source: &[u8]) -> Option<GuardFact> {
     let class = string_literal_text(call.child_by_field_name("arguments")?, source)?;
     Some(GuardFact {
         subject,
-        narrowed: InferredType::ClassName(class),
+        op: NarrowOp::To(InferredType::ClassName(class)),
         asserts_when_true: true,
     })
 }
@@ -164,7 +237,7 @@ fn recognize_ref_eq_guard(eq: Node, source: &[u8]) -> Option<GuardFact> {
     let ty = ref_string_to_type(&string_literal_text(lit, source)?)?;
     Some(GuardFact {
         subject,
-        narrowed: ty,
+        op: NarrowOp::To(ty),
         asserts_when_true: true,
     })
 }
@@ -298,12 +371,59 @@ impl<'a> Builder<'a> {
         if !point_lt(region.start, end) {
             return; // truncated to nothing
         }
-        self.bag.push(Witness {
-            attachment: WitnessAttachment::Variable { name, scope: self.current_scope() },
-            source: WitnessSource::Builder("narrowing".into()),
-            payload: WitnessPayload::InferredType(fact.narrowed),
-            span: Span { start: region.start, end },
-        });
+        let region = Span { start: region.start, end };
+        let scope = self.current_scope();
+        match fact.op {
+            NarrowOp::To(ty) => {
+                self.bag.push(Witness {
+                    attachment: WitnessAttachment::Variable { name, scope },
+                    source: WitnessSource::Builder("narrowing".into()),
+                    payload: WitnessPayload::InferredType(ty),
+                    span: region,
+                });
+            }
+            // `defined`/`blessed` strip `Optional<T>` to `T`, but the
+            // subject's type may only converge in the fold (a sub return),
+            // so record it and re-derive in `emit_defined_narrowing_witnesses`.
+            NarrowOp::StripOptional { query_point } => {
+                self.defined_narrowings.push(DefinedNarrowing {
+                    name,
+                    scope,
+                    region,
+                    query_point,
+                });
+            }
+        }
+    }
+
+    /// Re-emittable: `defined`/`blessed` narrowing. For each recorded
+    /// guard, read the subject's type at the guard point (BEFORE the
+    /// narrowed region, so this pass's own output is excluded — no
+    /// oscillation) and, if it is `Optional<T>`, narrow the region to `T`.
+    /// Clear-and-emit on tag `defined_narrowing`; converges as the
+    /// subject's (possibly fold-derived) `Optional` settles.
+    pub(super) fn emit_defined_narrowing_witnesses(&mut self) {
+        use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        self.bag.remove_by_source_tag("defined_narrowing");
+        let guards = self.defined_narrowings.clone();
+        let mut emits: Vec<(String, ScopeId, InferredType, Span)> = Vec::new();
+        for g in &guards {
+            if let Some(inner) = self
+                .bag_query_variable(&g.name, g.scope, g.query_point)
+                .as_ref()
+                .and_then(InferredType::optional_inner)
+            {
+                emits.push((g.name.clone(), g.scope, inner.clone(), g.region));
+            }
+        }
+        for (name, scope, inner, region) in emits {
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::Variable { name, scope },
+                source: WitnessSource::Builder("defined_narrowing".into()),
+                payload: WitnessPayload::InferredType(inner),
+                span: region,
+            });
+        }
     }
 
     /// Point of the first operation in `container` (at or after

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15215,6 +15215,37 @@ fn optional_not_applied_without_undef_arm() {
     );
 }
 
+#[test]
+fn optional_defined_narrows_to_inner() {
+    // maybe() : Optional<Foo>; `defined $r` strips it so $r->go dispatches Foo.
+    let fa = build_fa(
+        "package P;\nsub maybe { return undef unless 1; return Foo->new; }\nsub use_it {\n    my $r = maybe();\n    return unless defined $r;\n    $r->go;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "go").as_deref(), Some("Foo"));
+}
+
+#[test]
+fn optional_blessed_narrows_to_inner() {
+    let fa = build_fa(
+        "package P;\nsub maybe { return undef unless 1; return Foo->new; }\nsub use_it {\n    my $r = maybe();\n    return unless blessed $r;\n    $r->go;\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "go").as_deref(), Some("Foo"));
+}
+
+#[test]
+fn optional_without_defined_does_not_dispatch() {
+    // Without the guard, $r stays Optional<Foo>, which dispatches nowhere
+    // (an optional is not definitely an instance).
+    let fa = build_fa(
+        "package P;\nsub maybe { return undef unless 1; return Foo->new; }\nsub use_it {\n    my $r = maybe();\n    $r->go;\n}",
+    );
+    assert_eq!(
+        invocant_class_of(&fa, "go").as_deref(),
+        None,
+        "Optional<Foo> must be narrowed before it can dispatch",
+    );
+}
+
 // ── Place narrowing (v1b): `$self->{x}` ──
 
 /// Class an invocant resolves to for the method-call ref named `method`.

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1041,6 +1041,15 @@ impl InferredType {
         }
     }
 
+    /// The wrapped type of an `Optional<T>`, else `None`. The `defined` /
+    /// `blessed` guards strip an optional to its inner via this.
+    pub fn optional_inner(&self) -> Option<&InferredType> {
+        match self {
+            InferredType::Optional(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
     /// `->{key}` narrowing on a structurally-typed hash (rule #10: ask
     /// the value). `Some(Some(t))` = key present with a known value
     /// type; `Some(None)` = key present, value type unknown; `None` =

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 99;
+pub const EXTRACT_VERSION: i64 = 100;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/test_files/narrowing_playground.pl
+++ b/test_files/narrowing_playground.pl
@@ -166,18 +166,16 @@ sub reassign_in_region {
 
 # ── G. Weak guards — recognized, no v1 target (Optional dep) ─
 
-sub weak_defined {
-    my ($x) = @_;                       # outer: ideally Optional<T> someday
-    return unless defined $x;
-    $x->use;                            # NO-NARROW in v1; becomes T once
-                                        # Optional<T> lands (defined strips undef)
+sub defined_strips_optional {
+    my $r = maybe_make();               # $r => Optional<Foo>
+    return unless defined $r;
+    $r->use;                            # NARROW $r => Foo (defined strips undef)
 }
 
-sub weak_blessed {
-    my ($x) = @_;
-    if (blessed $x) {
-        $x->method;                     # NO-NARROW in v1 (no "object" type);
-                                        # future: narrows undef/non-ref away
+sub blessed_strips_optional {
+    my $r = maybe_make();               # $r => Optional<Foo>
+    if (blessed $r) {
+        $r->method;                     # NARROW $r => Foo
     }
 }
 


### PR DESCRIPTION
**Stacked on #85** (base is the Optional Phase 1 branch). The diff here is Phase 2 only.

## What — the payoff that ties optionals and narrowing together

`defined` / `blessed` guards now narrow `Optional<T> → T`:

```perl
my $r = maybe();            # Optional<Foo>   (Phase 1)
return unless defined $r;   # $r => Foo for the remainder   (Phase 2)
$r->go;                     # dispatches on Foo
```

"Optionals create the imprecision; narrowing resolves it" — now real, end to end.

## How

- `GuardFact` carries a `NarrowOp { To(InferredType), StripOptional { query_point } }`. `isa`/`ref-eq` stay `To(_)`; the newly-recognized `defined` (`func1op_call_expression`) and `blessed` (`ambiguous_/function_call_expression`) emit `StripOptional`.
- **The strip is a re-emittable fold pass** (`emit_defined_narrowing_witnesses`, tag `defined_narrowing`), not a walk-time emit — because the subject's `Optional` is usually a sub return that only converges during the fold. Each iteration it reads the subject's type **at the guard's own location** (`query_point`, *before* the narrowed region, so the pass's own output is scope-excluded — **no oscillation**) and narrows the region to the inner when it's `Optional`.
- `blessed` ships as `defined`'s strip (the "is an object" precision has no lattice target yet). Without a guard, `Optional<Foo>` dispatches nowhere (`class_name() → None`) — the third test pins this.

## Next (designed, from a parallel exploration agent)

- **Phase 3 — negative lattice:** add an `Undef` bottom variant + `defined`-family negatives (`else` of `if (defined)`, `return if defined`). The agent's finding: the early-exit negatives light up *for free* through the existing polarity plumbing once `defined` is recognized; only the `else`-block emit needs new code. General `Not`/`Difference` negation is **parked** (a negative class yields no positive lookup target → no consumer value).
- Ternary/slot Optional *production* (`$c ? Foo->new : undef`).

## Testing

- `cargo test`: **972 passed, 0 failed** (3 new: `defined` strip, `blessed` strip, and the no-guard-no-dispatch guardrail), no warnings.
- e2e + gold in CI.

Bumps `EXTRACT_VERSION` (100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_