### PR TITLE
feat(moo): fold a constant array-ref into `has` attribute-name synthesis

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9279,7 +9279,15 @@ impl<'a> Builder<'a> {
                         attr_names.push((text.to_string(), node_to_span(*child)));
                     }
                 }
-                "array_ref_expression" | "anonymous_array_expression" => {
+                // Literal arrayref (`has ['a','b']`) or a ref to a constant
+                // array (`has \@attrs` where `my @attrs = qw/.../`) flatten
+                // through the constant-fold seam: `extract_array_attr_names`
+                // → `string_list` resolves `\@attrs` against the constant table.
+                // NOT a bare `has @attrs` — that SPLATS the array into the call
+                // (`has 'a', 'b', is => …`), a different declaration entirely,
+                // so the `array` node is intentionally excluded. A non-constant
+                // arrayref folds to nothing and stays unclaimed.
+                "anonymous_array_expression" | "refgen_expression" => {
                     self.extract_array_attr_names(*child, &mut attr_names);
                 }
                 _ => {}
@@ -9698,7 +9706,15 @@ impl<'a> Builder<'a> {
                         attr_names.push((text.to_string(), node_to_span(*child)));
                     }
                 }
-                "array_ref_expression" | "anonymous_array_expression" => {
+                // Literal arrayref (`has ['a','b']`) or a ref to a constant
+                // array (`has \@attrs` where `my @attrs = qw/.../`) flatten
+                // through the constant-fold seam: `extract_array_attr_names`
+                // → `string_list` resolves `\@attrs` against the constant table.
+                // NOT a bare `has @attrs` — that SPLATS the array into the call
+                // (`has 'a', 'b', is => …`), a different declaration entirely,
+                // so the `array` node is intentionally excluded. A non-constant
+                // arrayref folds to nothing and stays unclaimed.
+                "anonymous_array_expression" | "refgen_expression" => {
                     self.extract_array_attr_names(*child, &mut attr_names);
                 }
                 _ => {}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1135,7 +1135,7 @@ fn parse_instance_of(isa: &str) -> Option<String> {
         return None;
     }
     let args = call.child_by_field_name("arguments")?;
-    if args.kind() != "anonymous_array_expression" && args.kind() != "array_ref_expression" {
+    if args.kind() != "anonymous_array_expression" {
         return None;
     }
     for i in 0..args.named_child_count() {
@@ -9235,7 +9235,7 @@ impl<'a> Builder<'a> {
         // CST: ambiguous_function_call_expression
         //   function: "has"
         //   arguments: list_expression
-        //     [0] string_literal 'name' | array_ref_expression [qw(a b)]
+        //     [0] string_literal 'name' | anonymous_array_expression [qw(a b)]
         //     [1] list_expression (is => 'ro', isa => 'Str')   -- options (Moo/Moose)
         //          OR absent (Mojo::Base: has 'name' or has 'name' => 'default')
         let mut attr_names: Vec<(String, Span)> = Vec::new();
@@ -9798,7 +9798,7 @@ impl<'a> Builder<'a> {
                 }
                 plugin::ValueShape::HashPairs(pairs)
             }
-            "array_ref_expression" | "anonymous_array_expression" => {
+            "anonymous_array_expression" => {
                 plugin::ValueShape::ArrayItems(
                     self.extract_string_list(node).into_iter().map(|(s, _)| s).collect(),
                 )
@@ -9939,7 +9939,7 @@ impl<'a> Builder<'a> {
         for i in 0..args.named_child_count() {
             let Some(child) = args.named_child(i) else { continue };
             match child.kind() {
-                "anonymous_array_expression" | "array_ref_expression" => {
+                "anonymous_array_expression" => {
                     for j in 0..child.named_child_count() {
                         if let Some(el) = child.named_child(j) {
                             params.push(self.constraint_param_for(el));
@@ -10761,7 +10761,7 @@ impl<'a> Builder<'a> {
                         names.push((text.to_string(), node_to_span(*child)));
                     }
                 }
-                "quoted_word_list" | "array_ref_expression" | "anonymous_array_expression" => {
+                "quoted_word_list" | "anonymous_array_expression" => {
                     self.extract_array_attr_names(*child, &mut names);
                 }
                 _ => {}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -3698,6 +3698,37 @@ has [qw(foo bar)] => (is => 'ro');
 }
 
 #[test]
+fn test_moo_has_constant_array_ref() {
+    // `has \@names` (a ref to a constant array) folds the array's elements
+    // through the same accessor synthesis as the literal-arrayref form. A
+    // bare `has @names` SPLATS the array into the call (`has 'a','b', is=>…`)
+    // — a different declaration — so it is NOT folded; nor is a non-constant
+    // array.
+    let fa = build_fa(
+        "
+package Foo;
+use Moo;
+my @attrs = qw(client_id client_secret);
+my @more  = ('refresh_token', 'profile_id');
+has \\@attrs, is => 'ro';
+has @more,    is => 'ro';
+has @runtime, is => 'ro';
+",
+    );
+    let accessor = |name: &str| {
+        fa.symbols
+            .iter()
+            .filter(|s| s.name == name && s.kind == SymKind::Method)
+            .count()
+    };
+    assert_eq!(accessor("client_id"), 1, "fold \\@attrs → client_id");
+    assert_eq!(accessor("client_secret"), 1, "fold \\@attrs → client_secret");
+    assert_eq!(accessor("refresh_token"), 0, "bare `has @more` splats — not a multi-attr decl, not folded");
+    assert_eq!(accessor("profile_id"), 0, "bare `has @more` splats — not a multi-attr decl, not folded");
+    assert_eq!(accessor("runtime"), 0, "non-constant array stays unclaimed");
+}
+
+#[test]
 fn test_moo_has_bare_no_accessor() {
     let fa = build_fa(
         "

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 111;
+pub const EXTRACT_VERSION: i64 = 112;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.


### PR DESCRIPTION
Moo `has \@names` (a ref to a constant array of attribute names) wasn't synthesized — only the inline literal forms (`has 'x'`, `has ['a','b']`) minted accessors. So a class declaring `my @cols = qw/.../; has \@cols, ...` got no accessors / goto-def / completion / hover for those columns.

The general array-fold table already existed (`constant_strings` + `cst::string_list`, which folds `array` nodes and recurses `refgen_expression`). The only gap was `visit_has_call` / `extract_has_options` not routing the `refgen_expression` arg shape into the existing `extract_array_attr_names` seam. Both now flatten `\@names` through the same constant-fold path the literal-arrayref case uses — no parallel `has`-only path (rule #10).

**Only the array-REF forms fold:** a literal `['a','b']` and a `\@names` ref to a constant array. A bare `has @names` is intentionally NOT folded — it *splats* the array into the call (`has 'a', 'b', is => …`), an entirely different declaration. A non-constant array-ref folds to nothing.

`EXTRACT_VERSION` 111 → 112. Test `test_moo_has_constant_array_ref` (covers `\@attrs` folds, bare `@more` splat does not, non-constant stays unclaimed). Surfaced by a false-positives audit against a real codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)