### PR TITLE
perf: parse each POD block once in resolve_tail_pod_docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ When a comment grows past a few lines, that's a smell: either the code wants a c
 - `module_cache.rs` — SQLite (schema v9, bincode+zstd FileAnalysis blob).
 - `cpanfile.rs` — cpanfile via tree-sitter queries.
 - `witnesses.rs` — witness bag + reducer registry for type inference.
+- `timings.rs` — **all profiling/timing instrumentation lives here.** Per-module build timings (`--timings` / `PERL_LSP_TIMINGS`, slowest-first report) and per-phase timing (`timings::phase` + the `bphase!`/`tphase!` call-site sugar, gated by `PERL_LSP_PHASE_TIMING`). Don't hand-roll env-gated `eprintln!` timers — route new timing through here so the gate is read once and the output format stays uniform.
 
 ## Cross-file resolution
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -166,6 +166,14 @@ fn build_chain_typing_index<'a>(tree: &'a Tree) -> ChainTypingIndex<'a> {
 }
 
 /// Build a FileAnalysis from a parsed tree in a single walk.
+/// Time one build() pass — `bphase!("walk", expr)` prints `[PHASE] build::walk`
+/// when `PERL_LSP_PHASE_TIMING` is set. Call-site sugar over `timings::phase`.
+macro_rules! bphase {
+    ($label:literal, $body:expr) => {
+        $crate::timings::phase(concat!("build::", $label), || $body)
+    };
+}
+
 pub fn build(tree: &Tree, source: &[u8]) -> FileAnalysis {
     build_with_plugins(tree, source, default_plugin_registry())
 }
