### PR TITLE
feat(narrowing): Undef bottom + defined-family negatives (negative lattice) — stacked on #86

### DIFF
--- a/docs/prompt-flow-narrowing.md
+++ b/docs/prompt-flow-narrowing.md
@@ -132,15 +132,25 @@ of the block.*
 
 A guard-internal negation (`if (!G)`, `return unless !G`) flips the row.
 
-**v1 ships only the G-true (✅) rows** — the guarded block and the
-early-return assert, the two dominant idioms. They yield a *positive*
-refinement (`$x` IS Foo), expressible in today's lattice.
+**v1 shipped the G-true (✅) rows** — the guarded block and the
+early-return assert. They yield a *positive* refinement (`$x` IS Foo).
 
-The G-false (✘) rows need a **negation / union** the lattice lacks ("`$x`
-is anything-but-Foo"). Deferred with the same dependency as the else
-branch — they light up when Optional/union lands. Skipping them is
-sound: emitting nothing leaves the wide outer type, which is correct if
-imprecise.
+**The G-false (✘) rows now land for the `defined`/`blessed` family only**
+(`InferredType::Undef`, the negative lattice). The complement of "is
+defined" is the concrete bottom element `Undef`, so the else of `if
+(defined $x)`, the remainder of `return if defined $x`, and the body of
+`unless (defined $x)` all narrow `$x` to `Undef`. Mechanically this is
+`NarrowOp::negated()`: `StripOptional` negates to `To(Undef)`, and the
+existing polarity plumbing (`GuardFact::op_for_region`) does the rest —
+the early-exit negatives came for free; only the `else`-block emit
+(`trailing_else`) was new.
+
+The `isa` / `ref-eq` G-false rows stay wide: `To(_).negated()` is `None`
+("not Foo" has no positive lookup target — no class to dispatch, complete,
+or goto, so it can't improve any consumer). General negation
+(`Not`/`Difference`) is parked; unblock condition is a real union lattice
++ a consumer that derives value from a negative fact (`docs/prompt
+-optional-types.md`). Emitting nothing leaves the wide type — sound.
 
 **Compound conditions:** a top-level `&&`/`and` chain narrows the body by
 the *intersection* — emit one narrowing per recognized conjunct

--- a/docs/prompt-optional-types.md
+++ b/docs/prompt-optional-types.md
@@ -106,16 +106,30 @@ green.
   and `SlotTypeFold` through the join so they *produce* Optional from a
   `{T, undef}` pair (needs the same undef-marker on branch/slot arms).
 
-**Phase 3 — negatives + provenance + Type::Tiny:**
-- Negative-polarity rows (`else` of `if (defined G)`, `return if defined
-  G`) become expressible **for the `defined`/`blessed` family only** —
-  the false arm is the undef side, a concrete element. Needs a bottom
-  (`Undef`) element for the else witness. `isa`/`ref-eq` negatives still
-  need real negation/union (parked).
+**Phase 3 — negative lattice (LANDED for the `defined` family):**
+- `InferredType::Undef` (bottom), appended at the enum END; bump
+  `EXTRACT_VERSION`. `class_name() → None`, `subsumes_narrowing` needs no
+  arm (the discriminant fallback gives `(Undef, Undef) → true` and
+  `false` elsewhere). Never produced by the return-arm join — purely a
+  narrowing witness.
+- `NarrowOp::negated()`: `StripOptional → To(Undef)`; `To(_) → None`
+  (no representable complement). `GuardFact::op_for_region(holds)` picks
+  the fact's op when its polarity matches, else the negation. So the
+  early-exit negatives (`return if defined`, `unless (defined){}`) light
+  up through the *existing* polarity plumbing; only the `else`-block emit
+  (`trailing_else` on `conditional_statement`) was new. elsif-chain `else`
+  (cumulative negation) is deferred — needs unions.
+- General `Not`/`Difference` negation for `isa`/`ref-eq` negatives:
+  **parked** — a negative class yields no positive lookup target, so no
+  consumer (goto/completion/hover/dispatch) benefits. Unblock: a real
+  union lattice + a consumer of negative facts.
+
+**Phase 4 — provenance + Type::Tiny + Optional production:**
+- Route `BranchArmFold` (ternary) + `SlotTypeFold` through the join so a
+  `{T, undef}` pair *produces* `Optional<T>`.
 - `TypeProvenance::ReducerFold { reducer: "optional_join" }` for
   `--dump-package`.
-- Map Type::Tiny `Maybe[T]` / `Optional[T]` onto `Optional(Box<T>)` at
-  the `type_constraint_names` seam.
+- Map Type::Tiny `Maybe[T]` / `Optional[T]` onto `Optional(Box<T>)`.
 
 ## Sequencing wrinkle (Phase 2+)
 

--- a/src/builder/narrowing.rs
+++ b/src/builder/narrowing.rs
@@ -32,6 +32,7 @@ fn narrow_subject_of(node: Node, src: &[u8]) -> Option<NarrowSubject> {
 }
 
 /// What a guard does to the subject's type where it holds.
+#[derive(Clone)]
 pub(super) enum NarrowOp {
     /// `isa` / `ref…eq` prove a concrete type.
     To(InferredType),
@@ -43,6 +44,20 @@ pub(super) enum NarrowOp {
     StripOptional { query_point: Point },
 }
 
+impl NarrowOp {
+    /// The op for the region where the guard is FALSE. Only `defined`/
+    /// `blessed` have a representable complement — the subject is `undef`
+    /// there. "Not a class" (`isa`/`ref-eq` negated) has no positive
+    /// target, so it self-suppresses (`None` → emit nothing, wide type
+    /// wins). See `docs/prompt-flow-narrowing.md` negative-polarity rows.
+    fn negated(&self) -> Option<NarrowOp> {
+        match self {
+            NarrowOp::To(_) => None,
+            NarrowOp::StripOptional { .. } => Some(NarrowOp::To(InferredType::Undef)),
+        }
+    }
+}
+
 /// A recognized guard fact: the subject, what the guard proves, and
 /// whether the proof holds where the guard *expression* is TRUE (`!`
 /// flips it).
@@ -50,6 +65,20 @@ pub(super) struct GuardFact {
     subject: NarrowSubject,
     op: NarrowOp,
     asserts_when_true: bool,
+}
+
+impl GuardFact {
+    /// The op to emit in a region where the guard holds iff the guard
+    /// expression is `holds`: the fact's own op when the polarity matches
+    /// (positive narrowing), else its negation (which may be
+    /// unrepresentable → `None`, so the region stays wide).
+    fn op_for_region(&self, holds: bool) -> Option<NarrowOp> {
+        if self.asserts_when_true == holds {
+            Some(self.op.clone())
+        } else {
+            self.op.negated()
+        }
+    }
 }
 
 /// A pending `defined`/`blessed` narrowing — its `Optional<T> → T` strip
@@ -265,6 +294,19 @@ fn is_exit_expression(node: Node, source: &[u8]) -> bool {
     }
 }
 
+/// The `block` of a direct `else` child of a `conditional_statement`, if
+/// any. elsif-chain `else` (which nests inside the trailing `elsif`) is
+/// deferred — its cumulative negation needs union types.
+fn trailing_else<'a>(cond_stmt: Node<'a>) -> Option<Node<'a>> {
+    for i in 0..cond_stmt.named_child_count() {
+        let c = cond_stmt.named_child(i)?;
+        if c.kind() == "else" {
+            return c.child_by_field_name("block");
+        }
+    }
+    None
+}
+
 impl<'a> Builder<'a> {
     /// `if/unless (G) { BODY }` — narrow the then-block where the guard's
     /// polarity is positive (`if`-body when G true, `unless`-body when
@@ -273,10 +315,27 @@ impl<'a> Builder<'a> {
         let Some(condition) = cond_stmt.child_by_field_name("condition") else { return };
         let Some(block) = cond_stmt.child_by_field_name("block") else { return };
         let Some(holds_when_true) = self.block_guard_polarity(cond_stmt, condition) else { return };
-        let region = node_to_span(block);
-        for fact in recognize_guards(condition, self.source) {
-            if fact.asserts_when_true == holds_when_true {
-                self.emit_narrowing_fact(fact, region, block);
+        let then_region = node_to_span(block);
+        // The else-block (if any) is the complement region — a direct
+        // `else` child of `conditional_statement`. A guard holds there iff
+        // its expression is FALSE, so the op is negated (only `defined`/
+        // `blessed` have a representable complement). elsif-chain else is
+        // deferred (cumulative negation needs unions).
+        let else_block = trailing_else(cond_stmt);
+        let facts = recognize_guards(condition, self.source);
+        for fact in &facts {
+            if let Some(op) = fact.op_for_region(holds_when_true) {
+                self.emit_narrowing_fact(&fact.subject, op, then_region, block);
+            }
+            if let Some(else_block) = else_block {
+                if let Some(op) = fact.op_for_region(!holds_when_true) {
+                    self.emit_narrowing_fact(
+                        &fact.subject,
+                        op,
+                        node_to_span(else_block),
+                        else_block,
+                    );
+                }
             }
         }
     }
@@ -347,24 +406,34 @@ impl<'a> Builder<'a> {
         }
         let region = Span { start: stmt.end_position(), end: block.end_position() };
         for fact in recognize_guards(condition, self.source) {
-            if fact.asserts_when_true == holds_when_true {
-                self.emit_narrowing_fact(fact, region, block);
+            if let Some(op) = fact.op_for_region(holds_when_true) {
+                self.emit_narrowing_fact(&fact.subject, op, region, block);
             }
         }
     }
 
     /// Push the span-extent narrowing witness on the subject's home scope,
     /// truncating the region at the first reassignment of the subject.
-    fn emit_narrowing_fact(&mut self, fact: GuardFact, region: Span, container: Node<'a>) {
+    /// Emit a guard's narrowing into `region`. `op` is the polarity-
+    /// resolved operation (`GuardFact::op_for_region`); the subject is
+    /// keyed and the region truncated at the first disturbance, exactly
+    /// as for a positive narrowing.
+    fn emit_narrowing_fact(
+        &mut self,
+        subject: &NarrowSubject,
+        op: NarrowOp,
+        region: Span,
+        container: Node<'a>,
+    ) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
-        let (name, end) = match fact.subject {
+        let (name, end) = match subject {
             NarrowSubject::Variable(var) => {
-                let end = self.first_subject_write(&var, region, container);
-                (var, end)
+                let end = self.first_subject_write(var, region, container);
+                (var.clone(), end)
             }
             NarrowSubject::Place { key, root } => {
-                let end = self.first_place_invalidation(&key, &root, region, container);
-                (key, end)
+                let end = self.first_place_invalidation(key, root, region, container);
+                (key.clone(), end)
             }
         };
         let end = end.unwrap_or(region.end);
@@ -373,7 +442,7 @@ impl<'a> Builder<'a> {
         }
         let region = Span { start: region.start, end };
         let scope = self.current_scope();
-        match fact.op {
+        match op {
             NarrowOp::To(ty) => {
                 self.bag.push(Witness {
                     attachment: WitnessAttachment::Variable { name, scope },

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15246,6 +15246,60 @@ fn optional_without_defined_does_not_dispatch() {
     );
 }
 
+// ── Negative lattice (phase 3): Undef on the `defined` family ──
+
+#[test]
+fn negative_return_if_defined_is_undef() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    return if defined $x;\n    my $y = $x;\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 12)),
+        Some(InferredType::Undef),
+        "after `return if defined $x`, $x is undef",
+    );
+}
+
+#[test]
+fn negative_unless_defined_block_is_undef() {
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    unless (defined $x) {\n        my $y = $x;\n    }\n}",
+    );
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(4, 16)),
+        Some(InferredType::Undef),
+        "inside `unless (defined $x)`, $x is undef",
+    );
+}
+
+#[test]
+fn negative_defined_then_else_split() {
+    // then-branch strips Optional<Foo> → Foo; else-branch → Undef.
+    let fa = build_fa(
+        "package P;\nsub maybe { return undef unless 1; return Foo->new; }\nsub f {\n    my $r = maybe();\n    if (defined $r) {\n        $r->a;\n    } else {\n        my $y = $r;\n    }\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "a").as_deref(), Some("Foo"));
+    assert_eq!(
+        fa.inferred_type_via_bag("$r", Point::new(7, 16)),
+        Some(InferredType::Undef),
+        "else-branch: $r is undef",
+    );
+}
+
+#[test]
+fn negative_isa_else_stays_wide() {
+    // `isa` has no representable complement, so the else is NOT narrowed.
+    let fa = build_fa(
+        "package P;\nsub f {\n    my ($x) = @_;\n    if ($x->isa('Foo')) {\n        $x->a;\n    } else {\n        my $y = $x;\n    }\n}",
+    );
+    assert_eq!(invocant_class_of(&fa, "a").as_deref(), Some("Foo"));
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(6, 16)),
+        None,
+        "isa else has no positive target — stays wide, not Undef",
+    );
+}
+
 // ── Place narrowing (v1b): `$self->{x}` ──
 
 /// Class an invocant resolves to for the method-call ref named `method`.

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -907,6 +907,15 @@ pub enum InferredType {
     /// `docs/prompt-optional-types.md`. Kept at the END for bincode
     /// variant-index stability (bump `EXTRACT_VERSION`).
     Optional(Box<InferredType>),
+    /// The bottom element — a value proven `undef`. Produced only by
+    /// flow narrowing: the negative side of a `defined`/`blessed` guard
+    /// (`if (defined $x) {} else { ... }`, `return if defined $x`). NOT a
+    /// class (`class_name()` → `None`), so a method call on it stays
+    /// unresolved (a value-known-undef can't dispatch). Never produced by
+    /// the return-arm join (that signals undef via a source tag, not a
+    /// type — `docs/prompt-optional-types.md`). Kept at the END for
+    /// bincode variant-index stability (bump `EXTRACT_VERSION`).
+    Undef,
 }
 
 /// Concrete parametric flavors + type-level operators. Each
@@ -8887,6 +8896,7 @@ pub fn inferred_type_to_tag(ty: &InferredType) -> String {
         // Optional dispatches nowhere until narrowed; tag the inner so the
         // wire format stays backward-compatible, prefixed Maybe.
         InferredType::Optional(inner) => format!("Maybe:{}", inferred_type_to_tag(inner)),
+        InferredType::Undef => "Undef".to_string(),
     }
 }
 
@@ -8952,6 +8962,7 @@ pub(crate) fn format_inferred_type(ty: &InferredType) -> String {
             None => base.clone(),
         },
         InferredType::Optional(inner) => format!("Maybe<{}>", format_inferred_type(inner)),
+        InferredType::Undef => "Undef".to_string(),
     }
 }
 

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 100;
+pub const EXTRACT_VERSION: i64 = 101;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/test_files/narrowing_playground.pl
+++ b/test_files/narrowing_playground.pl
@@ -179,6 +179,32 @@ sub blessed_strips_optional {
     }
 }
 
+# ── N. Negative lattice — `defined` family narrows to Undef ───
+
+sub defined_else_is_undef {
+    my $r = maybe_make();
+    if (defined $r) {
+        $r->use;                        # NARROW $r => Foo (strip)
+    } else {
+        $r;                             # NARROW $r => Undef (complement)
+    }
+}
+
+sub return_if_defined_remainder_undef {
+    my ($x) = @_;
+    return if defined $x;
+    $x;                                 # NARROW $x => Undef (remainder)
+}
+
+sub isa_else_no_negative {
+    my ($x) = @_;
+    if ($x->isa('Foo')) {
+        $x->go;                         # NARROW $x => Foo
+    } else {
+        $x;                             # NO-NARROW (not-Foo has no target)
+    }
+}
+
 # ── P. Place subjects (v1b) — narrow a slot, not a variable ──
 #    Canonical access path = root + constant projections. The
 #    narrowing region is TRUNCATED at the first op that could


### PR DESCRIPTION
**Stacked on #86** (base is the Optional Phase 2 branch). The negative lattice you asked for.

## What

Adds `InferredType::Undef` (the bottom element) and lights up the **negative-polarity narrowing rows** for the `defined`/`blessed` family:

```perl
if (defined $r) { $r->m }   # then: Optional<Foo> → Foo   (phase 2)
else            { ... }     # else: $r → Undef            (this PR)

return if defined $x; ...   # remainder: $x → Undef
unless (defined $x) { ... } # block:     $x → Undef
```

## How — almost free, exactly as the design predicted

- `NarrowOp::negated()`: `StripOptional → To(Undef)`; `To(_) → None`. `GuardFact::op_for_region(holds)` picks the fact's op when its polarity matches the region, else the negation.
- The **early-exit negatives** (`return if defined`, `unless (defined){}`) came *for free* through the existing polarity plumbing — `op_for_region` flips them automatically. **Only the `else`-block emit was new** (`trailing_else` walks the `conditional_statement`'s `else` child). `emit_narrowing_fact` now takes an explicit `(subject, op)` so positive and negative share one path.
- `Undef`: `class_name() → None` (a known-undef can't dispatch — the analyzer now *sees* that), `subsumes_narrowing` needs no arm (the discriminant fallback gives `(Undef, Undef) → true`, `false` elsewhere). Never produced by the return-arm join — purely a narrowing witness.

## What's deliberately out

- **`isa`/`ref-eq` negatives stay wide** — `To(_).negated()` is `None`. "Not Foo" has no positive lookup target (no class to dispatch/complete/goto), so it can't improve any consumer. A parallel design agent evaluated `Not`/`Difference`/union and recommended **parking** general negation; the `negative_isa_else_stays_wide` test pins that the else stays wide, not `Undef`.
- **elsif-chain `else`** (cumulative negation across the chain) — needs unions; deferred. Direct `if/else` + `unless/else` ship.

## Testing

- `cargo test`: **976 passed, 0 failed** (4 new: `return if defined`→Undef, `unless (defined)`→Undef, the then/else split (Foo / Undef), and isa-else-stays-wide), no warnings.
- e2e + gold in CI.

Bumps `EXTRACT_VERSION` (101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_