### PR TITLE
fix(diagnostics): skip unresolved-method when AUTOLOAD is in the MRO

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2728,6 +2728,13 @@ pub fn collect_diagnostics(
             continue;
         }
 
+        // A class with `AUTOLOAD` anywhere in its MRO answers ANY method name at
+        // runtime, so the static `sub` set isn't its real surface — stay silent
+        // (the role-contracts diagnostic uses the same skip, file_analysis.rs).
+        if analysis.resolve_method_in_ancestors(&class_name, "AUTOLOAD", Some(module_index)).is_some() {
+            continue;
+        }
+
         // Honest-silent on an incomplete ISA chain: if `class_name` (or any
         // resolvable ancestor) names a parent we can't resolve in the
         // workspace or @INC, the method might be inherited from there. One


### PR DESCRIPTION
A class with `AUTOLOAD` anywhere in its inheritance chain answers any method name at runtime, so its static `sub` set isn't its real method surface. The always-on local `unresolved-method` diagnostic was flagging such calls as false positives (e.g. proxy/delegator objects).

The role-contracts sibling (`unfulfilled_role_requires`, `file_analysis.rs`) already guards on AUTOLOAD the same way; this brings the `unresolved-method` pass to parity — skip when `resolve_method_in_ancestors(class, "AUTOLOAD", …).is_some()`.

Surfaced by a false-positives audit of the cross-file unresolved-method lint against a real codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)