### PR TITLE
Roadmap Now-list sweep: Optional production gaps, DBIC phase 2, method-resolution residuals, audit-driven inference fixes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,55 +3,62 @@
 Landed work lives in `docs/adr/` and `CHANGELOG.md` — never here.
 This file is only what's NEXT, in order.
 
-## Now (in order)
+## Now — the scheduled epics (in order)
 
-1. **Diagnostic flag graduation.** The narrowing/Optional lattice is
-   complete through its production gaps (element places, dynamic-key
-   places, `return ()` / all-undef arms, slot Optional lifts, bareword
-   `Maybe[T]` — decision records: `adr/flow-narrowing.md`,
-   `adr/optional-types.md`, `adr/narrowing-diagnostics.md`). What remains
-   is **trust**: graduate the opt-in diagnostic flags to default-on per
-   code as the gold substrate and real projects show no false-positive
-   flood (the promotion path in `adr/narrowing-diagnostics.md`).
-   `unresolvedMethodCrossFile` is WORKSPACE-scoped and its known
-   false-positive classes are closed (monkey_patch synthesis, `handles`
-   delegation incl. the Sub::HandlesVia curried shape, plugin-owned
-   meta-method suppression) — it still promotes last
-   (`prompt-method-resolution-residuals.md` §4 rides the long-distance
-   provenance tier).
+Each epic has a self-contained implementation prompt under
+`docs/epics/` — mission, exact code anchors, phase ladder with
+acceptance criteria, invariants, and the verification gate. Implementers
+start THERE (after CLAUDE.md); this section is only the schedule.
+
+1. **Epic 1 — DBIC out of core, phase 3** →
+   `docs/epics/01-dbic-phase-3.md`. Parametric emission + per-base
+   semantics move to declarative plugin manifests
+   (`parametric_bases()` / `parametric_mints()`); the per-method
+   projection table completes; the two pinned gaps close
+   (custom-resultset discovery, `->search({ | })` column completion).
+   Ends with core plugin-free except generic dispatch — the phase
+   ladder's end state. Design corpus: `prompt-dbic-as-plugin.md`.
+
+2. **Epic 2 — Openness** → `docs/epics/02-openness.md`. One structural
+   verdict ("walk the namespace chain; Open suppresses, exhausted
+   Closed warns") subsumes the pile of per-diagnostic suppression
+   rules, resolves `SUPER::`/qualified names instead of skipping them,
+   gates the D4 open-world-dispatch noise, and then executes the flag
+   promotion the audit evidence below supports. Design corpus:
+   `prompt-graph-walking.md` (Scope nodes), `open-problems.md`
+   (qualified-name suppression), `adr/narrowing-diagnostics.md`
+   (promotion path).
 
    *Promotion audit over the gold substrate (July 2026, all flags on,
-   after the disagreement-to-widen tier landed):* `undef-deref`
-   (always-on) 8 sites — exact parity with the pre-branch baseline;
-   `derefShape` 0 hits; `optionalDeref` 35 (honest Optional productions;
-   residual noise = value flow beyond static reach, e.g. an
-   arity-and-value-gated undef arm in `Path::Class::Dir::new`);
-   `redundantGuard` 59 (was 115) and `contradictory` 34 (was 53) after
-   reassignment barriers + the shift-invocant gate; `unresolved-method`
-   −180 from the same fixes. Remaining known noise classes: open-world
-   dispatch (a base class's own all-undef method typing `$self->m` when
-   the runtime receiver is a subclass — the Openness axis,
-   `prompt-graph-walking.md`) and the named-helper first-param-self
-   over-reach (`gold-corpus/KNOWN-GAPS.md`). `optionalDeref` looks
-   promotable at INFO severity; `redundantGuard` after an Openness gate.
-2. **DBIC out of core — phase 3.** Phases 1–2 landed (`visit_dbic_*`
-   gone; `frameworks/dbic.rhai` owns arg-name verbs, column-keyed verbs,
-   fluent verbs, and meta-method suppression via the `meta_methods()`
-   manifest). Remaining: parametric *emission* out of core
-   (`extract_resultset_parametric` + the hardcoded
-   `DBIx::Class::ResultSet` base still live in `builder.rs`) and
-   per-method return projection — the one axis-shaped piece; a
-   `parametric_returns` manifest field may sidestep full
-   type-system-encoding; decide at the boundary, not before. Ladder in
-   `prompt-dbic-as-plugin.md`. Ends with core plugin-free except generic
-   dispatch.
+   after the disagreement-to-widen tier landed) — the evidence Epic 2
+   §Phase E consumes:* `undef-deref` (always-on) 8 sites — exact parity
+   with the pre-branch baseline; `derefShape` 0 hits; `optionalDeref`
+   35 (honest Optional productions; residual noise = value flow beyond
+   static reach, e.g. an arity-and-value-gated undef arm in
+   `Path::Class::Dir::new`); `redundantGuard` 59 (was 115) and
+   `contradictory` 34 (was 53) after reassignment barriers + the
+   shift-invocant gate; `unresolved-method` −180 from the same fixes.
+   Remaining known noise classes: open-world dispatch (Epic 2 Phase D)
+   and the named-helper first-param-self over-reach
+   (`gold-corpus/KNOWN-GAPS.md`). `optionalDeref` looks promotable at
+   INFO severity now; `redundantGuard` after the Phase D gate;
+   `unresolvedMethodCrossFile` still promotes last.
+
+3. **Epic 3 — Value provenance, tier 1** →
+   `docs/epics/03-value-provenance.md`. Residual fact classes Parts 1,
+   2, and 5a (invocant-mutation consumers, hash-key unions,
+   value-indexed returns) as emitter+reducer pairs on the bag. The
+   named gate for un-parking instance brands and the untyped-receiver
+   residual. Design corpus: `prompt-type-inference-residual.md`.
 
 ## Queued (pull-driven — QA findings decide order)
 
 Type intelligence:
-- Residual fact classes Parts 1–5 (invocant mutations, hash-key
-  unions, method loops, functional operators, value-indexed returns)
-  — `prompt-type-inference-residual.md`.
+- Residual fact classes Parts 3–4 (method loops, functional
+  operators) and the 5c prefetch residual — after Epic 3;
+  `prompt-type-inference-residual.md`.
+- Constructor/field value flow — the remaining instance-brands
+  prerequisite once Epic 3 lands (`prompt-graph-walking.md` §PARKED).
 - Conditional-reassignment disagreement-to-widen — the widening tier
   LANDED (reassign barriers: an untypeable write drops earlier beliefs;
   a postfix-conditional write never asserts, only widens). Residual:
