### PR TITLE
feat(types): optional_join provenance for --dump-package — stacked on #89

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -13227,11 +13227,20 @@ impl<'a> Builder<'a> {
                 )
             );
             if !preserve {
+                // Tag an optional return so `--dump-package` explains the
+                // `{T, undef}` join that produced it.
+                let mut evidence = vec!["symbol_bag".to_string()];
+                if matches!(
+                    return_types.get(&sub_name),
+                    Some(InferredType::Optional(_))
+                ) {
+                    evidence.push("optional_join".into());
+                }
                 return_provenance.insert(
                     sub_name,
                     crate::file_analysis::TypeProvenance::ReducerFold {
                         reducer: "return_arms".into(),
-                        evidence: vec!["symbol_bag".into()],
+                        evidence,
                     },
                 );
             }

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15487,6 +15487,20 @@ fn narrow_place_ref_eq() {
 }
 
 #[test]
+fn optional_return_provenance() {
+    // --dump-package should explain an Optional return via the join.
+    let fa = build_fa("package P;\nsub maybe { return undef unless 1; return Foo->new; }\n");
+    let sid = fa.symbols.iter().find(|s| s.name == "maybe").unwrap().id;
+    match fa.type_provenance.get(&sid) {
+        Some(TypeProvenance::ReducerFold { evidence, .. }) => assert!(
+            evidence.iter().any(|e| e == "optional_join"),
+            "evidence should record the optional join, got {evidence:?}",
+        ),
+        other => panic!("expected ReducerFold provenance, got {other:?}"),
+    }
+}
+
+#[test]
 fn optional_maybe_isa_scalar() {
     let fa = build_fa("package P;\nuse Moo;\nhas x => (is => 'ro', isa => 'Maybe[Int]');\n");
     assert_eq!(

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 103;
+pub const EXTRACT_VERSION: i64 = 104;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.


### PR DESCRIPTION
**Stacked on #89.**

## What

Small observability win: an `Optional` sub-return's provenance now carries an `optional_join` evidence tag, so `perl-lsp --dump-package` explains the `{T, undef}` join that produced it (alongside the existing `return_arms` `ReducerFold` story).

## Testing

- `cargo test`: **982 passed, 0 failed** (1 new), no warnings.

Bumps `EXTRACT_VERSION` (104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCy28J1pr3w6Ja1BLN1mG)_