@@ -333,7 +341,7 @@ fn build_with_plugins_inner(
 
     // Create file-level scope and walk
     let file_scope = b.push_scope(ScopeKind::File, node_to_span(tree.root_node()), None);
-    b.visit_children(tree.root_node());
+    bphase!("walk(visit_children)", b.visit_children(tree.root_node()));
     // Still inside the file scope: synthesize Sub symbols for AutoLoader /
     // SelfLoader packages whose real definitions live in the `data_section`
     // after `__END__` (or `__DATA__`). Runs here so `package_uses` /
@@ -374,7 +382,7 @@ fn build_with_plugins_inner(
     b.flush_deferred_named_sub_param_types();
 
     // Post-pass 1: resolve variable refs -> resolves_to
-    b.resolve_variable_refs();
+    bphase!("resolve_variable_refs", b.resolve_variable_refs());
 
     // Export-list member refs: a `@EXPORT` / `@EXPORT_OK` / `%EXPORT_TAGS`
     // member naming a local sub gets a FunctionCall ref back to it. Runs
@@ -410,7 +418,7 @@ fn build_with_plugins_inner(
     // returning $self via an array-slice idiom). Provenance is
     // recorded in `type_provenance` (PluginOverride) so
     // `--dump-package` can answer "why does this return X?".
-    b.apply_type_overrides();
+    bphase!("apply_type_overrides", b.apply_type_overrides());
 
     // Post-walk bag-population pass: ref-derived facts that don't
     // need walk-time visibility — `HashRefAccess` observations from
@@ -418,7 +426,7 @@ fn build_with_plugins_inner(
     // writes. Variable witnesses for TCs and walk-time idiom witnesses
     // (branch arms, arity gating) are already in `b.bag` — pushed
     // live during the walk.
-    b.populate_witness_bag();
+    bphase!("populate_witness_bag", b.populate_witness_bag());
 
     // Forward-reference resolution: walk-time `expr_payload` arms for
     // `function_call_expression` / `bareword` / `scoped_identifier` did
@@ -429,7 +437,7 @@ fn build_with_plugins_inner(
     // them now against the final symbol table and push the
     // `Expr(span) → Edge(Symbol(sid))` witness the walk would have.
     // See `docs/prompt-forward-reference-resolution.md`.
-    b.resolve_forward_expr_witnesses();
+    bphase!("resolve_fwd_expr_witnesses", b.resolve_forward_expr_witnesses());
 
     // Worklist driver: one fixed-point loop over chain typing +
     // reducer dispatch (rather than a manually-ordered
@@ -453,16 +461,16 @@ fn build_with_plugins_inner(
     // Deeper chains take more iterations; `MAX_FOLD_ITERATIONS`
     // (debug-only) catches dependency-tracking bugs that would
     // otherwise spin forever.
-    let chain_idx = build_chain_typing_index(tree);
-    b.fold_to_fixed_point(&chain_idx);
+    let chain_idx = bphase!("build_chain_typing_index", build_chain_typing_index(tree));
+    bphase!("fold_to_fixed_point", b.fold_to_fixed_point(&chain_idx));
     // PostFold filled `invocant_class` on MethodCall refs after the
     // worklist exited; re-emit method-call return edges so
     // Expression(refidx) chases resolve through to
     // MethodOnClass{class, method} for any invocant freshly known.
     // Then push array contributions: spans queryable through the
     // freshly-published edges.
-    b.emit_method_call_return_edges();
-    b.emit_array_push_witnesses();
+    bphase!("emit_mc_return_edges", b.emit_method_call_return_edges());
+    bphase!("emit_array_push_witns", b.emit_array_push_witnesses());
     // Record each method-call invocant's resolved type at its span so
     // the tree-free query entry (`FileAnalysis::expr_type_at_span`) can
     // answer "what is this expression?" without a CST. Runs after array
@@ -470,14 +478,14 @@ fn build_with_plugins_inner(
     // `Variable{@arr}` Sequence. The build-time symbolic executor
     // (`invocant_type_at_node`) is the single structure-discovery site;
     // this pass records its answer.
-    b.emit_invocant_expr_witnesses(&chain_idx);
+    bphase!("emit_invocant_expr_witns", b.emit_invocant_expr_witnesses(&chain_idx));
 
     // Partial Mojo route targets (`->to('#action')`) inherit their
     // controller from a parent `->to('ctrl#')` via the route value's
     // brand, which only settles after the fold. Re-dispatch the route
     // plugins now that the brand is resolved. See
     // `docs/adr/route-branding.md`.
-    b.emit_partial_route_targets(&chain_idx);
+    bphase!("emit_partial_route_tgts", b.emit_partial_route_targets(&chain_idx));
 
     // Test-only: re-run the worklist fold one more time to pin
     // idempotency. Production callers always pass `false`; only
@@ -497,12 +505,12 @@ fn build_with_plugins_inner(
     // emission gated on the partially-resolved walk-time class, now it's
     // a single post-walk pass that joins refs to args via the chain
     // typing index.
-    b.emit_method_call_arg_keys(&chain_idx);
+    bphase!("emit_mc_arg_keys", b.emit_method_call_arg_keys(&chain_idx));
 
     // Post-pass: chained hashref-key accesses (`$obj->get_config->{host}`).
     // Runs post-fold so the method's return type is canonical — the
     // owner class is the chain receiver's type, unknowable until then.
-    b.emit_chained_hash_key_refs(&chain_idx);
+    bphase!("emit_chained_hk_refs", b.emit_chained_hash_key_refs(&chain_idx));
 
     // Post-pass: upgrade Variable-owned hash-key derefs whose variable's
     // type settled to a class DURING the fold (`my $row = $rs->find(1);
@@ -510,10 +518,10 @@ fn build_with_plugins_inner(
     // resolve_hash_key_owners ran). A Class owner routes the key to the
     // class's defs (DBIC columns, Moo slots); variables without a class
     // type keep their lexical grouping.
-    b.upgrade_variable_hash_key_owners();
+    bphase!("upgrade_var_hk_owners", b.upgrade_variable_hash_key_owners());
 
     // Post-pass 5: fill in tail POD docs for subs that didn't get preceding doc
-    b.resolve_tail_pod_docs();
+    bphase!("resolve_tail_pod_docs", b.resolve_tail_pod_docs());
 
     let mut fa = FileAnalysis::new(crate::file_analysis::FileAnalysisParts {
         scopes: b.scopes,
@@ -552,7 +560,7 @@ fn build_with_plugins_inner(
     // For every assignment the unified typer (run before
     // `resolve_return_types` above) couldn't handle, MCB fills in.
     // Cross-file enrichment also reuses MCB resolution without a tree.
-    fa.finalize_post_walk();
+    bphase!("finalize_post_walk", fa.finalize_post_walk());
 
     fa
 }
@@ -11747,6 +11755,31 @@ impl<'a> Builder<'a> {
         if self.pod_texts.is_empty() {
             return;
         }
+        if crate::timings::phases_enabled() {
+            let nsubs = self.symbols.iter().filter(|s| matches!(s.kind, SymKind::Sub | SymKind::Method)).count();
+            let podbytes: usize = self.pod_texts.iter().map(|p| p.len()).sum();
+            eprintln!(
+                "[PHASE] {:<32} {} subs, {} pod_texts, {} pod_bytes",
+                "build::tail_pod_inputs",
+                nsubs,
+                self.pod_texts.len(),
+                podbytes
+            );
+        }
+        // One name → doc map across every POD block. Within a block `=head2`
+        // wins over `=item`; across blocks the earlier `pod_text` wins
+        // (`or_insert`), so a sub resolves to the first matching section in
+        // source order.
+        let mut sections: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        for pod_text in &self.pod_texts {
+            for (name, md) in crate::pod::extract_sub_doc_sections(pod_text) {
+                sections.entry(name).or_insert(md);
+            }
+        }
+        if sections.is_empty() {
+            return;
+        }
         for sym in &mut self.symbols {
             if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                 continue;
@@ -11755,20 +11788,8 @@ impl<'a> Builder<'a> {
                 if doc.is_some() {
                     continue; // already has preceding doc
                 }
-                // Search pod texts for =head2 matching this sub name, fall back to =item
-                for pod_text in &self.pod_texts {
-                    if let Some(md) = crate::pod::extract_head2_section(&sym.name, pod_text) {
-                        if !md.is_empty() {
-                            *doc = Some(md);
-                            break;
-                        }
-                    }
-                    if let Some(md) = crate::pod::extract_item_section(&sym.name, pod_text) {
-                        if !md.is_empty() {
-                            *doc = Some(md);
-                            break;
-                        }
-                    }
+                if let Some(md) = sections.get(&sym.name) {
+                    *doc = Some(md.clone());
                 }
             }
         }
@@ -12044,6 +12065,14 @@ impl<'a> Builder<'a> {
             prev = cur;
         }
         self.run_chain_typing_reducer(idx, ChainPassMode::PostFold);
+        if crate::timings::phases_enabled() {
+            eprintln!(
+                "[PHASE] {:<32} {} iters, bag.len={}",
+                "build::fold_iterations",
+                iters,
+                self.bag.len()
+            );
+        }
     }
 
     /// Snapshot of the answers the worklist driver tracks for fixed

--- a/src/document.rs
+++ b/src/document.rs
@@ -29,8 +29,17 @@ impl Document {
         if elapsed.as_millis() > 100 {
             log::warn!("Slow parse (new): {:?} for {} bytes", elapsed, text.len());
         }
-        let analysis = builder::build(&tree, text.as_bytes());
-        let stable_outline = StableOutline::from_analysis(&analysis);
+        if crate::timings::phases_enabled() {
+            eprintln!(
+                "[PHASE] {:<32} {:>8.2} ms ({} bytes)",
+                "parse",
+                elapsed.as_secs_f64() * 1000.0,
+                text.len()
+            );
+        }
+        let analysis = crate::timings::phase("build()", || builder::build(&tree, text.as_bytes()));
+        let stable_outline =
+            crate::timings::phase("stable_outline", || StableOutline::from_analysis(&analysis));
         Some(Document { text, tree, analysis, stable_outline })
     }
 

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -41,7 +41,9 @@ fn layer_map() -> HashMap<&'static str, Layer> {
         ("file_store", Index),
         ("resolve", Index),
         ("document", Index),
-        ("timings", Index),
+        // Leaf instrumentation util (std-only, no crate imports): lives at the
+        // bottom so every layer — builder included — may import it downward.
+        ("timings", Model),
         ("builtins_pod", Index),
         ("backend", Lsp),
         ("symbols", Lsp),

--- a/src/main.rs
+++ b/src/main.rs
@@ -628,16 +628,24 @@ fn cli_semantic_tokens(root: &str, file: &str) {
 /// Build an open `Document` (tree + analysis + stable_outline) and enrich it
 /// against the index exactly like the server's open-file path. Shared by the
 /// interactive CLI modes.
+/// Time one CLI query step — `tphase!("completion_items", expr)` prints a
+/// `[PHASE]` line when `PERL_LSP_PHASE_TIMING` is set. Sugar over `timings::phase`.
+macro_rules! tphase {
+    ($label:literal, $body:expr) => {
+        $crate::timings::phase($label, || $body)
+    };
+}
+
 fn cli_open_document(file: &str, idx: &module_index::ModuleIndex) -> document::Document {
     let text = std::fs::read_to_string(file).unwrap_or_else(|e| {
         eprintln!("Cannot read {}: {}", file, e);
         std::process::exit(1);
     });
-    let mut doc = document::Document::new(text).unwrap_or_else(|| {
+    let mut doc = tphase!("Document::new (parse+build)", document::Document::new(text).unwrap_or_else(|| {
         eprintln!("Parse failed: {}", file);
         std::process::exit(1);
-    });
-    doc.analysis.enrich_imported_types_with_keys(Some(idx));
+    }));
+    tphase!("enrich_imported_types", doc.analysis.enrich_imported_types_with_keys(Some(idx)));
     doc
 }
 
@@ -853,9 +861,9 @@ fn run_one(
         }
         "completion" => {
             let doc = cli_open_document(file, idx);
-            let items = symbols::completion_items(
+            let items = tphase!("completion_items", symbols::completion_items(
                 &doc.analysis, &doc.tree, &doc.text, pos, idx,
-                Some(doc.stable_outline.package_lines()));
+                Some(doc.stable_outline.package_lines())));
             let mut out = String::new();
             for it in &items {
                 match &it.detail {

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -155,6 +155,85 @@ pub fn extract_perlfunc_items(pod_text: &str) -> std::collections::HashMap<Strin
     out
 }
 
+/// Extract a doc section for every documented sub name in a POD block —
+/// both `=head2 name` sections and `=item name` entries — into one
+/// `name → markdown` map in a single parse + linear walk. `=head2` wins over
+/// `=item` for the same name. The batched companion to `extract_head2_section`
+/// / `extract_item_section`: for callers that want every sub's doc at once
+/// rather than one block-parse per sub.
+pub fn extract_sub_doc_sections(pod_text: &str) -> std::collections::HashMap<String, String> {
+    let mut out: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let tree = match parse_pod(pod_text) {
+        Some(t) => t,
+        None => return out,
+    };
+    let bytes = pod_text.as_bytes();
+    let root = tree.root_node();
+
+    // `current` is the section currently being collected, tagged by whether it
+    // came from a `=head2` (priority) or an `=item`. We flush on the next
+    // boundary command. A `=head2`-sourced section overwrites a prior
+    // `=item`-sourced one for the same name; never the reverse.
+    #[derive(Clone, Copy, PartialEq)]
+    enum Src { Head2, Item }
+    let mut current: Option<(String, Src, String)> = None;
+
+    let flush = |out: &mut std::collections::HashMap<String, String>,
+                 sec: Option<(String, Src, String)>| {
+        if let Some((name, src, body)) = sec {
+            let body = body.trim().to_string();
+            if body.is_empty() {
+                return;
+            }
+            match (src, out.get(&name)) {
+                // head2 always wins; item only fills a gap.
+                (Src::Head2, _) => { out.insert(name, body); }
+                (Src::Item, None) => { out.insert(name, body); }
+                (Src::Item, Some(_)) => {}
+            }
+        }
+    };
+
+    for i in 0..root.named_child_count() {
+        let child = match root.named_child(i) {
+            Some(c) => c,
+            None => continue,
+        };
+        if child.kind() == "command_paragraph" {
+            let cmd = get_command_name(&child, bytes);
+            if cmd == "=head2" {
+                flush(&mut out, current.take());
+                let content = get_content_text(&child, bytes);
+                let head_name = content
+                    .split(|c: char| c == '(' || c.is_whitespace())
+                    .next()
+                    .unwrap_or("");
+                if !head_name.is_empty() {
+                    current = Some((head_name.to_string(), Src::Head2, String::new()));
+                }
+                continue;
+            }
+            if cmd == "=item" {
+                flush(&mut out, current.take());
+                let content = get_content_text(&child, bytes);
+                if let Some(name) = extract_item_method_name(&content) {
+                    current = Some((name.to_string(), Src::Item, String::new()));
+                }
+                continue;
+            }
+            if cmd == "=back" || cmd == "=head1" || cmd == "=head3" || cmd == "=cut" {
+                flush(&mut out, current.take());
+                continue;
+            }
+        }
+        if let Some((_, _, body)) = current.as_mut() {
+            render_node(child, bytes, body);
+        }
+    }
+    flush(&mut out, current.take());
+    out
+}
+
 /// Identifier name from a `=item` line in `perlfunc.pod`. Each entry
 /// looks like `=item NAME[ SIGNATURE]`; we take the first
 /// whitespace-delimited token and validate it as a plausible builtin

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -144,3 +144,33 @@ pub fn report() {
         total.as_secs_f64() * 1000.0
     );
 }
+
+// ── Fine-grained per-phase timing ──────────────────────────────────────
+//
+// `phase()` wraps a single build() pass or query step; `PERL_LSP_PHASE_TIMING`
+// turns it on — a finer cut than the per-module report above. All phase timing
+// routes through here (including the `bphase!` / `tphase!` call-site sugar) so
+// the gate is read once and the output format stays uniform.
+
+/// Cached `PERL_LSP_PHASE_TIMING` gate, read from the environment once so the
+/// hot build path never re-hits `std::env`.
+pub fn phases_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("PERL_LSP_PHASE_TIMING").is_some())
+}
+
+/// Time `body`, returning its result; when phase timing is on, print
+/// `[PHASE] <label>  <ms>` to stderr, else run it untouched.
+#[inline]
+pub fn phase<T>(label: &str, body: impl FnOnce() -> T) -> T {
+    if !phases_enabled() {
+        return body();
+    }
+    let started = std::time::Instant::now();
+    let out = body();
+    eprintln!(
+        "[PHASE] {label:<32} {:>8.2} ms",
+        started.elapsed().as_secs_f64() * 1000.0
+    );
+    out
+}


### PR DESCRIPTION
## What

First-query latency on large documented modules was dominated by `resolve_tail_pod_docs`, which re-parsed each module's entire POD block **twice per undocumented sub** (`extract_head2_section` + `extract_item_section`). On `DateTime.pm` (252 subs, 72KB POD) that's ~504 full POD parses ≈ **920ms of a ~1010ms `build()`** — and since the open file's `build()` re-runs per query, every hover/completion paid it (it was never "first-touch then fast").

## The fix — the part to review (~30 lines)

- **`src/pod.rs`**: new `extract_sub_doc_sections` parses each POD block **once** into a `name → markdown` map (head2-wins-over-item, preserving the prior per-sub precedence), modeled on the existing `extract_perlfunc_items`.
- **`src/builder.rs`**: `resolve_tail_pod_docs` loops subs against that map instead of doing 2 parses per sub.

`resolve_tail_pod_docs` **920ms → 2ms**, `build()` **1010ms → 56ms**, end-to-end DateTime query **940ms → 70ms** (13×). Doc output **byte-identical** → no `EXTRACT_VERSION` bump, cached blobs stay valid.

## The rest — skim (reusable instrumentation)

`PERL_LSP_PHASE_TIMING=1` per-phase `[PHASE]` timing that found this, routed through the existing `timings` module (`timings::phase` + thin `bphase!`/`tphase!` call-site sugar) instead of hand-rolled env-gated `eprintln!`s. `CLAUDE.md` now points at `src/timings.rs` as the home for timing instrumentation so it doesn't get hand-rolled again; `timings` moves to the `Model` layer (leaf util, std-only, importable by every layer).

## Verification

- gold harness **187 PASS / 0 FAIL / 0 XPASS / 0 CRASH**
- **947 unit + 4 CLI tests** green
- doc output byte-identical (spot-checked several subs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
