### PR TITLE
feat(generators): plugin-declared symbol generators (productive Perl projection)

### DIFF
--- a/docs/prompt-perl-generators.md
+++ b/docs/prompt-perl-generators.md
@@ -1,0 +1,91 @@
+# Productive Perl Projection (PPP) — symbol generators
+
+A **symbol generator** is a Perl helper whose call synthesizes a GROUP of
+symbols from its literal arguments — `make_crud_helpers('user')` projecting a
+`user_id` accessor plus `get_user`/`set_user` methods. This is the
+generalization of Moo `has` synthesis (`visit_has_call`): a call witness
+projected into a symbol group, every member tracing (provenance) to the call
+site so the outline shows it and goto-def / rename on it land on the
+invocation.
+
+Design is **structural projection, never execution**: the plugin DECLARES the
+synthesis rules abstractly (parameterized over the call args); core substitutes
+the literal args and runs a fixpoint worklist. Lifted from the
+`spike/cpp-support` PoC (`src/perl_generators.rs`).
+
+## What landed (first slice)
+
+The seam is a new plugin **manifest** `generators()` (rule #10 — the plugin
+owns the rules, core owns the mechanism), parallel to `dispatch_verbs()` /
+`role_makers()`.
+
+- **`src/plugin/mod.rs`** — `GeneratorDef { name, params, actions }` +
+  `GeneratorAction` (a flat struct: `emit`+`kind` to synthesize a symbol, or
+  `generate`+`args` to invoke a nested generator). Trait method
+  `FrameworkPlugin::generators()` (default empty) and
+  `PluginRegistry::generators()` yielding `(plugin_id, &GeneratorDef)`.
+- **`src/plugin/rhai_host.rs`** — parses `fn generators()` from a Rhai script
+  (fail-safe, same contract as the other manifests); `generators_manifest_parses_from_rhai`
+  test proves the round-trip.
+- **`src/generators.rs`** — the provenance-generic projection worklist
+  (`project(defs, root) -> Vec<GenSymbol>`): `${param}` interpolation, a
+  per-call seen-set (recursive generator terminates), nested `Generate`
+  chaining the root provenance. Pure unit tests.
+- **`src/builder.rs`** — bakes `generator_manifest` + `generator_plugin` at
+  init; `synthesize_generator_call(name, ctx)` runs at function/method-call
+  dispatch (same seam as `record_provisional_dispatch`), emitting each member
+  as a REAL `Namespace::Framework` symbol with `span = call site` (provenance)
+  and `selection_span = generator-name token`.
+- **`src/builder_tests.rs`** (`mod symbol_generators`) — integration test: the
+  synthesized group is present in `FileAnalysis` with span pinned to the call
+  site; nested generation synthesizes transitively with root provenance; a
+  non-generator call synthesizes nothing.
+
+Verified: `cargo test` (1009 pass). The generator fires regardless of triggers
+(keyed off the global manifest), so it works the same in any package.
+
+## What's next
+
+1. **Verify references / goto-def / rename end-to-end.** The synthesized
+   symbols are real `Method` symbols in the package, so `$self->get_user()`
+   should resolve via `stamp_method_call_targets` →
+   `resolve_method_in_ancestors` → the synthesized `sym_id`, and rename should
+   land on the generator call (its `selection_span`). Add a CLI/e2e test that
+   drives goto-def from a call site to the generator invocation, and a rename
+   round-trip. (Not yet covered — only symbol presence + provenance are
+   asserted.)
+
+2. **Ship a real bundled generator.** No universal CPAN generator was targeted
+   in this slice (the PoC's `make_crud_helpers` is illustrative). Candidates:
+   `MooseX::*` attribute-group sugar, `Class::Method::Modifiers`-style
+   installers, project-house `make_*` exporters. A bundled `frameworks/*.rhai`
+   should gate with a `UsesModule` trigger so it only fires for its module —
+   but note synthesis itself is trigger-independent, so the gate must be
+   enforced by checking the generator's provenance module if false positives
+   appear. (Today any call matching a declared generator name synthesizes.)
+
+3. **Args beyond positional string literals.** `synthesize_generator_call`
+   collects `ctx.args[*].string_value` in order. Extend to qw-lists / folded
+   constants / hashref option pairs (reuse the `classified_pairs` /
+   `string_list` helpers) so a generator can take `(name => ..., columns =>
+   [...])`. The `=>` is a human hint only — keep the walk separator-agnostic
+   (CLAUDE.md fat-comma rule).
+
+4. **Richer emitted symbols.** Members are `SymbolDetail::Sub` with empty
+   params and no return type. Let `GeneratorAction` carry params / return-type
+   templates and a `HashKeyDef` action (constructor key), matching the full
+   `has` synthesis (accessor + constructor key + internal hash key).
+
+5. **Cross-file generators.** A generator imported from another module: the
+   manifest is global so it already fires, but the synthesized symbols live in
+   the calling file. Confirm they survive the module-cache blob and resolve
+   cross-file (they are ordinary symbols, so they should).
+
+## Chosen seam (why)
+
+A `generators()` manifest, not an `on_function_call` that emits the group
+directly: the manifest gives core the worklist for free (nested + recursive
+generation in one pass), and keeps the synthesis rules as declarative plugin
+data (rule #10) rather than imperative script logic. The projection engine is
+isolated and provenance-generic, so the worklist/seen-set/interpolation is unit
+tested without the builder.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -269,6 +269,8 @@ fn build_with_plugins_inner(
         plugins,
         dispatch_manifest: std::collections::HashMap::new(),
         load_manifest: std::collections::HashMap::new(),
+        generator_manifest: std::collections::HashMap::new(),
+        generator_plugin: std::collections::HashMap::new(),
         type_constraint_names: std::collections::HashSet::new(),
         app_surface_consumers: Vec::new(),
         param_type_manifest: std::collections::HashMap::new(),
@@ -320,6 +322,10 @@ fn build_with_plugins_inner(
         .collect();
     b.role_maker_modules
         .extend(b.plugins.role_makers().map(|s| s.to_string()));
+    for (plugin_id, g) in b.plugins.generators() {
+        b.generator_plugin.insert(g.name.clone(), plugin_id.to_string());
+        b.generator_manifest.insert(g.name.clone(), g.clone());
+    }
     for pt in b.plugins.param_types() {
         match &pt.method {
             Some(name) => {
@@ -1461,6 +1467,13 @@ struct Builder<'a> {
     /// dispatch collection in the method-call walk.
     dispatch_manifest: std::collections::HashMap<String, plugin::DispatchVerb>,
     load_manifest: std::collections::HashMap<String, plugin::LoadVerb>,
+    /// Symbol-generator manifest from plugin `generators()`, keyed by call
+    /// name. A function / method call naming one of these projects its
+    /// synthesis rules into real symbols (`synthesize_generator_call`).
+    generator_manifest: std::collections::HashMap<String, plugin::GeneratorDef>,
+    /// Generator name → declaring plugin id, so synthesized symbols carry the
+    /// owning plugin's `Namespace::Framework`.
+    generator_plugin: std::collections::HashMap<String, String>,
     /// Constraint-constructor name gate from plugin `type_constraint_names()`
     /// (`InstanceOf`, …), flattened once. A call to one of these is typed as
     /// `TypeConstraintOf` via the plugin's fold rather than its callee return.
@@ -2784,7 +2797,62 @@ impl<'a> Builder<'a> {
     /// Run every applicable plugin's `on_function_call` hook. Used for
     /// top-level calls (`get '/path' => sub {}`, `has 'attr' => ...`)
     /// that aren't method calls. Mirrors dispatch_method_call_plugins.
+    /// Project a generator call site into its synthesized symbol GROUP. The
+    /// synthesis rules are the plugin's (`generator_manifest`, rule #10);
+    /// core substitutes the call's literal string args and runs the
+    /// projection worklist (`crate::generators`), which threads the call span
+    /// as provenance and chains it through nested generation. Each member is
+    /// a REAL symbol whose `span` points at the generator call, so
+    /// documentSymbol shows it and goto-def / rename on it (or on a call to
+    /// it) land on the invocation. This is the generalization of
+    /// `visit_has_call`'s Moo `has` accessor synthesis. Trigger-independent:
+    /// keyed off the global manifest, like `record_provisional_dispatch`.
+    fn synthesize_generator_call(&mut self, name: &str, ctx: &plugin::CallContext) {
+        if !self.generator_manifest.contains_key(name) {
+            return;
+        }
+        // Literal string args, in order — the substitution the templates
+        // interpolate (`make_crud_helpers('user')` → params bound to "user").
+        let args: Vec<String> =
+            ctx.args.iter().filter_map(|a| a.string_value.clone()).collect();
+        let root = crate::generators::GenWitness {
+            generator: name.to_string(),
+            args,
+            prov: ctx.call_span,
+        };
+        for m in crate::generators::project(&self.generator_manifest, root) {
+            let plugin_id = self
+                .generator_plugin
+                .get(&m.from_generator)
+                .cloned()
+                .unwrap_or_default();
+            let is_method = matches!(m.kind.as_str(), "method" | "accessor");
+            let kind = if is_method { SymKind::Method } else { SymKind::Sub };
+            let detail = SymbolDetail::Sub {
+                params: vec![],
+                is_method,
+                doc: None,
+                display: None,
+                hide_in_outline: false,
+                opaque_return: false,
+                is_constant: false,
+                lexical: false,
+            };
+            self.add_symbol_ns(
+                m.name,
+                kind,
+                m.prov,             // span: the generator call site (provenance)
+                ctx.selection_span, // selection: the generator-name token
+                detail,
+                Namespace::framework(plugin_id),
+            );
+        }
+    }
+
     fn dispatch_function_call_plugins(&mut self, ctx: plugin::CallContext) {
+        if let Some(name) = ctx.function_name.clone() {
+            self.synthesize_generator_call(&name, &ctx);
+        }
         if self.plugins.is_empty() { return; }
         let parents = self.current_package.as_ref()
             .map(|p| self.transitive_parents(p))
@@ -2810,6 +2878,9 @@ impl<'a> Builder<'a> {
     }
 
     fn dispatch_method_call_plugins(&mut self, ctx: plugin::CallContext) {
+        if let Some(name) = ctx.method_name.clone() {
+            self.synthesize_generator_call(&name, &ctx);
+        }
         if self.plugins.is_empty() { return; }
         let parents = self.current_package.as_ref()
             .map(|p| self.transitive_parents(p))

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15057,3 +15057,128 @@ fn plugin_loads_recorded_trigger_independent_and_multivalue() {
 
 #[path = "builder/narrowing_tests.rs"]
 mod narrowing;
+
+// Productive Perl projection: a plugin-declared symbol GENERATOR
+// (`generators()` manifest) projecting a call site into a real symbol group
+// with provenance to the call. The generalization of Moo `has` synthesis.
+mod symbol_generators {
+    use super::*;
+    use crate::file_analysis::{Namespace, SymKind};
+    use crate::plugin::{
+        CompletionQueryContext, FrameworkPlugin, GeneratorAction, GeneratorDef,
+        PluginCompletionAnswer, PluginRegistry, PluginSigHelpAnswer, SigHelpQueryContext, Trigger,
+    };
+    use std::sync::{Arc, OnceLock};
+
+    /// Declares two generators: `make_crud_helpers($thing)` synthesizes an
+    /// accessor + getter + setter; `make_resource($res)` emits a table
+    /// accessor AND invokes `make_crud_helpers` (nested generation).
+    struct CrudGenPlugin;
+
+    fn emit(name: &str, kind: &str) -> GeneratorAction {
+        GeneratorAction { emit: Some(name.into()), kind: Some(kind.into()), ..Default::default() }
+    }
+    fn generate(name: &str, args: &[&str]) -> GeneratorAction {
+        GeneratorAction {
+            generate: Some(name.into()),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    impl FrameworkPlugin for CrudGenPlugin {
+        fn id(&self) -> &str { "gen-test" }
+        fn triggers(&self) -> &[Trigger] {
+            static T: [Trigger; 1] = [Trigger::Always];
+            &T
+        }
+        fn generators(&self) -> &[GeneratorDef] {
+            static G: OnceLock<Vec<GeneratorDef>> = OnceLock::new();
+            G.get_or_init(|| {
+                vec![
+                    GeneratorDef {
+                        name: "make_crud_helpers".into(),
+                        params: vec!["thing".into()],
+                        actions: vec![
+                            emit("${thing}_id", "accessor"),
+                            emit("get_${thing}", "method"),
+                            emit("set_${thing}", "method"),
+                        ],
+                    },
+                    GeneratorDef {
+                        name: "make_resource".into(),
+                        params: vec!["res".into()],
+                        actions: vec![
+                            emit("${res}_table", "accessor"),
+                            generate("make_crud_helpers", &["${res}"]),
+                        ],
+                    },
+                ]
+            })
+        }
+        fn on_signature_help(&self, _: &SigHelpQueryContext) -> Option<PluginSigHelpAnswer> { None }
+        fn on_completion(&self, _: &CompletionQueryContext) -> Option<PluginCompletionAnswer> { None }
+    }
+
+    fn build(source: &str) -> FileAnalysis {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(CrudGenPlugin));
+        let plugins = Arc::new(reg);
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        super::super::build_with_plugins(&tree, source.as_bytes(), plugins)
+    }
+
+    #[test]
+    fn generator_call_synthesizes_real_symbol_group_with_provenance() {
+        // `make_crud_helpers('user')` is on row 1, columns 0..25.
+        let src = "package Thing;\nmake_crud_helpers('user');\n";
+        let fa = build(src);
+        let by_name = |n: &str| fa.symbols.iter().find(|s| s.name == n).cloned();
+
+        for name in ["user_id", "get_user", "set_user"] {
+            let s = by_name(name).unwrap_or_else(|| {
+                panic!(
+                    "missing synthesized symbol {name}; have {:?}",
+                    fa.symbols.iter().map(|s| s.name.clone()).collect::<Vec<_>>()
+                )
+            });
+            // Provenance: the symbol's span points at the generator CALL SITE,
+            // so goto-def / rename land on the invocation.
+            assert_eq!(s.span.start.row, 1, "{name} provenance row");
+            assert_eq!(s.span.start.column, 0, "{name} provenance start col");
+            assert_eq!(s.span.end.column, 25, "{name} span covers the call");
+            assert!(
+                matches!(s.namespace, Namespace::Framework { .. }),
+                "{name} is owned by the plugin namespace, not native Perl"
+            );
+        }
+        assert_eq!(by_name("user_id").unwrap().kind, SymKind::Method, "accessor → Method");
+        assert_eq!(by_name("get_user").unwrap().kind, SymKind::Method);
+    }
+
+    #[test]
+    fn nested_generator_synthesizes_transitively_with_root_provenance() {
+        let src = "package Thing;\nmake_resource('widget');\n";
+        let fa = build(src);
+        let by_name = |n: &str| fa.symbols.iter().find(|s| s.name == n).cloned();
+        // Direct (`widget_table`) + transitive via the worklist
+        // (`get_widget`/`set_widget`), all tracing to the one `make_resource`.
+        for name in ["widget_table", "get_widget", "set_widget"] {
+            let s = by_name(name)
+                .unwrap_or_else(|| panic!("missing {name} (nested generation)"));
+            assert_eq!(s.span.start.row, 1, "{name} traces to the make_resource call");
+            assert_eq!(s.span.start.column, 0);
+        }
+    }
+
+    #[test]
+    fn non_generator_call_synthesizes_nothing() {
+        let fa = build("package Thing;\nregular_function('user');\n");
+        assert!(
+            fa.symbols.iter().all(|s| s.name != "user_id"),
+            "a plain call that isn't a declared generator synthesizes no group"
+        );
+    }
+}

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1,0 +1,218 @@
+//! Productive Perl projection — the generator PROJECTION ENGINE.
+//!
+//! A plugin-declared symbol generator (`crate::plugin::GeneratorDef`) is a
+//! helper whose call synthesizes a GROUP of symbols from its literal args:
+//! `make_crud_helpers('user')` projects a `user_id` accessor +
+//! `get_user`/`set_user` methods. This is the generalization of Moo `has`
+//! synthesis — a call witness projected into a symbol group, every member
+//! tracing (provenance) to the call site.
+//!
+//! STRUCTURAL PROJECTION, never execution. Core collects the witness (the
+//! call site + its literal args — `builder.rs`, rule #1), substitutes the
+//! args into the plugin's abstract templates, and runs this worklist. A
+//! `Generate` action queues a NESTED generator call (the worklist's fuel); a
+//! per-call seen-set bounds a generator that generates itself — we never run
+//! Perl, so we never diverge.
+//!
+//! The engine is provenance-generic (`P`): the builder threads
+//! `file_analysis::Span` (the root call span) so goto-def / rename on a
+//! synthesized symbol land on the generator invocation; the unit tests below
+//! thread a cheap token. Provenance CHAINS through nested generation — a
+//! transitively-synthesized symbol carries the ROOT call site's `P`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::plugin::GeneratorDef;
+
+/// A generator call site to project — the witness. `prov` is the provenance
+/// payload threaded onto every synthesized member (and chained through nested
+/// generation to the root).
+#[derive(Debug, Clone)]
+pub struct GenWitness<P> {
+    pub generator: String,
+    pub args: Vec<String>,
+    pub prov: P,
+}
+
+/// A symbol produced by projecting a generator over a witness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenSymbol<P> {
+    pub name: String,
+    /// Plugin-declared kind string (`"method"` / `"accessor"` / `"sub"`); the
+    /// builder maps it to a `SymKind`.
+    pub kind: String,
+    pub from_generator: String,
+    pub prov: P,
+}
+
+/// Project ONE generator call site into its synthesized symbol group.
+///
+/// A fixpoint worklist: `Generate` actions enqueue nested generator calls
+/// (carrying the root's `prov`); the seen-set — keyed by `(generator, args)`,
+/// scoped to THIS call — drops a generator that re-queues itself with the same
+/// args, so a recursive generator terminates bounded rather than hanging.
+///
+/// One call site = one `project` call = one independent seen-set, so two
+/// sites that invoke the same generator with the same args still synthesize
+/// two distinct groups (each call gets its own provenance).
+pub fn project<P: Clone>(
+    defs: &HashMap<String, GeneratorDef>,
+    root: GenWitness<P>,
+) -> Vec<GenSymbol<P>> {
+    let mut seen: HashSet<(String, Vec<String>)> = HashSet::new();
+    let mut queue: Vec<GenWitness<P>> = vec![root];
+    let mut out = Vec::new();
+    while let Some(w) = queue.pop() {
+        if !seen.insert((w.generator.clone(), w.args.clone())) {
+            continue;
+        }
+        let Some(def) = defs.get(&w.generator) else { continue };
+        let subst: HashMap<&str, &str> = def
+            .params
+            .iter()
+            .map(String::as_str)
+            .zip(w.args.iter().map(String::as_str))
+            .collect();
+        for action in &def.actions {
+            if let Some(tmpl) = &action.emit {
+                out.push(GenSymbol {
+                    name: interpolate(tmpl, &subst),
+                    kind: action.kind.clone().unwrap_or_else(|| "sub".to_string()),
+                    from_generator: w.generator.clone(),
+                    prov: w.prov.clone(),
+                });
+            } else if let Some(generator) = &action.generate {
+                queue.push(GenWitness {
+                    generator: generator.clone(),
+                    args: action.args.iter().map(|t| interpolate(t, &subst)).collect(),
+                    prov: w.prov.clone(), // provenance chains to the root call site
+                });
+            }
+        }
+    }
+    out
+}
+
+/// `${param}` interpolation against the substitution. An unknown key expands
+/// to empty (a generator template referencing a param the call didn't pass).
+fn interpolate(tmpl: &str, subst: &HashMap<&str, &str>) -> String {
+    let mut out = String::with_capacity(tmpl.len());
+    let bytes = tmpl.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'{') {
+            if let Some(end) = tmpl[i + 2..].find('}') {
+                let key = &tmpl[i + 2..i + 2 + end];
+                out.push_str(subst.get(key).copied().unwrap_or(""));
+                i += 2 + end + 1;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{GeneratorAction, GeneratorDef};
+
+    fn emit(name: &str, kind: &str) -> GeneratorAction {
+        GeneratorAction { emit: Some(name.into()), kind: Some(kind.into()), ..Default::default() }
+    }
+    fn gen(name: &str, args: &[&str]) -> GeneratorAction {
+        GeneratorAction {
+            generate: Some(name.into()),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+    fn def(name: &str, params: &[&str], actions: Vec<GeneratorAction>) -> (String, GeneratorDef) {
+        (
+            name.into(),
+            GeneratorDef {
+                name: name.into(),
+                params: params.iter().map(|s| s.to_string()).collect(),
+                actions,
+            },
+        )
+    }
+    fn wit(generator: &str, args: &[&str], prov: u32) -> GenWitness<u32> {
+        GenWitness {
+            generator: generator.into(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            prov,
+        }
+    }
+
+    fn crud_defs() -> HashMap<String, GeneratorDef> {
+        HashMap::from([def(
+            "make_crud_helpers",
+            &["name"],
+            vec![emit("${name}_id", "accessor"), emit("get_${name}", "method"), emit("set_${name}", "method")],
+        )])
+    }
+
+    #[test]
+    fn projection_synthesizes_the_group_with_provenance() {
+        let out = project(&crud_defs(), wit("make_crud_helpers", &["user"], 7));
+        let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"user_id"), "{names:?}");
+        assert!(names.contains(&"get_user"), "{names:?}");
+        assert!(names.contains(&"set_user"), "{names:?}");
+        let id = out.iter().find(|s| s.name == "user_id").unwrap();
+        assert_eq!(id.prov, 7, "synthesized symbol traces to the call witness");
+        assert_eq!(id.kind, "accessor");
+    }
+
+    #[test]
+    fn two_call_sites_two_distinct_groups() {
+        let defs = crud_defs();
+        let user = project(&defs, wit("make_crud_helpers", &["user"], 1));
+        let post = project(&defs, wit("make_crud_helpers", &["post"], 2));
+        assert_eq!(user.iter().find(|s| s.name == "user_id").unwrap().prov, 1);
+        assert_eq!(post.iter().find(|s| s.name == "post_id").unwrap().prov, 2);
+    }
+
+    #[test]
+    fn nested_generation_runs_the_worklist_chaining_provenance() {
+        let defs = HashMap::from([
+            def(
+                "make_resource",
+                &["thing"],
+                vec![emit("${thing}_table", "accessor"), gen("make_crud_helpers", &["${thing}"])],
+            ),
+            def(
+                "make_crud_helpers",
+                &["name"],
+                vec![emit("get_${name}", "method"), emit("set_${name}", "method")],
+            ),
+        ]);
+        let out = project(&defs, wit("make_resource", &["widget"], 42));
+        let names: HashSet<&str> = out.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains("widget_table"), "direct: {names:?}");
+        assert!(names.contains("get_widget"), "transitive: {names:?}");
+        assert!(names.contains("set_widget"), "transitive: {names:?}");
+        // the transitively-synthesized symbol still traces to the ROOT call.
+        assert_eq!(out.iter().find(|s| s.name == "get_widget").unwrap().prov, 42);
+    }
+
+    #[test]
+    fn recursive_generator_terminates_via_seen_set() {
+        let defs = HashMap::from([def(
+            "loop_gen",
+            &["x"],
+            vec![emit("sym_${x}", "method"), gen("loop_gen", &["${x}"])],
+        )]);
+        let out = project(&defs, wit("loop_gen", &["a"], 0));
+        assert_eq!(out.iter().filter(|s| s.name == "sym_a").count(), 1, "bounded: {out:?}");
+    }
+
+    #[test]
+    fn unknown_generator_synthesizes_nothing() {
+        let out = project(&crud_defs(), wit("regular_function", &["user"], 0));
+        assert!(out.is_empty(), "no generator → no synthesis: {out:?}");
+    }
+}

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -31,6 +31,7 @@ fn layer_map() -> HashMap<&'static str, Layer> {
         ("graph", Model),
         ("cst", Cst),
         ("builder", Build),
+        ("generators", Build),
         ("plugin", Build),
         ("pod", Build),
         ("cpanfile", Build),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cursor_context;
 mod document;
 mod file_analysis;
 mod file_store;
+mod generators;
 mod graph;
 mod module_cache;
 mod module_index;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -844,6 +844,61 @@ pub enum OverrideTarget {
     },
 }
 
+/// A plugin-declared SYMBOL GENERATOR: a helper call that synthesizes a
+/// GROUP of symbols from its literal arguments — `make_crud_helpers('user')`
+/// projecting a `user_id` accessor + `get_user`/`set_user` methods. This is
+/// the generalization of Moo `has` synthesis: a call witness projected into a
+/// symbol group, every member tracing (provenance) to the call site.
+///
+/// The plugin owns the SYNTHESIS RULES (rule #10 — core never enumerates
+/// generator names); core owns the MECHANISM — collecting the call witnesses,
+/// substituting the literal args, and running the projection worklist
+/// (`crate::generators`). Trigger-independent, like `dispatch_verbs()` /
+/// `overrides()`: read from every loaded plugin and keyed by `name`.
+///
+/// Rhai shape:
+/// ```rhai
+/// fn generators() {
+///   [ #{ name: "make_crud_helpers", params: ["thing"], actions: [
+///         #{ emit: "${thing}_id", kind: "accessor" },
+///         #{ emit: "get_${thing}", kind: "method" },
+///         #{ generate: "make_audit", args: ["${thing}"] },
+///   ] } ]
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratorDef {
+    /// The generator's call name (`make_crud_helpers`). Matched against the
+    /// function-call / method-call name regardless of triggers.
+    pub name: String,
+    /// Positional parameter names the templates interpolate (`${thing}`).
+    pub params: Vec<String>,
+    /// The abstract synthesis actions, parameterized over `params`.
+    pub actions: Vec<GeneratorAction>,
+}
+
+/// One abstract synthesis step of a [`GeneratorDef`]. A flat struct (not a
+/// tagged enum) so it round-trips cleanly through Rhai maps. Exactly one of
+/// `emit` / `generate` is set per action:
+/// - `emit` + `kind`: synthesize a symbol whose name interpolates the params.
+/// - `generate` + `args`: invoke another generator (nested generation, the
+///   worklist's fuel — its symbols chain provenance to the ROOT call site).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GeneratorAction {
+    /// Name template of a symbol to synthesize, e.g. `"${thing}_id"`.
+    #[serde(default)]
+    pub emit: Option<String>,
+    /// Symbol kind for `emit` (`"method"` / `"accessor"` / `"sub"`).
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Name of a nested generator to invoke.
+    #[serde(default)]
+    pub generate: Option<String>,
+    /// Argument templates for the nested generator, e.g. `["${thing}"]`.
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
 pub trait FrameworkPlugin: Send + Sync {
     fn id(&self) -> &str;
     fn triggers(&self) -> &[Trigger];
@@ -911,6 +966,14 @@ pub trait FrameworkPlugin: Send + Sync {
     /// engine module here and consumers are marked roles directly.
     /// Default empty.
     fn role_makers(&self) -> &[String] {
+        &[]
+    }
+
+    /// Static SYMBOL GENERATOR manifest — see [`GeneratorDef`]. Read once at
+    /// plugin load; core matches a generator's `name` against every function /
+    /// method call and projects its synthesis rules into real symbols with
+    /// provenance to the call site. Trigger-independent. Default empty.
+    fn generators(&self) -> &[GeneratorDef] {
         &[]
     }
 
@@ -1236,6 +1299,15 @@ impl PluginRegistry {
         self.plugins
             .iter()
             .flat_map(|p| p.role_makers().iter().map(|s| s.as_str()))
+    }
+
+    /// Yield every (plugin_id, generator) pair across the registry.
+    /// Trigger-independent, same rationale as `dispatch_verbs` — a generator
+    /// call is recognized by its name regardless of the file's `use`s.
+    pub fn generators<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a GeneratorDef)> + 'a {
+        self.plugins
+            .iter()
+            .flat_map(|p| p.generators().iter().map(move |g| (p.id(), g)))
     }
 
     /// Fold a constraint constructor → its inner type, asking the plugin(s)

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -181,6 +181,7 @@ pub struct RhaiPlugin {
     type_constraint_names: Vec<String>,
     app_surface_consumers: Vec<String>,
     role_makers: Vec<String>,
+    generators: Vec<crate::plugin::GeneratorDef>,
     arg_name_verbs: Vec<String>,
     topic_route_dsl: Option<crate::plugin::TopicRouteDsl>,
     engine: Arc<Engine>,
@@ -369,6 +370,27 @@ impl RhaiPlugin {
             }
         }
 
+        // `generators()` — symbol-generator manifest; same optional,
+        // fail-safe array-of-maps contract as dispatch_verbs.
+        let mut generators: Vec<crate::plugin::GeneratorDef> = Vec::new();
+        if signatures.iter().any(|n| n == "generators") {
+            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "generators", ()) {
+                Ok(arr) => {
+                    for d in arr {
+                        match from_dynamic::<crate::plugin::GeneratorDef>(&d) {
+                            Ok(g) => generators.push(g),
+                            Err(e) => log::error!(
+                                "plugin `{}` generators() bad entry: {}",
+                                id,
+                                e
+                            ),
+                        }
+                    }
+                }
+                Err(e) => log::error!("plugin `{}` generators() failed: {}", id, e),
+            }
+        }
+
         // `arg_name_verbs()` — call verbs wanting flat-arg-name
         // extraction; same optional, fail-safe array-of-strings shape.
         let mut arg_name_verbs: Vec<String> = Vec::new();
@@ -419,6 +441,7 @@ impl RhaiPlugin {
             type_constraint_names,
             app_surface_consumers,
             role_makers,
+            generators,
             arg_name_verbs,
             topic_route_dsl,
             engine,
@@ -517,6 +540,10 @@ impl FrameworkPlugin for RhaiPlugin {
 
     fn role_makers(&self) -> &[String] {
         &self.role_makers
+    }
+
+    fn generators(&self) -> &[crate::plugin::GeneratorDef] {
+        &self.generators
     }
 
     fn arg_name_verbs(&self) -> &[String] {

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -890,6 +890,43 @@ mod tests {
     }
 
     #[test]
+    fn generators_manifest_parses_from_rhai() {
+        // The symbol-generator manifest round-trips through Rhai maps:
+        // flat `#{ emit, kind }` / `#{ generate, args }` actions.
+        let src = r#"
+            fn id() { "gen-demo" }
+            fn triggers() { [ #{ Always: () } ] }
+            fn generators() {
+                [
+                    #{ name: "make_crud_helpers", params: ["thing"], actions: [
+                        #{ emit: "${thing}_id", kind: "accessor" },
+                        #{ emit: "get_${thing}", kind: "method" },
+                    ] },
+                    #{ name: "make_resource", params: ["res"], actions: [
+                        #{ emit: "${res}_table", kind: "accessor" },
+                        #{ generate: "make_crud_helpers", args: ["${res}"] },
+                    ] },
+                ]
+            }
+        "#;
+        let engine = Arc::new(make_engine());
+        let plugin = RhaiPlugin::from_source(src, engine).expect("compiles");
+        let gens = plugin.generators();
+        assert_eq!(gens.len(), 2);
+
+        let crud = gens.iter().find(|g| g.name == "make_crud_helpers").unwrap();
+        assert_eq!(crud.params, vec!["thing".to_string()]);
+        assert_eq!(crud.actions.len(), 2);
+        assert_eq!(crud.actions[0].emit.as_deref(), Some("${thing}_id"));
+        assert_eq!(crud.actions[0].kind.as_deref(), Some("accessor"));
+
+        let res = gens.iter().find(|g| g.name == "make_resource").unwrap();
+        let nested = res.actions.iter().find(|a| a.generate.is_some()).unwrap();
+        assert_eq!(nested.generate.as_deref(), Some("make_crud_helpers"));
+        assert_eq!(nested.args, vec!["${res}".to_string()]);
+    }
+
+    #[test]
     fn plugin_fingerprint_invariants() {
         // Two contracts in one test (env var is process-global, so
         // splitting these into parallel-safe tests would race):


### PR DESCRIPTION
## What this is

A first slice of **Productive Perl Projection (PPP)** — plugin-declared **symbol generators**. A helper call like `make_crud_helpers('user')` now synthesizes a GROUP of REAL `FileAnalysis` symbols (`user_id` accessor + `get_user`/`set_user` methods), each tracing (provenance) to the generator **call site**, so documentSymbol shows them and goto-def/rename on them target the invocation. It is the generalization of Moo `has` synthesis.

The model: **structural projection, not execution.** A plugin declares the generator's synthesis rules abstractly; core collects the call sites (witnesses), substitutes the literal args as if written there, and runs the plugin's synthesis — symbolic, never running Perl. (Cross-language sibling: C++ template monomorphization. See the metaprogram-witness framing in `docs/prompt-cpp-reparse.md` on `spike/cpp-support`.)

## Design decisions worth knowing (non-evident)

- **Manifest, NOT an `on_function_call` hook.** A declarative `generators()` plugin manifest (parallel to `dispatch_verbs()` / `role_makers()`) hands core a worklist for free — nested + recursive generation resolve in one pass. Plugin owns the rules, core owns the mechanism (rule #10). `GeneratorDef { name, params, actions }`, flat `GeneratorAction` (`emit`+`kind` | `generate`+`args`).
- **The worklist lives in `src/generators.rs`** (new, Build layer) — provenance-generic `project(defs, root)`: `${param}` interpolation, **per-call seen-set** (a recursive generator terminates, never hangs — same discipline as the C++ template / overload-cycle spikes), nested `Generate` **chains the ROOT provenance** (a transitively-synthesized symbol still traces to the user's original call, not the hidden intermediate).
- **Seam:** baked at builder init; `synthesize_generator_call()` runs at function/method-call dispatch (the same seam as `record_provisional_dispatch`). Each member is emitted as a `Namespace::Framework` `Method`/`Sub` symbol with `span = call site`.
- **Rhai path:** `fn generators()` parsed from a `.rhai` plugin (fail-safe), round-trip tested.

## ⚠️ The gap that gates user-facing use (READ BEFORE BUILDING ON THIS)

**Synthesis is currently trigger-INDEPENDENT** — it fires on any call whose name matches a declared generator, **regardless of whether the defining module is in scope.** Inert today (no generator is bundled, so nothing fires), but **a real bundled CPAN generator MUST add a module/import gate first** (only synthesize when the generator's providing module is `use`d). This is the #1 follow-up.

## Other follow-ups (in `docs/prompt-perl-generators.md`)

- **E2E unverified:** only FileAnalysis-level symbol-presence + provenance are asserted. references / goto-def / rename through the LSP handlers on synthesized symbols *should* work (ordinary `Method` symbols) but are not tested end-to-end — verify with a CLI/e2e test.
- **Args:** positional string literals only. Richer args (qw-lists, hashref option pairs) and richer emitted symbols (params, return types, constructor `HashKeyDef`) are follow-ups.
- No real bundled generator shipped — `make_crud_helpers` is illustrative.

## Tests

`cargo test` 1009/0; `./e2e/run.sh` 112/0; layering DAG passes. `gold-corpus/run.pl` env-blocked (substrate not installed). Tests: pure worklist (`generators.rs`), integration (`builder_tests::symbol_generators` — group present + span pinned to call + nested generation + negative case), Rhai round-trip.

## Provenance to the PoC + roadmap

Lifted from the PoC `src/perl_generators.rs` on `spike/cpp-support`. Where this sits in the plan: `docs/gold-roadmap.md` (Tier 0) on `spike/cpp-support`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019XyWYaU9ffH25pMb74Udvp
