### PR TITLE
fix: stop serving linkedEditingRange (typing hijack via prefix match)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ Inspect any snippet's CST with `perl-lsp --parse <file>` (or `echo '...' | perl-
 
 ## LSP capabilities
 
-documentSymbol, definition, references, hover, rename (+ prepareRename), completion, signatureHelp, inlayHint, documentHighlight, selectionRange, foldingRange, formatting (perltidy), rangeFormatting, semanticTokens/full, codeAction (auto-import), linkedEditingRange, workspace/symbol, diagnostics (unresolved function/method warnings).
+documentSymbol, definition, references, hover, rename (+ prepareRename), completion, signatureHelp, inlayHint, documentHighlight, selectionRange, foldingRange, formatting (perltidy), rangeFormatting, semanticTokens/full, codeAction (auto-import), workspace/symbol, diagnostics (unresolved function/method warnings).
 
 ## Key dependencies
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -239,7 +239,13 @@ impl LanguageServer for Backend {
                     work_done_progress_options: Default::default(),
                 })),
                 document_range_formatting_provider: Some(OneOf::Left(true)),
-                linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(true)),
+                // Off: clients with linked edits on by default (Zed) replay
+                // keystrokes into every returned range, so a mid-typed `$abel`
+                // whose `$a` prefix matches a declared variable live-renames
+                // the declaration (#116). Identifier occurrence sets don't fit
+                // this verb; re-enable only for an atomic slot like heredoc
+                // terminators.
+                linked_editing_range_provider: None,
                 completion_provider: Some(CompletionOptions {
                     trigger_characters: Some(vec![
                         "$".to_string(),
@@ -906,22 +912,12 @@ impl LanguageServer for Backend {
 
     async fn linked_editing_range(
         &self,
-        params: LinkedEditingRangeParams,
+        _params: LinkedEditingRangeParams,
     ) -> Result<Option<LinkedEditingRanges>> {
-        let uri = &params.text_document_position_params.text_document.uri;
-        let pos = params.text_document_position_params.position;
-        let doc = match self.files.get_open(uri) {
-            Some(doc) => doc,
-            None => return Ok(None),
-        };
-
-        match symbols::linked_editing_ranges(&doc.analysis, pos, Some(&*self.module_index)) {
-            Some(ranges) => Ok(Some(LinkedEditingRanges {
-                ranges,
-                word_pattern: None,
-            })),
-            None => Ok(None),
-        }
+        // Capability is off (see initialize); null here keeps clients that
+        // ignore capabilities from co-editing anyway. The occurrence set
+        // stays CLI-queryable via --linked-editing.
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
Root-caused from #116 / zed-industries/zed#60167 (RPC log confirmed it): Zed ships linked edits on by default and replays every keystroke into all ranges the server returns for `linkedEditingRange`. Since we answered with the full `find_references` occurrence set, typing `$abel` inside a string would — at the moment the typed prefix parses as `$a` — link the in-string token to a declared `my $a` and live-rename the declaration on the next keystroke (`my $a=1;` → `my $al=1;`, straight from the reporter's `didChange` log). The server can't distinguish "cursor resting on `$a`" from "user mid-typing `$abel`", so no heuristic closes this; ordinary identifier occurrence sets just don't fit the verb's co-edit contract.

Changes (teeny by request):
- `initialize` no longer advertises `linked_editing_range_provider`.
- The handler answers `null` defensively for clients that ignore capabilities.
- `symbols::linked_editing_ranges` and the `--linked-editing` CLI verb are untouched — the occurrence set stays QA-queryable and the gold-corpus rows still run against it.
- CLAUDE.md capability list updated.

The verb can come back later for a slot where atomic co-editing is actually correct — heredoc `<<END` / `END` terminator pairs are the natural Perl candidate.

Verified: `cargo build --release`, full `cargo test` (1071+ green), and a scripted stdio LSP session confirming the exact hijack position from the reporter's log now returns `null`. e2e (`nvim`) left to CI; gold corpus unaffected since the CLI verb's output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

