### PR TITLE
feat(types): Type::Tiny Maybe[T] isa → Optional&lt;T&gt; — stacked on #88

### DIFF
--- a/docs/prompt-optional-types.md
+++ b/docs/prompt-optional-types.md
@@ -133,11 +133,17 @@ green.
   lifts the agreed `T` to `Optional<T>` when an undef arm is present.
   Composes with `defined`: `my $x = $c ? Foo->new : undef; return unless
   defined $x; $x->go` dispatches on `Foo`.
+- **Type::Tiny `Maybe[T]` / `Optional[T]` (LANDED):** `map_isa_to_type`
+  maps a `Maybe[…]` / `Optional[…]` isa string to `Optional<inner>`,
+  recursing on the wrapped constraint (`Maybe[Int] → Optional<Numeric>`,
+  `Maybe[InstanceOf['Foo']] → Optional<Foo>`). Checked before the
+  InstanceOf/Moose-class fallbacks. Covers the quoted-string isa form;
+  the bareword Type::Tiny constructor form (its own
+  `TypeConstraintOf` path) is a follow-up.
 - Still deferred: `SlotTypeFold` ({T, undef} slot writes → Optional);
   bare `return;` as an undef arm (wider gold blast radius);
   `TypeProvenance::ReducerFold { reducer: "optional_join" }` for
-  `--dump-package`; Type::Tiny `Maybe[T]` / `Optional[T]` →
-  `Optional(Box<T>)`.
+  `--dump-package`; the bareword Type::Tiny `Maybe[…]` form.
 
 ## Sequencing wrinkle (Phase 2+)
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10198,6 +10198,17 @@ impl<'a> Builder<'a> {
             "CodeRef" => Some(InferredType::CodeRef { return_edge: None }),
             "RegexpRef" => Some(InferredType::Regexp),
             _ => {
+                // `Maybe[T]` / `Optional[T]` (Type::Tiny / Types::Standard)
+                // → `Optional<inner>`, recursing on the wrapped constraint.
+                // Checked before the InstanceOf/Moose-class fallbacks so
+                // `Maybe[Int]` doesn't read as a class named "Maybe[Int]".
+                for prefix in ["Maybe[", "Optional["] {
+                    if let Some(inner) = isa.strip_prefix(prefix).and_then(|r| r.strip_suffix(']')) {
+                        return self
+                            .map_isa_to_type(inner.trim(), mode)
+                            .map(|t| InferredType::Optional(Box::new(t)));
+                    }
+                }
                 // InstanceOf['Foo::Bar'] (Moo style) — the isa value is
                 // valid-ish Perl syntax, so re-parse it with tree-sitter
                 // and pull the class name out of the tree rather than

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15485,3 +15485,25 @@ fn narrow_place_ref_eq() {
         "ref(place) eq 'HASH' narrows the slot",
     );
 }
+
+#[test]
+fn optional_maybe_isa_scalar() {
+    let fa = build_fa("package P;\nuse Moo;\nhas x => (is => 'ro', isa => 'Maybe[Int]');\n");
+    assert_eq!(
+        fa.sub_return_type_at_arity("x", Some(0)),
+        Some(InferredType::Optional(Box::new(InferredType::Numeric))),
+        "Maybe[Int] accessor returns Optional<Numeric>",
+    );
+}
+
+#[test]
+fn optional_maybe_isa_instance() {
+    let fa = build_fa(
+        "package P;\nuse Moo;\nhas thing => (is => 'ro', isa => 'Maybe[InstanceOf[\"Foo\"]]');\n",
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("thing", Some(0)),
+        Some(InferredType::Optional(Box::new(InferredType::ClassName("Foo".into())))),
+        "Maybe[InstanceOf['Foo']] accessor returns Optional<Foo>",
+    );
+}

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 102;
+pub const EXTRACT_VERSION: i64 = 103;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.


### PR DESCRIPTION
**Stacked on #88.**

## What

Maps Type::Tiny / Types::Standard `Maybe[T]` / `Optional[T]` `isa` constraints to `Optional<T>` — the lattice link the design has pointed at all along (`Maybe[T]` ↔ `Optional<T>`):

```perl
has x     => (isa => 'Maybe[Int]');                 # accessor → Optional<Numeric>
has thing => (isa => 'Maybe[InstanceOf["Foo"]]');   # accessor → Optional<Foo>
```

## How

`map_isa_to_type` gets a `Maybe[…]` / `Optional[…]` arm that recurses on the wrapped constraint, checked **before** the `InstanceOf`/Moose-class fallbacks (so `Maybe[Int]` doesn't read as a class literally named `Maybe[Int]`).

Composes with `defined` narrowing end to end: `my $t = $obj->thing; return unless defined $t; $t->m` dispatches on `Foo`.

## Scope

Covers the **quoted-string** isa form (`isa => 'Maybe[Int]'`). The bareword Type::Tiny constructor form (`isa => Maybe[Int]`) goes through the separate `TypeConstraintOf` path and is a follow-up.

## Testing

- `cargo test`: **981 passed, 0 failed** (2 new: `Maybe[Int]`→`Optional<Numeric>`, `Maybe[InstanceOf['Foo']]`→`Optional<Foo>`), no warnings.

Bumps `EXTRACT_VERSION` (103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_