@@ -59,14 +66,10 @@ Type intelligence:
   $spec` could keep `HashRef|prior` instead of widening to unknown) —
   that's the real lattice fold, wanted when precision (not soundness)
   becomes the complaint.
-- A4 v2: cross-FILE slot writes (`$self->{k} = Obj->new` in another
-  file) — the `MethodOnClass` bridge pattern.
-
-Graph / diagnostics (graph-walking pillar landed; residual only):
-- Scope-node taxonomy + Openness diagnostic (`home_namespace`,
-  "when is an unresolved call real?") — forward work in
-  `prompt-graph-walking.md`; subsumes the coarse qualified-name
-  suppression noted in `open-problems.md`.
+Graph / diagnostics: the Openness axis moved to Now (Epic 2). Residual
+after it: `Symbol.home_namespace` field migration if a consumer beyond
+the diagnostic ever needs it (Epic 2 deliberately ships the query, not
+the field).
 
 Plugin genericity:
 - `has_options` final dissolution: the option pairing already moved out

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,24 +5,31 @@ This file is only what's NEXT, in order.
 
 ## Now (in order)
 
-1. **Narrowing / Optional — completeness.** The flow-narrowing +
-   `Optional<T>` + `Undef` lattice and the bug-detection diagnostics it
-   feeds have both landed (decision records: `adr/flow-narrowing.md`,
+1. **Diagnostic flag graduation.** The narrowing/Optional lattice is
+   complete through its production gaps (element places, dynamic-key
+   places, `return ()` / all-undef arms, slot Optional lifts, bareword
+   `Maybe[T]` — decision records: `adr/flow-narrowing.md`,
    `adr/optional-types.md`, `adr/narrowing-diagnostics.md`). What remains
-   is **completeness** — widen what the narrower recognizes: direct-element
-   places (`$hash{key}`, `$arr[0]`), and dynamic-key places (`$self->{$k}`)
-   where the key scalar is stable enough to stay sound
-   (`prompt-flow-narrowing.md` / `prompt-optional-types.md`) — and graduate
-   the opt-in diagnostic flags to default-on per code as the gold substrate
-   and real projects show no false-positive flood (the promotion path in
-   `adr/narrowing-diagnostics.md`).
-2. **DBIC out of core — phases 2–3.** Phase 1 landed (`visit_dbic_*`
-   gone; `frameworks/dbic.rhai`, trigger `ClassIsa("DBIx::Class")`).
-   Remaining: meta-method suppression → manifest (the `universal_methods`
-   rule-#10 debt still hardcoded in `symbols.rs`) and parametric
-   emission + per-method return projection (the one axis-shaped piece).
-   Ladder in `prompt-dbic-as-plugin.md`. Ends with core plugin-free
-   except generic dispatch.
+   is **trust**: graduate the opt-in diagnostic flags to default-on per
+   code as the gold substrate and real projects show no false-positive
+   flood (the promotion path in `adr/narrowing-diagnostics.md`).
+   `unresolvedMethodCrossFile` is WORKSPACE-scoped and its known
+   false-positive classes are closed (monkey_patch synthesis, `handles`
+   delegation incl. the Sub::HandlesVia curried shape, plugin-owned
+   meta-method suppression) — it still promotes last
+   (`prompt-method-resolution-residuals.md` §4 rides the long-distance
+   provenance tier).
+2. **DBIC out of core — phase 3.** Phases 1–2 landed (`visit_dbic_*`
+   gone; `frameworks/dbic.rhai` owns arg-name verbs, column-keyed verbs,
+   fluent verbs, and meta-method suppression via the `meta_methods()`
+   manifest). Remaining: parametric *emission* out of core
+   (`extract_resultset_parametric` + the hardcoded
+   `DBIx::Class::ResultSet` base still live in `builder.rs`) and
+   per-method return projection — the one axis-shaped piece; a
+   `parametric_returns` manifest field may sidestep full
+   type-system-encoding; decide at the boundary, not before. Ladder in
+   `prompt-dbic-as-plugin.md`. Ends with core plugin-free except generic
+   dispatch.
 
 ## Queued (pull-driven — QA findings decide order)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,23 @@ start THERE (after CLAUDE.md); this section is only the schedule.
    named gate for un-parking instance brands and the untyped-receiver
    residual. Design corpus: `prompt-type-inference-residual.md`.
 
+## On deck — Epics 4–12
+
+The full slate, one implementation prompt per epic, lives in
+`docs/epics/` — see `docs/epics/README.md` for the schedule table AND
+the coverage map that accounts for every `prompt-*.md` and open design
+item (scheduled / parked-with-condition / landed / out-of-scope).
+
+4. One-seam sweep: magic tokens + cst backlog → `epics/04`
+5. Duplicate-package identity (H1) → `epics/05`
+6. Gated cross-file emission (ClassIsa) → `epics/06`
+7. Rename provenance → `epics/07`
+8. Diagnostic framework: PL-codes, config, SARIF → `epics/08`
+9. Heatmap residuals: Handlers + framework-consumed → `epics/09`
+10. Mojo polish: routes, stash, hooks, chains → `epics/10`
+11. CLI analysis subcommands + `--migrate` → `epics/11`
+12. Program boundaries + MAIN-1 → `epics/12`
+
 ## Queued (pull-driven — QA findings decide order)
 
 Type intelligence:
@@ -82,23 +99,22 @@ Plugin genericity:
   from `value_shape`/`arg_names`, options from `classified_pairs`).
 
 Hardening:
-- Options schema: `DiagnosticOptions` is serde-driven (the struct is the
-  schema). A `Config` god-struct (own-at-top, pass-slices), a generated
-  editor schema (`schemars`), and the per-code-config shape wait for their
-  forcing functions — `prompt-config-schema.md`.
+- Options schema → **Epic 8** (`prompt-config-schema.md`'s forcing
+  function).
 - Fold safety net: `eprintln!` → `tracing::error!` (builder.rs
   ~12061) + a synthetic-oscillator test so the release-mode
   `MAX_FOLD_ITERATIONS` break can't bit-rot.
 - Full-bag scans in `apply_chain_typing_assignments` /
   `FileAnalysis::inferred_type` — index when profiling flags them.
-- DBIC parametric column-key completion at an empty `->search({ | })`
-  (goto-def proves the chain; `complete_keyval_args` lacks the
-  parametric-receiver branch; pin in `e2e/dbic_parametric.lua`).
+- DBIC parametric column-key completion at `->search({ | })` →
+  **Epic 1** Phase D.
 - Cursor-context qualified-path/invocant detection should ask the
-  tree, not byte-walk (`extract_package_from_prefix` & sibling).
+  tree, not byte-walk (`extract_package_from_prefix` & sibling) —
+  adjacent to Epic 4's item-3 collapse; fold in there if touching.
 - `return_via_edge` chases lack `TypeProvenance` (stamp
   `Delegation{kind: "callable_return_edge"}` on the chase).
-- cst/conventions migration backlog — `prompt-cst-migration.md`.
+- cst/conventions migration backlog — ranked items → **Epic 4**; the
+  long tail stays the strangler rule (`prompt-cst-migration.md`).
 - Unify autoquoted-key-as-literal into `cst::string_list`. Today
   `string_list` routes `autoquoted_bareword` through the caller's
   `fold` (const resolution), so the DSL-arg callers (`extract_arg_name_list`)
@@ -118,9 +134,9 @@ Hardening:
   urgent (the per-caller fold is correct, just not DRY).
 
 QA tail:
-- MAIN-1 (`main::` across `require`) and H1 (duplicate packages) —
-  designs in `qa-design-items.md`. MooseX::Role::Parameterized — no
-  design yet.
+- MAIN-1 → **Epic 12**; H1 → **Epic 5** (designs in
+  `qa-design-items.md`). MooseX::Role::Parameterized — parked: the
+  runtime-export-generator open problem wearing role clothes.
 - Per-row known gaps: `gold-corpus/KNOWN-GAPS.md` (xfail rows are the
   live tracker).
 
@@ -146,15 +162,12 @@ QA tail:
 
 ## Backburner (user-facing, ship-when-ready)
 
-- Mojo polish: route naming/url_for, stash intelligence, hooks,
-  transitive plugin chains, config completion —
-  `prompt-mojo-todo.md`.
-- CLI diagnostic framework (PL-codes, suppression, SARIF), --migrate —
-  `prompt-cli-tools.md`.
-- Ref provenance: constant-fold `folded_from`, package→file rename,
-  inheritance override scoping — `prompt-ref-provenance.md`.
+- Mojo polish → **Epic 10**; CLI diagnostic framework → **Epic 8**;
+  analysis subcommands + `--migrate` → **Epic 11**; ref provenance →
+  **Epic 7** (all scheduled — see `docs/epics/README.md`).
 - Aspirational type features (effects/throws) —
-  `prompt-type-system-futures.md`.
+  `prompt-type-system-futures.md` (its narrowing pillar landed as
+  `adr/flow-narrowing.md`; only the effects pillar remains).
 - Web extension — `prompt-wasm-web-extension.md` (the crate split it
   assumed was executed and REJECTED; branch `workspace-split` is the
   playbook if wasm ever forces it).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,18 @@ This file is only what's NEXT, in order.
    meta-method suppression) — it still promotes last
    (`prompt-method-resolution-residuals.md` §4 rides the long-distance
    provenance tier).
+
+   *Promotion audit over the gold substrate (July 2026, all flags on):*
+   `undef-deref` (always-on) 8 sites, all verified; `derefShape` 0 hits;
+   `optionalDeref` 45 (honest Optional productions; noise class = value
+   flow beyond static reach, e.g. an arity-and-value-gated undef arm in
+   `Path::Class::Dir::new`); `redundantGuard`/`contradictory` 115+58,
+   with one dominant false-positive class: a stale belief surviving an
+   untypeable reassignment (`my $x = shift` typed to the enclosing class,
+   `my $x = undef; $x = f($y) if …`). That class is the queued
+   **conditional-reassignment disagreement-to-widen** work — closing it
+   is the gate for promoting `redundantGuard`; `optionalDeref` could
+   promote first if the INFO severity is judged quiet enough.
 2. **DBIC out of core — phase 3.** Phases 1–2 landed (`visit_dbic_*`
    gone; `frameworks/dbic.rhai` owns arg-name verbs, column-keyed verbs,
    fluent verbs, and meta-method suppression via the `meta_methods()`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,7 @@ start THERE (after CLAUDE.md); this section is only the schedule.
    named gate for un-parking instance brands and the untyped-receiver
    residual. Design corpus: `prompt-type-inference-residual.md`.
 
-## On deck — Epics 4–12
+## On deck — Epics 4–13
 
 The full slate, one implementation prompt per epic, lives in
 `docs/epics/` — see `docs/epics/README.md` for the schedule table AND
@@ -67,6 +67,7 @@ item (scheduled / parked-with-condition / landed / out-of-scope).
 10. Mojo polish: routes, stash, hooks, chains → `epics/10`
 11. CLI analysis subcommands + `--migrate` → `epics/11`
 12. Program boundaries + MAIN-1 → `epics/12`
+13. Type::Tiny completeness: check-guards, import-scoped vocab → `epics/13`
 
 ## Queued (pull-driven — QA findings decide order)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,17 +20,20 @@ This file is only what's NEXT, in order.
    (`prompt-method-resolution-residuals.md` §4 rides the long-distance
    provenance tier).
 
-   *Promotion audit over the gold substrate (July 2026, all flags on):*
-   `undef-deref` (always-on) 8 sites, all verified; `derefShape` 0 hits;
-   `optionalDeref` 45 (honest Optional productions; noise class = value
-   flow beyond static reach, e.g. an arity-and-value-gated undef arm in
-   `Path::Class::Dir::new`); `redundantGuard`/`contradictory` 115+58,
-   with one dominant false-positive class: a stale belief surviving an
-   untypeable reassignment (`my $x = shift` typed to the enclosing class,
-   `my $x = undef; $x = f($y) if …`). That class is the queued
-   **conditional-reassignment disagreement-to-widen** work — closing it
-   is the gate for promoting `redundantGuard`; `optionalDeref` could
-   promote first if the INFO severity is judged quiet enough.
+   *Promotion audit over the gold substrate (July 2026, all flags on,
+   after the disagreement-to-widen tier landed):* `undef-deref`
+   (always-on) 8 sites — exact parity with the pre-branch baseline;
+   `derefShape` 0 hits; `optionalDeref` 35 (honest Optional productions;
+   residual noise = value flow beyond static reach, e.g. an
+   arity-and-value-gated undef arm in `Path::Class::Dir::new`);
+   `redundantGuard` 59 (was 115) and `contradictory` 34 (was 53) after
+   reassignment barriers + the shift-invocant gate; `unresolved-method`
+   −180 from the same fixes. Remaining known noise classes: open-world
+   dispatch (a base class's own all-undef method typing `$self->m` when
+   the runtime receiver is a subclass — the Openness axis,
+   `prompt-graph-walking.md`) and the named-helper first-param-self
+   over-reach (`gold-corpus/KNOWN-GAPS.md`). `optionalDeref` looks
+   promotable at INFO severity; `redundantGuard` after an Openness gate.
 2. **DBIC out of core — phase 3.** Phases 1–2 landed (`visit_dbic_*`
    gone; `frameworks/dbic.rhai` owns arg-name verbs, column-keyed verbs,
    fluent verbs, and meta-method suppression via the `meta_methods()`
@@ -49,9 +52,13 @@ Type intelligence:
 - Residual fact classes Parts 1–5 (invocant mutations, hash-key
   unions, method loops, functional operators, value-indexed returns)
   — `prompt-type-inference-residual.md`.
-- Conditional-reassignment disagreement-to-widen (`$spec = {...}
-  unless ref $spec`) — replaces the `reassigned_scalars` trust-gate
-  clause with a real lattice fold.
+- Conditional-reassignment disagreement-to-widen — the widening tier
+  LANDED (reassign barriers: an untypeable write drops earlier beliefs;
+  a postfix-conditional write never asserts, only widens). Residual:
+  the true JOIN for typed conditional writes (`$spec = {...} unless ref
+  $spec` could keep `HashRef|prior` instead of widening to unknown) —
+  that's the real lattice fold, wanted when precision (not soundness)
+  becomes the complaint.
 - A4 v2: cross-FILE slot writes (`$self->{k} = Obj->new` in another
   file) — the `MethodOnClass` bridge pattern.
 

--- a/docs/epics/01-dbic-phase-3.md
+++ b/docs/epics/01-dbic-phase-3.md
@@ -1,0 +1,224 @@
+# Epic 1 — DBIC out of core, phase 3 (parametric emission + projection)
+
+> **Status:** scheduled, next up. Finishes ROADMAP "Now #2".
+> **Design owner-doc:** `docs/prompt-dbic-as-plugin.md` (read it whole —
+> the phase ladder, the projection table, the open questions).
+> **End state, verbatim from the ladder:** core is plugin-free except
+> generic dispatch.
+
+## Mission
+
+Move the last DBIC-specific machinery out of the builder and into the
+plugin layer, so `frameworks/dbic.rhai` (plus generic core seams) owns
+everything DBIC-shaped. Phases 1–2 already landed: accessor/relationship
+synthesis, arg-name verbs, column-keyed verbs, fluent verbs, and
+meta-method suppression all live in the plugin. What remains in core is
+the **parametric ResultSet minting** and the **hardcoded semantics of
+`DBIx::Class::ResultSet`** — plus two pinned user-facing gaps that only
+make sense to fix on the plugin side of the move.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — especially rules #1 (tree traversal only in build()),
+   #8 (plugin-synthesized content), #10 (never special-case shapes),
+   "Worklist invariants" (re-emittable passes are clear-and-emit;
+   edges, not values), and "Type inference (witness bag)".
+2. `docs/prompt-dbic-as-plugin.md` — the design, including the
+   per-method projection table and the `parametric_semantics()` sketch.
+3. `docs/adr/parametric-types.md` — the sealed-flavor Parametric data
+   model and its per-axis policy.
+4. `docs/adr/return-expr.md` — the receiver-relative return machinery
+   (`Operator(RowOf)` is how `find` already projects to the row class).
+5. `docs/adr/plugin-system.md` — manifest families, emit vs query hooks.
+
+## Current state — exact anchors (verify with grep before editing)
+
+Core-side DBIC residue to remove or generify:
+
+| What | Where | Find it |
+| --- | --- | --- |
+| Fold-time ResultSet minting | `src/builder.rs` | `grep -n 'fn extract_resultset_parametric' src/builder.rs` |
+| Its re-emittable dedup set | `src/builder.rs` | `grep -n 'parametric_emitted_refs' src/builder.rs` (struct field + clear-and-emit doc + the two insert sites) |
+| Hardcoded default base + `+`-prefix expansion | `src/builder.rs` | `grep -n '"DBIx::Class' src/builder.rs` (the `DBIx::Class::ResultSet` fallback and the `DBIx::Class::{}` bare-name prefixing near the `load_components` helper) |
+| Open-key arg emission ("type is the gate") | `src/builder.rs` | `grep -n 'fn emit_call_arg_key_accesses_open' src/builder.rs` |
+| Parametric semantics read side (core-owned policy) | `src/file_analysis.rs` | `grep -n 'fn hash_key_class\|fn dispatch_class\|fn element_type' src/file_analysis.rs` — `ParametricType`'s accessors currently ENCODE DBIC's semantics ("type_args[0] is the row class") in core |
+| Plugin as it stands | `frameworks/dbic.rhai` | already owns `arg_name_verbs`, `column_keyed_verbs`, `fluent_verbs`, `meta_methods`, accessor/relationship synthesis |
+
+Pinned gaps this epic closes (both listed in `docs/ROADMAP.md` Hardening):
+
+- **Custom resultset discovery** — `$schema->resultset('Users')` should
+  resolve to `<SchemaNS>::ResultSet::Users` when that package exists,
+  else default. Red-pinned by `goto_def_offers_custom_resultset_method`
+  (grep for it in tests; it documents the expected behavior).
+- **Column-key completion at `->search({ | })`** — goto-def through a
+  typed key already works; `complete_keyval_args`
+  (`grep -n 'fn complete_keyval_args' src/file_analysis.rs`) has no
+  parametric-receiver branch. E2E pin: `e2e/dbic_parametric.lua`.
+
+## Non-goals — do NOT do these
+
+- Do NOT build the full type-system-encoding axis machinery
+  (`docs/prompt-type-system-encoding.md` stays parked). The decision
+  gate from the owner doc: a declarative manifest field sidesteps it.
+  Phases 1–2 proved the manifest route works; stay on it.
+- Do NOT port the plugin to Rhai-executed *fold* logic. Rhai hooks run
+  at parse time only. Anything the worklist fold re-derives per
+  iteration must be DATA the plugin declares (a manifest), consumed by
+  a generic core pass. If you find yourself wanting to call Rhai from
+  `fold_to_fixed_point`, stop — declare instead.
+- Do NOT leave a name-keyed lookup table for DBIC methods in core
+  (rule #10). Core dispatches on manifest-declared data only.
+- Do NOT touch `load_components` parent registration — it stays core
+  (generic mixin machinery, per the owner doc).
+
+## Phase breakdown
+
+### Phase A — `parametric_bases()` manifest (semantics move out)
+
+**Goal:** the read-side policy "what does `Parametric{base, args}` mean"
+comes from the plugin, not from `ParametricType`'s hardcoded accessors.
+
+1. Add a manifest hook `parametric_bases()` to `FrameworkPlugin`
+   (default empty) + the rhai read (one line now —
+   `read_manifest_list::<ParametricBase>` in `src/plugin/rhai_host.rs`)
+   + registry union (copy the `meta_methods()` plumbing shape, it is the
+   freshest example: trait default → registry iterator → rhai field →
+   struct init → `FrameworkPlugin for RhaiPlugin` impl).
+2. Shape (serde struct in `src/plugin/mod.rs`):
+   ```rust
+   pub struct ParametricBase {
+       pub base: String,                 // "DBIx::Class::ResultSet"
+       pub hash_key_arg_class: Projection, // where column-key args resolve
+       pub element_type: Projection,      // what ->find/element access yields
+       pub dispatch_class: Projection,    // where methods dispatch
+   }
+   pub enum Projection { TypeArg(usize), SelfBase } // closed, tiny
+   ```
+3. Bake the union onto `FileAnalysis` (serde-`default` field, mirror
+   `meta_methods` exactly: parts struct, both constructors, builder
+   assignment at the `FileAnalysisParts` literal).
+4. `ParametricType::hash_key_class` / `dispatch_class` / `element_type`
+   become lookups against the baked table (pass it in, or store the
+   resolved projections on the `ParametricType` at mint time —
+   PREFER mint-time resolution: the value carries its own answers,
+   consumers stay zero-argument. Check how many call sites each
+   accessor has before choosing; if accessors are called from places
+   without `FileAnalysis` access, mint-time is the only option).
+5. `frameworks/dbic.rhai` declares the entry for
+   `DBIx::Class::ResultSet` (`hash_key_arg_class: TypeArg(0)`,
+   `element_type: TypeArg(0)`, `dispatch_class: SelfBase`).
+6. **Acceptance:** all existing `parametric_resultset_tests.rs` tests
+   pass unchanged; `grep -rn 'DBIx' src/file_analysis.rs` returns only
+   comments/docs, no logic.
+
+### Phase B — minting moves to a declarative manifest
+
+**Goal:** delete `extract_resultset_parametric` from core; the fold's
+re-emittable pass mints Parametric values from plugin-declared data.
+
+1. New manifest hook `parametric_mints()` returning entries like:
+   ```rust
+   pub struct ParametricMint {
+       pub verb: String,             // "resultset"
+       pub base_default: String,     // "DBIx::Class::ResultSet"
+       pub row_from_first_string_arg: bool,
+       pub discover_base: Option<String>, // "{schema_ns}::ResultSet::{row}"
+   }
+   ```
+   (Template string with two placeholders is fine; core substitutes
+   `{schema_ns}` = the invocant class's namespace root and `{row}` =
+   the resolved row-class tail, then checks `module_index` /
+   workspace symbols for existence — that is the custom-resultset
+   discovery, done generically.)
+2. The generic fold pass replaces `extract_resultset_parametric`: same
+   trigger conditions (method call whose verb matches a mint entry,
+   invocant class known), same output witness shape, same
+   `parametric_emitted_refs` clear-and-emit idempotency (KEEP the
+   dedup set and its invariant comment — rename it if you like, but
+   the worklist invariant it enforces must survive verbatim).
+3. Delete the DBIC name literals from `builder.rs`. The `+`-prefix /
+   `DBIx::Class::` bare-name expansion near `load_components` is
+   component-loading (phase-1 territory, stays) — ONLY if it is used
+   solely for parent registration. Verify with grep before deciding;
+   if it also feeds parametric minting, split it.
+4. **Acceptance:** `parametric_resultset_tests.rs` green;
+   `gold-corpus/run.pl` shows no regression on the dbic rows (grep the
+   fixtures for `dbic`); a new unit test proves a THIRD-PARTY rhai
+   plugin (test fixture, not dbic.rhai) can mint a Parametric on its
+   own verb — that's the proof the seam is generic, not a DBIC rename.
+
+### Phase C — per-method projection completes
+
+**Goal:** the owner doc's projection table fully declared by the plugin.
+
+Current state: `search`/`search_rs` preserve via `fluent_verbs`;
+`find`-family projects via the `RowOf` ReturnExpr operator (verify:
+`grep -n 'RowOf' src/witnesses.rs frameworks/dbic.rhai`). Missing:
+`all`/`slice` (ArrayRef-of-row — plain `ArrayRef` is acceptable, note
+the honest loss), `count`/`exists`/`update`/`delete` (Numeric).
+
+1. Extend the plugin's declarations so every row of the table in
+   `prompt-dbic-as-plugin.md` §"Per-method return-type projection" is
+   covered. Use the EXISTING seams: `overrides()` with a class-scoped
+   method target if it supports that, else the same `ReturnExpr`
+   publication path `RowOf` rides. Do not invent a third mechanism if
+   either existing one fits.
+2. **Acceptance:** unit tests: `$rs->count` types Numeric,
+   `$rs->all` types ArrayRef, `$rs->find(1)->name` still resolves the
+   column accessor (regression), `$rs->search({...})->count` chains.
+
+### Phase D — the two pinned gaps
+
+1. Custom-resultset discovery lands automatically with Phase B's
+   `discover_base` — flip `goto_def_offers_custom_resultset_method`
+   from red pin to green assertion.
+2. `complete_keyval_args` parametric branch: when the receiver types
+   `Parametric` and the verb is column-keyed, complete the row class's
+   column keys (ask the typed receiver via `hash_key_arg_class`, then
+   the row class's `HashKeyDef`s — cross-file via the same lookup
+   goto-def already uses; DO NOT write a parallel reverse index,
+   rule #8). Verify with `e2e/dbic_parametric.lua` (CI runs it; note
+   in the PR that e2e needs nvim).
+3. **Acceptance:** a gold-corpus completion row for
+   `->search({ | })` column keys — author it with
+   `gold-corpus/run.pl --emit completion <file> <row> <col>` against
+   the substrate, status `gold`.
+
+### Phase E — deletion sweep + verification
+
+1. `grep -rn 'DBIx' src/` → only comments and generic examples remain.
+2. Bump `EXTRACT_VERSION` (`src/module_cache.rs`) — FA shape changed
+   (new baked table) and bag rules changed.
+3. Full gate: `cargo test` (all green), `./e2e/run.sh` (or CI),
+   `gold-corpus/run.pl` (0 FAIL, 0 XPASS — if XPASS, promote the row
+   per `gold-corpus/README.md`), and the substrate diagnostic audit:
+   ```
+   perl-lsp --clear-cache gold-corpus/local/lib/perl5
+   perl-lsp --check gold-corpus/local/lib/perl5 --format json --severity hint \
+     --optional-deref --redundant-guard --deref-shape --unresolved-method-cross-file
+   ```
+   Diff per-code counts against a main-branch binary (build one in a
+   worktree). Always-on `undef-deref` must be at exact parity.
+4. Update `docs/prompt-dbic-as-plugin.md` (mark phase 3 landed, keep
+   the honest residuals — e.g. prefetch `join =>` key extension stays
+   out) and `docs/ROADMAP.md`.
+
+## Invariants that MUST survive
+
+- Rule #1: only `build()` walks the tree. Manifest data is consumed by
+  existing walk/fold passes; no new tree consumers.
+- Worklist: any pass that pushes witnesses per fold iteration is
+  clear-and-emit under a source tag (see `witnesses::tags` and the
+  "Re-emittable passes" bullet in CLAUDE.md). New tags go in
+  `witnesses::tags`, never as inline literals.
+- Edges, not values: if the mint can point at an existing attachment,
+  push an Edge, not a materialized type.
+- Provenance: minted Parametrics should keep whatever
+  `TypeProvenance` trail the current code records (grep
+  `type_provenance` near the mint) so `--dump-package` stays honest.
+
+## Sizing & sequencing
+
+A → B → C → D → E strictly in order; A and C are independent of each
+other but both precede D. Each phase is one reviewable commit. Expect
+A+B to be the bulk (~2/3 of the work).

--- a/docs/epics/02-openness.md
+++ b/docs/epics/02-openness.md
@@ -1,0 +1,204 @@
+# Epic 2 — Openness: one answer to "is this unresolved name real?"
+
+> **Status:** scheduled, second. Runs after Epic 1 (no code dependency,
+> but Epic 1 finishes the Now list first).
+> **Design owner-docs:** `docs/prompt-graph-walking.md` §"Deferred:
+> Scope nodes", `docs/open-problems.md` §"Qualified-name resolution
+> suppression is coarse", `docs/adr/graph-walking.md` (the landed
+> walker this builds on), and the promotion-audit note in
+> `docs/ROADMAP.md` Now #1 (the evidence this epic monetizes).
+
+## Mission
+
+Every "couldn't resolve X" decision in the diagnostics currently uses a
+different, partial suppression rule: a `framework_imports` string set, a
+`universal_methods` + `meta_methods` list, an AUTOLOAD-in-MRO skip, an
+unresolved-ancestor skip, a syntactic `SUPER::`/qualified-name skip, and
+(the audit's remaining noise class) nothing at all for open-world
+dispatch. This epic replaces the pile with ONE structural question the
+graph answers — *walk outward from the reference site; if you reach an
+OPEN namespace before exhausting CLOSED ones, stay silent; if every
+namespace on the chain is closed and the name still doesn't resolve,
+warn* — then uses the trust gained to flip diagnostic flags default-on
+per the promotion path in `docs/adr/narrowing-diagnostics.md`.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — rules #10 (this epic exists because of it), the
+   resolution CandidateSet paragraph, "Inheritance & frameworks".
+2. `docs/adr/graph-walking.md` — `GraphView`, the closed `EdgeKind`,
+   exhaustive `edges_from`, why file roles are NOT graph nodes.
+3. `docs/prompt-graph-walking.md` — the deferred Scope-node taxonomy;
+   note its warning that scope parent-climbing is a linked list, so
+   `Node::Scope` must be earned by Openness, not ported for its own sake.
+4. `docs/adr/narrowing-diagnostics.md` — the flag ladder and promotion
+   path.
+5. `src/graph.rs` (172 lines, read all of it) and the unresolved-method
+   block in `src/symbols.rs` (grep `unresolved-method`).
+
+## Current state — exact anchors
+
+| Suppression rule to subsume | Where | Find it |
+| --- | --- | --- |
+| `framework_imports` string set (unresolved-function) | `src/symbols.rs` | `grep -n 'framework_imports' src/symbols.rs` |
+| `universal_methods` + `analysis.meta_methods` | `src/symbols.rs` | `grep -n 'universal_methods' src/symbols.rs` — KEEP both (they are genuine UNIVERSAL:: + plugin-declared facts), but they become inputs to the one walk, not a parallel path |
+| AUTOLOAD-in-MRO skip | `src/symbols.rs` | `grep -n 'AUTOLOAD' src/symbols.rs` — this IS an openness fact (AUTOLOAD makes a class Open); fold it in |
+| Unresolved-ancestor skip | `src/file_analysis.rs` | `grep -n 'class_has_unresolved_ancestor' src/` — an unresolvable parent makes the chain Open |
+| `SUPER::`/qualified-name syntactic skip | `src/symbols.rs` | `grep -n 'SUPER::' src/symbols.rs` — replace with real resolution (below) |
+| Open-world dispatch noise (D4) | `src/file_analysis.rs` | `grep -n 'fn guard_redundancies' src/file_analysis.rs` — the Software::License case from the audit: `$self->meta_name` typed by the base class's own all-undef method while runtime receivers are subclasses |
+| Role-ness (already an openness fact) | `FileAnalysis.role_packages` / `is_role_package` | roles are Open by definition (`docs/adr/role-contracts.md`) |
+| Descendant fan-out (already landed) | `children_index` via `GraphView` INHERITS_INV | used by goto-implementation; reuse for "is this method overridden below me" |
+
+## Non-goals — do NOT do these
+
+- Do NOT build instance brands, `main::` program-boundary analysis, or
+  `Symbol.home_namespace` field migrations. `home_namespace` is listed
+  in the owner doc as a possible future; this epic needs only a QUERY
+  (`openness of package P in file F`), not a stored field. If you find
+  yourself running a serde migration on `Symbol`, you have overreached.
+- Do NOT delete `universal_methods`/`meta_methods`/`RoleMask` — they
+  are inputs, not competitors.
+- Do NOT make the walk recursive over arbitrary scopes. Perl lexical
+  scopes don't affect method resolution; the namespace chain here is
+  package → ancestry (+ bridges + app surface), which `parents_of`
+  already enumerates. `Node::Scope` is justified ONLY if the
+  implementation genuinely needs lexical nodes — the expected outcome
+  is that it does NOT, and the taxonomy stays package-level. Record
+  the decision either way in the ADR you write.
+
+## Phase breakdown
+
+### Phase A — the openness verdict, as data
+
+**Goal:** a single function answers Open/Closed for a class, from facts
+that already exist.
+
+1. New module-level API (suggest `src/graph.rs` or a sibling that stays
+   in the Model layer — check `src/layering_tests.rs` `layer_map` and
+   assign the file if new):
+   ```rust
+   pub enum Openness { Open(OpenCause), Closed }
+   pub enum OpenCause { Autoload, Role, UnresolvedAncestor,
+                        PluginNamespace, AppSurface, DynamicParent }
+   ```
+   `openness_of(class, analysis, module_index) -> Openness` walks the
+   ancestry via the existing `parents_of` seam (NEVER a second
+   parent enumeration — CLAUDE.md names `parents_of` as the single
+   seam) and answers Open on the FIRST open fact:
+   - `AUTOLOAD` resolves anywhere in the MRO,
+   - any ancestor is a role (`is_role_package`) or unresolvable
+     (`class_has_unresolved_ancestor`'s condition, inlined here so the
+     old helper can eventually retire),
+   - the class participates in a plugin namespace bridge or the app
+     surface (`for_each_entity_bridged_to` non-empty /
+     `app_surface_consumers`),
+   - `dynamic_parent_packages` contains it (runtime `@ISA` mutation).
+2. `OpenCause` is for diagnostics text and tests — the verdict message
+   should say WHY it stayed silent when a `--verbose`-ish path wants it.
+3. **Acceptance:** unit tests per cause, plus a Closed case (plain
+   class, full local MRO, no bridges) that stays Closed.
+
+### Phase B — unresolved-method/function rewired to the verdict
+
+1. In the `symbols.rs` diagnostic block: after the existing universal/
+   meta-method skips and the local/workspace gates, replace the
+   AUTOLOAD skip + unresolved-ancestor skip with one
+   `openness_of(class) == Open → continue`.
+2. unresolved-function: replace the `framework_imports.contains` skip
+   with openness of the ENCLOSING package (a package that `use`s a
+   framework whose plugin injects keywords is Open to bare-name calls —
+   derive this from `package_uses` × plugin triggers, which
+   `framework_imports` already approximates; keep `framework_imports`
+   as the implementation detail behind the verdict if that is the
+   honest mapping, but the diagnostic consults ONE function).
+3. **Behavior must not regress:** run the substrate audit (commands in
+   Epic 1 Phase E) before and after; `unresolved-method` /
+   `unresolved-function` counts may only go DOWN or stay equal, and the
+   always-on `undef-deref` must be at exact parity.
+4. **Acceptance:** existing `symbols_tests.rs` d8/meta tests green
+   unchanged; new tests: AUTOLOAD-suppression now reports through the
+   same path (assert message/absence identical to before).
+
+### Phase C — qualified names resolve instead of hiding
+
+The `open-problems.md` item: `SUPER::method` and `Pkg::method` refs are
+skipped by token shape. Fix:
+
+1. `conventions::MethodToken` already parses the qualifier (FQ / SUPER /
+   main). For `MethodToken::Super`, resolve the method against the
+   enclosing class's PARENTS (`resolve_method_in_ancestors` starting
+   from parents, not self). For `MethodToken::Qualified(pkg)`, resolve
+   against `pkg`'s MRO.
+2. Resolved → no diagnostic (and, bonus, the ref gains a proper target
+   for goto-def if it lacks one — check `resolve.rs` handles these; if
+   it already does, reuse its answer rather than re-resolving: the
+   CandidateSet is the one resolution entry point).
+3. Unresolved AND the target package is Closed → the diagnostic now
+   fires where it used to stay silent. Run the substrate audit; triage
+   every new hit BEFORE merging (each is either a real find — document
+   it — or an openness fact you missed in Phase A).
+4. **Acceptance:** unit tests: `$self->SUPER::real_parent_method()`
+   silent; `$self->SUPER::typo()` in a Closed chain fires;
+   `Some::Pkg->method` against a Closed resolvable package with no such
+   method fires.
+
+### Phase D — the open-world-dispatch gate on D4
+
+The audit's remaining contradictory-guard noise: a base class's own
+method types `$self->m` (e.g. `sub meta_name { return undef }`), but
+runtime receivers are subclasses that override it, so "guard can never
+pass" is wrong.
+
+1. In `guard_redundancies`: when the belief that decides a verdict came
+   from a method call on `$self`-like receivers (the belief's
+   provenance is a `MethodOnClass{enclosing_class, m}` resolution — you
+   will need to thread WHERE the belief came from; the cheapest honest
+   signal is: the guarded subject was assigned from
+   `$self->method(...)` and `children_index` shows ANY descendant of
+   the enclosing class overriding `method`), downgrade the verdict to
+   silence.
+2. If threading provenance is too invasive, the coarser sound gate:
+   suppress definitive verdicts on subjects assigned from a
+   `$self`-receiver method call when the enclosing class HAS
+   descendants (in workspace or index). Prefer the precise gate;
+   document which you shipped.
+3. **Acceptance:** a two-file unit test reproducing Software::License
+   (base with `sub meta_name { undef }` + subclass overriding it;
+   `defined $meta1` guard in the base must NOT flag); the substrate
+   audit's contradictory-guard count drops by at least the
+   open-world-dispatch entries recorded in the ROADMAP audit note.
+
+### Phase E — promotion
+
+1. Rerun the full substrate audit. Update the ROADMAP audit note with
+   the new numbers.
+2. Flip `optionalDeref` default-on (INFO severity): change the
+   `DiagnosticOptions` default, the serde/CLI tests in
+   `symbols_tests.rs`, and `docs/adr/narrowing-diagnostics.md`'s ladder
+   text. The evidence bar (from the existing audit note): ~35 hits over
+   the whole substrate, all honest productions.
+3. `redundantGuard`/`contradictory`: if Phase D's numbers put the
+   noise classes at ~zero, flip them too; otherwise record precisely
+   which class remains and leave them opt-in. Do NOT flip
+   `unresolvedMethodCrossFile` in this epic (its ladder says it
+   promotes last; the named-helper first-param-self gap in
+   `gold-corpus/KNOWN-GAPS.md` is still open).
+4. Write the ADR: `docs/adr/openness.md` — the verdict enum, the single
+   `parents_of`-seam walk, what subsumed what, the Node::Scope
+   decision from the Non-goals box, and the promotion results.
+
+## Invariants that MUST survive
+
+- `parents_of` stays the single ancestor-enumeration seam.
+- The CandidateSet stays the one resolution entry point — Phase C
+  reuses its answers, never a parallel resolve.
+- Always-on `undef-deref` at exact parity in every audit re-run.
+- New diagnostics behavior = fewer or equal false positives, never a
+  silent new class of them: every count that goes UP in the audit gets
+  a per-site triage note in the PR.
+
+## Sizing & sequencing
+
+A → B and A → D are independent after A; C after B (shares the
+diagnostic block); E last. Expect C to surface the surprises — budget
+triage time for the new SUPER:: hits.

--- a/docs/epics/03-value-provenance.md
+++ b/docs/epics/03-value-provenance.md
@@ -1,0 +1,218 @@
+# Epic 3 — Value provenance, tier 1 (residual Parts 1, 2, 5a)
+
+> **Status:** scheduled, third. Independent of Epics 1–2 in code, but
+> run it last: it is the largest, and Epic 2's audit tooling habits
+> (before/after substrate diffs) are the safety net you will want.
+> **Design owner-doc:** `docs/prompt-type-inference-residual.md`
+> (Parts 1, 2, 5a — read the whole doc; Parts 3, 4, 5b, 7 are NOT in
+> this epic).
+> **Strategic payoff:** this tier is the named gate for un-parking
+> instance brands (`docs/prompt-graph-walking.md` §PARKED) and for the
+> untyped-receiver residual (`docs/prompt-method-resolution-residuals.md`
+> §4). Do not build those here — build the tier they wait on.
+
+## Mission
+
+Three fact classes that trace VALUES (not just declarations) through
+the program, each landing as **an emitter + reducer pair on the witness
+bag** with no `InferredType` enum expansion:
+
+1. **Part 1 — invocant mutations, consumer wiring.** The facts exist
+   (`mutated_keys_on_class`, `SlotType` folds); nothing user-facing
+   consumes them. Wire dynamic-key completion and the ro-write hint.
+2. **Part 2 — hash-key unions.** `{ %$defaults, %$overrides }` — keys
+   of a merged hash resolve to their source hashes.
+3. **Part 5a — value-indexed returns.** `get_config('host')` types from
+   the literal-keyed return table.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — "Type inference (witness bag)" and "Worklist
+   invariants" in full. This epic lives entirely inside those rules.
+2. `docs/adr/bag-canonical.md` — the bag is the only source of types.
+3. `docs/adr/structural-shapes.md` — `HashWithKeys`, `Projected`
+   drills, mutation extension, the whole-story trust gate. Part 2
+   composes with these; do not duplicate them.
+4. `docs/adr/return-expr.md` — `ReturnExpr` variants and how
+   `UnionOnArgs` dispatches on `arity_hint`; Part 5a adds the same
+   pattern on a literal-arg hint.
+5. `docs/prompt-long-distance.md` — A4 v2 already landed cross-file
+   slot-read narrowing; Part 1 must NOT rebuild it.
+
+## Current state — exact anchors
+
+| Existing piece | Where | Find it |
+| --- | --- | --- |
+| Class-keyed mutated-key union (read API) | `src/file_analysis.rs` | `grep -n 'fn mutated_keys_on_class' src/file_analysis.rs` |
+| Mutation Facts + slot-type seeds (emitters) | `src/builder.rs` | `grep -n 'FACT_MUTATION\|slot_writes' src/builder.rs` (in `populate_witness_bag`) |
+| `SlotTypeFold` (typed slot reads, incl. cross-file/ancestry) | `src/witnesses.rs` | `grep -n 'SlotTypeFold' src/witnesses.rs` |
+| `$self->{` completion path (where Part 1 wires in) | `src/file_analysis.rs` + `src/backend.rs` | `grep -rn 'hash_key' src/cursor_context.rs src/backend.rs \| grep -i complet` — find where hash-key candidates are gathered; completion SOURCES go through the CandidateSet's `complete()` projections (see `docs/adr/resolution-candidate-set.md` for the honest boundary) |
+| Moo `is => 'ro'` knowledge | `frameworks/moo.rhai` + `has_options` | the plugin owns the vocabulary; core sees classified pairs |
+| Hash-literal shape builder | `src/builder.rs` | `grep -n 'fn hash_literal_type\|fn visit_anon_hash' src/builder.rs` |
+| `HashKeyOwner` enum + linker | `src/file_analysis.rs` | `grep -n 'enum HashKeyOwner' src/file_analysis.rs`; index rebuild in `rebuild_enrichment_indices` |
+| Constant folding for string lists | `src/builder.rs` | `grep -n 'declared_constants\|resolve_constant_strings' src/builder.rs` |
+| Arity-hint threading (the pattern 5a copies) | `src/witnesses.rs` | `grep -n 'arity_hint' src/witnesses.rs \| head` — how a call-site hint reaches reducers |
+
+## Non-goals — do NOT do these
+
+- No instance brands, no birth-site chase, no `home` qualifiers — that
+  is the NEXT epic's candidate, explicitly parked until this one plus
+  constructor/field flow exist.
+- No Parts 3 (method loops), 4 (map/grep), 5b (already superseded by
+  the landed flow-narrowing lattice — verify before touching: the
+  narrowing ADR covers `ref…eq`/`defined` regions; Part 5b's table is
+  historical), 7 (Rhai reducers).
+- No new `InferredType` variants. If a design wants one, the design is
+  wrong for this epic — encode as witnesses/owners (the doc's header
+  says exactly this).
+- No parallel reverse indexes (rule #8) — Part 2's union expansion
+  reuses the existing `(target_name, owner)` index machinery.
+- `delete $self->{k}` drop-tracking: out (owner doc says ignore).
+
+## Phase breakdown
+
+### Phase A — Part 1: dynamic-key completion
+
+**Goal:** typing `$self->{` inside a class completes the union of
+Moo/Moose/framework-declared keys (already works via `HashKeyDef`) plus
+every key the class's methods were OBSERVED writing.
+
+1. Find the completion gathering site for `$self->{` (anchors above).
+   Where declared `HashKeyDef`s are offered for the invocant class,
+   also merge `mutated_keys_on_class(class)`, deduped against the
+   declared set, marked with a distinct `CompletionItemKind`/detail
+   ("observed write") so users can tell contract from observation.
+2. Cross-file: `mutated_keys_on_class` reads the local bag. For a class
+   whose methods span files, ask the same question of the cached
+   module's FA (mirror how declared keys already cross files — find
+   that path first and do it the same way; if declared keys DON'T cross
+   files here, do not fix that in this epic, just note it).
+3. Ordering guard: completion noise is a regression class. The gold
+   harness has `exact_labels`/`max_items` assertion modes
+   (`gold-corpus/README.md`) — author one row that pins the union AND
+   one that proves an unrelated class does NOT see these keys.
+4. **Acceptance:** unit test on a two-method class (one `has`, one
+   `$self->{observed} = 1`) → completion contains both, observed one
+   flagged; gold rows green.
+
+### Phase B — Part 1: ro-write hint
+
+1. New opt-in diagnostic `roWrite` (follow `DiagnosticOptions` serde +
+   `from_cli_args` + docs pattern — grep `optional_deref` for every
+   site a flag touches; there are exactly: struct field, CLI flag,
+   ADR ladder text, tests).
+2. The fact: a `HashKeyAccess` Write (or accessor-method call with args
+   — start with the direct slot write ONLY) on `$self->{attr}` where
+   `attr` is a Moo/Moose attribute whose `is` is `ro`. The `ro`
+   knowledge lives in the plugin: extend the `has` synthesis to record
+   read-only-ness on the emitted symbol/HashKeyDef (an EmitAction
+   field), NOT a core name-table.
+3. Severity HINT, message names the attribute and the declaring `has`.
+4. **Acceptance:** unit tests both directions (`ro` flags, `rw`
+   silent); substrate audit — expect near-zero hits (direct writes to
+   ro-backed slots inside the owning class are usually intentional
+   builder patterns like `_build_*`; if the audit shows >10 hits,
+   check whether `_build`/BUILD/BUILDARGS contexts need exemption and
+   document what you chose).
+
+### Phase C — Part 2: hash-key unions
+
+**Goal:** `my $full = { %$defaults, key => 1 };` — `$full->{host}`
+resolves (goto-def/completion) into `$defaults`'s key set.
+
+1. In `visit_anon_hash` (rule #1 — this is the only tree consumer),
+   detect splice elements (`%$var` / `%hash` inside the literal — get
+   the exact node kinds from `perl-lsp --parse` on a snippet FIRST,
+   do not guess).
+2. Encode as a UNION-witness, not an eager copy: push
+   `HashWithKeys`-shaped structure for the literal keys (existing
+   path) PLUS an Edge-per-splice from the literal's shape attachment
+   to the spliced variable's attachment. Check `structural-shapes.md`
+   for whether `HashWithKeys` already supports an `open` flag — a
+   splice makes the shape OPEN (unknown extra keys) even when the
+   source resolves; set it.
+3. Reducer side: when a `Projected { base, HashKey(k) }` misses the
+   literal keys, chase the splice edges (registry materialization
+   already chases Edges — confirm the attachment shapes line up, and
+   add a cycle guard via the existing `QueryState` visited set;
+   the owner doc's `$a = { %$b }; $b = { %$a }` case is the test).
+4. Owner expansion for the LINKER (`(target_name, owner)` lookups —
+   goto-def on a key): the owner doc offers
+   `HashKeyOwner::Union(Vec<HashKeyOwner>)` OR index-time expansion of
+   one def per member. PREFER index-time expansion (no enum change
+   ripples through serde/rename/match sites); expand in
+   `rebuild_enrichment_indices` where owner indexes are already built.
+   Record the choice + why in the commit message.
+5. Cross-file splices (`%$imported_config`) defer to enrichment —
+   emit the edge; if the source is cross-file it resolves when the
+   registry chases with a module index, exactly like slot types. Do
+   not build a special enrichment pass.
+6. **Acceptance:** unit tests: merged-literal key goto-def lands on the
+   source hash's key def; completion on `$full->{` offers both spliced
+   and literal keys; the cycle case terminates (test with the exact
+   `$a`/`$b` shape); `EXTRACT_VERSION` bump if the cached shape grew.
+
+### Phase D — Part 5a: value-indexed returns
+
+**Goal:** `sub get_config { my ($key) = @_; return $TABLE->{$key} }`
+with a literal-keyed table types `get_config('host')` per key.
+
+1. Recognition in the walk (rule #1): a sub whose return expression is
+   `<hash-literal or literal-initialized my %t>` subscripted by the
+   sub's first param. Start with the two shapes the owner doc names:
+   `return { ... }->{$param}` and `my %t = (...); return $t{$param}`.
+   Anything else is an honest miss.
+2. Encoding: do NOT add `keyed_returns` to `SymbolDetail::Sub` (the
+   owner doc predates bag-canonical; CLAUDE.md's "the bag is the only
+   source of types" wins). Instead follow the `UnionOnArgs` pattern:
+   a `ReturnExpr::KeyedOnFirstArg(HashMap<String, InferredType>)`
+   payload pushed on `Symbol(sid)` (and mirrored to `MethodOnClass` by
+   the existing writeback — verify it mirrors ReturnExpr payloads; if
+   not, that is a writeback gap to fix generically, not to special-case).
+3. Hint threading: `ReducerQuery` carries `arity_hint`; add
+   `first_arg_lit: Option<String>` beside it, populated at the SAME
+   call sites that populate arity (grep `arity_hint` construction
+   sites; `method_call_arity` shows how call-site facts are recorded).
+   `ReturnExprReducer` dispatches `KeyedOnFirstArg` on it; no hint or
+   unknown key → fall through to the agreement of the table's value
+   types if they agree, else None.
+4. Serde: `ReturnExpr` rides the cache blob — bump `EXTRACT_VERSION`.
+5. **Acceptance:** unit tests: literal-arg call types per key; unknown
+   key → the agreed-or-None fallback; no-arg call unchanged; a
+   method-form test through `MethodOnClass`. One gold row on the
+   substrate if a real module exhibits the idiom (search the substrate
+   with grep — Mojo and Plack config tables are likely candidates; if
+   none found, unit tests suffice, say so in the PR).
+
+### Phase E — verification + docs
+
+1. Full gate: `cargo test`, gold harness (0 FAIL / 0 XPASS or promote),
+   substrate diagnostic audit vs a pre-epic binary (always-on parity;
+   completion changes don't show there, hence the gold completion rows
+   in Phases A/C).
+2. Update `docs/prompt-type-inference-residual.md` (mark 1, 2, 5a
+   landed with pointers), `docs/ROADMAP.md`, and the instance-brands
+   PARKED note in `docs/prompt-graph-walking.md` — its prerequisite
+   list shrinks to "constructor/field value flow", which becomes the
+   candidate Epic 4.
+
+## Invariants that MUST survive
+
+- Bag-canonical: type production is `bag.push`, consumption is the
+  registry. No side-table of types (this kills the owner doc's
+  `keyed_returns` field idea — see Phase D step 2).
+- Monotone witnesses + clear-and-emit for anything a fold pass
+  re-derives; new source tags into `witnesses::tags`.
+- Edges, not values, for anything reachable through an attachment.
+- Rule #10: nothing keys on hash names, sub names, or "looks like a
+  config table" heuristics beyond the two recognized syntactic shapes,
+  which are grammar shapes, not name shapes.
+- Completion additions always come with a noise-guard gold row
+  (`exact_labels`/`max_items`).
+
+## Sizing & sequencing
+
+A (small) → B (small) → C (large) → D (medium) → E. A/B are the warm-up
+and independently shippable; C and D are independent of each other.
+Each phase is one reviewable commit; C may want two (emitter, then
+reducer+linker).

--- a/docs/epics/04-one-seam-sweep.md
+++ b/docs/epics/04-one-seam-sweep.md
@@ -1,0 +1,132 @@
+# Epic 4 — One-seam sweep: magic tokens + the cst/conventions backlog
+
+> **Status:** scheduled (4th). Small, self-contained, zero unlanded
+> prerequisites — a good warm-up epic for a fresh implementer.
+> **Design owner-docs:** `docs/prompt-magic-tokens.md` (whole thing),
+> `docs/prompt-cst-migration.md` (ranked backlog items 1–5 and 7).
+
+## Mission
+
+Two flavors of the same discipline — "encode the shape once, every
+consumer asks the value":
+
+1. **Magic compile-time tokens** (`__PACKAGE__`, `__SUB__`, `__FILE__`,
+   `__LINE__`) resolve to typed values in the canonical expression
+   machinery, so dispatch / column-keyed args / goto-def / rename work
+   on them with **no per-consumer handling**.
+2. **The cst/conventions migration backlog, ranked items 1–5 + 7** —
+   the remaining places that re-derive shapes `cst.rs`/`conventions.rs`
+   already own or should own.
+
+## Read first
+
+1. `CLAUDE.md` rule #1 (the cst.rs paragraph) and rule #10.
+2. `docs/prompt-magic-tokens.md` — the token/value table and the
+   "single seam" fix shape. Note its verified non-gap:
+   `__PACKAGE__->search` on a Result class is an ERROR in DBIC, so NOT
+   linking it is correct.
+3. `docs/prompt-cst-migration.md` — the ranked list. Items 1–5 and 7
+   are this epic; item 6 (the ~400-poke long tail) is a standing
+   strangler rule, NOT this epic.
+
+## Phase breakdown
+
+### Phase A — `__PACKAGE__` uniform resolution
+
+1. Anchors: `grep -n '__PACKAGE__' src/builder.rs | head -30` — the
+   constructor/bless/`mk_classdata` paths already mint
+   `ClassName(current_package)`; the gap is uniformity.
+2. Emit an `Expr(span)` witness with
+   `InferredType::ClassName(current_package)` for the token in
+   `expr_payload` (it parses as `func0op_call_expression`, text
+   `__PACKAGE__` — verify with `perl-lsp --parse` on a snippet first).
+   `invocant_type_at_node` gets the same answer through its existing
+   func0op arm or a sibling — ONE resolution rule, both entry points.
+3. Consumers must NOT grow token checks. The test of success:
+   `__PACKAGE__->new({ name => 1 })` in a DBIC Result class links the
+   `name` arg key to the column (the column-keyed seam reads the
+   invocant type and never sees the token), and
+   `__PACKAGE__->my_method` resolves goto-def/references/rename.
+4. **Acceptance:** unit tests for the two cases above + hover type on
+   the token; grep proof that no consumer outside the two typing entry
+   points mentions `__PACKAGE__` (except `conventions.rs`, which owns
+   recognition).
+
+### Phase B — `__SUB__`, `__FILE__`, `__LINE__`
+
+1. `__SUB__` → `InferredType::CodeRef { return_edge }` pointing at the
+   enclosing sub's symbol (the same `return_edge` shape
+   `coderef_return_edge_for` builds — grep it). Test:
+   `__SUB__->(@args)` inside a sub types its return as the sub's own
+   return type; goto-def on the token lands on the sub.
+2. `__FILE__` → `String`, `__LINE__` → `Numeric` — hover/type only.
+3. **Acceptance:** one unit test each.
+
+### Phase C — cst backlog item 1: the `$self` short-circuit
+
+`invocant_type_at_node`'s literal `"$self"` check is the last
+invocant-name site not routed through
+`is_conventional_invocant_name` (`$class`/`$proto` invocants miss the
+short-circuit). One-line fix + a `$proto->method` regression test.
+
+### Phase D — cst backlog item 2: positional-receiver node predicate
+
+`is_shift_call` / `is_positional_receiver` (builder) answer the
+node-level version of `InvocantText::PositionalReceiver`. Move the
+node-shape predicate into `cst.rs`
+(`is_positional_receiver_node(node, src)`); the builder keeps only
+`shift_is_invocant_here`'s context sensitivity. All existing tests
+green — this is a pure move.
+
+### Phase E — cst backlog item 3: one text→class resolver
+
+`FileAnalysis::invocant_text_to_class`,
+`FileAnalysis::resolve_invocant_class`, and cursor_context's
+`resolve_text_invocant` are three near-duplicates with different
+fallbacks. Collapse to one `FileAnalysis` seam; `cursor_context`
+composes it (rules #3/#5). Before collapsing, table the three
+fallback behaviors (package_at vs scope-chain vs analysis-optional)
+and preserve each caller's semantics — write the table into the
+commit message. If the fallbacks genuinely conflict, the seam takes a
+small options enum; do NOT silently pick one.
+
+### Phase F — cst backlog item 4: one string-value extractor
+
+`extract_node_string`, `extract_string_content`, `extract_key_text`
+(+ `arg_info_for`'s inline copy) overlap. cst.rs gains
+`string_value(node, src) -> Option<(String, Span)>` encoding the
+quote-flavor trap (the `string_content` child; empty literals have
+none). Migrate the four callers. `extract_key_text` also returns an
+`is_dynamic` flag — keep that at its call site, composed on top.
+
+### Phase G — cst backlog items 5 + 7
+
+- Route `for_each_has_option_pair` and the export-pair detectors
+  through `pair_nodes` (they pre-date it).
+- Add `typed_node!` wrappers as far as the visitors you touched in
+  C–F warrant: `SubDecl`, `VariableDecl` (the paren-list trap),
+  `Assignment` (the `child_by_field_name("right")`-returns-paren
+  trap), `AnonHash`, `UseStatement`. Only wrap what a migrated call
+  site actually uses — wrappers without consumers are dead weight.
+
+## Non-goals
+
+- Item 6's ~400-poke long tail (strangler rule only).
+- Anything DBIC-shaped (Epic 1 owns it; the cst doc's own "Not cst
+  work" list applies).
+- `__DATA__`/`__END__` (section markers, not values).
+
+## Verification gate
+
+`cargo test` green; gold harness 0 FAIL / 0 XPASS; behavior-neutral
+phases (C–G) additionally: substrate diagnostic audit at exact parity
+per code (commands in `docs/epics/01-dbic-phase-3.md` Phase E).
+Phases A–B may move counts — only DOWNWARD for unresolved-*.
+`EXTRACT_VERSION` bump if any witness emission changed (Phases A–B: yes).
+
+## Sizing
+
+Small. A–B one commit each; C one-liner; D–G one commit each. Fully
+parallel-safe with Epics 1–3 except Phase D touches
+`shift_denotes_invocant`'s neighborhood — coordinate if Epic 3 is
+in flight.

--- a/docs/epics/05-duplicate-package-identity.md
+++ b/docs/epics/05-duplicate-package-identity.md
@@ -1,0 +1,98 @@
+# Epic 5 — Duplicate-package identity (QA item H1)
+
+> **Status:** scheduled (5th). Small and self-contained; scheduled
+> early because H1 blocks re-testing QA item B4 (a shadowed package
+> exporting the wrong `@EXPORT` surface may be H1 in disguise).
+> **Design owner-doc:** `docs/qa-design-items.md` §H1 — including its
+> options analysis and the recommendation this epic implements.
+
+## Mission
+
+Two files both declare `package Bugzilla;` (`contrib/Bugzilla.pm`
+shadowing the root `Bugzilla.pm`); today whichever the resolver happens
+to pick wins, breaking type inference and exports for the real one.
+Implement the owner-doc's recommendation: a **typed canonicality
+ranking computed once at index time and carried on the indexed entry**,
+so the resolver asks the entry "are you canonical?" and the entry
+answers — never a path-string branch at the resolution site (rule #10).
+
+## Read first
+
+1. `docs/qa-design-items.md` §H1 — options and recommendation.
+2. `CLAUDE.md` "Workspace indexing" and "Cross-file resolution" (the
+   documents → workspace_index → module_index priority; duplicates
+   WITHIN a tier are the gap).
+3. `src/module_index.rs` — `register_workspace_module` (where a
+   module-name collision currently last-write-wins into `cache`) and
+   `src/file_store.rs` (`FileRole` — note it is currently only
+   Open/Workspace/Dependency/BuiltIn; H1 needs a finer rank, which may
+   or may not belong on this enum — see Phase A decision).
+
+## Phase breakdown
+
+### Phase A — the rank, as data
+
+1. Compute, at index/registration time, a canonicality rank per
+   (module_name, file) pair:
+   1. **Path–package agreement**: does the file's path end with the
+      package name's path form (`Bugzilla::Foo` →
+      `.../Bugzilla/Foo.pm`)? Longest-suffix match wins; a `lib/`
+      prefix strengthens it.
+   2. **Directory role**: `lib/` (and the workspace root for root-level
+      `.pm`) outranks `t/`, `xt/`, `contrib/`, `examples/`,
+      `inc/`, `local/`. Encode as an ordered enum
+      (`DirRole::Lib > Root > Other > Contrib > Test`), computed ONCE
+      from the path at index time. The resolver never sees a path
+      string.
+2. Where the rank lives: on the indexed entry (the `CachedModule` or a
+   sibling field in the registration map). DECISION to record: extend
+   `FileRole` vs a separate `Canonicality` type. Default to a separate
+   type — `FileRole` is a visibility/lifecycle tag consumed by
+   `RoleMask`, and overloading it risks changing rename/visibility
+   semantics. Write the decision and why in the ADR (Phase C).
+3. Registration keeps ALL duplicates (a secondary map
+   `module_name → Vec<entry>` or rank-compare-and-swap on insert —
+   compare-and-swap is simpler and sufficient: keep the best, remember
+   only that a conflict existed + the loser paths for diagnostics).
+
+### Phase B — resolution + diagnostics
+
+1. `get_cached`/`register_workspace_module` collision behavior becomes:
+   highest rank wins deterministically (ties: stable on path sort, so
+   re-index order can't flip winners — determinism is the point).
+2. A HINT diagnostic on the SHADOWED file's package statement:
+   "package Bugzilla is also declared in <winner>; this file is not
+   the canonical provider" — only when ranks differ; equal-rank
+   genuine conflicts get the hint on both.
+3. `.perl-lsp`-config override (owner doc option 2) is OUT of this
+   epic — note it as the escape hatch in the ADR; it lands with the
+   config epic (Epic 8) if demand appears.
+
+### Phase C — verification + ADR
+
+1. Unit tests: contrib-shadows-lib picks lib; path-agreement beats
+   directory role when they conflict (construct such a case and DECIDE
+   the precedence — the owner doc implies agreement first; pin it);
+   determinism under reversed registration order.
+2. Re-test B4 against the substrate (the Bugzilla fixture is in the
+   gold substrate — `grep -rn 'package Bugzilla' gold-corpus/local`
+   to find it; if the substrate lacks the contrib shadow, reproduce in
+   a test fixture).
+3. `docs/adr/duplicate-package-identity.md`: the rank order, where it
+   lives, the FileRole decision, and the explicit non-goal (no
+   runtime-`@INC` emulation).
+4. Full gate: cargo test, gold 0 FAIL / 0 XPASS, substrate audit at
+   parity (resolution changes CAN move unresolved-* counts — each
+   moved site gets a triage note; expect improvements around the
+   Bugzilla cluster).
+
+## Non-goals
+
+- No `@INC`-order emulation, no per-project config this round.
+- No path-string checks at resolution sites — if you write
+  `path.contains("contrib")` anywhere but the one index-time rank
+  function, stop.
+
+## Sizing
+
+Small-to-medium: A+B ~one day-scale session, C the second. One PR.

--- a/docs/epics/06-gated-cross-file-emission.md
+++ b/docs/epics/06-gated-cross-file-emission.md
@@ -1,0 +1,137 @@
+# Epic 6 — Gated cross-file emission (ClassIsa triggers + in_role params through cross-file ancestors)
+
+> **Status:** scheduled (6th).
+> **Design owner-doc:** `docs/prompt-enrichment-inheritance-residual.md`
+> — read it WHOLE; its applicability matrix is the epic's map, and its
+> two `#[ignore]`d probes are the acceptance tests. The landed pattern
+> to copy is `docs/adr/receiver-gated-dispatch.md`.
+
+## Mission
+
+Plugin **emission** gated on a class's ancestry is not cross-file
+aware: `package Leaf; use parent 'Mid';` where `Mid` (another file)
+extends `Mojo::EventEmitter` means `Leaf`'s `$self->on('ready', …)`
+synthesizes NO Handler — the `ClassIsa("Mojo::EventEmitter")` trigger
+sees only local parents. The fix is the same move `dispatch_verbs`
+already made: **defer the ancestry check to query time on the
+`ReceiverGated` seam** — the builder emits an ungated candidate, and
+consumers resolve the isa-check against the module index when they
+read. The owner doc names this exactly: "Phase 2 mints it on the same
+seam."
+
+## Read first
+
+1. `docs/prompt-enrichment-inheritance-residual.md` — the matrix, §"The
+   `ClassIsa` trigger axis", and why a mid-walk index consult is
+   forbidden (rule #1: the builder is index-free; indexing order is
+   not guaranteed).
+2. `docs/adr/receiver-gated-dispatch.md` — the landed seam:
+   `ReceiverGated<T>` wraps a payload unreadable without the isa check;
+   `resolve_for` walks the single `class_isa` seam.
+3. `CLAUDE.md` rules #1, #8; "Cross-file enrichment".
+
+## Current state — anchors
+
+- The failing probe (your acceptance test #1):
+  `grep -n 'probe_class_isa_trigger_through_cross_file_parent' src/builder_tests.rs`
+  — `#[ignore]`d, FAILS today. Un-ignore it at the end.
+- Trigger matching: `PluginRegistry::applicable`
+  (`grep -n 'fn applicable' src/plugin/mod.rs`) matches `ClassIsa`
+  against `transitive_parents` — LOCAL `package_parents` only
+  (`grep -n 'fn transitive_parents' src/builder.rs`).
+- The seam to extend: `grep -n 'ReceiverGated' src/file_analysis.rs src/builder.rs | head`
+  — how `gated_param_types` and dispatch candidates ride the FA and
+  resolve lazily.
+- Emit-hook dispatch sites: `dispatch_function_call_plugins` /
+  `dispatch_method_call_plugins` in `src/builder.rs`.
+
+## The design (prescribed)
+
+At build time, when a plugin's `ClassIsa(T)` trigger does NOT match
+locally, the builder cannot know it never will — so for call shapes a
+ClassIsa-triggered plugin registered interest in, the builder records a
+**gated emission candidate**: the plugin id + the `CallContext`
+ingredients needed to re-run the hook + `gate = ClassIsa(T)` on the
+enclosing package. These ride `FileAnalysis` (serde, like
+`gated_param_types`). At query/enrichment time, a resolver with the
+module index checks the gate via the single `class_isa` seam and, on
+pass, applies the plugin's emissions.
+
+Two honest constraints shape the implementation — confront them
+up front:
+
+1. **Re-running a Rhai hook needs the engine, not just data.** Two
+   options; pick per measurement, record in the ADR:
+   - (a) Store the ungated hook's OUTPUT: run the hook at build time
+     regardless of trigger, wrap the resulting `Vec<EmitAction>` in
+     `ReceiverGated`, apply on gate-pass. Cost: hooks run for
+     non-matching packages (measure with `--timings` on the substrate;
+     plugin hooks are cheap and verb-filtered, so this is the expected
+     winner). Benefit: pure data rides the cache; no engine at query
+     time.
+   - (b) Store the `CallContext` and re-run at enrichment (engine
+     available in-process, NOT in cached-dep consumers) — weaker: dep
+     files served purely from cache can't re-run. Prefer (a) unless
+     timings veto it.
+2. **Which EmitActions can apply post-build?** Symbol/Handler/
+   HashKeyDef synthesis appends to FA — the enrichment idempotency
+   machinery (`base_symbol_count` truncation,
+   `rebuild_enrichment_indices`) already supports append-after-build;
+   route through it. Actions that steer the WALK itself (VarType at a
+   span the fold already consumed) may need the fold re-entered —
+   `enrich_imported_types_with_keys` already re-runs fold pieces;
+   study it before assuming.
+
+## Phase breakdown
+
+### Phase A — gated candidates for `ClassIsa` emit hooks
+
+Implement design option (a): run ClassIsa-triggered hooks ungated at
+build; wrap outputs `ReceiverGated<Vec<EmitAction>>` keyed on the
+enclosing package + trigger class; store on FA (new serde-default
+field; EXTRACT_VERSION bump). Apply at the same points enrichment
+applies its synthesis for OPEN docs, and lazily via the query paths
+non-open files already use for gated dispatch (mirror
+`applicable_dispatches`' consumption shape).
+
+**Acceptance:** the `probe_class_isa_trigger_through_cross_file_parent`
+probe un-ignored and green: `Leaf` (child file) + `Mid` (parent file,
+extends Mojo::EventEmitter) → `$self->on('ready', …)` in Leaf
+synthesizes the Handler, cross-file, without Leaf being open.
+
+### Phase B — `param_types` `in_role` cross-file (verify, then close)
+
+The matrix says this landed via `gated_param_type_for`; the owner doc's
+header still lists "two real gaps". Verify which probe is which:
+if `probe_*` for param_types is still ignored/failing, apply the same
+Phase-A consumption path; if it is already green, update the owner doc
+and move on. Do not build machinery for a closed gap.
+
+### Phase C — timings + docs
+
+1. `--timings` on the substrate before/after (option (a) runs more
+   hooks at build): the per-module build report must not regress the
+   slowest-modules tail by more than noise; if it does, gate the
+   ungated-run to packages with ANY parents (cheap prefilter) and
+   re-measure.
+2. Update `docs/prompt-enrichment-inheritance-residual.md` (matrix
+   rows → landed), write `docs/adr/gated-emission.md` (the option-(a)
+   decision, the honest boundary: emission still cannot depend on
+   values only the index knows at WALK time — it is gate-then-apply,
+   not a re-walk).
+3. Full gate: cargo test, gold, substrate audit at parity or improved
+   (`unresolved-method` should DROP for cross-file-ancestry framework
+   classes — note the sites).
+
+## Non-goals
+
+- No mid-walk module-index access (rule #1 stands).
+- No enrichment of dependency files (the "OPEN documents only"
+  lifecycle stands; consumption is lazy/query-time for everything
+  else, exactly like receiver-gated dispatch).
+- Helper-consumption phase 3 (per-app surfaces) — different gate
+  (instance brands), stays parked.
+
+## Sizing
+
+Medium. Phase A is the bulk; B is verification; C is half a day.

--- a/docs/epics/07-rename-provenance.md
+++ b/docs/epics/07-rename-provenance.md
@@ -1,0 +1,128 @@
+# Epic 7 — Rename provenance: derived refs update their sources
+
+> **Status:** scheduled (7th).
+> **Design owner-doc:** `docs/prompt-ref-provenance.md` — the residual
+> list this epic implements, including its proposed shapes and its
+> three sketched regression tests (write all three).
+
+## Mission
+
+CLAUDE.md rule #9: derived refs trace to source. Today rename FINDS
+derived call sites but cannot UPDATE what they were derived from:
+`my $m = 'process'; $self->$m()` renames the sub and finds the call,
+but leaves the `'process'` string literal behind — silently breaking
+the program. This epic lands `Ref.folded_from`, the unified
+framework-attribute rename group, verifies import-list rename, and
+takes the two stretch goals (package→file rename, inheritance override
+scoping) as explicitly separable phases.
+
+## Read first
+
+1. `docs/prompt-ref-provenance.md` — whole doc.
+2. `docs/adr/resolution-candidate-set.md` — rename is a projection
+   (`rename_edits()` / `renameable()`); ALL new grouping goes into
+   CandidateSet construction, NEVER into the rename handler. This is
+   the epic's one architectural landmine — the owner doc predates the
+   CandidateSet; translate its "rename_sub checks folded_from" language
+   into "the set's construction includes the folded-source span as an
+   edit site".
+3. `CLAUDE.md` rule #9 + the CandidateSet paragraph; `src/resolve.rs`
+   module docs.
+4. `grep -n 'attr_projections\|AttrProjection' src/file_analysis.rs | head`
+   — the projection-group machinery that already unions attribute
+   spellings; the framework-attribute phase EXTENDS this, it does not
+   build a parallel group.
+
+## Phase breakdown
+
+### Phase A — `Ref.folded_from`
+
+1. Add `folded_from: Option<Span>` to `Ref` (serde-default;
+   EXTRACT_VERSION bump). The builder sets it when a ref's target name
+   came from constant folding: `constant_strings` must carry the source
+   literal's span alongside the value
+   (`grep -n 'constant_strings' src/builder.rs` — change the map's
+   value type to carry `(String, Span)`; the span follows the value
+   through fold chains, FIRST source wins and document why: the
+   literal the user must edit is where the name is spelled).
+2. CandidateSet construction: when a member ref carries `folded_from`,
+   the rename edit set includes an edit at that span (the string
+   CONTENT span, not the quotes — reuse the content-span machinery
+   `ArgInfo.content_span` uses).
+3. Same shape for the lexical-hash-literal dynamic key the owner doc
+   describes (`my $k = 'name'; my %h = ($k => 1);`):
+   `emit_lexical_hash_literal_keys` currently skips non-literal keys;
+   with `folded_from` it can emit the key ref carrying the `'name'`
+   literal's span. Renaming the key rewrites the source literal, NOT
+   `$k` — that inversion is the whole point; test it explicitly.
+4. **Acceptance:** the owner doc's
+   `test_constant_fold_rename_updates_source_string` — def + call site
+   + string literal all edited; a references query on `process` lists
+   the call site (unchanged behavior) — and gold rename rows stay green.
+
+### Phase B — framework-attribute unified rename (verify-first)
+
+The owner doc predates the attr-projection groups; much of this may
+already work (this branch's history landed inheritance-aware attribute
+groups). VERIFY FIRST:
+
+1. Write the owner doc's `test_framework_attribute_unified_rename`
+   (accessor + constructor key + internal `$self->{name}` + call
+   sites, renamed from EVERY position) and run it. For each position
+   that already passes, done. For failures, extend the projection
+   group (`AttrProjection` + the group machinery in resolve.rs) —
+   never a rename-handler special case.
+2. **Acceptance:** the test green from all four positions; prepareRename
+   returns the right range at each.
+
+### Phase C — import-list rename (verify, pin)
+
+Owner doc says "may already work". Write
+`test_import_list_renamed_with_sub` (rename `sub bar` in Foo updates
+`use Foo qw(bar)` + call sites). If green: commit the pin. If not: the
+import-spec ref exists (`emit_refs_for_strings`) — the gap will be in
+CandidateSet membership; fix there.
+
+### Phase D — package rename → file rename (stretch, separable)
+
+LSP `WorkspaceEdit.documentChanges` supports `RenameFile`. When the
+rename target is a package/class symbol whose defining file's path
+agrees with the package name (reuse Epic 5's path–package agreement
+rank if it has landed; else a local check), append a `RenameFile`
+operation to the computed new path. Guard: only when the file exists
+and the new path does not; never move files whose path did NOT agree
+with the old name (out-of-convention layouts stay untouched).
+**Acceptance:** e2e test (this is client-visible surface — verify the
+nvim harness supports documentChanges; if it does not, assert the
+WorkspaceEdit JSON shape in a unit test and note the e2e gap).
+
+### Phase E — inheritance override scoping (stretch, separable)
+
+Renaming `Animal::speak` should offer `Dog::speak` (override family)
+and must NOT touch `Unrelated::speak`. The pieces exist:
+`children_index` (descendants) and the override-family machinery the
+heatmap already counts through. Verify current behavior first —
+`OverrideScope` env knob exists (`grep -rn 'OverrideScope' src/`);
+this phase may be "wire the knob into LSP rename + default it
+sanely" rather than new analysis. The name-collision NEGATIVE test
+(`Unrelated::speak` untouched) is the acceptance bar.
+
+## Non-goals
+
+- Cross-file rename of DEPENDENCY files (RoleMask::EDITABLE stands).
+- Renaming through dynamic dispatch that constant folding could NOT
+  resolve — honest miss, never a guess.
+
+## Verification gate
+
+cargo test + gold (rename rows especially; author a folded_from gold
+row via `--emit rename`) + the substrate audit at parity. Rename is
+the highest-blast-radius verb: every phase lands with its negative
+tests (what must NOT be edited) — Phase A: `$k` not renamed in the
+hash-literal case; Phase D: disagreeing paths not moved; Phase E:
+unrelated same-name subs untouched.
+
+## Sizing
+
+Medium. A is the bulk; B/C may be verification-only; D/E are
+independent and individually droppable if QA pull shifts.

--- a/docs/epics/08-diagnostic-framework.md
+++ b/docs/epics/08-diagnostic-framework.md
@@ -1,0 +1,156 @@
+# Epic 8 — The diagnostic framework: PL-codes, config, suppressions, SARIF
+
+> **Status:** scheduled (8th). The CI-readiness gate.
+> **Design owner-docs:** `docs/prompt-cli-tools.md` §"Diagnostic
+> framework" (codes table, config JSON, suppression comments, SARIF)
+> and `docs/prompt-config-schema.md` (whose "forcing function" section
+> says THIS epic is the moment its three deferred pieces land).
+
+## Mission
+
+`--check` and the LSP diagnostics grow a real framework: stable
+diagnostic codes, per-code severity config from `.perl-lsp.json` +
+LSP `initializationOptions`, in-source comment suppressions, and SARIF
+output for CI annotation. The config-schema doc's deferred pieces —
+the owning `Config` struct and the generated editor schema — land here
+because per-code objects are their named forcing function.
+
+## Read first
+
+1. `docs/prompt-cli-tools.md` — the PL-code table (PL001–PL010), the
+   config JSON shape, the suppression comment grammar, SARIF.
+2. `docs/prompt-config-schema.md` — WHOLE doc; it prescribes the
+   `Config` shape (own at top, pass slices) and the schemars plan, and
+   warns off the `define_options!` macro.
+3. `docs/adr/narrowing-diagnostics.md` — the existing flag ladder; the
+   new framework must express it, not replace its semantics.
+4. `grep -n 'struct DiagnosticOptions' -A 20 src/symbols.rs` and the
+   `cli_flags_match_diagnostic_option_fields` drift test — the pattern
+   every config surface here must keep.
+
+## Ordering constraint
+
+Do NOT renumber or re-key existing diagnostics' string codes
+(`unresolved-function`, `undef-deref`, `optional-deref`, …) — editors
+and gold rows key on them. PL-codes are an ADDITIONAL stable alias
+(SARIF ruleId + suppression key); the LSP `code` field can carry
+`PLxxx` with the descriptive name in `codeDescription`/message, but
+decide ONE presentation and write it in the ADR. The owner doc's table
+maps PL001/PL002 onto the two existing unresolved lints; extend the
+table with rows for every diagnostic that exists TODAY (the narrowing
+family: undef-deref, optional-deref, redundant/contradictory-guard,
+deref-shape; helper-not-loaded; composer-mismatch; shadowed-package
+if Epic 5 landed) BEFORE adding any new lint — registering the
+existing surface is Phase A; new lints (PL003+) are LAST.
+
+## Phase breakdown
+
+### Phase A — the registry + codes for existing diagnostics
+
+1. `src/diagnostics.rs` (new; add to `layering_tests.rs` `layer_map` —
+   it sits beside symbols.rs in the LSP-adapter layer): a static
+   registry `DiagnosticCode { pl: &'static str, name: &'static str,
+   default_severity, default_enabled }` — one row per EXISTING
+   diagnostic. Every `Diagnostic { code: … }` construction site in
+   `symbols.rs` routes through the registry (grep
+   `NumberOrString::String` to find all sites).
+2. A drift test in the spirit of
+   `cli_flags_match_diagnostic_option_fields`: every emitted code
+   string appears in the registry, and PL numbers are unique.
+3. **Acceptance:** `--check` output unchanged by default except each
+   diagnostic now also carries its PL code.
+
+### Phase B — `Config` + `.perl-lsp.json` + per-code severity
+
+1. Per `prompt-config-schema.md` piece 1: one owning
+   `struct Config { diagnostics: DiagnosticsConfig, exclude: Vec<String> }`,
+   parsed ONCE (workspace root `.perl-lsp.json` + LSP
+   `initializationOptions` + `didChangeConfiguration`, later sources
+   overriding earlier field-wise). Backend holds `Arc<RwLock<Config>>`.
+   **Call sites keep taking the narrow slice** — the doc is explicit
+   and gives the reasons; keep `collect_diagnostics(&cfg.diagnostics, …)`.
+2. `DiagnosticsConfig`: per-code `"error"|"warning"|"info"|"hint"|"off"`
+   keyed by either the PL code or the descriptive name (accept both;
+   normalize through the registry). The existing `DiagnosticOptions`
+   bools become the LEGACY spelling — keep deserializing them (serde
+   alias or a merge step) so current users' configs keep working;
+   document the mapping.
+3. `exclude` globs honored by `--check` and workspace indexing's
+   diagnostic pass (NOT by indexing itself — resolution still needs
+   excluded files' symbols; only reporting is filtered).
+4. **Acceptance:** unit tests for precedence (file < init options <
+   didChange), per-code override, `"off"`, legacy-bool compatibility;
+   the drift test extended to assert every registry row is
+   configurable.
+
+### Phase C — comment suppressions
+
+1. Grammar (owner doc): `# perl-lsp: ignore(PL001)`,
+   `ignore-next-line(PL001)`, `ignore-file(PL004)` (file-form only in
+   the first 10 lines). Also accept descriptive names in the parens.
+2. Rule #1: comments are scanned during build — collect
+   `FileAnalysis.suppressions: Vec<Suppression>` (serde;
+   EXTRACT_VERSION bump) in the builder's comment handling; the
+   registry lookup/validation happens at DIAGNOSTIC time (the builder
+   stores the raw code string; unknown codes get their own
+   `unknown-suppression` hint from the framework — self-hosting).
+3. `collect_diagnostics` filters through suppressions before emitting.
+4. **Acceptance:** unit tests per form + the unknown-code hint; a gold
+   diagnostics row exercising `ignore-next-line`.
+
+### Phase D — SARIF 2.1.0 (`--check --format sarif`)
+
+1. Serialize the same diagnostics to SARIF: `runs[0].tool.driver`
+   from the registry (rules = registry rows, with help text from the
+   registry's doc strings), `results` with ruleId = PL code,
+   locations with 1-based line/col matching `--check`'s existing
+   coordinate contract, level from severity.
+2. Validate against the SARIF schema in a test (embed the minimal
+   checks: required fields, enum values — do not pull a validator
+   dependency; hand-assert the shape on a golden file).
+3. Wire a CI smoke: the repo's own workflow uploads the SARIF of a
+   fixture run (optional; if touching CI is out of scope for the
+   implementer, note it in the PR).
+4. **Acceptance:** golden-file test; `jq` sanity commands in the doc.
+5. This also discharges the heatmap doc's deferred SARIF note — record
+   that in `docs/prompt-heatmap.md` (heatmap SARIF stays deferred;
+   only `--check` gains it here).
+
+### Phase E — schemars + new lints (only now)
+
+1. `prompt-config-schema.md` piece 2: `#[derive(schemars::JsonSchema)]`
+   on the config structs + `--dump-options-schema`. Field `///` docs
+   become descriptions — write them as user-facing.
+2. New lints from the table, EACH as its own commit with a substrate
+   audit before/after (the Epic-1 Phase-E commands) and default
+   severity per the table: PL003 unused-import, PL004 unused-variable,
+   PL007 shadow-variable, PL010 deprecated-pattern (`use base` →
+   `use parent`). PL005 unused-export / PL006 dead-sub REUSE the
+   heatmap's guards verbatim (`exported`, constructor,
+   framework-synthesized, dynamic-dispatch — grep
+   `reachable_guard` in `src/main.rs`) — a lint that flags what the
+   heatmap shields is a bug. PL008 missing-import and PL009
+   circular-dependency: only if the audit shows clean signal;
+   otherwise leave registered-but-default-off with a note.
+3. **Acceptance per lint:** unit tests + substrate hit count recorded
+   in the PR + zero hits on the repo's own `t/`-style fixtures unless
+   genuinely justified.
+
+## Non-goals
+
+- `define_options!` macro (config-schema doc says the drift test is
+  cheaper; it stays).
+- `--migrate` and the analysis subcommands (Epic 11).
+- Changing any diagnostic's SEMANTICS — this epic is packaging.
+
+## Verification gate
+
+cargo test + gold + substrate audit at exact parity for Phases A–D
+(pure packaging), per-lint audited deltas in Phase E. The promotion
+states from `adr/narrowing-diagnostics.md` (post-Epic-2) must survive
+the config migration exactly.
+
+## Sizing
+
+Large-ish but mechanical; A→B→C→D→E strictly ordered. E is droppable
+to a follow-up without hurting A–D's value.

--- a/docs/epics/09-heatmap-residuals.md
+++ b/docs/epics/09-heatmap-residuals.md
@@ -1,0 +1,129 @@
+# Epic 9 — Heatmap residuals: Handlers + plugin-owned reachability
+
+> **Status:** scheduled (9th).
+> **Design owner-doc:** `docs/prompt-heatmap.md` §"What's next" — the
+> two residuals are specified there in detail, including the verified
+> false positive each one fixes. Both are the same generalization: the
+> plugin knows an edge the static graph can't see.
+
+## Mission
+
+Two heatmap gaps, both plugin-knowledge-shaped (rule #10 — never a
+per-verb/per-name list in core):
+
+1. **Handlers become heatmap-eligible** with a plugin-stamped
+   definition site, so orphan routes / never-enqueued Minion tasks /
+   never-emitted events surface in the dead-code queue (verified: the
+   reference graph already computes their fan-in correctly — only the
+   listing elides them).
+2. **Plugin-declared "framework-consumed" reachability** replaces the
+   blanket dynamic-dispatch shield for lifecycle hooks — fixing the
+   verified false positive where a Mojolicious `sub startup` is
+   flagged dead (a violation of the heatmap's "never falsely flag a
+   live symbol" promise).
+
+## Read first
+
+1. `docs/prompt-heatmap.md` — WHOLE doc, especially "What's next" #1
+   and #2 and the guard table.
+2. `docs/adr/resolution-candidate-set.md` — heatmap fan-in is the
+   `references()` projection; nothing here may add a parallel count.
+3. `docs/adr/plugin-system.md` — EmitAction shapes; how Handlers are
+   minted.
+
+## Current state — anchors
+
+- Listing policy: `grep -n 'heatmap_symbol_eligible' src/main.rs` —
+  admits `Sub|Method|Package|Class|Module`, elides `Handler`.
+- Declaration subtraction: the fan-in logic near `cli_heatmap` in
+  `src/main.rs` subtracts `AccessKind::Declaration` + the decl
+  name-token span — insufficient for Handlers, whose registration IS
+  one of their refs (the owner doc explains).
+- Handler minting: `grep -n 'Handler' src/plugin/mod.rs | head` — the
+  EmitAction that creates them; the definition-site stamp goes here.
+- Guards: `grep -n 'reachable_guard' src/main.rs`.
+
+## Phase breakdown
+
+### Phase A — plugin-stamped Handler definition site
+
+1. Extend the Handler-minting EmitAction with a definition-site marker
+   — the Handler-shaped equivalent of `AccessKind::Declaration`. The
+   cleanest shape: the emitted Handler's OWN declaration ref/span is
+   already known to the plugin at mint time (the string key in
+   `add_task(cleanup => …)`, the `Controller#action` string in
+   `->to(…)`, the event name in `->on(…)`); make the mint record that
+   span as the Handler's declaration site the same way Sub symbols
+   record theirs (grep how `selection_span`/declaration refs are set
+   for plugin Methods and mirror it). If Handlers already carry a
+   decl span that the fan-in subtraction just doesn't use, this phase
+   is wiring, not schema — CHECK FIRST.
+2. Update every bundled plugin that mints Handlers (minion,
+   mojo-routes, mojo-events, mojo-lite, dancer, catalyst — grep
+   `Handler` in `frameworks/*.rhai`) to stamp it. A plugin that
+   doesn't stamp gets the old behavior (eligible but with
+   registration counted in fan-in) — decide whether unstamped
+   Handlers stay ELIDED instead, and write the decision down;
+   eliding-unless-stamped is the safe default (no fan-in ≥ 1 noise).
+3. **Acceptance:** unit tests on a fixture: a wired+dispatched task
+   (`fan_in ≥ 1`, not dead), a wired-never-dispatched task
+   (`fan_in = 0`, dead-candidate), plus the same pair for a route and
+   an event. EXTRACT_VERSION bump if the Handler shape changed.
+
+### Phase B — Handlers in the report
+
+1. `heatmap_symbol_eligible` admits stamped Handlers; the fan-in
+   subtraction uses the stamped site.
+2. The HTML viewer (`src/heatmap.html`): Handlers get their outline
+   word (route/task/event — `HandlerDisplay` already knows) in the
+   treemap tooltip and dead-code table.
+3. **Acceptance:** `--heatmap` JSON schema stays `v1`-compatible
+   (additive fields only) or bumps to `v2` with the schema string
+   updated — decide, document in the doc's schema section.
+
+### Phase C — framework-consumed reachability
+
+1. New plugin manifest `framework_consumed()` → method names (or
+   name+trigger pairs) the framework invokes through its own
+   machinery: mojo (`startup`), minion workers if any, Moo/Moose
+   lifecycle (`BUILD`, `BUILDARGS`, `DEMOLISH`, `_build_*` builders —
+   note `_build_*` is a PATTERN; support a simple `prefix:` form or
+   enumerate from `has` options at emit time — prefer emit-time
+   enumeration: the moo plugin SEES the `builder => '_build_x'`
+   option and can mark that symbol precisely, no pattern needed),
+   DBIC (`sqlt_deploy_hook`, `register`…).
+2. Carrier: a marker on the Symbol (an EmitAction field for
+   plugin-minted syms; for USER-WRITTEN syms like `sub startup`, the
+   plugin can't mint — it must mark. Add a small EmitAction
+   (`MarkFrameworkConsumed { name }`) applied per-package when the
+   trigger fires; bake as a set on FA, serde-default).
+3. Heatmap: `reachable_guard = "framework-consumed"` checked BEFORE
+   the blanket dynamic-dispatch shield (most-specific-first per the
+   guard table), and such syms are skipped for fan-OUT hotspot
+   dilution per the owner doc's note.
+4. Epic 8 interlock: PL006 dead-sub must consult the same guard —
+   if Epic 8 landed first, extend its guard reuse; if not, leave a
+   pointer.
+5. **Acceptance:** the verified FP as a regression test — a
+   `sub startup` in a Mojolicious app fixture is NOT a dead candidate
+   and carries the new guard; a genuinely-uncalled non-lifecycle
+   method in the same fixture STILL flags (the shield must not
+   over-widen).
+
+## Non-goals
+
+- SARIF for heatmap (deferred; `--check` SARIF is Epic 8).
+- Transitive fan-out depth (deferred, owner doc).
+- Fan-in precision split by RefKind (deferred until `RefLocation`
+  carries kind).
+
+## Verification gate
+
+cargo test + gold + `--heatmap` run over the substrate committed as a
+before/after summary in the PR (counts of dead candidates by kind —
+the Handler additions should ADD candidates (orphans found) while
+framework-consumed REMOVES false ones; both deltas listed).
+
+## Sizing
+
+Medium-small. A+B one PR arc, C a second.

--- a/docs/epics/10-mojo-polish.md
+++ b/docs/epics/10-mojo-polish.md
@@ -1,0 +1,141 @@
+# Epic 10 — Mojo polish: route names, stash intelligence, hooks, transitive plugins
+
+> **Status:** scheduled (10th). User-facing feature epic.
+> **Design owner-doc:** `docs/prompt-mojo-todo.md` — read WHOLE; its
+> stash section contains a fully-made design decision (per-action
+> ownership via the brand) that this epic implements as written.
+
+## Mission
+
+The four missing Mojo features, all landing as plugin patches
+(`frameworks/mojo-*.rhai`) on existing core seams: route naming +
+`url_for`, stash-key intelligence, hook completion + signatures, and
+transitive plugin-chain helper discovery. Plus the `.conf` config
+completion stretch, explicitly droppable.
+
+## Read first
+
+1. `docs/prompt-mojo-todo.md` — the spec. Its "Ready vs missing"
+   paragraph for stash is the checklist.
+2. `docs/adr/route-branding.md` — `BrandedRoute` accumulates route
+   defaults; the stash key set per action IS the brand's stash at the
+   terminal `->to`.
+3. `docs/adr/plugin-system.md` + `docs/PLUGIN_AUTHORING.md` — emit vs
+   query hooks; `Handler` + bridges; `classified_pairs`.
+4. `frameworks/mojo-routes.rhai` and `frameworks/mojo-helpers.rhai` —
+   the plugins being extended.
+
+## Phase breakdown
+
+### Phase A — route naming + `url_for`
+
+1. At `->name('show_user')` chain links, `mojo-routes.rhai` emits a
+   Handler keyed by the route NAME (display `Route`), bridged the same
+   way routes already are. Lite auto-naming (the route path with
+   non-word chars stripped — check Mojolicious docs for the exact
+   rule; implement only the documented default) emits the same Handler
+   when no explicit `->name` exists — mark synthesized-name Handlers
+   `hide_in_outline` to avoid outline noise.
+2. `url_for('…')` / `redirect_to('…')` first-string-arg becomes a
+   dispatch ref to that Handler (the existing dispatch-verb machinery:
+   register the verbs via the manifest — grep `dispatch_verbs` in the
+   rhai files for the pattern).
+3. Completion inside the string arg offers known route names — an
+   `on_completion` query hook enumerating the route-name namespace.
+4. **Acceptance:** goto-def from `url_for('show_user')` to the
+   `->name` call; references on the name lists both; completion offers
+   it; a gold row for each (author with `--emit`); heatmap treats a
+   never-`url_for`ed named route honestly (fan-in 0 → orphan — this
+   composes with Epic 9 if landed; note it either way).
+
+### Phase B — stash intelligence (the big one)
+
+Implement the owner doc's decision EXACTLY — keys are per-ACTION,
+sourced from the brand; do not relitigate per-controller ownership
+(the doc explains why it over-broadens):
+
+1. **Emission, route side:** at each terminal `->to` that names an
+   action, emit `HashKeyDef`s for the in-force `BrandedRoute.stash`
+   keys (inherited overlay + local), owned per-action. Ownership
+   shape: the doc's option (a)+(b) BOTH — a new
+   `HashKeyOwner::MojoAction { class, action }`-style owner for deref
+   reads AND namespace registration for string-arg enumeration. The
+   owner enum lives in core (file_analysis) but is generic
+   ("action-scoped key"), the MINTING is the plugin's.
+2. **Emission, body side:** `render(k => v)` / `stash(k => v)` inside
+   `sub action` add body-local keys to the same per-action set —
+   plugin `on_method_call` with `classified_pairs`, skipping the known
+   render options (`template`/`format`/`status`/`handler`/… — the
+   plugin owns this vocabulary list).
+3. **Identity bridge:** body-side `<current_package>#<sub>` must meet
+   decl-side `users#list` through the SAME decamelize+namespace rule
+   goto-def already uses — grep the controller resolution in
+   `mojo-routes.rhai` and REUSE it; a second spelling of decamelize is
+   the bug the doc warns about.
+4. **Read side:** `$c->stash('|')` string-arg completion (query hook
+   enumerating the action's set); `$c->stash->{|}` hash-key completion
+   + goto-def via the owner path; hover on a key shows the defining
+   `->to`/`render` site.
+5. **Honest boundary (from the doc):** an action whose chain roots at
+   an unbranded hashref param has empty inherited stash — body-local
+   keys still work. Do not attempt to fix the boundary here
+   (`open-problems.md` owns it).
+6. **Acceptance:** the doc's worked example as a fixture (under +
+   local defaults + render keys; completion at both read forms lists
+   exactly `layout`,`title`,`count` for `list` and NOT for `show`);
+   gold completion rows with `exact_labels` (noise guard); cross-file
+   (app file + controller file) versions of the same.
+
+### Phase C — hook completion + signatures
+
+1. New `mojo-hooks.rhai` (or extend mojo-helpers — prefer a new small
+   plugin; hooks are their own concept): `on_completion` inside
+   `->hook('|')` returns the hook-name table from the owner doc;
+   `on_signature_help` returns the per-hook param shape (the doc's
+   table is complete — encode it as plugin data).
+2. The handler sub's params get typed via the existing
+   `NamedSubParamType`/`VarType` emission the helpers plugin already
+   uses (`$c` → controller, etc.) per the table.
+3. **Acceptance:** completion + sig-help unit/gold rows for two hooks
+   with different shapes (`before_dispatch` vs `around_dispatch`).
+
+### Phase D — transitive plugin chains
+
+Plugin A's `register` calls `$app->plugin('B')` — B's helpers should
+reach the host. Short-name resolution + one hop landed; this adds the
+transitive walk at RESOLVE time (not parse time): where helper
+resolution consults loaded plugins (grep `SyntheticUse` +
+`plugin_loads` consumption in resolve/enrichment), follow
+`plugin_loads` found in an already-loaded plugin's module one more
+level, with a seen-set and a small depth cap (the dispatcher owns
+termination — rule #10's "termination on the dispatcher" note).
+**Acceptance:** three-file fixture (app loads A; A's register loads B;
+B registers helper `h`) — `$c->h` resolves in the app's controllers;
+cycle fixture terminates.
+
+### Phase E — `.conf` config completion (STRETCH — droppable)
+
+Only if A–D land with room: parse workspace `*.conf` (Mojo config is a
+Perl hashref — it can be parsed with the existing parser as an
+expression file), emit its key shape, and complete
+`$app->config->{…}` off it via the existing hash-key machinery. If the
+parse story gets ugly, drop the phase and record why in the owner doc.
+
+## Non-goals
+
+- Multi-app workspaces (the doc's cross-cutting note — parked with
+  instance brands).
+- The unbranded-root boundary (`open-problems.md`).
+
+## Verification gate
+
+cargo test + gold (each phase authors its rows) + e2e additions in
+`e2e/mojo_*.lua` where cursor-position behavior is the deliverable
+(completion inside strings is exactly what e2e catches and unit tests
+fake) + substrate audit at parity (emission changes can move
+unresolved counts — triage any).
+
+## Sizing
+
+Large overall but cleanly phased; A/C/D are each small, B is the bulk.
+Ship phases as separate PRs.

--- a/docs/epics/11-cli-analysis-and-migrate.md
+++ b/docs/epics/11-cli-analysis-and-migrate.md
@@ -1,0 +1,125 @@
+# Epic 11 — CLI analysis subcommands + `--migrate`
+
+> **Status:** scheduled (11th).
+> **Design owner-doc:** `docs/prompt-cli-tools.md` §"Analysis
+> subcommands still missing" and §"`--migrate`" (targets table,
+> implementation shape, phase order).
+
+## Mission
+
+Round out the CLI: the thin-wrapper analysis subcommands over existing
+`FileAnalysis` queries, then the marquee `--migrate` (framework
+translation via span-based edits), in the owner doc's easy→ambitious
+order.
+
+## Read first
+
+1. `docs/prompt-cli-tools.md` — the two sections.
+2. `src/main.rs` — the CLI dispatch `match`, `cli_full_startup`,
+   and an existing thin subcommand (`cli_heatmap` or
+   `cli_workspace_symbol`) as the template.
+3. For `--migrate`: `CLAUDE.md` on `FileAnalysis` being the semantic
+   model; how `--rename` builds span-based `WorkspaceEdit`s (grep
+   `cli_rename` in main.rs) — migrate reuses that edit-application
+   shape.
+
+## Phase breakdown
+
+### Phase A — thin analysis subcommands
+
+Each is a small `cli_*` fn + a `--help` entry + tests; implement in
+this order and keep each a separate commit:
+
+1. `--completions <root> <file> <line> <col>` — the LSP completion
+   engine at a position (mirror `--signature-help`'s plumbing; the
+   0-based input / 1-based output coordinate contract from `--help`
+   applies — copy an existing position-taking subcommand EXACTLY).
+2. `--dependency-graph <root> [--format dot|json|list]` — module
+   import edges from each FA's `imports` (+ `package_parents` as a
+   distinct edge kind in dot/json); cycles via DFS reported in all
+   formats.
+3. `--export-api <root> <module> [--format json|markdown]` — exports,
+   params, return types, parents, framework, from the cached FA
+   (`--dump-package` is the debugging sibling; this is the
+   user-facing one — share extraction where trivial).
+4. `--impact <root> <file-or-module>` — reverse deps: who imports /
+   inherits from this (the reverse index + `children_index` already
+   answer both; this is formatting).
+5. `--framework-report <root>` — classes by framework
+   (`package_framework` + parents), counts + list.
+6. `--unused-exports` / `--dead-code`: implement as ALIASES over the
+   Epic 8/9 machinery if those landed (PL005/PL006 + heatmap guards);
+   if this epic runs first, SKIP them here and leave the pointer —
+   do not build a third dead-code path.
+7. `--repl-complete` — stdin-accumulated source, complete at EOF.
+   Lowest priority; drop if time-boxed out.
+
+**Acceptance per subcommand:** a golden-output test on a fixture
+workspace; `--help` text updated; stderr/stdout discipline preserved
+(chatter to stderr, data to stdout — the heatmap's pattern).
+
+### Phase B — `--migrate` step 1: `use base` → `use parent`
+
+The deliberately-trivial first target to build the harness:
+
+1. Harness: `cli_migrate(root, target, from, to, dry_run)` — index,
+   select files by `--from` detection (the FA knows its frameworks),
+   produce span edits, `--dry-run` prints a unified diff (reuse or
+   hand-roll minimal diff output), else write files.
+2. The edit itself goes through the semantic model (the `use base`
+   statement's span from the FA/refs — NOT a regex), preserving
+   everything else byte-for-byte.
+3. **Acceptance:** golden diff test; idempotence (re-run produces no
+   edits); `--dry-run` writes nothing (assert file mtimes/content).
+
+### Phase C — Moose → Moo, Moo → Moose
+
+Mostly removals / small additions per the owner table. Every
+construct the writer cannot translate emits
+`# TODO: manual migration needed — <reason>` at the site (the owner
+doc's rule) rather than guessing. **Acceptance:** golden diffs both
+directions on a fixture exercising `has` flavors, `extends`, `with`,
+method modifiers; untranslatable constructs produce TODOs not edits.
+
+### Phase D — Moo/Moose → core `class` (the headline)
+
+The owner doc's table row-by-row: `class`/`:isa`/`:does`,
+`has` → `field` with `:param :reader (:writer)`, defaults, lazy via
+`ADJUST`, `sub`→`method` with invocant dropped. Untranslatable list
+(BUILD/BUILDARGS→ADJUST note, DEMOLISH, complex isa constraints,
+coercions, triggers, delegation) → TODO comments. Span-based, never
+whole-file regeneration; comments and non-framework code
+byte-identical. **Acceptance:** golden diffs on a fixture per table
+row; a `perl -c` syntax check of migrated output in the test (system
+perl ≥ 5.38 has `class` behind `use experimental` — emit the
+`use v5.38; use experimental 'class';` preamble and assert compile).
+
+### Phase E — bless → Moo (heuristic; LAST, gated)
+
+Only attempt when the FA's evidence is strong: a conventional
+constructor blessing a hash literal + accessor-shaped subs. Anything
+below full confidence → TODO comment, no edit. If the heuristic's
+false-edit rate on the substrate is nonzero, ship it behind
+`--allow-heuristic` or drop the phase; record the measurement.
+
+## Non-goals
+
+- Diagnostic codes/config/SARIF (Epic 8 owns those).
+- Editing files the semantic model didn't fully parse (any ERROR node
+  in a target file → skip file with a warning; never edit around
+  broken syntax).
+
+## Verification gate
+
+cargo test + gold untouched (these are additive CLI surfaces); for
+migrate phases, the golden-diff suite IS the gate plus `perl -c`
+compile checks of outputs. Run `--migrate --dry-run` for each target
+over the gold substrate and attach the summary (files matched, edits,
+TODO counts) to the PR — the substrate is the honesty check that the
+writers do not touch what they should not.
+
+## Sizing
+
+Phase A is a string of small wins (good for ramping a new
+implementer). B small; C medium; D large; E small-but-risky. Separate
+PRs per phase.

--- a/docs/epics/12-program-boundaries.md
+++ b/docs/epics/12-program-boundaries.md
@@ -1,0 +1,133 @@
+# Epic 12 — Program boundaries: file→program assignment + `main::` unification (MAIN-1)
+
+> **Status:** scheduled (12th, last of the current slate). Half-gated:
+> the file→program assignment and MAIN-1 are unblocked NOW; the
+> instance-brand consumer additionally waits on Epic 3 + the
+> constructor/field-flow follow-on.
+> **Design owner-docs:** `docs/prompt-entrypoint-analysis.md` (the
+> program-boundary concept and the landed conservative fallback) and
+> `docs/qa-design-items.md` §MAIN-1 (the require-edge design and its
+> recommendation, which this epic implements as option 1).
+
+## Mission
+
+Give the analyzer the notion of a **program**: which entrypoint(s) a
+file belongs to, via each entrypoint's statically-resolvable
+`use`/`require`/`do` closure. Two consumers land with it:
+
+1. **MAIN-1** — package-less files `require`d into a script share its
+   `main::`; unqualified calls resolve along require edges (the
+   AWStats shape, ~270 FPs each direction), WITHOUT unifying unrelated
+   scripts' `main::` (every `t/*.t` keeps its own).
+2. **`main::` rename fan-out lift** — the deliberately-file-local
+   `main` fallback in `resolve.rs` widens to program-scoped.
+
+## Read first
+
+1. Both owner docs, whole.
+2. `CLAUDE.md` "Workspace indexing" — `scan_entrypoint_scripts` and
+   its `extra: &[String]` seam (reserved for workspace-config
+   `entrypoint_dirs`; if Epic 8's `.perl-lsp.json` landed, this epic
+   wires that key).
+3. `src/resolve.rs` — the `package == "main"` file-local arm
+   (`grep -n '"main"' src/resolve.rs`).
+4. `docs/prompt-heatmap.md` §"Honest failure modes" — entrypoint-script
+   free-subs are deliberately listed as dead candidates pending THIS
+   tier; this epic upgrades that.
+
+## Phase breakdown
+
+### Phase A — the require/do edge, as data
+
+1. During the walk (rule #1), record load edges the builder can see:
+   `require "literal/path.pl"`, `require Bare::Module`,
+   `do "literal/path"`, and the constant-folded variable forms
+   (`require $file` where `$file` folds via `constant_strings` — the
+   same folding rename provenance uses; a dynamic path that doesn't
+   fold is an honest miss, per the owner doc's "degrade silently").
+   Store on FA: `load_edges: Vec<LoadEdge { target: PathOrModule,
+   span }>` (serde-default; EXTRACT_VERSION bump). `use` already
+   populates `imports` — do NOT duplicate it; LoadEdge is for
+   require/do path forms that `imports` doesn't carry.
+2. **Acceptance:** unit tests per form incl. the folded-variable case
+   and a non-folding dynamic path producing nothing.
+
+### Phase B — program assignment
+
+1. At workspace-index completion (module_resolver's post-index hook —
+   where the resolver refresh callback lives), compute programs:
+   for each entrypoint from `scan_entrypoint_scripts` (+ configured
+   `entrypoint_dirs` if available), BFS its closure over
+   `imports` ∪ `load_edges` (paths resolved workspace-relative and
+   against the entrypoint's own dir — match Perl's `do`/`require`
+   relative semantics conservatively: try entrypoint-dir first, then
+   workspace root; unresolvable → skip). A file reachable from N
+   entrypoints belongs to all N; a file reachable from none belongs
+   to a synthetic "unassigned" program.
+2. Store the assignment where resolve-time code can read it (the
+   ModuleIndex or a sibling map `path → SmallVec<ProgramId>`), rebuilt
+   on watcher changes with the same incremental hooks indexing uses.
+   This is derived state — never serialized into per-file FAs (it is
+   workspace-shaped, not file-shaped; recompute is cheap).
+3. **Acceptance:** fixture workspace with two scripts requiring
+   disjoint plugin files + one shared library — assignments come out
+   {A: script1}, {B: script2}, {lib: both}.
+
+### Phase C — MAIN-1 consumption
+
+1. Unqualified-call resolution for `main`-package files consults the
+   program's other `main` files: extend the `resolve.rs` `main` arm —
+   same-file first (current behavior), then same-program `main::`
+   symbols. Bounded by the program set; NO workspace-wide `main`
+   union, ever (the owner doc's "modeling it wrong is worse than the
+   FP").
+2. The unresolved-function diagnostic gains the same visibility, so
+   the AWStats-shaped FPs drop.
+3. Rename fan-out for `main` globals/subs widens file-local →
+   program-scoped, still never cross-program. The negative test is
+   mandatory: two scripts each with `our $x` / `sub helper` — rename
+   in one MUST NOT touch the other.
+4. **Acceptance:** an AWStats-shaped fixture (host script +
+   `require`d package-less plugin, calls both directions) — goto-def,
+   references, and diagnostics all resolve across the pair;
+   the negative-pair test above; substrate audit (if any substrate
+   module is affected) at parity-or-better.
+
+### Phase D — heatmap upgrade + docs
+
+1. Entrypoint-reachable `main` free-subs: a sub in a program whose
+   entrypoint's top-level statements call it is reachable — feed
+   fan-in through the normal reference graph now that same-program
+   `main` calls resolve (no new guard needed; the guard table's
+   deliberate listing note in `prompt-heatmap.md` gets updated to
+   reflect the improved floor).
+2. Update `docs/prompt-entrypoint-analysis.md` (the fallback-lift
+   landed; instance brands remain parked on their own gate) and
+   `docs/qa-design-items.md` (MAIN-1 → landed, keep H1's own state
+   accurate).
+3. ADR: `docs/adr/program-boundaries.md` — the closure rules, the
+   relative-path resolution order, multi-membership, the "unassigned"
+   program, and the explicit non-goal below.
+
+## Non-goals
+
+- Instance brands / per-app helper surfaces — still parked on the
+  value-provenance tier (Epic 3) plus constructor/field flow; this
+  epic only supplies the file→program key they will eventually use.
+- No runtime `@INC` emulation; no execution of config to resolve
+  dynamic require paths.
+- No cross-program anything: the entire point is isolation by default,
+  sharing only along proven edges.
+
+## Verification gate
+
+cargo test + gold + substrate audit at parity-or-better + the fixture
+suite above. Watcher incrementality: touch a require line in the
+fixture, assert reassignment without full restart (mirror how existing
+watcher tests assert index updates, if any exist — else a unit test on
+the recompute function).
+
+## Sizing
+
+Medium. A small; B the design core; C the payoff; D cleanup. One PR
+per phase or A+B together.

--- a/docs/epics/13-type-tiny-completeness.md
+++ b/docs/epics/13-type-tiny-completeness.md
@@ -1,0 +1,161 @@
+# Epic 13 — Type::Tiny completeness: check-guards, import-scoped vocabulary
+
+> **Status:** scheduled (13th; independent — can run any time, pairs
+> naturally with Epic 4's small-seam character).
+> **Design owner-docs:** `docs/adr/type-constraints.md` (the landed
+> `TypeConstraintOf` design — the foundation everything here projects
+> through), `frameworks/type-tiny.rhai` (the vocabulary plugin),
+> `docs/adr/flow-narrowing.md` + `docs/adr/narrowing-diagnostics.md`
+> (the lattice the guards feed).
+
+## What is ALREADY designed and landed (do not rebuild)
+
+- `InferredType::TypeConstraintOf(inner)` — a constraint is a VALUE
+  over the type it constrains, never conflated with it; consumers
+  project via `constrained_inner()` (`adr/type-constraints.md`).
+- The vocabulary plugin: `InstanceOf`/`ConsumerOf`, `Maybe[T]` →
+  `Optional<T>`, the 0-arity base constants (`Str`/`Int`/`Num`/
+  `ArrayRef`/…) folding to their reps — both `isa` spellings (quoted
+  string and bareword constructor) type accessors identically.
+- Import vocabulary: `Types::Standard` / `Types::Common::{String,
+  Numeric}` / `Types::Common` full export lists incl. the
+  `is_X`/`assert_X`/`to_X` companions, `-all`/`:all` expansion, and
+  the BYO story for house type libraries (their plugin emits
+  `SyntheticUse "Types::Standard"`).
+
+## Mission — what is NOT yet designed, in one epic
+
+1. **Check-function guards feed the narrowing lattice.**
+   `if (is_ArrayRef($x)) { $x->[0] }` and
+   `assert_Str($name); …` are type guards exactly like
+   `ref $x eq 'ARRAY'` / `defined $x` — today they narrow nothing.
+   The vocabulary already enumerates every `is_X`/`assert_X` name;
+   the lattice already has the ops. Connect them, plugin-declared.
+2. **The constraint-constructor gate becomes import-scoped.** The
+   `type_constraint_names()` gate is global ("first cut" caveat on the
+   trait doc, `src/plugin/mod.rs`): ANY call named `Str`/`Int`
+   anywhere types as a constraint, colliding with user subs. Scope it
+   to packages that actually imported the name.
+3. **Close the `completion-typetiny-imported-blessed` xfail** — a
+   generic completion gap (imported names missing from bareword
+   completion) that happens to be pinned on a Type::Tiny fixture.
+4. **Doc hygiene:** `frameworks/type-tiny.rhai` cites
+   `docs/prompt-type-constraint-types.md`, which does not exist —
+   the design lives in `adr/type-constraints.md`; fix the pointer
+   (this epic's README-coverage update is where Type::Tiny's
+   disposition now lives).
+
+## Read first
+
+1. `CLAUDE.md` — rules #1, #10; the narrowing/witness sections.
+2. `docs/adr/type-constraints.md`, `docs/adr/flow-narrowing.md`.
+3. `src/builder/narrowing.rs` — `recognize_guards` and the
+   `GuardFact`/`NarrowOp` shapes (the truthiness recognizer added
+   July 2026 is the freshest example of extending it).
+4. `frameworks/type-tiny.rhai` — `types_standard_exports()` (the
+   `is_`/`assert_` companion generation) and `base_constant_type`.
+
+## Phase breakdown
+
+### Phase A — `type_check_guards()` manifest + narrowing recognizer
+
+1. New plugin manifest `type_check_guards()` returning
+   `{ fn_name, constraint_name, asserts }` entries. The plugin
+   DERIVES them from the same base list that generates the exports —
+   one vocabulary, three projections (`is_X` → check-guard,
+   `assert_X` → asserting guard, the export list) — never a second
+   hand-kept table. Only names whose constraint folds to an
+   expressible type contribute (ask `base_constant_type`; `is_Object`
+   etc. fold to nothing → omit).
+2. Core resolves each entry's `constraint_name` → `InferredType`
+   through the EXISTING `type_constraint_inner` fold (empty params) at
+   registry-load/bake time — no second name→type mapping in core.
+   Bake the resolved map onto `FileAnalysis` (serde-default;
+   EXTRACT_VERSION bump) like `meta_methods`.
+3. `recognize_guards` gains a function-call arm: a
+   condition `is_X($subject)` whose name is in the baked map and whose
+   argument is a narrowable subject (`narrow_subject_of`) yields
+   `GuardFact { subject, op: To(resolved) or the StripOptional analog
+   for defined-like reps, asserts_when_true: true }`. `HashRef`/
+   `ArrayRef`/`CodeRef` reps → `To(rep)` (same as `ref…eq`);
+   `Str`/`Num` → `To(String/Numeric)`; negation/polarity/elsif-chains
+   come free from the existing machinery.
+4. `assert_X($subject);` at statement level: the fall-through narrows
+   (assert dies otherwise) — reuse the early-exit statement machinery
+   (`narrow_block_remainder`'s shape; the assert IS the guard and the
+   region is the rest of the block). Postfix and bare-statement forms.
+5. **Object form:** `$type->check($x)` where the invocant types
+   `TypeConstraintOf(T)` narrows `$x` to `T` in the guarded region;
+   `$type->assert_valid($x)` narrows the fall-through. Recognizer asks
+   the invocant's type — no name matching on `$type` (rule #10). This
+   is the payoff of the ADR's "constraint is a value" decision.
+6. **Acceptance:** unit tests per form (`is_ArrayRef` if/unless/
+   postfix; `assert_Str` fall-through; `->check` object form;
+   a NON-imported `is_Foo` user sub narrows nothing — see Phase B);
+   the D6 deref-shape diagnostic composes (an `is_ArrayRef`-guarded
+   `$x->{k}` hash deref flags) — one test proving the lattice, not
+   just the type, sees the guard. Substrate audit: guard-lint counts
+   move only DOWN (new narrowing can only remove false "maybe undef"/
+   unresolved noise) — triage anything up.
+
+### Phase B — import-scoped constraint gate
+
+1. The builder's `type_constraint_names` gate (grep
+   `self.type_constraint_names.contains` in `src/builder.rs`) and the
+   new Phase-A guard map both consult per-package import state: the
+   name must be imported in the enclosing package (literal qw-list,
+   meta-import expansion, or SyntheticUse — all already recorded on
+   `imports` / handled by the plugin's `on_use`).
+2. Keep a compatibility carve-out ONLY if the substrate shows real
+   code using the constructors without importable evidence (measure
+   first; the expected answer is no carve-out needed — Type::Tiny
+   constants MUST be imported to compile).
+3. **Acceptance:** a user package with its own `sub Str` — calls type
+   as the sub's return, not a constraint; the existing bareword-isa
+   tests still green (they `use Types::Standard qw/…/` properly);
+   substrate audit at parity-or-better.
+
+### Phase C — imported names in bareword completion
+
+Per the KNOWN-GAPS fix sketch: bareword/function completion candidates
+fold in `analysis.imports[].imported_symbols` (goto-def and
+diagnostics already consult them; completion doesn't). Route through
+the CandidateSet's completion sources (`complete()` — see the ADR's
+honest-boundary list) — not a handler-side append. Flip the
+`completion-typetiny-imported-blessed` xfail row to gold. Add an
+`exact_labels`/`max_items` noise-guard row alongside (imports can be
+large; if the candidate flood is bad, complete only on ≥1 typed char
+prefix match and record the policy).
+
+### Phase D — doc hygiene
+
+Fix the stale `prompt-type-constraint-types.md` pointer in
+`frameworks/type-tiny.rhai` → `docs/adr/type-constraints.md` (+ this
+epic). Note: touching the rhai changes the plugin fingerprint →
+caches self-invalidate; expected, harmless.
+
+## Non-goals
+
+- `ArrayRef[T]` / `HashRef[T]` ELEMENT typing — parked with
+  sequence-types phase 3 (`prompt-sequence-types.md`, QA pulls).
+- House Type::Library generators (`Clove::Types`-style runtime
+  `setup_import_methods`) — the runtime-export-generator open problem
+  (`open-problems.md`); the BYO SyntheticUse plugin story is the
+  supported answer. Do not attempt static execution.
+- Coercions (`to_X`, `coerce => …`) — recognized as exports for
+  suppression only; no semantic modeling this epic.
+- `Enum[…]`/`Dict[…]`/`Tuple[…]` semantics beyond what already folds —
+  each is its own design conversation; decline cleanly (the fold
+  already returns unit for unhandled shapes).
+
+## Verification gate
+
+The standard gate (README house rules): cargo test, gold 0 FAIL /
+0 XPASS with the Phase-C promotion, substrate audit — Phase A/B deltas
+individually triaged, always-on parity.
+
+## Sizing
+
+Small-to-medium. A is the core (recognizer + manifest); B is a
+contained gate change with a measurement step; C/D are small. One PR
+for A+B, one for C+D works.

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -7,7 +7,7 @@ verification gate. An implementing session starts with `CLAUDE.md`,
 then its epic file, then the epic's listed design docs.
 
 Ordering is a schedule, not a dependency graph — dependencies are
-stated inside each epic. Epics 4–12 are mutually independent unless
+stated inside each epic. Epics 4–13 are mutually independent unless
 their docs say otherwise; 1–3 come first because they finish the
 standing roadmap commitments.
 
@@ -25,6 +25,7 @@ standing roadmap commitments.
 | 10 | [Mojo polish: routes, stash, hooks, chains](10-mojo-polish.md) | L | — |
 | 11 | [CLI analysis subcommands + --migrate](11-cli-analysis-and-migrate.md) | L | 8/9 for the two lint aliases |
 | 12 | [Program boundaries + MAIN-1](12-program-boundaries.md) | M | brands-half waits on 3 |
+| 13 | [Type::Tiny completeness: check-guards, import-scoped vocab](13-type-tiny-completeness.md) | S–M | — |
 
 ## Coverage map — every `docs/prompt-*.md` and open design item
 
@@ -42,6 +43,7 @@ residuals, or (d) explicitly out of scope. Nothing is unaccounted for.
 | `prompt-type-inference-residual.md` Part 5c residuals (prefetch, `join =>` keys) | Queued; natural follow-on to Epic 1 |
 | `prompt-type-inference-residual.md` Part 7 (Rhai reducers) | **Parked**: wants a second concrete consumer beyond route aggregation |
 | `prompt-magic-tokens.md` | **Epic 4** (phases A–B) |
+| Type::Tiny surface (`adr/type-constraints.md` + `frameworks/type-tiny.rhai`) | Constraint model + vocabulary LANDED; check-fn guards, import-scoped gate, and the typetiny completion xfail → **Epic 13**; `ArrayRef[T]` elements parked with sequence-types; house Type::Library generators stay on the runtime-export open problem |
 | `prompt-cst-migration.md` items 1–5, 7 | **Epic 4** (phases C–G); item 6 is a standing strangler rule, not schedulable |
 | `qa-design-items.md` §H1 | **Epic 5** |
 | `qa-design-items.md` §MAIN-1 | **Epic 12** (phase C) |

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -1,0 +1,95 @@
+# Epics — the scheduled work, and where every design doc stands
+
+Each numbered file here is a **self-contained implementation prompt**:
+mission, reading list, grep-able code anchors, phased ladder with
+per-phase acceptance criteria, hard non-goals, invariants, and the
+verification gate. An implementing session starts with `CLAUDE.md`,
+then its epic file, then the epic's listed design docs.
+
+Ordering is a schedule, not a dependency graph — dependencies are
+stated inside each epic. Epics 4–12 are mutually independent unless
+their docs say otherwise; 1–3 come first because they finish the
+standing roadmap commitments.
+
+| # | Epic | Size | Depends on |
+|---|---|---|---|
+| 1 | [DBIC out of core, phase 3](01-dbic-phase-3.md) | M | — |
+| 2 | [Openness + flag promotion](02-openness.md) | M | — |
+| 3 | [Value provenance, tier 1](03-value-provenance.md) | L | — |
+| 4 | [One-seam sweep: magic tokens + cst backlog](04-one-seam-sweep.md) | S | — |
+| 5 | [Duplicate-package identity (H1)](05-duplicate-package-identity.md) | S | — |
+| 6 | [Gated cross-file emission (ClassIsa)](06-gated-cross-file-emission.md) | M | — |
+| 7 | [Rename provenance](07-rename-provenance.md) | M | Epic 5 helps Phase D |
+| 8 | [Diagnostic framework: PL-codes, config, SARIF](08-diagnostic-framework.md) | L | after Epic 2's promotions |
+| 9 | [Heatmap residuals: Handlers + framework-consumed](09-heatmap-residuals.md) | S–M | interlocks with 8 (PL006) |
+| 10 | [Mojo polish: routes, stash, hooks, chains](10-mojo-polish.md) | L | — |
+| 11 | [CLI analysis subcommands + --migrate](11-cli-analysis-and-migrate.md) | L | 8/9 for the two lint aliases |
+| 12 | [Program boundaries + MAIN-1](12-program-boundaries.md) | M | brands-half waits on 3 |
+
+## Coverage map — every `docs/prompt-*.md` and open design item
+
+The rule: every forward-design doc is either (a) scheduled in an epic,
+(b) parked with a named unblock condition, (c) landed with only parked
+residuals, or (d) explicitly out of scope. Nothing is unaccounted for.
+
+| Doc / item | Disposition |
+|---|---|
+| `prompt-dbic-as-plugin.md` | **Epic 1** (phases 1–2 landed) |
+| `prompt-graph-walking.md` — Scope nodes / Openness | **Epic 2** |
+| `prompt-graph-walking.md` — instance brands | **Parked**: unblocks after Epic 3 + constructor/field flow (queued); rebuild ONLY per its birth-site rule, never the syntactic spike |
+| `prompt-type-inference-residual.md` Parts 1, 2, 5a | **Epic 3** |
+| `prompt-type-inference-residual.md` Parts 3, 4 | Queued after Epic 3 (same engine, QA pulls decide) |
+| `prompt-type-inference-residual.md` Part 5c residuals (prefetch, `join =>` keys) | Queued; natural follow-on to Epic 1 |
+| `prompt-type-inference-residual.md` Part 7 (Rhai reducers) | **Parked**: wants a second concrete consumer beyond route aggregation |
+| `prompt-magic-tokens.md` | **Epic 4** (phases A–B) |
+| `prompt-cst-migration.md` items 1–5, 7 | **Epic 4** (phases C–G); item 6 is a standing strangler rule, not schedulable |
+| `qa-design-items.md` §H1 | **Epic 5** |
+| `qa-design-items.md` §MAIN-1 | **Epic 12** (phase C) |
+| `qa-design-items.md` §MooseX::Role::Parameterized | **Parked**: it is the runtime-export-generator open problem (`open-problems.md`) wearing role clothes; no static answer without a probe/eval tier |
+| `prompt-enrichment-inheritance-residual.md` | **Epic 6** |
+| `prompt-ref-provenance.md` | **Epic 7** |
+| `prompt-cli-tools.md` — diagnostic framework | **Epic 8** |
+| `prompt-config-schema.md` | **Epic 8** (its named forcing function) |
+| `prompt-heatmap.md` residuals | **Epic 9** (SARIF piece rides Epic 8) |
+| `prompt-mojo-todo.md` | **Epic 10** |
+| `prompt-cli-tools.md` — analysis subcommands + `--migrate` | **Epic 11** |
+| `prompt-entrypoint-analysis.md` | **Epic 12** (brands-half stays parked) |
+| `prompt-helper-consumption.md` | Phases 1–2 landed; phase 3 (per-app surfaces) **parked** with instance brands |
+| `prompt-long-distance.md` | Landed (epic record); open-world caller gather **parked** on Epic 2's openness/unresolved bucket giving an enumerability witness |
+| `prompt-method-resolution-residuals.md` | §§1–3 landed; §3's probe-based plugin generation **parked** (needs a runtime-probe design); §4 rides Epic 3's tier |
+| `prompt-flow-narrowing.md` | Landed; residuals deliberately parked in-doc (accessor places, Option B knob, negation) |
+| `prompt-optional-types.md` | Landed incl. production gaps |
+| `prompt-sequence-types.md` | **Parked — QA pulls** (its own status header; phases additive, no do-now tax) |
+| `prompt-type-is-the-gate.md` | **Parked**: waits for the next motivating strict-eq gate; Epic 1's emission work is the likeliest place it surfaces — implementers there should re-read it |
+| `prompt-type-system-encoding.md` | **Parked**: Epic 1 decides the manifest-vs-axis question at the boundary; revisit only if the manifest route fails |
+| `prompt-type-system-futures.md` | Pillar 1 (narrowing) LANDED (`adr/flow-narrowing.md`); pillar 2 (effects/throws) aspirational, **out of the QA loop by its own charter** |
+| `prompt-wasm-web-extension.md` | **Parked**: crate split was executed and REJECTED (layering tests enforce the DAG instead); `workspace-split` branch is the playbook if wasm demand materializes |
+| `open-problems.md` — untyped param/hash-element boundary | Hard boundary; Epic 3 + the queued constructor/field flow are the approach vector; stays listed there |
+| `open-problems.md` — qualified-name suppression | **Epic 2** phase C |
+| `open-problems.md` — runtime export generators | Hard boundary; stays; MooseX::R::P and Sub::Exporter ride it |
+| Re-export chains (ROADMAP parked) | **Parked** on the ts-parser-perl X1 scanner thread-safety fix |
+| Multi-language engine (ROADMAP backburner) | **Parked** on branch `worktree-query-extraction-spike` |
+
+## House rules for implementers (apply to every epic)
+
+- Read `CLAUDE.md` first; its numbered rules override anything an
+  epic doc accidentally contradicts. When in doubt, the rule wins and
+  the epic doc gets a PR comment.
+- Every epic ends at the same gate: `cargo test` green, gold harness
+  0 FAIL / 0 XPASS (XPASS → promote the row), `./e2e/run.sh` via CI if
+  nvim is absent locally, and — for anything touching inference or
+  diagnostics — the substrate audit diffed against a pre-epic binary
+  with always-on `undef-deref` at exact parity:
+
+  ```
+  perl-lsp --clear-cache gold-corpus/local/lib/perl5
+  perl-lsp --check gold-corpus/local/lib/perl5 --format json --severity hint \
+    --optional-deref --redundant-guard --deref-shape --unresolved-method-cross-file
+  ```
+
+- Bump `EXTRACT_VERSION` whenever FA shape or bag rules change; new
+  Fact families / source tags go into `witnesses::tags`, never inline.
+- One phase = one reviewable commit (or PR); each lands with its
+  negative tests, not just its happy path.
+- Update the owner design doc + this README's coverage map in the
+  same PR that changes a disposition.

--- a/docs/prompt-dbic-as-plugin.md
+++ b/docs/prompt-dbic-as-plugin.md
@@ -23,9 +23,11 @@ synthesis out. Only phase 3 below still touches the axis question.
    moved onto the same registration gate. `load_components` parent
    registration stays core (generic parent machinery). Custom-resultset
    discovery + per-column `data_type` typing are deferred to phase 3.
-2. **Meta-method suppression → manifest.** The DBIC entries in
-   `symbols.rs`' `universal_methods` (comment-flagged debt) become a
-   plugin manifest field; core's diagnostic consults the registry.
+2. **Meta-method suppression → manifest.** ✅ LANDED. The
+   `meta_methods()` manifest field (dbic.rhai + moo.rhai) bakes the
+   registry union into `FileAnalysis.meta_methods`; the
+   unresolved-method diagnostic consults it, and core's
+   `universal_methods` holds only the true UNIVERSAL:: surface.
 3. **Parametric emission + per-method projection** (the tables below)
    — the one genuinely axis-shaped piece. A `parametric_returns`
    manifest field may sidestep full type-system-encoding; decide at

--- a/docs/prompt-method-resolution-residuals.md
+++ b/docs/prompt-method-resolution-residuals.md
@@ -10,31 +10,26 @@ closed. The remaining false positives cluster into four gaps below — most also
 improve completion / hover / goto-def, not just the lint. Until they're closed,
 the cross-file form stays opt-in.
 
-## 1. `monkey_patch`-generated methods → bundled plugin
+## 1. `monkey_patch`-generated methods → bundled plugin — ✅ LANDED
 
-Classes that install methods at load time via a `monkey_patch $class => $name
-=> sub {…}` loop (`Mojo::Util::monkey_patch`, `Sub::Install`,
-`Class::Method::Modifiers`) expose no static `sub` — e.g. `Mojo::UserAgent`'s
-HTTP-verb methods (`get`/`post`/`put`/`delete`/…) are generated this way. But
-the registration call site **is** visible in source. A bundled plugin (or core)
-should recognize `monkey_patch` / `install`-shaped registrations and synthesize
-the named methods, the same way Moo `has` synthesizes accessors. Knowable in
-the engine.
+`frameworks/monkey-patch.rhai` synthesizes the named methods from
+`monkey_patch $class => $name => sub {…}` registrations (string class,
+`__PACKAGE__`, multi-pair calls, and loop registrations via the
+`string_values` fan-out). Dynamic class / unfolded names are honest
+misses. Residual: the `Sub::Install` / `Class::Method::Modifiers` family
+uses a hashref-options shape (`install_sub({ code, into, as })`) — it
+rides the same plugin once `CallContext` classifies hashref args for
+function calls.
 
-## 2. `Sub::HandlesVia` `handles => { … }` delegations → bundled Moo plugin
+## 2. `Sub::HandlesVia` `handles => { … }` delegations → bundled Moo plugin — ✅ LANDED
 
-`has $attr => (handles => { method => [target, @args], … })` (Sub::HandlesVia,
-and the Moo/Moose `handles` family) delegates named methods onto the consuming
-class. These aren't synthesized today — the same shape as Moo accessor
-synthesis but for delegated names.
-
-This is **bundled-plugin** territory, NOT core. The accessor-option vocabulary
-(`predicate`/`clearer`/`writer`/…/`handles`) already lives in the bundled Moo
-plugin (`frameworks/moo.rhai`): core walks the `has` CST into decision-ready
-options (rule #1) and the plugin owns which keyword maps to which synthesized
-method (rule #10). Adding `handles => { … }` delegation is the plugin emitting
-the delegated method names — a per-keyword delegation table baked into core
-would be exactly the rule-#10 violation to avoid.
+The Moo/Moose `handles` family (hashref `local => remote`, arrayref
+`[qw/m/]`) already synthesized; the Sub::HandlesVia curried shape
+(`handles => { local => [remote, @args] }`) now does too — the HashPairs
+classification pair-walks via `cst::pair_nodes`, an arrayref value
+contributes its first string element as the remote, and a non-string
+value no longer shifts alignment of the pairs after it. The vocabulary
+stays in `frameworks/moo.rhai` (rule #10), the CST walk in core (rule #1).
 
 ## 3. Opaque generated / XS classes → scoping + probe-gen
 
@@ -42,11 +37,11 @@ Fully generated API clients (OpenAPI/Swagger codegen), XS classes, and
 Exporter-injected method sets have no statically visible method declarations at
 all — there is nothing in source to read. Two complementary mitigations:
 
-- **WORKSPACE-only scoping for the cross-file lint.** Flag a receiver only when
-  its class is one you wrote (WORKSPACE role); stay silent on pure
-  `@INC`/DEPENDENCY classes, where generated/XS methods you can't see are
-  common. The `RoleMask` already distinguishes these — a principled gate, not
-  whack-a-mole.
+- **WORKSPACE-only scoping for the cross-file lint.** ✅ LANDED — the lint
+  fires only for classes registered from the workspace tree
+  (`ModuleIndex::is_workspace_module`); pure `@INC`/DEPENDENCY classes,
+  where generated/XS methods you can't see are common, stay silent. A
+  principled gate, not whack-a-mole.
 - **Probe-based plugin generation.** Run the generator against a recording
   probe to capture the produced method surface and emit a plugin (see the
   generator-coderef probe direction).

--- a/docs/prompt-optional-types.md
+++ b/docs/prompt-optional-types.md
@@ -1,34 +1,17 @@
 # Optional / Maybe types
 
-**Landed.** Decision record: `docs/adr/optional-types.md`.
+**Landed, including the production gaps.** Decision record:
+`docs/adr/optional-types.md`.
 
-## Residual forward work
-
-### Production gaps
-
-- **Empty-list `return ()` arm.** The ternary form (`$c ? Foo->new : ()`)
-  is handled — `()` (a `stub_expression`) is marked an undef arm in the
-  branch-arm emission, lifting `{T, ()}` to `Optional<T>`. The `return ()`
-  statement form is not yet: the return-arm undef check (`is_undef_arm`)
-  recognizes a bodyless `return;` and `return undef`, but not a
-  `stub_expression` body. Same scalar-context coercion rationale as bare
-  `return;`; extend `is_undef_arm` to cover `stub_expression`.
-- **All-undef returns → `Undef`.** A sub whose every arm is `undef`
-  (`sub f { return undef }`) types `None` today, not the definitive
-  `Undef` — `join_return_arms` sees `arms=[] && has_undef` and falls
-  through. Soundness gate: return `Undef` only when `undef_count ==
-  total_arm_count`, because `arms=[] && has_undef` also covers "a value
-  arm we couldn't type (its edge materialized to nothing → no witness)
-  plus an undef arm", where the sub returns *something*. So it needs a
-  total-arm count the fold doesn't track (untypeable arms leave no
-  trace). Payoff: feeds the method-on-`Undef` (D1) and always-false-guard
-  (D4) diagnostics.
-- **`SlotTypeFold` production** — `{T, undef}` slot writes (`$self->{x} =
-  $maybe`) → `Optional` on the slot.
-- **Bareword Type::Tiny `Maybe[…]` constructor form** — the
-  `TypeConstraintOf` path; the quoted-string `isa => 'Maybe[T]'` form
-  landed, the bareword `isa => Maybe[Int]` form goes through the separate
-  constructor path.
+Production covers: bare `return;` / `return undef` / `return ()` arms
+(each an undef arm; `{T, undef} → Optional<T>`); all-undef subs typing
+the definitive `Undef` (gated on the per-arm `value_arm` Fact count so an
+untypeable value arm or a fallthrough tail blocks the verdict); slot
+writes (`SlotTypeFold` strips undef-ness — a literal `undef` write or an
+`Optional` RHS — into a flag, agrees the value arms, re-lifts); and both
+`isa` spellings (quoted `'Maybe[T]'` and the bareword `Maybe[Int]` /
+`Maybe[InstanceOf['X']]` constructor forms, via `type_optional` and the
+0-arity base constants in `frameworks/type-tiny.rhai`).
 
 ### Consumption
 

--- a/docs/prompt-type-system-futures.md
+++ b/docs/prompt-type-system-futures.md
@@ -10,7 +10,17 @@ the payload rides and **how much control-flow** they need.
 
 ---
 
-## 1. Narrowing (flow-sensitivity) — the "we don't model conditionals" pillar
+## 1. Narrowing (flow-sensitivity) — LANDED
+
+> **Status update (July 2026):** this pillar landed as the
+> flow-narrowing lattice — `docs/adr/flow-narrowing.md` +
+> `docs/adr/optional-types.md` + `docs/adr/narrowing-diagnostics.md`
+> cover guards (`ref…eq` / `isa` / `defined` / `blessed` / truthiness
+> bindings), places, polarity, and the diagnostics built on it. The
+> sketch below is kept as the original framing; only the effects
+> pillar (§2) remains forward work.
+
+### Original framing (historical)
 
 A guard refines a variable's type *within a branch*:
 

--- a/frameworks/dbic.rhai
+++ b/frameworks/dbic.rhai
@@ -40,6 +40,15 @@ fn column_keyed_verbs() {
      "update", "update_or_create", "create", "new", "count", "single"]
 }
 
+// Class-level DSL verbs inherited from DBIx::Class::Core with no visible
+// `sub` anywhere the walker can see — the unresolved-method diagnostic
+// consults this union so `__PACKAGE__->set_primary_key(...)` never flags.
+fn meta_methods() {
+    ["add_columns", "add_column", "set_primary_key", "table",
+     "resultset_class", "has_many", "has_one", "belongs_to", "might_have",
+     "many_to_many", "load_components"]
+}
+
 // Fluent verbs — the call returns the invocant's type UNCHANGED, so they only
 // apply to an actual resultset (`$rs->search` → a same-row resultset). DBIC has
 // no `Class->search`: search/find live on the resultset, which only comes from

--- a/frameworks/monkey-patch.rhai
+++ b/frameworks/monkey-patch.rhai
@@ -1,0 +1,80 @@
+// monkey-patch: load-time method installation. Classes that build their
+// method surface with `Mojo::Util::monkey_patch $class => $name => sub {…}`
+// expose no static `sub NAME` — but the registration call site IS visible
+// in source, so synthesize the named methods the same way Moo `has`
+// synthesizes accessors (docs/prompt-method-resolution-residuals.md §1).
+// Mojo::UserAgent's HTTP verbs are the canonical case.
+//
+// The Sub::Install / Class::Method::Modifiers family is the same capability
+// with a hashref-options shape (`install_sub({ code, into, as })`); it rides
+// this seam once CallContext classifies hashref args for function calls.
+
+fn id() { "monkey-patch" }
+
+fn triggers() {
+    [ #{ UsesModule: "Mojo::Util" } ]
+}
+
+// monkey_patch $class, name => sub {…}, name2 => sub {…};
+fn on_function_call(ctx) {
+    let out = [];
+    if ctx.function_name != "monkey_patch" { return out; }
+    let args = ctx.args;
+    if args.len() < 3 { return out; }
+
+    // Target class: a literal string/bareword, or __PACKAGE__. A runtime
+    // `$class` doesn't fold — honest miss, never a guess.
+    let cls = args[0].string_value;
+    if args[0].text == "__PACKAGE__" { cls = ctx.current_package; }
+    if cls == () { return out; }
+
+    // (name => sub) pairs from arg 1 on. Loop registrations
+    // (`monkey_patch $c, $_, sub {…} for qw(a b)`) fold the topic's
+    // candidates into `string_values` — fan out over them.
+    let i = 1;
+    while i + 1 < args.len() {
+        let name_arg = args[i];
+        let code_arg = args[i + 1];
+        i += 2;
+
+        let names = name_arg.string_values;
+        if names == () { names = []; }
+        if names.len() == 0 {
+            let single = name_arg.string_value;
+            if single == () { continue; }
+            names = [single];
+        }
+
+        let name_span = name_arg.content_span;
+        if name_span == () { name_span = name_arg.span; }
+        // Installed subs are invoked as methods; their first positional
+        // is the receiver — flag it so display drops it at call sites.
+        let params = as_invocant_params(code_arg.sub_params);
+        if params == () { params = []; }
+
+        for name in names {
+            // Unfolded dynamics (`lc $name`, interpolations) are honest
+            // misses, not methods named "$_".
+            if name.contains("$") { continue; }
+            out += #{
+                Method: #{
+                    name: name,
+                    span: name_span,
+                    selection_span: name_span,
+                    params: params,
+                    is_method: true,
+                    return_type: (),
+                    doc: (),
+                    on_class: cls,
+                    display: (),
+                    hide_in_outline: false,
+                    opaque_return: false,
+                    outline_label: (),
+                    return_via_edge: code_arg.callable_return_edge,
+                    attr: (),
+                }
+            };
+        }
+    }
+    out
+}

--- a/frameworks/moo.rhai
+++ b/frameworks/moo.rhai
@@ -44,6 +44,14 @@ fn arg_name_verbs() {
     ["has", "option"]
 }
 
+// Meta-methods the object system installs on every consuming class with no
+// visible `sub`: the MOP handle (`->meta`) and Moose's lowercase `does`
+// (alongside UNIVERSAL's uppercase DOES). Consulted by the
+// unresolved-method diagnostic's suppression list.
+fn meta_methods() {
+    ["meta", "does"]
+}
+
 fn triggers() {
     [
         #{ UsesModule: "Moo" },

--- a/frameworks/type-tiny.rhai
+++ b/frameworks/type-tiny.rhai
@@ -10,9 +10,12 @@
 // list; arity lives here.
 //
 // Scope: the "first string param is a class" shape — InstanceOf and its role
-// twin ConsumerOf — plus `Maybe[T]`, a passthrough wrapper whose param is
-// itself a constructor. That unlocks `$self->attr->method` chains where attr
-// is `isa => InstanceOf['X']` or `isa => Maybe[InstanceOf['X']]`.
+// twin ConsumerOf — plus `Maybe[T]`, whose value is undef-or-T
+// (`Optional<T>`), plus the 0-arity base constants (`isa => Int`,
+// `Maybe[Str]`) folding to their rep. That unlocks `$self->attr->method`
+// chains where attr is `isa => InstanceOf['X']` or `Maybe[InstanceOf['X']]`
+// (optional receivers dispatch leniently), and feeds the optional-deref
+// diagnostics the honest maybe-undef type.
 //
 // Import scoping (docs/prompt-type-constraint-types.md §"Future: registration
 // moves to the injection level"): when a package does `use Types::Standard
@@ -27,21 +30,48 @@ fn id() { "type-tiny" }
 // Manifest hooks are global (consulted by name), so triggers are irrelevant.
 fn triggers() { [] }
 
-// Cheap dispatch gate: which call names are constraint constructors.
-fn type_constraint_names() { ["InstanceOf", "ConsumerOf", "Maybe"] }
+// Cheap dispatch gate: which call names are constraint constructors. The
+// base constants are constraint VALUES too (`isa => Int` is a Type::Tiny
+// object, same as `InstanceOf['X']`); only the unambiguous reps are listed
+// — names likelier to collide with user subs (Value, Item, Any, Object,
+// Bool, Map…) stay out, since this gate fires on bare NAME, not import.
+fn type_constraint_names() {
+    ["InstanceOf", "ConsumerOf", "Maybe",
+     "Str", "Int", "Num", "LaxNum", "StrictNum",
+     "ArrayRef", "HashRef", "CodeRef", "RegexpRef", "Undef"]
+}
+
+// The rep a 0-arity base constant constrains to; () for names we can't
+// express. Parameterized containers (`ArrayRef[Int]`) fold to their base
+// rep — the element type has no InferredType slot to ride.
+fn base_constant_type(name) {
+    if name == "Str" { return type_string(); }
+    if name == "Int" || name == "Num" || name == "LaxNum" || name == "StrictNum" {
+        return type_numeric();
+    }
+    if name == "ArrayRef" { return type_arrayref(); }
+    if name == "HashRef" { return type_hashref(); }
+    if name == "CodeRef" { return type_coderef(); }
+    if name == "RegexpRef" { return type_regexp(); }
+    if name == "Undef" { return type_undef(); }
+    ()
+}
 
 // Fold the constructor's params into the constrained INNER type, or () to
 // decline. `params` is a list of #{ string, ty }. Arity is ours to handle.
 fn type_constraint_inner(name, params) {
-    if params.is_empty() { return (); }
     if name == "Maybe" {
-        // `Maybe[T]` permits undef OR a T; for resolution purposes the
-        // constrained value (when present) is whatever T constrains to. The
-        // single param is a nested constructor the core typed
-        // `TypeConstraintOf(T)`; pass through to T's inner. (Optionalness
-        // itself isn't modeled — see docs/adr/type-constraints.md.)
-        return constrained_inner(params[0].ty);
+        // `Maybe[T]` permits undef OR a T — the honest `Optional<T>`.
+        // The single param is a nested constructor the core typed
+        // `TypeConstraintOf(T)`; project T's inner, lift to Optional.
+        if params.is_empty() { return (); }
+        let inner = constrained_inner(params[0].ty);
+        if inner == () { return (); }
+        return type_optional(inner);
     }
+    let base = base_constant_type(name);
+    if base != () { return base; }
+    if params.is_empty() { return (); }
     // InstanceOf['Foo'] / ConsumerOf['Role'] — first string param is the class.
     let cls = params[0].string;
     if cls == () { return (); }

--- a/frameworks/type-tiny.rhai
+++ b/frameworks/type-tiny.rhai
@@ -17,8 +17,9 @@
 // (optional receivers dispatch leniently), and feeds the optional-deref
 // diagnostics the honest maybe-undef type.
 //
-// Import scoping (docs/prompt-type-constraint-types.md §"Future: registration
-// moves to the injection level"): when a package does `use Types::Standard
+// Import scoping (design: docs/adr/type-constraints.md; the package-scoped
+// gate + check-guards are docs/epics/13-type-tiny-completeness.md): when a
+// package does `use Types::Standard
 // qw/Str Int/`, those names become known via an Import action — suppressing
 // unresolved-function diagnostics for explicitly imported type constants.
 // `-all` / `:all` / bare use → full vocab emitted.  `Clove::Types` and

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -172,15 +172,17 @@ query-time seam, not the build-time `return_types` map. **Subsystem:** build-tim
 `return_types` seed vs query-time cross-file method-return composition.
 **Difficulty:** medium–high.
 
-### `diag-mojo-cookiejar-helper-fp` / `diag-mojo-daemon-callback-fp` — first-param-self over-reach in OO classes
-In an OO class, a plain helper (`sub _compare { my ($cookie,…)=@_ }`) or an
-anonymous callback (`on(request => sub { my $tx = shift; … })` ) has its first
-param typed as the enclosing class, so a method call on it (`$cookie->path`,
-`$tx->req`) fires a false `unresolved-method`. The `-strict` (non-OO module) case
-of this is now fixed; the in-OO-class helper/callback case is the harder residual —
-there's no clean static signal distinguishing a method from a helper in an OO
-class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
-**Difficulty:** high (inherently ambiguous).
+### `diag-mojo-cookiejar-helper-fp` — first-param-self over-reach in OO classes
+In an OO class, a plain helper (`sub _compare { my ($cookie,…)=@_ }`) has its
+first param typed as the enclosing class, so a method call on it
+(`$cookie->path`) fires a false `unresolved-method`. The `-strict` (non-OO
+module) case is fixed, and the anonymous-callback case
+(`diag-mojo-daemon-callback-fp`, `on(request => sub { my $tx = shift; … })`)
+was promoted to gold — the shift gate keeps first-param-self out of anon subs
+(a callback's first arg is a payload, not a receiver). The named in-OO-class
+helper is the residual — there's no clean static signal distinguishing a
+method from a helper in an OO class. **Subsystem:** first-param-self heuristic
+(`detect_first_param_type`). **Difficulty:** high (inherently ambiguous).
 
 ---
 
@@ -195,7 +197,7 @@ class. **Subsystem:** first-param-self heuristic (`detect_first_param_type`).
 | def-16-codegen-type-function | Type::Library synthesis | medium |
 | completion-datetime-hashkey | slot-write harvest (A4 tail) | medium–high |
 | mojo-url clone *sub-return* (variable is fixed) | build-time `return_types` seed vs query-time cross-file method-return | medium–high |
-| diag-mojo-cookiejar/daemon first-param-self | invocant heuristic in OO class | **high** (ambiguous) |
+| diag-mojo-cookiejar first-param-self (named helper) | invocant heuristic in OO class | **high** (ambiguous) |
 
 Quickest wins: the signature-help invocant gate, imported-names in completion,
 the `bootstrap` loader recognition, and the `(shift, shift)` param extraction —

--- a/gold-corpus/fixtures/diagnostics.json
+++ b/gold-corpus/fixtures/diagnostics.json
@@ -140,8 +140,8 @@
           "\"file\":\"Daemon.pm\",\"line\":\"92\""
         ]
       },
-      "status": "xfail",
-      "note": "GAP: `on(request => sub { my $tx = shift; $tx->req })` — $tx is a transaction, but first-param-self leaks into the anonymous callback and types it as the Daemon. Unfixed."
+      "status": "gold",
+      "note": "`on(request => sub { my $tx = shift; $tx->req })` — an anonymous callback's first shift is a payload, not the invocant; the shift gate keeps first-param-self out of anon subs."
     }
   ]
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -291,6 +291,7 @@ fn build_with_plugins_inner(
         lite_brand: vec![None],
         topic_dsls,
         reassigned_scalars: std::collections::HashSet::new(),
+        scalar_reassign_writes: Vec::new(),
         key_writes: Vec::new(),
         method_call_arity: std::collections::HashMap::new(),
         parametric_emitted_refs: std::collections::HashSet::new(),
@@ -813,6 +814,51 @@ impl<'a> Builder<'a> {
                 source: WitnessSource::Builder("implicit_return".into()),
                 payload: WitnessPayload::Edge(WitnessAttachment::Expr(expr_span)),
                 span: sym_span,
+            });
+        }
+
+        // Reassignment barriers. Each whole-scalar write becomes a
+        // `reassign_barrier` Fact on the attachment the variable's
+        // standing beliefs live on (first scope up the chain with
+        // Variable witnesses — the same probe the mutation-extension
+        // pass uses). The temporal fold then drops beliefs older than
+        // the latest barrier before the query point: a write whose RHS
+        // typed pushes its own TC at the same position (>= keeps it);
+        // a write we couldn't type leaves only the barrier, widening
+        // to unknown instead of resurrecting the stale belief.
+        // The write's own chain-typing edge is scope-keyed at the WRITE's
+        // scope, while the belief to erase may live scopes up (a decl in
+        // the sub body, the write in a loop block). Barrier every chain
+        // scope that holds witnesses — the read-side walk answers from
+        // whichever attachment it reaches first, so each needs its own
+        // boundary.
+        let barrier_pushes: Vec<(String, ScopeId, Span)> = self
+            .scalar_reassign_writes
+            .iter()
+            .flat_map(|(name, scope, span)| {
+                crate::file_analysis::scope_chain_of(&self.scopes, *scope)
+                    .into_iter()
+                    .filter(|sid| {
+                        let att = WitnessAttachment::Variable {
+                            name: name.clone(),
+                            scope: *sid,
+                        };
+                        !self.bag.for_attachment(&att).is_empty()
+                    })
+                    .map(|sid| (name.clone(), sid, *span))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        for (name, scope, span) in barrier_pushes {
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::Variable { name, scope },
+                source: WitnessSource::Builder("reassign_barrier".into()),
+                payload: WitnessPayload::Fact {
+                    family: "reassign_barrier".into(),
+                    key: String::new(),
+                    value: FactValue::Bool(true),
+                },
+                span,
             });
         }
 
@@ -1607,6 +1653,14 @@ struct Builder<'a> {
     /// variable itself; element writes go to `key_writes` instead).
     /// Flushed into `FileAnalysis.reassigned_scalars`.
     reassigned_scalars: std::collections::HashSet<String>,
+    /// Every whole-scalar reassignment site (name, scope at the write,
+    /// write span). `populate_witness_bag` turns each into a
+    /// `reassign_barrier` Fact on the variable's belief attachment: a
+    /// write is a belief boundary, so a stale type must not survive an
+    /// assignment whose RHS we couldn't type (`my $ct = undef;
+    /// while (…) { $ct = f($_); } … defined $ct` — the loop write is
+    /// invisible to the outer temporal fold without the barrier).
+    scalar_reassign_writes: Vec<(String, ScopeId, Span)>,
 
     /// `$var->{key} = …` writes in walk order — input to the
     /// mutation-extension pass (shape extension / open-widening).
@@ -2506,7 +2560,7 @@ impl<'a> Builder<'a> {
             // post-walk correctness; same reason as the `$self`
             // case above.
             "func1op_call_expression" if self.is_shift_call(node) => {
-                if !self.shift_is_invocant_here(node) {
+                if !self.shift_is_invocant_here(node) || !self.shift_denotes_invocant(node) {
                     return None;
                 }
                 self.package_for_node(node).map(InferredType::ClassName)
@@ -2571,6 +2625,9 @@ impl<'a> Builder<'a> {
             }
             "function_call_expression" | "ambiguous_function_call_expression" => {
                 if self.is_shift_call(node) {
+                    if !self.shift_denotes_invocant(node) {
+                        return None;
+                    }
                     return self.package_for_node(node).map(InferredType::ClassName);
                 }
                 let func = node.child_by_field_name("function")?;
@@ -4551,6 +4608,74 @@ impl<'a> Builder<'a> {
         self.get_var_text_from_lhs(left)
     }
 
+    /// Does this `shift` denote the sub's INVOCANT (and so type as the
+    /// enclosing class)? Expression position (`shift->method`, `bless {},
+    /// shift`) always does — it reads arg 0 directly. A declaration
+    /// binding (`my $x = shift`) does only when `$x` is the receiver:
+    /// a conventional invocant name, or the sub's extracted invocant
+    /// param. `my $uri = shift;` — the SECOND shift — is a plain
+    /// argument read; typing it as the class was the audit's
+    /// `defined $value`-guard false-positive maker.
+    fn shift_denotes_invocant(&self, node: Node<'a>) -> bool {
+        // Climb to the binding assignment, stopping at the statement
+        // boundary (no binding → expression position → invocant).
+        let mut cur = node;
+        let assign = loop {
+            let Some(p) = cur.parent() else { return true };
+            match p.kind() {
+                "assignment_expression" => break p,
+                "expression_statement" | "block" => return true,
+                _ => cur = p,
+            }
+        };
+        // The shift must sit on the RHS; a shift inside the LHS (odd,
+        // but cheap to guard) is not a binding of it.
+        let Some(left) = assign.child_by_field_name("left") else { return true };
+        let Some(var) = self.get_var_text_from_lhs(left) else { return true };
+        if crate::conventions::is_conventional_invocant_name(&var) {
+            return true;
+        }
+        // The sub's extracted param list knows which param is the
+        // invocant (params[0] for methods; params[1] under `around`).
+        // Scope-derived (not the live walk stack) so the post-walk
+        // chain-typing callers resolve identically.
+        let scope = self.scope_at_point(node.start_position());
+        let sub_scope_name = crate::file_analysis::scope_chain_of(&self.scopes, scope)
+            .into_iter()
+            .find_map(|sid| match &self.scopes[sid.0 as usize].kind {
+                ScopeKind::Sub { name } | ScopeKind::Method { name } => {
+                    Some((sid, name.clone()))
+                }
+                _ => None,
+            })
+            // An anonymous sub's first arg is a callback payload, not a
+            // receiver — the audit's `Maybe`-checker false-positive shape
+            // (`sub { my $value = shift; return if !defined($value) }`).
+            // Only a conventional name (handled above) types there.
+            .filter(|(_, name)| name != "(anon)");
+        let invocant_param = sub_scope_name
+            .and_then(|(sid, name)| self.find_sub_symbol_for(&name, sid))
+            .and_then(|sid| self.symbols.iter().find(|s| s.id == sid))
+            .and_then(|sym| match &sym.detail {
+                // The marked invocant when extraction decided one, else
+                // the FIRST positional — in a named sub of an OO-by-
+                // convention package that slot IS the receiver regardless
+                // of its name (`my $x = shift` in a Mojo class).
+                // Anonymous subs never reach here (no named Sub scope):
+                // their first arg is a callback payload, not a receiver,
+                // so they stay on the conventional-name rule above —
+                // that's the audit's `Maybe`-checker false-positive shape
+                // (`sub { my $value = shift; return if !defined $value }`).
+                SymbolDetail::Sub { params, .. } => params
+                    .iter()
+                    .find(|p| p.is_invocant)
+                    .or(params.first())
+                    .map(|p| p.name.clone()),
+                _ => None,
+            });
+        invocant_param.as_deref() == Some(var.as_str())
+    }
+
     /// Check if a node is a `shift` call (bare or with parens).
     fn is_shift_call(&self, node: Node<'a>) -> bool {
         match node.kind() {
@@ -6396,7 +6521,34 @@ impl<'a> Builder<'a> {
                 // ternaries; Edge payloads resolve through the
                 // registry's materialization.
                 self.emit_expr_witness(right);
-                let mut inferred = self.bag_query_expr_span(node_to_span(right));
+                // A postfix-conditional write (`$isbn = undef if …`) may not
+                // happen — an unconditional belief from it is wrong on both
+                // axes: conditionality (the honest post-statement type is
+                // old-or-new — widen, don't assert) and position (the TC
+                // anchors at statement start, so a deref inside the guard
+                // condition itself would read the not-yet-happened write;
+                // `$isbn = undef if $isbn && !$isbn->is_valid` fed D1 a
+                // false "is undef" for the `->is_valid` call). Skip the
+                // belief; the write's reassign barrier still lands, which
+                // IS the widening.
+                let conditional_write = {
+                    let mut cur = node;
+                    loop {
+                        match cur.parent() {
+                            Some(p) if p.kind() == "postfix_conditional_expression" => {
+                                break true
+                            }
+                            Some(p) if p.kind() == "expression_statement" => break false,
+                            Some(p) => cur = p,
+                            None => break false,
+                        }
+                    }
+                };
+                let mut inferred = if conditional_write {
+                    None
+                } else {
+                    self.bag_query_expr_span(node_to_span(right))
+                };
                 // `my %h = (k => v, …)` — the list IS a hash literal in
                 // this position, the hashref's second spelling. The
                 // list's own Expr witness can't carry that (its meaning
@@ -6418,14 +6570,17 @@ impl<'a> Builder<'a> {
                             inferred_type: it,
                         });
                     }
-                } else if let Some(vt) = self.get_var_text_from_lhs(left) {
+                } else if let Some(vt) =
+                    (!conditional_write).then(|| self.get_var_text_from_lhs(left)).flatten()
+                {
                     // RHS didn't resolve at build time — typically a cross-file
                     // method chain whose type needs the module index, absent
                     // during the parallel per-file workspace build. Don't drop
                     // it to a dead end: link the variable to the RHS expr as an
                     // EDGE so a query that carries the index chases it lazily
                     // ("Edges, not values"). In-file chains never reach here —
-                    // they resolved above and materialized.
+                    // they resolved above and materialized. (Conditional writes
+                    // skip the edge for the same reason they skip the TC.)
                     use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
                     let scope = self.current_scope();
                     let rhs_span = node_to_span(right);
@@ -7556,6 +7711,35 @@ impl<'a> Builder<'a> {
                 && !crate::cst::is_element_access_base(node)
             {
                 self.reassigned_scalars.insert(text.to_string());
+                // Barrier position is the enclosing STATEMENT's start, so
+                // the same statement's own TC (whose constraint_span also
+                // starts at/inside the statement) survives the fold's
+                // `>= barrier` rule while earlier statements' beliefs
+                // don't. Two exclusions:
+                // - a DECLARATION (`my $x = …`) is the first binding, not
+                //   a belief-erasing reassignment — and its barrier would
+                //   wrongly kill the sub-spanning `FirstParam` TC of
+                //   `my $self = shift`;
+                // - no expression_statement ancestor (a foreach header
+                //   var): loop-var typing spans the whole loop and isn't
+                //   a reassignment of a prior belief.
+                if text.starts_with('$') {
+                    let mut stmt = node;
+                    while let Some(p) = stmt.parent() {
+                        match p.kind() {
+                            "variable_declaration" => break,
+                            "expression_statement" => {
+                                self.scalar_reassign_writes.push((
+                                    text.to_string(),
+                                    self.current_scope(),
+                                    node_to_span(p),
+                                ));
+                                break;
+                            }
+                            _ => stmt = p,
+                        }
+                    }
+                }
             }
             // Hash variables escape only by reference-taking (`\%h`):
             // a bare `%h` in a call or list FLATTENS TO COPIES — the

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -562,6 +562,7 @@ fn build_with_plugins_inner(
         dynamic_dispatch_sites: b.dynamic_dispatch_sites,
         role_packages: b.role_packages,
         column_keyed_verbs: b.plugins.column_keyed_verbs().map(|s| s.to_string()).collect(),
+        meta_methods: b.plugins.meta_methods().map(|s| s.to_string()).collect(),
         plugin_loads: b.plugin_loads,
         loader_config_params: b.loader_config_params,
     });

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -229,6 +229,7 @@ fn build_with_plugins_inner(
         return_infos: Vec::new(),
         pending_array_pushes: Vec::new(),
         last_expr_span: std::collections::HashMap::new(),
+        last_expr_is_return: std::collections::HashMap::new(),
         slot_write_rhs_span: std::collections::HashMap::new(),
         call_bindings: Vec::new(),
         method_call_bindings: Vec::new(),
@@ -648,7 +649,8 @@ impl<'a> Builder<'a> {
     /// inside the worklist, once `invocant_class` is filled.
     fn populate_witness_bag(&mut self) {
         use crate::witnesses::{
-            TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
+            FactValue, TypeObservation, Witness, WitnessAttachment, WitnessPayload,
+            WitnessSource,
         };
 
         // Rep observations from `$v->{k}` access. Method-call return
@@ -782,6 +784,42 @@ impl<'a> Builder<'a> {
                 source: WitnessSource::Builder("implicit_return".into()),
                 payload: WitnessPayload::Edge(WitnessAttachment::Expr(expr_span)),
                 span: sym_span,
+            });
+        }
+
+        // Fallthrough tails are value arms. A sub with explicit returns
+        // can still fall off its final statement (`return undef if $x;
+        // compute()`), and that tail never passes through
+        // `publish_return_arm_witnesses`. Count it so the all-undef gate
+        // in `SymbolReturnArmFold` types a sub `Undef` only when every
+        // way out is provably undef. Conservative by construction: a
+        // stale `last_expr_span` (sub ends in a block statement) still
+        // counts as a value arm — under-claiming `Undef`, never lying.
+        let mut tail_value_arms: Vec<(SymbolId, Span)> = Vec::new();
+        for scope in &self.scopes {
+            if !matches!(scope.kind, ScopeKind::Sub { .. } | ScopeKind::Method { .. }) {
+                continue;
+            }
+            if !self.return_infos.iter().any(|ri| ri.scope == scope.id) {
+                continue;
+            }
+            let Some(span) = self.last_expr_span.get(&scope.id).copied() else { continue };
+            if self.last_expr_is_return.get(&scope.id).copied().unwrap_or(false) {
+                continue;
+            }
+            let Some(sym_id) = self.find_sub_symbol_for_scope(scope.id) else { continue };
+            tail_value_arms.push((sym_id, span));
+        }
+        for (sym_id, span) in tail_value_arms {
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
+                source: WitnessSource::Builder("value_arm".into()),
+                payload: WitnessPayload::Fact {
+                    family: "value_arm".into(),
+                    key: String::new(),
+                    value: FactValue::Bool(true),
+                },
+                span,
             });
         }
     }
@@ -1307,6 +1345,12 @@ struct Builder<'a> {
     /// Types ride the bag; this map only carries the structural
     /// pointer to the source span.
     last_expr_span: std::collections::HashMap<ScopeId, Span>,
+    /// Whether the scope's last top-level statement IS a `return` —
+    /// distinguishes "the tail is one of the explicit return arms" from
+    /// "the tail is a fallthrough value expression" (`return undef if $x;
+    /// compute()`). The all-undef-arms gate needs the distinction: a
+    /// fallthrough tail is a value arm the per-`return` walk never sees.
+    last_expr_is_return: std::collections::HashMap<ScopeId, bool>,
     /// For each `$obj->{k} = <rhs>` hash-key WRITE, maps the key node's
     /// span (the span the matching `HashKeyAccess` Write ref carries) to
     /// the RHS expression's span. `populate_witness_bag`'s mutation loop
@@ -3651,6 +3695,8 @@ impl<'a> Builder<'a> {
                             // payload doesn't bake to a witness shape.
                             self.emit_expr_witness(child);
                             self.last_expr_span.insert(scope, node_to_span(child));
+                            self.last_expr_is_return
+                                .insert(scope, child.kind() == "return_expression");
                         }
                     }
                 }
@@ -6747,6 +6793,11 @@ impl<'a> Builder<'a> {
                 Some(WitnessPayload::InferredType(InferredType::String))
             }
             "number" => Some(WitnessPayload::InferredType(InferredType::Numeric)),
+            // A literal `undef` is the definitive bottom — closed under
+            // syntax. Makes undef WRITES visible: `$self->{x} = undef` seeds
+            // a `SlotType` arm the fold lifts to `Optional<T>`, and
+            // `my $x = undef` feeds the undef-deref diagnostic.
+            "undef_expression" => Some(WitnessPayload::InferredType(InferredType::Undef)),
             "anonymous_hash_expression" => {
                 Some(WitnessPayload::InferredType(self.hash_literal_type(node)))
             }
@@ -7127,13 +7178,14 @@ impl<'a> Builder<'a> {
         let Some(sub_name) = self.enclosing_sub_name() else { return };
         let Some(sym_id) = self.find_sub_symbol_for(&sub_name, scope) else { return };
 
-        // A bare `return;` and `return undef` are undef arms — the sub's
-        // value is optional. Neither has an rvalue type to ride an `Expr`
-        // edge, so mark the arm with a Fact the fold counts; the arm join
-        // lifts `{T, undef}` to `Optional<T>`.
+        // A bare `return;`, `return undef`, and `return ()` (a
+        // `stub_expression`, which coerces to undef in scalar context) are
+        // undef arms — the sub's value is optional. None has an rvalue type
+        // to ride an `Expr` edge, so mark the arm with a Fact the fold
+        // counts; the arm join lifts `{T, undef}` to `Optional<T>`.
         let is_undef_arm = match body {
             None => true,
-            Some(b) => b.kind() == "undef_expression",
+            Some(b) => matches!(b.kind(), "undef_expression" | "stub_expression"),
         };
         if is_undef_arm {
             self.bag.push(Witness {
@@ -7152,6 +7204,20 @@ impl<'a> Builder<'a> {
                 attachment: WitnessAttachment::SymbolReturnArm(sym_id),
                 source: WitnessSource::Builder("return_arm".into()),
                 payload: WitnessPayload::Edge(WitnessAttachment::Expr(arm_span)),
+                span: arm_span,
+            });
+            // Every value arm is also counted with a Fact: an Edge whose
+            // target never materializes leaves no trace in the fold, and
+            // the all-undef gate (`{undef arms only} → Undef`) must not
+            // fire when an untypeable value arm exists.
+            self.bag.push(Witness {
+                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
+                source: WitnessSource::Builder("value_arm".into()),
+                payload: WitnessPayload::Fact {
+                    family: "value_arm".into(),
+                    key: String::new(),
+                    value: FactValue::Bool(true),
+                },
                 span: arm_span,
             });
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9918,13 +9918,24 @@ impl<'a> Builder<'a> {
                 plugin::ValueShape::Str(node.utf8_text(self.source).unwrap_or("").to_string())
             }
             "anonymous_hash_expression" => {
-                let mut tokens: Vec<String> = Vec::new();
-                self.collect_hash_tokens(node, &mut tokens);
+                // Pair-walk (cst::pair_nodes — separator-agnostic, position
+                // keeps alignment even when a value isn't a string). An
+                // arrayref VALUE contributes its first string element: the
+                // Sub::HandlesVia curried-delegation shape
+                // (`local => [remote, @args]`) names its remote there.
                 let mut pairs = Vec::new();
-                let mut i = 0;
-                while i + 1 < tokens.len() {
-                    pairs.push((tokens[i].clone(), tokens[i + 1].clone()));
-                    i += 2;
+                for (k, v) in crate::cst::pair_nodes(node) {
+                    let Some(key) = self.extract_node_string(k) else { continue };
+                    let val = self.extract_node_string(v).or_else(|| {
+                        if v.kind() == "anonymous_array_expression" {
+                            self.extract_string_list(v).into_iter().next().map(|(s, _)| s)
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(val) = val {
+                        pairs.push((key, val));
+                    }
                 }
                 plugin::ValueShape::HashPairs(pairs)
             }
@@ -9943,55 +9954,6 @@ impl<'a> Builder<'a> {
             "bareword" | "autoquoted_bareword" => node.utf8_text(self.source).ok().map(|s| s.to_string()),
             "string_literal" | "interpolated_string_literal" => self.extract_string_content(node),
             _ => None,
-        }
-    }
-
-    /// Flatten a fat-comma hash node into alternating key/value strings,
-    /// recursing into tree-sitter-perl's right-associative nested
-    /// `list_expression` wrappers.
-    fn collect_hash_tokens(&self, node: Node<'_>, out: &mut Vec<String>) {
-        match node.kind() {
-            "anonymous_hash_expression" => {
-                for i in 0..node.child_count() {
-                    if let Some(child) = node.child(i) {
-                        if matches!(child.kind(), "list_expression" | "parenthesized_expression") {
-                            self.collect_hash_tokens(child, out);
-                            return;
-                        }
-                    }
-                }
-                self.collect_hash_tokens_flat(node, out);
-            }
-            "list_expression" | "parenthesized_expression" => {
-                self.collect_hash_tokens_flat(node, out);
-            }
-            _ => {
-                if let Some(s) = self.extract_node_string(node) {
-                    out.push(s);
-                }
-            }
-        }
-    }
-
-    fn collect_hash_tokens_flat(&self, node: Node<'_>, out: &mut Vec<String>) {
-        let count = node.child_count();
-        let mut i = 0;
-        while i < count {
-            if let Some(child) = node.child(i) {
-                match child.kind() {
-                    "=>" | "," => {}
-                    "list_expression" | "parenthesized_expression" => {
-                        self.collect_hash_tokens_flat(child, out);
-                    }
-                    _ if child.is_named() => {
-                        if let Some(s) = self.extract_node_string(child) {
-                            out.push(s);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            i += 1;
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -697,7 +697,22 @@ impl<'a> Builder<'a> {
                 let resolved_owner = match owner {
                     Some(o @ (HashKeyOwner::Class(_) | HashKeyOwner::Sub { .. })) => Some(o.clone()),
                     _ => {
-                        if var_text == "$self" {
+                        // A conventional receiver spelling ($self/$class, the
+                        // positional `$_[0]`, `__PACKAGE__`) writes to the
+                        // enclosing class's slot. Classified by conventions.rs
+                        // — never by raw string compare — so `$_[0]->{k} =
+                        // $_[1]` setters count as writes too (the opaque-write
+                        // gate depends on seeing them).
+                        use crate::conventions::InvocantText;
+                        let is_receiver = match InvocantText::parse(var_text) {
+                            InvocantText::Scalar(name) => {
+                                crate::conventions::is_conventional_invocant_name(name)
+                            }
+                            InvocantText::PositionalReceiver
+                            | InvocantText::CurrentPackage => true,
+                            _ => false,
+                        };
+                        if is_receiver {
                             let scope = &self.scopes[r.scope.0 as usize];
                             scope.package.clone().map(HashKeyOwner::Class)
                         } else {
@@ -733,11 +748,24 @@ impl<'a> Builder<'a> {
             });
         }
         for (class, key, span, rhs_span) in slot_writes {
-            // Only seed when the RHS actually resolves to a type — a bare
-            // `Edge(Expr(rhs_span))` to an unresolved span folds to None,
-            // which is honest, but emitting nothing for `= shift` / `= $param`
-            // keeps the attachment absent entirely (no guess).
+            // A write whose RHS doesn't resolve (`= shift` / `= $param`)
+            // contributes no typed arm, but it must not vanish: the fold's
+            // all-undef verdict (`{undef} → Undef`) is only sound when we
+            // saw EVERY write, and `$self->{h} = undef; … set { $_[0]->{h}
+            // = $_[1] }` is exactly the init-then-mutate shape where the
+            // typed story is partial. The Fact records the opaque write so
+            // the fold declines the definitive claim.
             if self.bag_query_expr_span(rhs_span).is_none() {
+                self.bag.push(Witness {
+                    attachment: WitnessAttachment::SlotType { class, key },
+                    source: WitnessSource::Builder("slot_type".into()),
+                    payload: WitnessPayload::Fact {
+                        family: "opaque_slot_write".into(),
+                        key: String::new(),
+                        value: FactValue::Bool(true),
+                    },
+                    span,
+                });
                 continue;
             }
             self.bag.push(Witness {
@@ -9649,6 +9677,12 @@ impl<'a> Builder<'a> {
                 } else {
                     None
                 };
+                // `has parent => undef` means "starts empty, set later" — the
+                // attribute is a mutable slot, so `Undef` as a return CONTRACT
+                // is a lie the moment anyone sets it (and D1 would flag every
+                // `$self->parent->…` as a guaranteed die). No claim instead.
+                let getter_type =
+                    getter_type.filter(|t| !matches!(t, InferredType::Undef));
                 let fluent_type = self
                     .current_package
                     .as_ref()
@@ -11532,6 +11566,21 @@ impl<'a> Builder<'a> {
             if let Some(child) = node.named_child(i) {
                 if matches!(child.kind(), "container_variable" | "keyval_container_variable" | "scalar" | "hash") {
                     return child.utf8_text(self.source).ok().map(|s| s.to_string());
+                }
+                // The positional-receiver container (`$_[0]->{k}` in a
+                // shiftless setter) has no variable identity, but its
+                // conventional-receiver meaning is a classification
+                // consumers make via `InvocantText::parse` — carry the
+                // spelling through so they can.
+                if child.kind() == "array_element_expression" {
+                    if let Ok(text) = child.utf8_text(self.source) {
+                        if matches!(
+                            crate::conventions::InvocantText::parse(text),
+                            crate::conventions::InvocantText::PositionalReceiver
+                        ) {
+                            return Some(text.to_string());
+                        }
+                    }
                 }
             }
         }
@@ -13801,8 +13850,19 @@ impl<'a> Builder<'a> {
             // two edges on `MethodOnClass(child, m)` and the
             // materializer's latest-wins reducer would silently pick
             // the second-emitted parent.
+            //
+            // Seeded with the child's OWN method names: an override
+            // dispatches to the child's sub, so the parent's type must
+            // never answer for it — even (especially) when the local
+            // override's type didn't resolve. Mirrors the cross-file
+            // projection in `enrich_imported_types_with_keys`.
             let mut emitted_for_child: std::collections::HashSet<String> =
                 std::collections::HashSet::new();
+            emitted_for_child.extend(self.symbols.iter().filter_map(|s| {
+                (matches!(s.kind, SymKind::Sub | SymKind::Method)
+                    && s.package.as_deref() == Some(child.as_str()))
+                .then(|| s.name.clone())
+            }));
             for parent in parents {
                 if parent == child {
                     continue;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -741,7 +741,7 @@ impl<'a> Builder<'a> {
                 attachment: WitnessAttachment::HashKey { owner, name: key.clone() },
                 source: WitnessSource::Builder("invocant_mutation".into()),
                 payload: WitnessPayload::Fact {
-                    family: "mutation".into(),
+                    family: crate::witnesses::tags::FACT_MUTATION.into(),
                     key: "written_at".into(),
                     value: crate::witnesses::FactValue::Str(key),
                 },
@@ -761,7 +761,7 @@ impl<'a> Builder<'a> {
                     attachment: WitnessAttachment::SlotType { class, key },
                     source: WitnessSource::Builder("slot_type".into()),
                     payload: WitnessPayload::Fact {
-                        family: "opaque_slot_write".into(),
+                        family: crate::witnesses::tags::FACT_OPAQUE_SLOT_WRITE.into(),
                         key: String::new(),
                         value: FactValue::Bool(true),
                     },
@@ -852,9 +852,9 @@ impl<'a> Builder<'a> {
         for (name, scope, span) in barrier_pushes {
             self.bag.push(Witness {
                 attachment: WitnessAttachment::Variable { name, scope },
-                source: WitnessSource::Builder("reassign_barrier".into()),
+                source: WitnessSource::Builder(crate::witnesses::tags::FACT_REASSIGN_BARRIER.into()),
                 payload: WitnessPayload::Fact {
-                    family: "reassign_barrier".into(),
+                    family: crate::witnesses::tags::FACT_REASSIGN_BARRIER.into(),
                     key: String::new(),
                     value: FactValue::Bool(true),
                 },
@@ -886,16 +886,7 @@ impl<'a> Builder<'a> {
             tail_value_arms.push((sym_id, span));
         }
         for (sym_id, span) in tail_value_arms {
-            self.bag.push(Witness {
-                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
-                source: WitnessSource::Builder("value_arm".into()),
-                payload: WitnessPayload::Fact {
-                    family: "value_arm".into(),
-                    key: String::new(),
-                    value: FactValue::Bool(true),
-                },
-                span,
-            });
+            self.push_value_arm_fact(sym_id, span);
         }
     }
 
@@ -1133,6 +1124,12 @@ fn point_lt(a: tree_sitter::Point, b: tree_sitter::Point) -> bool {
 /// gates on (for `emit_arity_return_witnesses`), and the body span
 /// (the `Expr(span)` key both `emit_arity_return_witnesses` and
 /// `seed_return_types_from_bag` query inline via `bag_query_expr_span`).
+/// Sentinel name for anonymous-sub scopes and symbols. One definition —
+/// producers (scope + symbol creation) and consumers (the shift-invocant
+/// gate) share it, so "is this sub anonymous?" is never a re-typed
+/// string compare.
+const ANON_SUB_NAME: &str = "(anon)";
+
 struct ReturnInfo {
     /// The scope (Sub/Method) this return belongs to.
     scope: ScopeId,
@@ -4377,7 +4374,7 @@ impl<'a> Builder<'a> {
         let span = node_to_span(node);
         self.ensure_anon_sub_symbol(node, &params);
         self.push_scope(
-            ScopeKind::Sub { name: "(anon)".into() },
+            ScopeKind::Sub { name: ANON_SUB_NAME.into() },
             span,
             None,
         );
@@ -4405,7 +4402,7 @@ impl<'a> Builder<'a> {
             return *id;
         }
         let sym_id = self.add_symbol(
-            "(anon)".into(),
+            ANON_SUB_NAME.into(),
             SymKind::Sub,
             span,
             self.sub_keyword_span(node).unwrap_or(span),
@@ -4617,16 +4614,12 @@ impl<'a> Builder<'a> {
     /// argument read; typing it as the class was the audit's
     /// `defined $value`-guard false-positive maker.
     fn shift_denotes_invocant(&self, node: Node<'a>) -> bool {
-        // Climb to the binding assignment, stopping at the statement
-        // boundary (no binding → expression position → invocant).
-        let mut cur = node;
-        let assign = loop {
-            let Some(p) = cur.parent() else { return true };
-            match p.kind() {
-                "assignment_expression" => break p,
-                "expression_statement" | "block" => return true,
-                _ => cur = p,
-            }
+        // No binding assignment within the statement → expression
+        // position (`shift->method`) → the receiver read itself.
+        let Some(assign) =
+            crate::cst::stmt_context(node).and_then(|c| c.binding_assignment)
+        else {
+            return true;
         };
         // The shift must sit on the RHS; a shift inside the LHS (odd,
         // but cheap to guard) is not a binding of it.
@@ -4638,7 +4631,11 @@ impl<'a> Builder<'a> {
         // The sub's extracted param list knows which param is the
         // invocant (params[0] for methods; params[1] under `around`).
         // Scope-derived (not the live walk stack) so the post-walk
-        // chain-typing callers resolve identically.
+        // chain-typing callers resolve identically. Anonymous subs are
+        // excluded: their first arg is a callback payload, not a
+        // receiver — the audit's `Maybe`-checker false-positive shape
+        // (`sub { my $value = shift; return if !defined($value) }`) —
+        // so only a conventional name (above) types there.
         let scope = self.scope_at_point(node.start_position());
         let sub_scope_name = crate::file_analysis::scope_chain_of(&self.scopes, scope)
             .into_iter()
@@ -4648,11 +4645,7 @@ impl<'a> Builder<'a> {
                 }
                 _ => None,
             })
-            // An anonymous sub's first arg is a callback payload, not a
-            // receiver — the audit's `Maybe`-checker false-positive shape
-            // (`sub { my $value = shift; return if !defined($value) }`).
-            // Only a conventional name (handled above) types there.
-            .filter(|(_, name)| name != "(anon)");
+            .filter(|(_, name)| name != ANON_SUB_NAME);
         let invocant_param = sub_scope_name
             .and_then(|(sid, name)| self.find_sub_symbol_for(&name, sid))
             .and_then(|sid| self.symbols.iter().find(|s| s.id == sid))
@@ -4661,11 +4654,6 @@ impl<'a> Builder<'a> {
                 // the FIRST positional — in a named sub of an OO-by-
                 // convention package that slot IS the receiver regardless
                 // of its name (`my $x = shift` in a Mojo class).
-                // Anonymous subs never reach here (no named Sub scope):
-                // their first arg is a callback payload, not a receiver,
-                // so they stay on the conventional-name rule above —
-                // that's the audit's `Maybe`-checker false-positive shape
-                // (`sub { my $value = shift; return if !defined $value }`).
                 SymbolDetail::Sub { params, .. } => params
                     .iter()
                     .find(|p| p.is_invocant)
@@ -6531,19 +6519,8 @@ impl<'a> Builder<'a> {
                 // false "is undef" for the `->is_valid` call). Skip the
                 // belief; the write's reassign barrier still lands, which
                 // IS the widening.
-                let conditional_write = {
-                    let mut cur = node;
-                    loop {
-                        match cur.parent() {
-                            Some(p) if p.kind() == "postfix_conditional_expression" => {
-                                break true
-                            }
-                            Some(p) if p.kind() == "expression_statement" => break false,
-                            Some(p) => cur = p,
-                            None => break false,
-                        }
-                    }
-                };
+                let conditional_write = crate::cst::stmt_context(node)
+                    .is_some_and(|c| c.under_postfix_conditional);
                 let mut inferred = if conditional_write {
                     None
                 } else {
@@ -7231,9 +7208,9 @@ impl<'a> Builder<'a> {
                 if matches!(arm.kind(), "undef_expression" | "stub_expression") {
                     self.bag.push(Witness {
                         attachment: arm_att.clone(),
-                        source: WitnessSource::Builder("undef_arm".into()),
+                        source: WitnessSource::Builder(crate::witnesses::tags::FACT_UNDEF_ARM.into()),
                         payload: WitnessPayload::Fact {
-                            family: "undef_arm".into(),
+                            family: crate::witnesses::tags::FACT_UNDEF_ARM.into(),
                             key: String::new(),
                             value: crate::witnesses::FactValue::Bool(true),
                         },
@@ -7340,6 +7317,25 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// One `value_arm` counting Fact on the sub's return-arm attachment.
+    /// Pushed for every value arm — typed or not — because an Edge whose
+    /// target never materializes leaves no trace in the fold, and the
+    /// all-undef verdict (`{undef arms only} → Undef`) must not fire
+    /// while an untypeable value arm exists.
+    fn push_value_arm_fact(&mut self, sym_id: SymbolId, span: Span) {
+        use crate::witnesses::{FactValue, Witness, WitnessAttachment, WitnessPayload, WitnessSource};
+        self.bag.push(Witness {
+            attachment: WitnessAttachment::SymbolReturnArm(sym_id),
+            source: WitnessSource::Builder(crate::witnesses::tags::FACT_VALUE_ARM.into()),
+            payload: WitnessPayload::Fact {
+                family: crate::witnesses::tags::FACT_VALUE_ARM.into(),
+                key: String::new(),
+                value: FactValue::Bool(true),
+            },
+            span,
+        });
+    }
+
     /// Publish witnesses for one explicit `return EXPR`:
     /// - `Expr(body_span)` is populated by `emit_expr_witness` —
     ///   directly with the body's payload for non-ternary, or
@@ -7374,9 +7370,9 @@ impl<'a> Builder<'a> {
         if is_undef_arm {
             self.bag.push(Witness {
                 attachment: WitnessAttachment::SymbolReturnArm(sym_id),
-                source: WitnessSource::Builder("undef_arm".into()),
+                source: WitnessSource::Builder(crate::witnesses::tags::FACT_UNDEF_ARM.into()),
                 payload: WitnessPayload::Fact {
-                    family: "undef_arm".into(),
+                    family: crate::witnesses::tags::FACT_UNDEF_ARM.into(),
                     key: String::new(),
                     value: FactValue::Bool(true),
                 },
@@ -7390,20 +7386,7 @@ impl<'a> Builder<'a> {
                 payload: WitnessPayload::Edge(WitnessAttachment::Expr(arm_span)),
                 span: arm_span,
             });
-            // Every value arm is also counted with a Fact: an Edge whose
-            // target never materializes leaves no trace in the fold, and
-            // the all-undef gate (`{undef arms only} → Undef`) must not
-            // fire when an untypeable value arm exists.
-            self.bag.push(Witness {
-                attachment: WitnessAttachment::SymbolReturnArm(sym_id),
-                source: WitnessSource::Builder("value_arm".into()),
-                payload: WitnessPayload::Fact {
-                    family: "value_arm".into(),
-                    key: String::new(),
-                    value: FactValue::Bool(true),
-                },
-                span: arm_span,
-            });
+            self.push_value_arm_fact(sym_id, arm_span);
         }
         self.bag.push(Witness {
             attachment: WitnessAttachment::Symbol(sym_id),
@@ -7724,20 +7707,14 @@ impl<'a> Builder<'a> {
                 //   var): loop-var typing spans the whole loop and isn't
                 //   a reassignment of a prior belief.
                 if text.starts_with('$') {
-                    let mut stmt = node;
-                    while let Some(p) = stmt.parent() {
-                        match p.kind() {
-                            "variable_declaration" => break,
-                            "expression_statement" => {
-                                self.scalar_reassign_writes.push((
-                                    text.to_string(),
-                                    self.current_scope(),
-                                    node_to_span(p),
-                                ));
-                                break;
-                            }
-                            _ => stmt = p,
-                        }
+                    if let Some(c) =
+                        crate::cst::stmt_context(node).filter(|c| !c.in_declaration)
+                    {
+                        self.scalar_reassign_writes.push((
+                            text.to_string(),
+                            self.current_scope(),
+                            node_to_span(c.statement),
+                        ));
                     }
                 }
             }
@@ -9865,8 +9842,7 @@ impl<'a> Builder<'a> {
                 // attribute is a mutable slot, so `Undef` as a return CONTRACT
                 // is a lie the moment anyone sets it (and D1 would flag every
                 // `$self->parent->…` as a guaranteed die). No claim instead.
-                let getter_type =
-                    getter_type.filter(|t| !matches!(t, InferredType::Undef));
+                let getter_type = getter_type.filter(|t| !t.is_undef());
                 let fluent_type = self
                     .current_package
                     .as_ref()
@@ -13906,7 +13882,7 @@ impl<'a> Builder<'a> {
     ) {
         use crate::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
 
-        self.bag.remove_by_source_tag("local_return");
+        self.bag.remove_by_source_tag(crate::witnesses::tags::TAG_LOCAL_RETURN);
         self.bag.remove_by_source_tag("plugin_bridge");
         self.bag.remove_by_source_tag("inheritance");
 
@@ -13962,7 +13938,7 @@ impl<'a> Builder<'a> {
                         class,
                         name: sym.name.clone(),
                     },
-                    source: WitnessSource::Builder("local_return".into()),
+                    source: WitnessSource::Builder(crate::witnesses::tags::TAG_LOCAL_RETURN.into()),
                     payload: WitnessPayload::Edge(WitnessAttachment::Symbol(sym.id)),
                     span: sym.span,
                 });
@@ -14042,11 +14018,8 @@ impl<'a> Builder<'a> {
             // projection in `enrich_imported_types_with_keys`.
             let mut emitted_for_child: std::collections::HashSet<String> =
                 std::collections::HashSet::new();
-            emitted_for_child.extend(self.symbols.iter().filter_map(|s| {
-                (matches!(s.kind, SymKind::Sub | SymKind::Method)
-                    && s.package.as_deref() == Some(child.as_str()))
-                .then(|| s.name.clone())
-            }));
+            emitted_for_child
+                .extend(crate::file_analysis::own_method_names(&self.symbols, child));
             for parent in parents {
                 if parent == child {
                     continue;

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -15396,3 +15396,111 @@ fn overridden_method_never_answers_with_parent_type() {
     let t = fa.inferred_type_via_bag_ctx("$path", tree_sitter::Point::new(16, 20), Some(&idx));
     assert_eq!(t, None, "overridden file()'s unresolved return must not inherit Base's Undef");
 }
+// ---- Reassignment barriers (disagreement-to-widen, audit FP class) ----
+
+#[test]
+fn reassign_barrier_untypeable_write_widens_stale_undef() {
+    // The LWP::MediaTypes shape: decl-undef, an untypeable write inside a
+    // loop, a `defined` guard after. The stale `Undef` must not survive
+    // the write — the guard is doing its job, not "never passes".
+    let src = "sub guess {\n    my $ct = undef;\n    while (my $x = nxt()) {\n        $ct = lookup($x);\n    }\n    return unless defined $ct;\n    return $ct;\n}\n";
+    let fa = build_fa(src);
+    // Query at the guard line (row 5).
+    assert_eq!(
+        fa.inferred_type_via_bag("$ct", Point::new(5, 26)),
+        None,
+        "belief must widen across the untypeable loop write",
+    );
+}
+
+#[test]
+fn reassign_barrier_typed_write_keeps_its_own_type() {
+    // A typed reassignment's own TC lands at the same statement as the
+    // barrier — it survives, and later reads see it.
+    let src = "sub f {\n    my $x = undef;\n    $x = 'hello';\n    my $y = $x;\n}\n";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(3, 12)),
+        Some(InferredType::String),
+        "the typed write's own belief must survive its barrier",
+    );
+}
+
+#[test]
+fn reassign_barrier_no_write_keeps_decl_belief() {
+    // No reassignment → the decl belief stands (undef-deref D1 still has
+    // its straight-line signal).
+    let src = "sub f {\n    my $x = undef;\n    my $y = $x;\n}\n";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.inferred_type_via_bag("$x", Point::new(2, 12)),
+        Some(InferredType::Undef),
+    );
+}
+// ---- shift-invocant gating ----
+
+#[test]
+fn second_shift_is_not_the_invocant() {
+    // `my $uri = shift;` (the SECOND shift) is a plain argument read —
+    // typing it as the enclosing class made `defined $uri`-style guards
+    // read as redundant/contradictory (the audit FP class).
+    let src = "package Foo;\nsub file {\n    my $class = shift;\n    my $uri = shift;\n    my $x = $uri;\n}\n";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.inferred_type_via_bag("$class", Point::new(4, 4)),
+        Some(InferredType::ClassName("Foo".into())),
+        "the invocant param keeps its class",
+    );
+    assert_ne!(
+        fa.inferred_type_via_bag("$uri", Point::new(4, 4)),
+        Some(InferredType::ClassName("Foo".into())),
+        "a second shift must not type as the class",
+    );
+}
+
+#[test]
+fn expression_position_shift_still_receiver() {
+    // `shift->_generate_route(...)` — expression-position shift reads
+    // arg 0 directly; still the receiver.
+    let src = "package Foo;\nsub patch { shift->helper() }\nsub helper { my $self = shift; return $self; }\n";
+    let fa = build_fa(src);
+    assert_eq!(
+        fa.find_method_return_type("Foo", "patch", None, Some(0)),
+        Some(InferredType::ClassName("Foo".into())),
+        "shift->method chains must keep receiver typing",
+    );
+}
+#[test]
+fn anon_sub_shift_binding_not_class_typed() {
+    // The Types::Standard::StrMatch checker shape: an anonymous sub's
+    // `my $value = shift` binds a callback payload, not a receiver —
+    // typing it as the enclosing class made `return if !defined($value)`
+    // read as a contradictory guard (the audit FP class).
+    let src = "package T;\nuse parent 'X';\nsub compile {\n    my $cb = sub {\n        my $value = shift;\n        return if !defined($value);\n        return 1;\n    };\n    $cb;\n}\n";
+    let fa = build_fa(src);
+    assert_ne!(
+        fa.inferred_type_via_bag("$value", Point::new(5, 8)),
+        Some(InferredType::ClassName("T".into())),
+        "an anon sub's first shift is not the invocant",
+    );
+}
+#[test]
+fn postfix_conditional_write_widens_not_asserts() {
+    // `$isbn = undef if $isbn && !$isbn->is_valid;` — the write may not
+    // happen, and the condition's own deref precedes it. No unconditional
+    // Undef belief; the barrier widens instead.
+    let src = "sub _isbn {\n    my $isbn = Business::ISBN->new(shift);\n    $isbn = undef if $isbn && !$isbn->is_valid;\n    return $isbn;\n}\n";
+    let fa = build_fa(src);
+    // At the deref inside the condition (row 2), the ctor class holds.
+    assert_eq!(
+        fa.inferred_type_via_bag("$isbn", Point::new(2, 30)),
+        Some(InferredType::ClassName("Business::ISBN".into())),
+        "the condition's deref must read the pre-write type",
+    );
+    // After the statement (row 3), the belief is widened — old-or-undef.
+    assert_eq!(
+        fa.inferred_type_via_bag("$isbn", Point::new(3, 12)),
+        None,
+        "a conditional write widens the belief",
+    );
+}

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -12446,6 +12446,104 @@ has 'logger' => (is => 'ro', isa => 'Log::Any', handles => { log => 'debug', war
 }
 
 #[test]
+fn test_monkey_patch_synthesizes_methods() {
+    // `monkey_patch $class => $name => sub {…}` installs methods with no
+    // static `sub` — the registration site is the declaration. String
+    // class + __PACKAGE__ + multiple (name => sub) pairs all synthesize.
+    let fa = build_fa(
+        "
+package My::Patcher;
+use Mojo::Util qw(monkey_patch);
+monkey_patch 'My::Target', hello => sub { my ($self) = @_; 1 };
+monkey_patch __PACKAGE__, world => sub { 2 }, again => sub { 3 };
+",
+    );
+    let method = |n: &str| {
+        fa.symbols
+            .iter()
+            .find(|s| s.name == n && s.kind == SymKind::Method)
+            .unwrap_or_else(|| panic!("monkey_patch must synthesize '{n}'"))
+    };
+    assert_eq!(
+        method("hello").package.as_deref(),
+        Some("My::Target"),
+        "string class arg targets the named class",
+    );
+    assert_eq!(
+        method("world").package.as_deref(),
+        Some("My::Patcher"),
+        "__PACKAGE__ targets the current package",
+    );
+    assert_eq!(
+        method("again").package.as_deref(),
+        Some("My::Patcher"),
+        "every (name => sub) pair in one call synthesizes",
+    );
+}
+
+#[test]
+fn test_monkey_patch_loop_registration_fans_out() {
+    // The Mojo::UserAgent idiom: one registration statement looped over a
+    // literal list — every folded candidate becomes a method.
+    let fa = build_fa(
+        "
+package My::UA;
+use Mojo::Util qw(monkey_patch);
+monkey_patch __PACKAGE__, $_ => sub { 1 } for qw(get post put);
+",
+    );
+    for n in ["get", "post", "put"] {
+        assert!(
+            fa.symbols.iter().any(|s| s.name == n && s.kind == SymKind::Method),
+            "loop registration must synthesize '{n}'",
+        );
+    }
+}
+
+#[test]
+fn test_monkey_patch_dynamic_class_and_name_honest_miss() {
+    // A runtime `$class` / unfolded name must synthesize NOTHING — an
+    // honest miss, never a guessed method.
+    let fa = build_fa(
+        "
+package My::Patcher;
+use Mojo::Util qw(monkey_patch);
+my $class = compute();
+monkey_patch $class, hello => sub { 1 };
+monkey_patch 'My::Target', lc($n) => sub { 2 };
+",
+    );
+    assert!(
+        !fa.symbols.iter().any(|s| s.kind == SymKind::Method && (s.name == "hello" || s.name.contains('$'))),
+        "dynamic registrations must not synthesize",
+    );
+}
+
+#[test]
+fn test_handles_curried_arrayref_value() {
+    // Sub::HandlesVia's curried shape: `local => [remote, @args]` — the
+    // remote is the array's first string element. The arrayref value must
+    // also not shift pair alignment: `dec => 'remove'` after it still
+    // synthesizes correctly.
+    let fa = build_fa(
+        "
+package Counter;
+use Moo;
+use Sub::HandlesVia;
+has 'items' => (is => 'ro', handles => { inc => ['add', 1], dec => 'remove' });
+",
+    );
+    let names: Vec<&str> = fa
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymKind::Method)
+        .map(|s| s.name.as_str())
+        .collect();
+    assert!(names.contains(&"inc"), "curried arrayref value synthesizes 'inc': {names:?}");
+    assert!(names.contains(&"dec"), "pair after an arrayref value stays aligned: {names:?}");
+}
+
+#[test]
 fn test_moose_has_handles_arrayref() {
     let fa = build_fa(
         "

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -1443,9 +1443,48 @@ fn test_return_type_bare_return_optional() {
 
 #[test]
 fn test_return_type_all_bare_returns() {
-    // All bare returns → no return type
+    // Every arm is a provable undef → the definitive `Undef`, not the
+    // silent None (docs/adr/optional-types.md). Feeds the method-on-Undef
+    // and always-false-guard diagnostics.
     let fa = build_fa("sub noop {\n    return;\n}");
-    assert_eq!(fa.sub_return_type_at_arity("noop", None), None);
+    assert_eq!(
+        fa.sub_return_type_at_arity("noop", None),
+        Some(InferredType::Undef)
+    );
+}
+
+#[test]
+fn test_return_type_all_undef_returns() {
+    // `sub f { return undef }` — the explicit spelling of the same fact.
+    let fa = build_fa("sub nothing {\n    return undef;\n}");
+    assert_eq!(
+        fa.sub_return_type_at_arity("nothing", None),
+        Some(InferredType::Undef)
+    );
+}
+
+#[test]
+fn test_return_type_undef_arm_with_fallthrough_tail_not_undef() {
+    // `return undef if $x; compute()` — the fallthrough tail is a value
+    // arm the per-`return` walk never sees. The all-undef gate must not
+    // fire: the sub returns compute()'s value when the guard fails.
+    let fa = build_fa("sub gated {\n    my ($x) = @_;\n    return undef if $x;\n    compute();\n}");
+    assert_ne!(
+        fa.sub_return_type_at_arity("gated", None),
+        Some(InferredType::Undef)
+    );
+}
+
+#[test]
+fn test_return_type_empty_list_return_optional() {
+    // `return ()` coerces to undef in scalar context — an undef arm, same
+    // as bare `return;`, so `{T, ()}` lifts to Optional<T>.
+    let fa = build_fa("sub find {\n    return () unless 1;\n    return { row => 1 };\n}");
+    let t = fa.sub_return_type_at_arity("find", None);
+    assert!(
+        matches!(&t, Some(InferredType::Optional(inner)) if inner.is_hash_shaped()),
+        "Optional<hash-shaped>, got {t:?}",
+    );
 }
 
 #[test]
@@ -10976,17 +11015,47 @@ fn moo_instanceof_isa_types_both_getter_and_writer() {
 
 /// `Maybe[InstanceOf['Foo']]` — the nested constructor is itself a constraint
 /// value. The core types the inner call (`TypeConstraintOf(ClassName(Foo))`)
-/// into the param's `ty`; the `Maybe` passthrough fold projects its inner, so
-/// the accessor returns `Foo` (optionalness unmodeled — unwrap for resolution).
+/// into the param's `ty`; the `Maybe` fold projects the inner and lifts it to
+/// `Optional<Foo>` — the accessor value is honestly maybe-undef (optional
+/// receivers dispatch leniently, and the optional-deref lint sees the truth).
 #[test]
-fn moo_maybe_instanceof_isa_unwraps_to_inner_class() {
+fn moo_maybe_instanceof_isa_lifts_to_optional_class() {
     let fa = build_fa(
         "package T;\nuse Moo;\nuse Types::Standard qw/Maybe InstanceOf/;\nhas thing => (is=>'ro', isa=>Maybe[InstanceOf['My::Thing']]);\n1;\n",
     );
+    let t = fa.sub_return_type_at_arity("thing", Some(0));
+    assert!(
+        matches!(&t, Some(InferredType::Optional(inner)) if inner.class_name() == Some("My::Thing")),
+        "Maybe[InstanceOf['My::Thing']] must type the accessor Optional<My::Thing>, got {t:?}",
+    );
+}
+
+/// Bareword `Maybe[Int]` — the base constant is a 0-arity constraint value;
+/// the plugin folds it to its rep and `Maybe` lifts to Optional. Parity with
+/// the quoted `isa => 'Maybe[Int]'` spelling.
+#[test]
+fn moo_bareword_maybe_int_isa_types_optional_numeric() {
+    let fa = build_fa(
+        "package T;\nuse Moo;\nuse Types::Standard qw/Maybe Int/;\nhas count => (is=>'ro', isa=>Maybe[Int]);\n1;\n",
+    );
     assert_eq!(
-        fa.sub_return_type_at_arity("thing", Some(0)),
-        Some(InferredType::ClassName("My::Thing".to_string())),
-        "Maybe[InstanceOf['My::Thing']] must unwrap to a My::Thing accessor return",
+        fa.sub_return_type_at_arity("count", Some(0)),
+        Some(InferredType::Optional(Box::new(InferredType::Numeric))),
+        "bareword Maybe[Int] must type the accessor Optional<Numeric>",
+    );
+}
+
+/// Bareword `isa => Int` (no wrapper) — the same 0-arity constant fold gives
+/// the accessor its rep, matching the quoted `isa => 'Int'` spelling.
+#[test]
+fn moo_bareword_int_isa_types_numeric() {
+    let fa = build_fa(
+        "package T;\nuse Moo;\nuse Types::Standard qw/Int/;\nhas count => (is=>'ro', isa=>Int);\n1;\n",
+    );
+    assert_eq!(
+        fa.sub_return_type_at_arity("count", Some(0)),
+        Some(InferredType::Numeric),
+        "bareword isa => Int must type the accessor Numeric",
     );
 }
 
@@ -14305,6 +14374,41 @@ fn slot_type_keyed_by_owner_class() {
     // The enclosing-package write lands on Bar, not Foo — no cross-contamination.
     let bar_h = slot_type(&fa, "Bar", "h").expect("SlotType{Bar,h} from $self write");
     assert_eq!(bar_h.class_name(), Some("Sidecar"), "got {bar_h:?}");
+}
+
+#[test]
+fn slot_type_typed_write_plus_undef_write_optional() {
+    // `{T, undef}` writes across methods lift the slot to `Optional<T>`:
+    // one method installs the helper, another clears it.
+    let src = "package Foo;\nsub init {\n  my $self = shift;\n  $self->{h} = Helper->new;\n}\nsub clear {\n  my $self = shift;\n  $self->{h} = undef;\n}\n";
+    let fa = build_fa(src);
+    let t = slot_type(&fa, "Foo", "h").expect("SlotType{Foo,h} should fold");
+    assert!(
+        matches!(&t, InferredType::Optional(inner) if inner.class_name() == Some("Helper")),
+        "Optional<Helper>, got {t:?}",
+    );
+}
+
+#[test]
+fn slot_type_all_undef_writes_undef() {
+    // Every observed write is undef → the slot IS undef.
+    let src = "package Foo;\nsub clear {\n  my $self = shift;\n  $self->{h} = undef;\n}\n";
+    let fa = build_fa(src);
+    assert_eq!(slot_type(&fa, "Foo", "h"), Some(InferredType::Undef));
+}
+
+#[test]
+fn slot_type_optional_rhs_write_optional() {
+    // Writing a maybe-undef value (`Optional<T>` RHS) makes the slot
+    // optional — the Optional strips into the undef flag and re-lifts,
+    // so it also agrees with a sibling plain-`T` write.
+    let src = "package Foo;\nsub maybe_helper {\n  return undef unless 1;\n  return Helper->new;\n}\nsub init {\n  my $self = shift;\n  $self->{h} = maybe_helper();\n}\nsub force {\n  my $self = shift;\n  $self->{h} = Helper->new;\n}\n";
+    let fa = build_fa(src);
+    let t = slot_type(&fa, "Foo", "h").expect("SlotType{Foo,h} should fold");
+    assert!(
+        matches!(&t, InferredType::Optional(inner) if inner.class_name() == Some("Helper")),
+        "Optional<Helper>, got {t:?}",
+    );
 }
 
 

--- a/src/builder_tests.rs
+++ b/src/builder_tests.rs
@@ -14496,6 +14496,17 @@ fn slot_type_all_undef_writes_undef() {
 }
 
 #[test]
+fn slot_type_undef_init_plus_opaque_setter_no_claim() {
+    // The init-then-mutate idiom: `= undef` in the constructor, `= $param`
+    // in the setter. The setter's write is untypeable, so the typed story
+    // is partial — the definitive `Undef` (which would flag every
+    // downstream `$self->{h}->…` as a guaranteed die) must NOT fire.
+    let src = "package Foo;\nsub new {\n  my $self = bless {}, shift;\n  $self->{h} = undef;\n  return $self;\n}\nsub set_h {\n  $_[0]->{h} = $_[1];\n}\n";
+    let fa = build_fa(src);
+    assert_eq!(slot_type(&fa, "Foo", "h"), None);
+}
+
+#[test]
 fn slot_type_optional_rhs_write_optional() {
     // Writing a maybe-undef value (`Optional<T>` RHS) makes the slot
     // optional — the Optional strips into the undef flag and re-lifts,
@@ -15366,3 +15377,22 @@ fn plugin_loads_recorded_trigger_independent_and_multivalue() {
 
 #[path = "builder/narrowing_tests.rs"]
 mod narrowing;
+#[test]
+fn overridden_method_never_answers_with_parent_type() {
+    // `URI::file::Base::file { undef }` under an overriding `Mac::file`:
+    // dispatch goes to the LOCAL sub, so when the override's type doesn't
+    // resolve the honest answer is None — never the parent's `Undef`
+    // (which fed a false "guard can never pass" on `defined $path`).
+    let src = "package URI::file::Mac;\nuse parent 'URI::file::Base';\n\nsub file\n{\n    my $class = shift;\n    my $pre = \"\";\n    my @path;\n    return unless $pre || @path;\n    $pre . join(\":\", @path);\n}\n\nsub dir\n{\n    my $class = shift;\n    my $path = $class->file(@_);\n    return unless defined $path;\n    $path;\n}\n1;\n";
+    let mut fa = build_fa(src);
+    fa.finalize_post_walk();
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let base_src = "package URI::file::Base;\nsub file\n{\n    undef;\n}\nsub dir { my $self = shift; $self->file(@_); }\n1;\n";
+    idx.insert_cache("URI::file::Base", Some(std::sync::Arc::new(crate::module_index::CachedModule::new(
+        std::path::PathBuf::from("/fake/URI/file/Base.pm"),
+        std::sync::Arc::new(build_fa(base_src)),
+    ))));
+    fa.enrich_imported_types_with_keys(Some(&idx));
+    let t = fa.inferred_type_via_bag_ctx("$path", tree_sitter::Point::new(16, 20), Some(&idx));
+    assert_eq!(t, None, "overridden file()'s unresolved return must not inherit Base's Undef");
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -253,6 +253,55 @@ pub(crate) fn pair_nodes_in<'a>(children: &[Node<'a>]) -> Vec<(Node<'a>, Node<'a
     out
 }
 
+/// A node's enclosing STATEMENT plus the wrappers crossed climbing to it
+/// — the one place the "where does my statement start / what wraps me"
+/// grammar shape lives. Consumers ask the flags instead of re-spelling
+/// ancestor climbs with per-site stop-kind sets.
+pub(crate) struct StmtContext<'a> {
+    /// The `expression_statement` containing the node.
+    pub statement: Node<'a>,
+    /// Crossed a `postfix_conditional_expression` (`EXPR if COND`) —
+    /// whatever the node does is conditional on the statement's guard.
+    pub under_postfix_conditional: bool,
+    /// Crossed a `variable_declaration` — the node sits inside a
+    /// `my`/`our` declaration (a first binding, not a reassignment).
+    pub in_declaration: bool,
+    /// Nearest `assignment_expression` crossed, if any — for an RHS
+    /// node, the assignment that binds its value.
+    pub binding_assignment: Option<Node<'a>>,
+}
+
+/// Climb to the enclosing `expression_statement`, recording what was
+/// crossed. `None` when no statement ancestor exists (a foreach-header
+/// variable, a signature default) — callers treat that as "no statement
+/// context", each with its own conservative default.
+pub(crate) fn stmt_context(node: Node) -> Option<StmtContext> {
+    let mut under_postfix_conditional = false;
+    let mut in_declaration = false;
+    let mut binding_assignment: Option<Node> = None;
+    let mut cur = node;
+    while let Some(p) = cur.parent() {
+        match p.kind() {
+            "expression_statement" => {
+                return Some(StmtContext {
+                    statement: p,
+                    under_postfix_conditional,
+                    in_declaration,
+                    binding_assignment,
+                });
+            }
+            "postfix_conditional_expression" => under_postfix_conditional = true,
+            "variable_declaration" => in_declaration = true,
+            "assignment_expression" if binding_assignment.is_none() => {
+                binding_assignment = Some(p)
+            }
+            _ => {}
+        }
+        cur = p;
+    }
+    None
+}
+
 /// Pair-walk a container node: a bare `list_expression` /
 /// `parenthesized_expression`, or an `anonymous_hash_expression` (its inner
 /// list is unwrapped). Composition of [`flatten_list`] + [`pair_nodes_in`].

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -4021,6 +4021,17 @@ impl FileAnalysis {
                 // edge emission in `write_back_sub_return_types`.
                 let mut emitted_for_child: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
+                // A locally-overridden method dispatches to the CHILD's
+                // sub — the parent never runs for this receiver, so its
+                // type must not answer (`URI::file::Base::file { undef }`
+                // under an overriding `Mac::file` is the canonical
+                // miscarriage). Seed the seen-set with the child's own
+                // method names so no parent edge is minted for them.
+                emitted_for_child.extend(self.symbols.iter().filter_map(|s| {
+                    (matches!(s.kind, SymKind::Sub | SymKind::Method)
+                        && s.package.as_deref() == Some(child.as_str()))
+                    .then(|| s.name.clone())
+                }));
                 for parent in parents {
                     if parent == child {
                         continue;

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -1158,6 +1158,13 @@ impl InferredType {
     /// non-constraint type. This is the rule-#10 "ask the value" entry
     /// point: `has`'s isa→accessor projection calls it without ever
     /// matching on the constraint's shape itself.
+    /// Is this the definitive bottom (`Undef`)? Consumers deciding
+    /// whether a value can back a contract ask the value, not match the
+    /// variant (rule #10).
+    pub fn is_undef(&self) -> bool {
+        matches!(self, InferredType::Undef)
+    }
+
     pub fn constrained_inner(&self) -> Option<&InferredType> {
         match self {
             InferredType::TypeConstraintOf(inner) => Some(inner),
@@ -1551,6 +1558,23 @@ pub const APP_SURFACE_CLASS: &str = "Mojolicious::_AppSurface";
 /// wrapper. A scope has one parent and no cycles, so this is a linked-
 /// list climb, not a graph walk — the graph deliberately does not model
 /// it (`docs/adr/graph-walking.md`).
+/// Names of the Sub/Method symbols `class` itself defines — the override
+/// set that must shadow inherited answers wherever a parent walk
+/// enumerates methods (Perl dispatch goes to the local sub, so a
+/// parent's type must never answer for a name in this set). Shared by
+/// the writeback's local inheritance edges and enrichment's cross-file
+/// projection so the rule can't drift between them.
+pub(crate) fn own_method_names<'a>(
+    symbols: &'a [Symbol],
+    class: &'a str,
+) -> impl Iterator<Item = String> + 'a {
+    symbols.iter().filter_map(move |s| {
+        (matches!(s.kind, SymKind::Sub | SymKind::Method)
+            && s.package.as_deref() == Some(class))
+        .then(|| s.name.clone())
+    })
+}
+
 pub fn scope_chain_of(scopes: &[Scope], start: ScopeId) -> Vec<ScopeId> {
     let mut chain = Vec::new();
     let mut current = Some(start);
@@ -3690,7 +3714,7 @@ impl FileAnalysis {
                 }
                 if matches!(
                     &w.payload,
-                    WitnessPayload::Fact { family, .. } if family == "mutation"
+                    WitnessPayload::Fact { family, .. } if family == crate::witnesses::tags::FACT_MUTATION
                 ) && !out.contains(name)
                 {
                     out.push(name.clone());
@@ -4027,11 +4051,7 @@ impl FileAnalysis {
                 // under an overriding `Mac::file` is the canonical
                 // miscarriage). Seed the seen-set with the child's own
                 // method names so no parent edge is minted for them.
-                emitted_for_child.extend(self.symbols.iter().filter_map(|s| {
-                    (matches!(s.kind, SymKind::Sub | SymKind::Method)
-                        && s.package.as_deref() == Some(child.as_str()))
-                    .then(|| s.name.clone())
-                }));
+                emitted_for_child.extend(own_method_names(&self.symbols, child));
                 for parent in parents {
                     if parent == child {
                         continue;

--- a/src/file_analysis.rs
+++ b/src/file_analysis.rs
@@ -2564,6 +2564,12 @@ pub struct FileAnalysis {
     /// here so query-time owner resolution can mint the column owner cross-file.
     #[serde(default)]
     pub column_keyed_verbs: HashSet<String>,
+    /// Framework meta-methods — class-level DSL verbs installed on every
+    /// consuming class with no visible `sub` (`add_columns`, `meta`). The
+    /// plugin-declared union, baked here so the unresolved-method
+    /// diagnostic's suppression list is plugin-owned, not hardcoded.
+    #[serde(default)]
+    pub meta_methods: HashSet<String>,
     /// Number of dynamic method-dispatch sites (`$obj->$method(...)`) in
     /// this file — calls whose method name is a scalar, not a bareword.
     /// They produce no nameable `MethodCall` ref (unless const-folding
@@ -2652,6 +2658,7 @@ pub struct FileAnalysisParts {
     pub dynamic_parent_packages: HashSet<String>,
     pub role_packages: HashSet<String>,
     pub column_keyed_verbs: HashSet<String>,
+    pub meta_methods: HashSet<String>,
     pub dynamic_dispatch_sites: u32,
     pub plugin_loads: Vec<PluginLoadFact>,
     pub loader_config_params: Vec<LoaderConfigParam>,
@@ -2813,6 +2820,7 @@ impl FileAnalysis {
             dynamic_parent_packages,
             role_packages,
             column_keyed_verbs,
+            meta_methods,
             dynamic_dispatch_sites,
             plugin_loads,
             loader_config_params,
@@ -2854,6 +2862,7 @@ impl FileAnalysis {
             dynamic_parent_packages,
             role_packages,
             column_keyed_verbs,
+            meta_methods,
             dynamic_dispatch_sites,
             plugin_loads,
             loader_config_params,

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 115;
+pub const EXTRACT_VERSION: i64 = 116;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/module_cache.rs
+++ b/src/module_cache.rs
@@ -19,7 +19,7 @@ const SCHEMA_VERSION: &str = "9";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 114;
+pub const EXTRACT_VERSION: i64 = 115;
 
 /// zstd compression level for the `analysis` blob. Lower numbers are faster;
 /// 3 is zstd's default and gives a solid space/speed tradeoff.

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -947,6 +947,15 @@ pub trait FrameworkPlugin: Send + Sync {
         &[]
     }
 
+    /// Meta-methods this framework installs on every consuming class —
+    /// class-level DSL verbs with no visible `sub` declaration
+    /// (`__PACKAGE__->add_columns`, `$obj->meta`). The unresolved-method
+    /// diagnostic consults the registry union so framework DSL calls never
+    /// flag as unresolved. Default empty.
+    fn meta_methods(&self) -> &[String] {
+        &[]
+    }
+
     /// Fluent verbs — a call that returns the invocant's type unchanged (DBIC
     /// `search`/`search_rs` on a resultset → a same-row resultset). Only fires on
     /// an actual resultset invocant; the chain composes through the existing
@@ -1287,6 +1296,15 @@ impl PluginRegistry {
         self.plugins
             .iter()
             .flat_map(|p| p.column_keyed_verbs().iter().map(|s| s.as_str()))
+    }
+
+    /// Union of framework meta-methods across the registry — class-level
+    /// DSL verbs with no visible declaration. Baked onto `FileAnalysis`
+    /// for the unresolved-method diagnostic's suppression list.
+    pub fn meta_methods<'a>(&'a self) -> impl Iterator<Item = &'a str> + 'a {
+        self.plugins
+            .iter()
+            .flat_map(|p| p.meta_methods().iter().map(|s| s.as_str()))
     }
 
     /// Union of fluent verbs (call type follows the invocant) across the registry.

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -74,8 +74,22 @@ pub fn make_engine() -> Engine {
         to_dynamic(InferredType::CodeRef { return_edge: None }).unwrap()
     });
     engine.register_fn("type_regexp", || to_dynamic(InferredType::Regexp).unwrap());
+    engine.register_fn("type_undef", || to_dynamic(InferredType::Undef).unwrap());
     engine.register_fn("type_class", |class: String| {
         to_dynamic(InferredType::ClassName(class)).unwrap_or(Dynamic::UNIT)
+    });
+    // Lift a type to `Optional<T>` (idempotent — an already-Optional value
+    // passes through). Unit-in → Unit-out so a fold can pipe a declined
+    // inner straight through without re-checking.
+    engine.register_fn("type_optional", |inner: Dynamic| -> Dynamic {
+        let Ok(t) = from_dynamic::<InferredType>(&inner) else {
+            return Dynamic::UNIT;
+        };
+        let lifted = match t {
+            InferredType::Optional(_) => t,
+            other => InferredType::Optional(Box::new(other)),
+        };
+        to_dynamic(lifted).unwrap_or(Dynamic::UNIT)
     });
 
     // Project a constraint type to what it constrains — the rhai mirror of

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -735,6 +735,7 @@ const BUNDLED: &[(&str, &str)] = &[
     ("dancer", include_str!("../../frameworks/dancer.rhai")),
     ("moo", include_str!("../../frameworks/moo.rhai")),
     ("catalyst", include_str!("../../frameworks/catalyst.rhai")),
+    ("monkey-patch", include_str!("../../frameworks/monkey-patch.rhai")),
 ];
 
 pub fn load_bundled(engine: Arc<Engine>) -> Vec<Box<dyn FrameworkPlugin>> {

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -202,6 +202,7 @@ pub struct RhaiPlugin {
     app_surface_consumers: Vec<String>,
     role_makers: Vec<String>,
     column_keyed_verbs: Vec<String>,
+    meta_methods: Vec<String>,
     fluent_verbs: Vec<String>,
     arg_name_verbs: Vec<String>,
     topic_route_dsl: Option<crate::plugin::TopicRouteDsl>,
@@ -412,6 +413,27 @@ impl RhaiPlugin {
             }
         }
 
+        // `meta_methods()` — class-level DSL verbs the framework installs
+        // with no visible declaration; same optional, fail-safe shape.
+        let mut meta_methods: Vec<String> = Vec::new();
+        if signatures.iter().any(|n| n == "meta_methods") {
+            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "meta_methods", ()) {
+                Ok(arr) => {
+                    for d in arr {
+                        match from_dynamic::<String>(&d) {
+                            Ok(s) => meta_methods.push(s),
+                            Err(e) => log::error!(
+                                "plugin `{}` meta_methods() bad entry: {}",
+                                id,
+                                e
+                            ),
+                        }
+                    }
+                }
+                Err(e) => log::error!("plugin `{}` meta_methods() failed: {}", id, e),
+            }
+        }
+
         // `fluent_verbs()` — verbs whose call type follows the invocant; same
         // optional, fail-safe array-of-strings shape.
         let mut fluent_verbs: Vec<String> = Vec::new();
@@ -484,6 +506,7 @@ impl RhaiPlugin {
             app_surface_consumers,
             role_makers,
             column_keyed_verbs,
+            meta_methods,
             fluent_verbs,
             arg_name_verbs,
             topic_route_dsl,
@@ -587,6 +610,10 @@ impl FrameworkPlugin for RhaiPlugin {
 
     fn column_keyed_verbs(&self) -> &[String] {
         &self.column_keyed_verbs
+    }
+
+    fn meta_methods(&self) -> &[String] {
+        &self.meta_methods
     }
 
     fn fluent_verbs(&self) -> &[String] {

--- a/src/plugin/rhai_host.rs
+++ b/src/plugin/rhai_host.rs
@@ -216,6 +216,35 @@ pub struct RhaiPlugin {
     has_on_completion: bool,
 }
 
+/// Read an optional list-shaped manifest hook: a missing fn is empty, a
+/// failed call or bad element logs and skips — the shared fail-safe
+/// contract for every manifest family (a broken plugin must not break
+/// the build).
+fn read_manifest_list<T: serde::de::DeserializeOwned>(
+    engine: &Engine,
+    ast: &AST,
+    signatures: &[String],
+    id: &str,
+    fn_name: &str,
+) -> Vec<T> {
+    let mut out = Vec::new();
+    if !signatures.iter().any(|n| n == fn_name) {
+        return out;
+    }
+    match engine.call_fn::<Array>(&mut rhai::Scope::new(), ast, fn_name, ()) {
+        Ok(arr) => {
+            for d in arr {
+                match from_dynamic::<T>(&d) {
+                    Ok(v) => out.push(v),
+                    Err(e) => log::error!("plugin `{}` {}() bad entry: {}", id, fn_name, e),
+                }
+            }
+        }
+        Err(e) => log::error!("plugin `{}` {}() failed: {}", id, fn_name, e),
+    }
+    out
+}
+
 impl RhaiPlugin {
     /// Compile a script from source text and interrogate its metadata
     /// (`id()`, `triggers()`) up-front so dispatch is cheap.
@@ -247,234 +276,31 @@ impl RhaiPlugin {
             .map(|f| f.name.to_string())
             .collect();
 
-        // `overrides()` is optional. Read once at compile time; missing
-        // function == no overrides. A bad return shape logs and treats
-        // as empty — same fail-safe as the emit hooks (a broken plugin
-        // shouldn't break the build).
-        let mut overrides: Vec<TypeOverride> = Vec::new();
-        if signatures.iter().any(|n| n == "overrides") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "overrides", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<TypeOverride>(&d) {
-                            Ok(o) => overrides.push(o),
-                            Err(e) => log::error!(
-                                "plugin `{}` overrides() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` overrides() failed: {}", id, e),
-            }
-        }
-
-        // `dispatch_verbs()` — same optional, fail-safe contract as overrides.
-        let mut dispatch_verbs: Vec<DispatchVerb> = Vec::new();
-        if signatures.iter().any(|n| n == "dispatch_verbs") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "dispatch_verbs", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<DispatchVerb>(&d) {
-                            Ok(v) => dispatch_verbs.push(v),
-                            Err(e) => log::error!(
-                                "plugin `{}` dispatch_verbs() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` dispatch_verbs() failed: {}", id, e),
-            }
-        }
-
-        // `load_verbs()` — same optional, fail-safe contract.
-        let mut load_verbs: Vec<crate::plugin::LoadVerb> = Vec::new();
-        if signatures.iter().any(|n| n == "load_verbs") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "load_verbs", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<crate::plugin::LoadVerb>(&d) {
-                            Ok(v) => load_verbs.push(v),
-                            Err(e) => log::error!(
-                                "plugin `{}` load_verbs() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` load_verbs() failed: {}", id, e),
-            }
-        }
-
-        // `param_types()` — role-contract parameter typing.
-        let mut param_types: Vec<ParamType> = Vec::new();
-        if signatures.iter().any(|n| n == "param_types") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "param_types", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<ParamType>(&d) {
-                            Ok(v) => param_types.push(v),
-                            Err(e) => log::error!(
-                                "plugin `{}` param_types() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` param_types() failed: {}", id, e),
-            }
-        }
-
-        // `type_constraint_names()` — the constraint-constructor dispatch gate.
-        let mut type_constraint_names: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "type_constraint_names") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "type_constraint_names", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => type_constraint_names.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` type_constraint_names() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` type_constraint_names() failed: {}", id, e),
-            }
-        }
-
-        // `app_surface_consumers()` — the declared receiver set for the
-        // app surface; same optional, fail-safe array-of-strings shape.
-        let mut app_surface_consumers: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "app_surface_consumers") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "app_surface_consumers", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => app_surface_consumers.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` app_surface_consumers() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` app_surface_consumers() failed: {}", id, e),
-            }
-        }
-
-        // `role_makers()` — modules whose `use` makes the consuming
-        // package a role; same optional, fail-safe array-of-strings shape.
-        let mut role_makers: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "role_makers") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "role_makers", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => role_makers.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` role_makers() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` role_makers() failed: {}", id, e),
-            }
-        }
-
-        // `column_keyed_verbs()` — verbs whose first hashref arg is keyed by the
-        // receiver class's columns; same optional, fail-safe array-of-strings.
-        let mut column_keyed_verbs: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "column_keyed_verbs") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "column_keyed_verbs", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => column_keyed_verbs.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` column_keyed_verbs() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` column_keyed_verbs() failed: {}", id, e),
-            }
-        }
-
-        // `meta_methods()` — class-level DSL verbs the framework installs
-        // with no visible declaration; same optional, fail-safe shape.
-        let mut meta_methods: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "meta_methods") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "meta_methods", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => meta_methods.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` meta_methods() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` meta_methods() failed: {}", id, e),
-            }
-        }
-
-        // `fluent_verbs()` — verbs whose call type follows the invocant; same
-        // optional, fail-safe array-of-strings shape.
-        let mut fluent_verbs: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "fluent_verbs") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "fluent_verbs", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => fluent_verbs.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` fluent_verbs() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` fluent_verbs() failed: {}", id, e),
-            }
-        }
-
-        // `arg_name_verbs()` — call verbs wanting flat-arg-name
-        // extraction; same optional, fail-safe array-of-strings shape.
-        let mut arg_name_verbs: Vec<String> = Vec::new();
-        if signatures.iter().any(|n| n == "arg_name_verbs") {
-            match engine.call_fn::<Array>(&mut rhai::Scope::new(), &ast, "arg_name_verbs", ()) {
-                Ok(arr) => {
-                    for d in arr {
-                        match from_dynamic::<String>(&d) {
-                            Ok(s) => arg_name_verbs.push(s),
-                            Err(e) => log::error!(
-                                "plugin `{}` arg_name_verbs() bad entry: {}",
-                                id,
-                                e
-                            ),
-                        }
-                    }
-                }
-                Err(e) => log::error!("plugin `{}` arg_name_verbs() failed: {}", id, e),
-            }
-        }
+        // List-shaped manifest hooks all share one optional, fail-safe
+        // contract (see `read_manifest_list`): missing fn == empty, bad
+        // shapes log and skip.
+        let overrides: Vec<TypeOverride> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "overrides");
+        let dispatch_verbs: Vec<DispatchVerb> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "dispatch_verbs");
+        let load_verbs: Vec<crate::plugin::LoadVerb> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "load_verbs");
+        let param_types: Vec<ParamType> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "param_types");
+        let type_constraint_names: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "type_constraint_names");
+        let app_surface_consumers: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "app_surface_consumers");
+        let role_makers: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "role_makers");
+        let column_keyed_verbs: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "column_keyed_verbs");
+        let meta_methods: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "meta_methods");
+        let fluent_verbs: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "fluent_verbs");
+        let arg_name_verbs: Vec<String> =
+            read_manifest_list(&engine, &ast, &signatures, &id, "arg_name_verbs");
 
         // `topic_route_dsl()` — optional manifest map; bad shapes log
         // and disable rather than fail the plugin.

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2258,8 +2258,15 @@ pub fn collect_diagnostics(
         let is_local_class = analysis.symbols.iter().any(|s| {
             matches!(s.kind, FaSymKind::Class | FaSymKind::Package) && s.name == class_name
         });
-        let is_cached_class =
-            options.unresolved_method_cross_file && module_index.get_cached(&class_name).is_some();
+        // Cross-file receivers only count when the class is one the USER
+        // wrote (registered from the workspace tree). Pure @INC/DEPENDENCY
+        // classes routinely carry codegen/XS/exporter-injected methods the
+        // static walker can't see — flagging those is noise, and the
+        // role split is the principled gate (docs/
+        // prompt-method-resolution-residuals.md §3).
+        let is_cached_class = options.unresolved_method_cross_file
+            && module_index.is_workspace_module(&class_name)
+            && module_index.get_cached(&class_name).is_some();
         if !is_local_class && !is_cached_class {
             continue;
         }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -2198,21 +2198,12 @@ pub fn collect_diagnostics(
     }
 
     // 5e: Unresolved method diagnostics for locally-defined classes.
-    // Rule-#10 debt: the framework entries below (DBIC/Moose) belong to the
-    // frameworks, not core diagnostics — they move out when plugins can
-    // register meta-methods (docs/prompt-dbic-as-plugin.md) or the Openness
-    // rule lands (docs/prompt-graph-walking.md, Openness).
+    // Only the genuinely UNIVERSAL:: surface lives here; framework
+    // meta-methods (DBIC's `add_columns`, Moose's `meta`/`does`) come from
+    // the plugins' `meta_methods()` manifests, baked into
+    // `analysis.meta_methods` at build time.
     let universal_methods = [
-        "new", "AUTOLOAD", "DESTROY", "can", "isa", "DOES",
-        // Moose adds lowercase `does` alongside UNIVERSAL's uppercase DOES.
-        "does",
-        "VERSION",
-        // DBIC meta-methods (inherited from DBIx::Class::Core)
-        "add_columns", "add_column", "set_primary_key", "table", "resultset_class",
-        "has_many", "has_one", "belongs_to", "might_have", "many_to_many",
-        "load_components",
-        // Moose/Moo meta-methods
-        "meta",
+        "new", "AUTOLOAD", "DESTROY", "can", "isa", "DOES", "VERSION",
     ];
     for r in &analysis.refs {
         let (invocant, _invocant_span) = match &r.kind {
@@ -2226,8 +2217,10 @@ pub fn collect_diagnostics(
         };
         let method_name = &r.target_name;
 
-        // Skip universal methods
-        if universal_methods.contains(&method_name.as_str()) {
+        // Skip universal methods and plugin-declared framework meta-methods.
+        if universal_methods.contains(&method_name.as_str())
+            || analysis.meta_methods.contains(method_name.as_str())
+        {
             continue;
         }
 

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -346,6 +346,21 @@ fn cached_class(module: &str, methods: &[&str]) -> std::sync::Arc<crate::module_
     ))
 }
 
+/// Register a class as a WORKSPACE module (the path the cross-file
+/// unresolved-method lint fires for — a class the user wrote). Contrast
+/// `insert_cache`, which models a pure @INC/DEPENDENCY module.
+fn workspace_class(idx: &crate::module_index::ModuleIndex, module: &str, methods: &[&str]) {
+    let mut src = format!("package {};\n", module);
+    for m in methods {
+        src.push_str(&format!("sub {} {{}}\n", m));
+    }
+    src.push_str("1;\n");
+    idx.register_workspace_module(
+        std::path::PathBuf::from(format!("/fake/{}.pm", module.replace("::", "/"))),
+        std::sync::Arc::new(parse_analysis(&src)),
+    );
+}
+
 fn unresolved_method_diags(
     source: &str,
     idx: &crate::module_index::ModuleIndex,
@@ -418,7 +433,7 @@ sub g {
 1;
 "#;
     let idx = crate::module_index::ModuleIndex::new_for_test();
-    idx.insert_cache("My::Dep", Some(cached_class("My::Dep", &["known_method"])));
+    workspace_class(&idx, "My::Dep", &["known_method"]);
 
     // Default: cross-file extension off → no diagnostic.
     assert!(
@@ -426,11 +441,36 @@ sub g {
         "cross-file unresolved-method must stay silent without the opt-in",
     );
 
-    // Opt-in: the cross-file class is known and lacks `bogus` → fires.
+    // Opt-in: the workspace class is known and lacks `bogus` → fires.
     let on = DiagnosticOptions { unresolved_method_cross_file: true, ..Default::default() };
     let diags = unresolved_method_diags(src, &idx, on);
     assert_eq!(diags.len(), 1, "opt-in cross-file bogus fires: {:?}", diags);
     assert!(diags[0].contains("My::Dep"), "{}", diags[0]);
+}
+
+#[test]
+fn d8_dependency_class_stays_silent_even_with_flag() {
+    // The same shape, but the class comes from @INC (insert_cache — a
+    // DEPENDENCY, not a workspace file). Generated/XS/exporter-injected
+    // methods are invisible to the static walker exactly there, so the
+    // cross-file lint is WORKSPACE-scoped and stays silent.
+    let src = r#"
+package Main;
+sub g {
+    my ($self, $x) = @_;
+    if ($x->isa('My::Dep')) {
+        $x->bogus;
+    }
+}
+1;
+"#;
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    idx.insert_cache("My::Dep", Some(cached_class("My::Dep", &["known_method"])));
+    let on = DiagnosticOptions { unresolved_method_cross_file: true, ..Default::default() };
+    assert!(
+        unresolved_method_diags(src, &idx, on).is_empty(),
+        "a pure-dependency class must not be flagged even with the opt-in",
+    );
 }
 
 #[test]
@@ -446,7 +486,7 @@ sub g {
 1;
 "#;
     let idx = crate::module_index::ModuleIndex::new_for_test();
-    idx.insert_cache("My::Dep", Some(cached_class("My::Dep", &["known_method"])));
+    workspace_class(&idx, "My::Dep", &["known_method"]);
     let on = DiagnosticOptions { unresolved_method_cross_file: true, ..Default::default() };
     assert!(
         unresolved_method_diags(src, &idx, on).is_empty(),

--- a/src/symbols_tests.rs
+++ b/src/symbols_tests.rs
@@ -360,6 +360,30 @@ fn unresolved_method_diags(
 }
 
 #[test]
+fn framework_meta_methods_suppressed_via_plugin_manifest() {
+    // `set_primary_key` / `meta` have no visible `sub` anywhere — they're
+    // framework meta-methods, declared by the dbic/moo plugins'
+    // `meta_methods()` manifests and baked into `analysis.meta_methods`.
+    // Core's diagnostic holds only the true UNIVERSAL:: list.
+    let src = r#"
+package Foo;
+sub real { 1 }
+package Main;
+sub g {
+    Foo->set_primary_key('id');
+    Foo->meta;
+}
+1;
+"#;
+    let idx = crate::module_index::ModuleIndex::new_for_test();
+    let diags = unresolved_method_diags(src, &idx, DiagnosticOptions::default());
+    assert!(
+        diags.is_empty(),
+        "plugin-declared meta-methods must not flag as unresolved: {diags:?}",
+    );
+}
+
+#[test]
 fn d8_narrowed_local_class_fires_by_default() {
     // The local-class narrowing case is always-on (no flag) — the receiver
     // narrows to an in-file class that lacks the method.

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -569,13 +569,19 @@ impl WitnessReducer for FrameworkAwareTypeFold {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        matches!(
+        if !matches!(
             w.attachment,
             WitnessAttachment::Variable { .. } | WitnessAttachment::Expression(_)
-        ) && matches!(
-            w.payload,
-            WitnessPayload::InferredType(_) | WitnessPayload::Observation(_)
-        )
+        ) {
+            return false;
+        }
+        match &w.payload {
+            WitnessPayload::InferredType(_) | WitnessPayload::Observation(_) => true,
+            // Whole-scalar reassignment marker — a belief boundary the
+            // temporal fold honors (see reduce).
+            WitnessPayload::Fact { family, .. } => family == "reassign_barrier",
+            _ => false,
+        }
     }
 
     fn reduce(&self, ws: &[&Witness], q: &ReducerQuery) -> ReducedValue {
@@ -633,12 +639,42 @@ impl WitnessReducer for FrameworkAwareTypeFold {
         let mut re = false;
         let mut plain_type: Option<InferredType> = None;
 
+        // A whole-scalar reassignment is a belief boundary: witnesses
+        // strictly BEFORE the latest barrier (that is itself at or before
+        // the query point) describe a value the write replaced. A typed
+        // write pushes its own TC at the barrier's position (>= keeps
+        // it); an untypeable write leaves only the barrier, so the fold
+        // widens to unknown instead of resurrecting the stale belief
+        // (`my $ct = undef; while (…) { $ct = f($_) } … defined $ct`).
+        // A barrier is in effect only for query points past its whole
+        // STATEMENT (span end): a read inside the write statement itself
+        // (`… if $isbn && !$isbn->is_valid` — the condition runs first)
+        // still sees the pre-write belief. It then drops beliefs from
+        // strictly earlier statements (span start comparison), so the
+        // same statement's own TC — anchored at the statement start —
+        // survives its own barrier.
+        let latest_barrier: Option<Point> = narrow_point.and_then(|point| {
+            ws.iter()
+                .filter(|w| {
+                    matches!(&w.payload,
+                        WitnessPayload::Fact { family, .. } if family == "reassign_barrier")
+                        && w.span.end <= point
+                })
+                .map(|w| w.span.start)
+                .max()
+        });
+
         for w in ws {
             // Temporal ordering: only consider witnesses emitted at or
             // before the query point — a later reassignment shouldn't
             // influence a lookup at an earlier line.
             if let Some(point) = narrow_point {
                 if w.span.start > point {
+                    continue;
+                }
+            }
+            if let Some(barrier) = latest_barrier {
+                if w.span.start < barrier {
                     continue;
                 }
             }

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -368,6 +368,36 @@ impl FrameworkFact {
     }
 }
 
+// ---- Shared fact-family / source-tag identifiers ----
+
+/// The Fact `family` strings and builder source tags that form a
+/// producer↔consumer contract between the builder's emission sites and
+/// the reducers here. A bare literal on either side is a silent-unlink
+/// typo hazard (the fold just stops seeing the fact); both sides
+/// reference these so the identifier is compiler-checked.
+pub(crate) mod tags {
+    /// `SymbolReturnArm` Fact: a `return;` / `return undef` / `return ()`
+    /// arm — no rvalue type to ride an Edge; the arm join counts it.
+    pub(crate) const FACT_UNDEF_ARM: &str = "undef_arm";
+    /// `SymbolReturnArm` Fact: a value arm, typed or not — the all-undef
+    /// verdict must account for arms whose Edge never materialized.
+    pub(crate) const FACT_VALUE_ARM: &str = "value_arm";
+    /// `SlotType` Fact: a slot write whose RHS didn't type — blocks the
+    /// fold's definitive all-undef claim (partial story).
+    pub(crate) const FACT_OPAQUE_SLOT_WRITE: &str = "opaque_slot_write";
+    /// `Variable` Fact: a whole-scalar reassignment statement — the
+    /// temporal fold's belief barrier (span = the write's statement).
+    pub(crate) const FACT_REASSIGN_BARRIER: &str = "reassign_barrier";
+    /// `HashKey` Fact: a hash-key write observed on the owner (feeds
+    /// `mutated_keys_on_class` dynamic-key completion).
+    pub(crate) const FACT_MUTATION: &str = "mutation";
+    /// Writeback source tag on `MethodOnClass(class, m) → Edge(Symbol)`
+    /// primaries — doubles as the "a local definition exists" fact the
+    /// inheritance fallback walk gates on (an override's parent must
+    /// never answer for it).
+    pub(crate) const TAG_LOCAL_RETURN: &str = "local_return";
+}
+
 // ---- Witness bag ----
 
 /// Attachment-indexed bag. Kept separate from the raw witness vec so
@@ -579,7 +609,7 @@ impl WitnessReducer for FrameworkAwareTypeFold {
             WitnessPayload::InferredType(_) | WitnessPayload::Observation(_) => true,
             // Whole-scalar reassignment marker — a belief boundary the
             // temporal fold honors (see reduce).
-            WitnessPayload::Fact { family, .. } => family == "reassign_barrier",
+            WitnessPayload::Fact { family, .. } => family == tags::FACT_REASSIGN_BARRIER,
             _ => false,
         }
     }
@@ -657,7 +687,7 @@ impl WitnessReducer for FrameworkAwareTypeFold {
             ws.iter()
                 .filter(|w| {
                     matches!(&w.payload,
-                        WitnessPayload::Fact { family, .. } if family == "reassign_barrier")
+                        WitnessPayload::Fact { family, .. } if family == tags::FACT_REASSIGN_BARRIER)
                         && w.span.end <= point
                 })
                 .map(|w| w.span.start)
@@ -845,7 +875,7 @@ impl WitnessReducer for BranchArmFold {
         }
         match &w.payload {
             WitnessPayload::InferredType(_) => true,
-            WitnessPayload::Fact { family, .. } => family == "undef_arm",
+            WitnessPayload::Fact { family, .. } => family == tags::FACT_UNDEF_ARM,
             _ => false,
         }
     }
@@ -856,7 +886,7 @@ impl WitnessReducer for BranchArmFold {
         for w in ws {
             match &w.payload {
                 WitnessPayload::InferredType(t) => typed.push(t.clone()),
-                WitnessPayload::Fact { family, .. } if family == "undef_arm" => undef_arms += 1,
+                WitnessPayload::Fact { family, .. } if family == tags::FACT_UNDEF_ARM => undef_arms += 1,
                 _ => {}
             }
         }
@@ -911,7 +941,7 @@ impl WitnessReducer for SymbolReturnArmFold {
             // Edge whose target never materializes leaves no InferredType,
             // so the all-undef gate counts arms through these Facts.
             WitnessPayload::Fact { family, .. } => {
-                family == "undef_arm" || family == "value_arm"
+                family == tags::FACT_UNDEF_ARM || family == tags::FACT_VALUE_ARM
             }
             _ => false,
         }
@@ -924,10 +954,10 @@ impl WitnessReducer for SymbolReturnArmFold {
         for w in ws {
             match &w.payload {
                 WitnessPayload::InferredType(t) => arms.push(t.clone()),
-                WitnessPayload::Fact { family, .. } if family == "undef_arm" => {
+                WitnessPayload::Fact { family, .. } if family == tags::FACT_UNDEF_ARM => {
                     has_undef_arm = true
                 }
-                WitnessPayload::Fact { family, .. } if family == "value_arm" => {
+                WitnessPayload::Fact { family, .. } if family == tags::FACT_VALUE_ARM => {
                     value_arms += 1
                 }
                 _ => {}
@@ -978,7 +1008,7 @@ impl WitnessReducer for SlotTypeFold {
             WitnessPayload::InferredType(_) => true,
             // The "a write we couldn't type exists" marker — gates the
             // all-undef verdict on having seen the whole story.
-            WitnessPayload::Fact { family, .. } => family == "opaque_slot_write",
+            WitnessPayload::Fact { family, .. } => family == tags::FACT_OPAQUE_SLOT_WRITE,
             _ => false,
         }
     }
@@ -993,7 +1023,7 @@ impl WitnessReducer for SlotTypeFold {
         let mut arms: Vec<InferredType> = Vec::new();
         for w in ws {
             match &w.payload {
-                WitnessPayload::Fact { family, .. } if family == "opaque_slot_write" => {
+                WitnessPayload::Fact { family, .. } if family == tags::FACT_OPAQUE_SLOT_WRITE => {
                     opaque_writes += 1;
                 }
                 WitnessPayload::InferredType(t) => match t {
@@ -1666,7 +1696,7 @@ impl ReducerRegistry {
                 // canonical miscarriage). The writeback's `local_return`
                 // witness IS the "a local definition exists" fact.
                 let has_local_override = bag.for_attachment(q.attachment).iter().any(|w| {
-                    matches!(&w.source, WitnessSource::Builder(t) if t == "local_return")
+                    matches!(&w.source, WitnessSource::Builder(t) if t == tags::TAG_LOCAL_RETURN)
                 });
                 if has_local_override {
                     return ReducedValue::None;

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -870,8 +870,13 @@ impl WitnessReducer for SymbolReturnArmFold {
         }
         match &w.payload {
             WitnessPayload::InferredType(_) => true,
-            // The `return undef` arm marker (no rvalue type to materialize).
-            WitnessPayload::Fact { family, .. } => family == "undef_arm",
+            // `undef_arm`: the `return undef` marker (no rvalue type to
+            // materialize). `value_arm`: the per-value-arm counter — an
+            // Edge whose target never materializes leaves no InferredType,
+            // so the all-undef gate counts arms through these Facts.
+            WitnessPayload::Fact { family, .. } => {
+                family == "undef_arm" || family == "value_arm"
+            }
             _ => false,
         }
     }
@@ -879,14 +884,25 @@ impl WitnessReducer for SymbolReturnArmFold {
     fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
         let mut arms: Vec<InferredType> = Vec::new();
         let mut has_undef_arm = false;
+        let mut value_arms = 0usize;
         for w in ws {
             match &w.payload {
                 WitnessPayload::InferredType(t) => arms.push(t.clone()),
                 WitnessPayload::Fact { family, .. } if family == "undef_arm" => {
                     has_undef_arm = true
                 }
+                WitnessPayload::Fact { family, .. } if family == "value_arm" => {
+                    value_arms += 1
+                }
                 _ => {}
             }
+        }
+        // Every arm is a provable undef → the definitive bottom `Undef`,
+        // not the silent `None`. Gated on zero value arms: `arms` being
+        // empty is NOT enough — an untypeable value arm leaves no
+        // InferredType but does leave its `value_arm` Fact.
+        if arms.is_empty() && has_undef_arm && value_arms == 0 {
+            return ReducedValue::Type(InferredType::Undef);
         }
         match crate::file_analysis::join_return_arms(&arms, has_undef_arm) {
             Some(t) => ReducedValue::Type(t),
@@ -924,13 +940,31 @@ impl WitnessReducer for SlotTypeFold {
     }
 
     fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
-        let arms: Vec<InferredType> = ws
-            .iter()
-            .filter_map(|w| match &w.payload {
-                WitnessPayload::InferredType(t) => Some(t.clone()),
-                _ => None,
-            })
-            .collect();
+        // Undef-ness is a flag, not an arm: an `undef` write (literal or a
+        // maybe-undef RHS) makes the slot optional without disturbing the
+        // agreement among the value writes. Strip it off, agree the value
+        // arms, re-lift `{T, undef} → Optional<T>` at the end.
+        let mut saw_undef = false;
+        let mut arms: Vec<InferredType> = Vec::new();
+        for w in ws {
+            let WitnessPayload::InferredType(t) = &w.payload else { continue };
+            match t {
+                InferredType::Undef => saw_undef = true,
+                InferredType::Optional(inner) => {
+                    saw_undef = true;
+                    arms.push((**inner).clone());
+                }
+                other => arms.push(other.clone()),
+            }
+        }
+        // Every observed write is undef → the slot IS undef.
+        if arms.is_empty() {
+            return if saw_undef {
+                ReducedValue::Type(InferredType::Undef)
+            } else {
+                ReducedValue::None
+            };
+        }
         // Two distinct class identities never agree: a slot can't be
         // both `A` and `B`. `class_name()` is the value's own "what
         // class am I" answer (rule #10) — distinct answers → None.
@@ -945,6 +979,9 @@ impl WitnessReducer for SlotTypeFold {
             }
         }
         match crate::file_analysis::resolve_return_type(&arms) {
+            Some(t) if saw_undef && !matches!(t, InferredType::Optional(_)) => {
+                ReducedValue::Type(InferredType::Optional(Box::new(t)))
+            }
             Some(t) => ReducedValue::Type(t),
             None => ReducedValue::None,
         }

--- a/src/witnesses.rs
+++ b/src/witnesses.rs
@@ -935,8 +935,16 @@ impl WitnessReducer for SlotTypeFold {
     }
 
     fn claims(&self, w: &Witness) -> bool {
-        matches!(w.attachment, WitnessAttachment::SlotType { .. })
-            && matches!(w.payload, WitnessPayload::InferredType(_))
+        if !matches!(w.attachment, WitnessAttachment::SlotType { .. }) {
+            return false;
+        }
+        match &w.payload {
+            WitnessPayload::InferredType(_) => true,
+            // The "a write we couldn't type exists" marker — gates the
+            // all-undef verdict on having seen the whole story.
+            WitnessPayload::Fact { family, .. } => family == "opaque_slot_write",
+            _ => false,
+        }
     }
 
     fn reduce(&self, ws: &[&Witness], _q: &ReducerQuery) -> ReducedValue {
@@ -945,21 +953,31 @@ impl WitnessReducer for SlotTypeFold {
         // agreement among the value writes. Strip it off, agree the value
         // arms, re-lift `{T, undef} → Optional<T>` at the end.
         let mut saw_undef = false;
+        let mut opaque_writes = 0usize;
         let mut arms: Vec<InferredType> = Vec::new();
         for w in ws {
-            let WitnessPayload::InferredType(t) = &w.payload else { continue };
-            match t {
-                InferredType::Undef => saw_undef = true,
-                InferredType::Optional(inner) => {
-                    saw_undef = true;
-                    arms.push((**inner).clone());
+            match &w.payload {
+                WitnessPayload::Fact { family, .. } if family == "opaque_slot_write" => {
+                    opaque_writes += 1;
                 }
-                other => arms.push(other.clone()),
+                WitnessPayload::InferredType(t) => match t {
+                    InferredType::Undef => saw_undef = true,
+                    InferredType::Optional(inner) => {
+                        saw_undef = true;
+                        arms.push((**inner).clone());
+                    }
+                    other => arms.push(other.clone()),
+                },
+                _ => {}
             }
         }
-        // Every observed write is undef → the slot IS undef.
+        // Every observed write is undef → the slot IS undef — but only
+        // when every write WAS observed. The init-then-mutate idiom
+        // (`$self->{h} = undef` in new, `= $param` in the setter) leaves
+        // the typed story partial; the definitive claim would flag every
+        // downstream deref as a guaranteed die.
         if arms.is_empty() {
-            return if saw_undef {
+            return if saw_undef && opaque_writes == 0 {
                 ReducedValue::Type(InferredType::Undef)
             } else {
                 ReducedValue::None
@@ -1602,6 +1620,21 @@ impl ReducerRegistry {
                 // cross-file ∪ synthetic app-surface edge — `parents_of`
                 // is the single edge-injection site shared with the
                 // FA-side ancestor walks).
+                //
+                // Gated on the class NOT defining the method itself: an
+                // override dispatches to the LOCAL sub under Perl's MRO,
+                // so when its type didn't resolve the honest answer is
+                // None — never the parent's type (the parent never runs
+                // for this receiver; `URI::file::Base::file { undef }`
+                // under an overriding `URI::file::Mac::file` is the
+                // canonical miscarriage). The writeback's `local_return`
+                // witness IS the "a local definition exists" fact.
+                let has_local_override = bag.for_attachment(q.attachment).iter().any(|w| {
+                    matches!(&w.source, WitnessSource::Builder(t) if t == "local_return")
+                });
+                if has_local_override {
+                    return ReducedValue::None;
+                }
                 let parents = crate::file_analysis::parents_of(
                     class,
                     ctx.package_parents,


### PR DESCRIPTION
Works the roadmap's Now list end to end, with a substrate-verified audit pass, then lands the disagreement-to-widen tier the audit pointed at.

## Optional / narrowing production gaps (Now #1 tail)

- `return ()` (a `stub_expression`) is an undef arm — `{T, ()}` lifts to `Optional<T>`, matching the ternary form.
- Every arm provably undef → the definitive `Undef`, not silent None. Gated on a per-arm `value_arm` Fact count so an untypeable value arm or a fallthrough tail (`return undef if $x; compute()`) blocks the verdict.
- `SlotTypeFold` lifts `{T, undef}` slot writes to `Optional<T>`; literal `undef` bakes to `InferredType::Undef` in `expr_payload`.
- Bareword `Maybe[InstanceOf['X']]` → `Optional<X>` (previously unwrapped to plain `X`), via a new `type_optional` rhai helper; the 0-arity Types::Standard base constants (`Str`/`Int`/…) join the constraint vocabulary so bareword `isa => Int` types accessors like the quoted spelling.

## DBIC phase 2

- New `meta_methods()` plugin manifest field. The DBIC/Moose entries hardcoded in `symbols.rs`' `universal_methods` move to `frameworks/dbic.rhai` / `frameworks/moo.rhai`; the registry union bakes into `FileAnalysis.meta_methods` and the unresolved-method diagnostic consults it. Core keeps only the true UNIVERSAL:: surface.

## Method-resolution residuals 1–3

- New bundled `frameworks/monkey-patch.rhai`: `monkey_patch $class => $name => sub {…}` registrations synthesize the named methods (string class, `__PACKAGE__`, multi-pair calls, loop registrations via the `string_values` fan-out). Dynamic class / unfolded names are honest misses.
- Sub::HandlesVia curried `handles => { local => [remote, @args] }` synthesizes; the HashPairs classification now pair-walks via `cst::pair_nodes`, fixing a real alignment bug where an arrayref value silently dropped itself *and* misparsed the pairs after it.
- The cross-file unresolved-method lint is WORKSPACE-scoped (`ModuleIndex::is_workspace_module`) — pure @INC/DEPENDENCY classes with codegen/XS methods stay silent.

## Audit-driven inference fixes

Ran the full diagnostic set over the gold substrate, diffed against a pre-branch binary, and fixed everything the audit surfaced:

- **Overrides shadow parents.** Both the writeback's inheritance edges and enrichment's cross-file projection seed their per-child dedup with the child's own method names — a locally-overridden method never answers with the parent's type (`URI::file::Base::file { undef }` under an overriding `Mac::file` was the canonical miscarriage).
- Mojo::Base `has parent => undef` no longer claims an `Undef` getter return — undef is the initial value of a mutable slot, not a contract.
- `SlotTypeFold`'s all-undef verdict requires having seen every write: untypeable RHS setters push an `opaque_slot_write` Fact that blocks the definitive claim, and positional-receiver writes (`$_[0]->{h} = $_[1]`) now count as slot writes via conventions.rs classification.
- Truthiness-binding guards narrow: `if (my $x = f())` / `return $self unless my $parent = $self->parent` / `if ($x)` strip `Optional` where the condition holds (new `NarrowOp::StripOptionalTruthy` — negates to nothing, stays out of the D3/D4 guard-site records).

## Disagreement-to-widen tier

The audit's dominant guard-lint FP class was a stale belief surviving a reassignment the walker couldn't type:

- **Reassignment barriers.** Every whole-scalar write records a `reassign_barrier` Fact on each scope-chain attachment holding the variable's witnesses. The temporal fold drops beliefs from strictly earlier statements once the barrier's statement completes — a typed write's own TC survives, an untypeable write widens to unknown. Declarations are the first binding, not a barrier.
- **Shift-invocant gating.** `my $x = shift` types as the enclosing class only when `$x` is the receiver (conventional invocant name, or the named sub's first positional). An anonymous sub's first shift is a callback payload, and a *second* shift is a plain argument read.
- **Conditional writes widen, never assert.** `$isbn = undef if $isbn && !$isbn->is_valid` pushed an unconditional `Undef` anchored before the condition's own deref; a postfix-conditional assignment now leaves only the barrier.

## Verification

- `cargo test`: 1103 passed, 0 failed.
- Gold harness: **173 PASS, 11 xfail, 0 FAIL** — `diag-mojo-daemon-callback-fp` promoted xfail→gold (the anon-sub shift gate closed the known first-param-self-in-callback gap).
- Substrate audit vs pre-branch: always-on `undef-deref` at **exact parity (8 = 8 sites)**; `redundantGuard` 115→59; `contradictory` 53→34; `unresolved-method` −180; `derefShape` 0 hits. Remaining noise classes are recorded in the ROADMAP promotion-audit note (open-world dispatch → Openness axis; named-helper first-param-self → KNOWN-GAPS).
- `EXTRACT_VERSION` → 116 (bag rules + FA shape changed).

Docs refreshed: ROADMAP Now-list + promotion-audit evidence, `prompt-optional-types.md`, `prompt-method-resolution-residuals.md`, `prompt-dbic-as-plugin.md`, `gold-corpus/KNOWN-GAPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8aHmG2m3EXXR2GdX2jsEj