### PR TITLE
review: the narrow seams, two silent bugs, and the gate split's verdict

### DIFF
--- a/docs/review-narrow-seams.md
+++ b/docs/review-narrow-seams.md
@@ -1,0 +1,562 @@
+# Narrow-seam review — the few hundred lines where a bug is silent
+
+The "Validation still owed" row of `docs/prompt-scale-validation-hitlist.md`,
+against `5cf44dfd`. Five seams: cache byte accounting, residency, invalidation,
+the enrichment writer, `IndexCore` shared state — plus the adjudication the
+deferred `attached`/`durable` gate split was waiting on.
+
+Ranked by "silent and catastrophic", not by cost to fix. Two findings landed
+with base-verified tests; the rest are reported with the evidence that decides
+them. **Clean verdicts are stated as verdicts** — an unbroken seam with a
+reason is a result, and four of the five are mostly that.
+
+---
+
+## 1. `PackInvalidator::swap` strips against a persist it never checked
+
+`src/index/pack_invalidator.rs:413-484`. **Reported, not fixed — see "why not
+landed".**
+
+The watcher's re-analysis path hand-rolls its own persist loop instead of
+using `run_persist_writer`, and discards both signals that say whether a blob
+landed: `save_to_db`'s `bool` return, and `tx.commit()`'s `Result` (`let _ =
+tx.commit()`, not even logged). `persisted` is then set to `true`
+unconditionally, and it is the strip license:
+
+```rust
+if persisted && !arc.degraded && eviction_enabled() {
+    let _ = pack.register_symbols_stripping((*p).clone(), (**arc).clone(), true, true);
+}
+```
+
+So `persisted` means "a connection opened", not "a blob landed". It lies when
+the commit fails (`SQLITE_FULL`, I/O error, an unretryable busy — the whole
+batch rolls back), when one file's `save_to_db` fails while the commit
+succeeds, or when `unchecked_transaction()` errored and a mid-loop failure
+left the autocommit batch partial.
+
+**The failure is stale, not empty, which is worse.** A rollback leaves the
+previous generation's row intact, and `load_one_diag`
+(`module_cache/blob.rs:163-175`) deliberately skips stamp validation for a
+single-row path:
+
+> `// Single-row paths deliberately skip stamp validation — the registered`
+> `// generation may legitimately predate an unsaved edit, and the caller`
+> `// invalidates the LRU on file change.`
+
+The loader therefore **succeeds**, returning the pre-edit analysis. References,
+goto-def and types answer against the pre-edit generation of an edited file for
+the rest of the session, with no `REHYDRATION_MISSES` increment, no log line,
+and no `PERL_LSP_STRICT_RESIDENCY` panic. Only a file never persisted before
+takes the honest wrong-empty-and-counted path.
+
+The rest of the codebase already has this right, which is what makes it a
+defect rather than a design question: `run_persist_writer`
+(`module_resolver/persist.rs:136-199`) owns BEGIN/COMMIT/ROLLBACK and routes
+every entry to `on_committed` or `on_fallback`; `save_module_generation`
+returns "whether the blob row landed (**the strip-legality signal**)";
+`conn.rs:58-61` already names this exact hazard — *"a failed commit after
+resident copies were stripped is unrecoverable for the session"* — and
+mitigates only the BUSY lane with a 10 s `busy_timeout`. `PackInvalidator::swap`
+is the one persist site that opted out of all of it.
+
+Fix shape: thread the real signal per path.
+
+```rust
+let mut landed: HashSet<PathBuf> = HashSet::new();
+...
+    if module_cache::save_to_db(&conn, &p_str, &Some(cached), "workspace") {
+        landed.insert(p.clone());
+    }
+...
+    let committed = match tx {
+        Some(tx) => match tx.commit() {
+            Ok(()) => true,
+            Err(e) => { log::error!("pack swap: commit failed ({e}) — registering whole copies"); false }
+        },
+        None => true,   // autocommit: each save_to_db reported for itself
+    };
+    if !committed { landed.clear(); }
+```
+then gate the strip on `landed.contains(p)`.
+
+**Why not landed.** `open_cache_db` is `#[cfg(test)] -> None` unconditionally
+(`module_cache/conn.rs:97-100`), so under `cargo test` `persisted` is always
+`false` and the strip branch never executes. The entire persist-then-strip path
+in `PackInvalidator::swap` has **zero unit coverage by construction** — which
+is also why the bug is comfortable there. A fix cannot be base-verified without
+first giving the harness a real cache DB, which is a larger change than the fix.
+That harness gap is finding #2.
+
+## 2. The persist/strip licence is untestable, and it is the one thing worth testing
+
+`#[cfg(test)] open_cache_db -> None` makes every strip-licensing decision —
+`persisted`, `strip_import_copy`'s gate, the writer's committed/fallback fork —
+unreachable from `cargo test`. Everything that decides whether a resident copy
+may be stripped is therefore exercised only by the gold harness and by
+corpus runs, and only when those happen to take the failure lane, which they
+essentially never do.
+
+This is the coverage shape that lets #1 exist and would let the gate split's
+two failure lanes (below) ship unexercised. A test-mode `open_cache_db` that
+opens a temp-dir DB (env-keyed, or a `#[cfg(test)]` override cell) is the
+enabling change for all of it.
+
+## 3. `ResolveQueue`'s priority lane can lose its wakeup — **fixed, `7febd2b`**
+
+`IndexCore`'s `ResolveQueue` guards two lanes with two mutexes but parks on one
+condvar, and a condvar is bound to the mutex it waits on — `pending`. A
+`priority` push therefore has no ordering against the drain at all:
+
+1. drain locks `priority`, sees empty, unlocks;
+2. `request_resolve` locks `priority`, pushes a stale module, unlocks,
+   `notify_one()` — **nobody is parked yet, the notification is discarded**;
+3. drain locks `pending`, sees empty, parks in `wait(pending)`.
+
+The wait loop never re-checked `priority`, so the batch slept until unrelated
+`pending` traffic arrived. On an `EXTRACT_VERSION` bump — the documented
+priority trigger — every `request_resolve` takes the priority branch, so
+nothing ever pushes `pending` and the resolver thread sleeps for the rest of
+the session: cross-file resolution silently never completes and every affected
+verb answers unresolved, permanently.
+
+Both halves were needed. The loop now checks `priority` inside the wait with
+`pending` held, and producers notify through `ResolveQueue::notify_new_work`,
+which takes `pending` so a push can neither be missed by the check nor land its
+notify in the pre-park window. Lock order is pending-then-priority in the drain,
+so producers release `priority` first.
+
+Base-verified: `priority_push_wakes_a_parked_drain` hits its 5 s timeout before
+the change (exit 101) and returns in 0.3 s after.
+
+The rest of `IndexCore`'s locking is clean, and the specific hazard family the
+brief named is not present:
+
+- **No guard held across `resolve()`.** Every `lsp/backend/server.rs` handler
+  snapshots `(Arc::clone(&doc.analysis), text, language)` and drops the
+  `FileStore` shard guard before `run_query`, each site carrying the reason.
+  `document_symbol` holds its guard across `extract_symbols`, which is a pure
+  read of the snapshot with no `for_each_open` and no await — safe.
+- **No lock-order cycle into the queue.** `request_resolve` is called under a
+  `FileStore` open-shard guard (`server.rs:331`), giving shard→queue. There is
+  no reverse edge: producers hold a queue mutex only across the push, and
+  `on_resolved` fires *outside* `core.resolved.mu` (`thread.rs:295-305`).
+- `ensure_workspace_indexed` does no synchronous `FileStore` work under the
+  caller's guard — it swaps a latch and `spawn_blocking`s.
+
+## 4. The byte-accounting alarm fired on a designed state — **fixed, `841ef9e`**
+
+`evict_to_cap` never evicts `keep` ("a single oversized bag over the whole cap
+still resolves the query it was loaded for"), so an entry larger than the cap
+reaches the out-of-victims arm on **every** insert, with the charge total
+perfectly correct — and that arm called `resync_bytes`, which unconditionally
+counted `pack_bag_cache.resync_bytes_fired`. That is the counter `5cf44dfd`
+added to name the drift that collapsed the LRU to one entry and grew the
+process to 13.9 GB. A benign, reachable trigger on that counter is exactly what
+the next real instance would hide behind — and the oversized-entry case is not
+exotic at 122×.
+
+`resync_bytes` now recomputes first and reports only when the stored total
+actually needed correcting; the count is also readable off the cache rather
+than only under `PERL_LSP_GHOST_STATS`, so both halves are assertable.
+Base-verified: `an_oversized_entry_is_not_reported_as_drift` fails before
+(`left: 1, right: 0`) and passes after, while `a_drifted_counter_is_reported`
+passes throughout.
+
+### The two-flavors-one-budget question: clean, and structurally so
+
+The brief flagged the rows lane (`b6312ea2`) sharing one byte budget with the
+whole lane as "exactly where accounting drifts". It does not, and the reason is
+worth stating because it is a property of the design rather than of the current
+code:
+
+**No flavor-specific accounting exists.** The charge travels with the entry as
+`(Arc<FileAnalysis>, usize)`, so `entries.insert` returns the displaced entry's
+own charge and `credit()` refunds exactly it, in the same DashMap operation
+that installs the replacement. A stripped→whole upgrade debits the new size and
+credits the exact old one; there is no path where a flavor is charged at one
+size and refunded at another. `heap_estimate()` is taken **after**
+`evict_witness_bag()` on the rows lane, so the stripped entry is charged its
+stripped size. One key means one entry, so the two flavors can never coexist
+for a path.
+
+I also walked the race interleavings (two threads decoding one path in either
+insert order; `invalidate` racing an insert; eviction racing `invalidate`) and
+the counter stays exact in each: every debit precedes its entry becoming
+visible and every credit is keyed to a removal that returned `Some`.
+
+Two residuals, neither an accounting bug:
+
+- **Thrash, not drift, is the two-lane risk.** The lanes compete for one budget
+  with entry sizes differing ~2×, and the LRU has no notion of "this path is
+  mostly wanted stripped". A reference walk populates stripped entries; a hover
+  on any of those re-decodes whole and roughly doubles that path's charge,
+  evicting ~2 stripped entries. Near the cap this is the classic
+  two-populations-one-LRU problem. It is invisible to every functional test and
+  to a Perl-only soak, and the instrument that would show it is precisely the
+  **pack-language soak the hitlist already lists as owed**. Recommend measuring
+  the ratio of `refs.matcher_upgrade` to `refs.matcher_rows_view` and the
+  rows/whole re-decode counts in that soak before trusting the density win at
+  hour scale.
+- `generation` and `recency` accumulate `PathBuf` keys that nothing removes
+  (`invalidate` inserts a generation entry forever; a lost insert/recency race
+  can strand a recency key). Bounded by corpus size, not by time — ~14 MB of
+  path strings at 138k files — and not byte-accounted, in a module whose whole
+  point is byte accounting. Low priority, worth a sweep on invalidate.
+
+## 5. Residency: the invariant holds, and I checked it exhaustively
+
+The rule that matters — **a reader must never see resident-or-empty** — is
+intact. `b6312ea2` made this a live question by changing `symbols_present` from
+"a whole copy" to "a deliberately bag-stripped copy" (via `rows_for`), so any
+pre-existing consumer that read the bag off a `symbols_present` view was
+previously right by accident and would now be silently wrong. I audited all of
+them:
+
+| site | reads | verdict |
+|---|---|---|
+| `resolve/refs.rs:664, 777, 797, 859` | `.symbols()` only | clean |
+| `resolve/definitions.rs:786` | `sub_info_view(..).def_line()` — primary symbol span | clean |
+| `resolve/definitions.rs:826` | `package_var_def_line` — symbols | clean |
+| `model/ancestry.rs:464` | symbols + `symbol_is_class_content` (no bag reads) | clean |
+| `model/class_queries.rs:543` | name/kind/package scan | clean |
+| `model/cross_file.rs:460, 464` | `has_sub_in_package` / `sub_info_view(..).is_some()` — existence | clean |
+| `module_index/queries.rs:246, 376` | existence probes | clean |
+| `module_index/lookup.rs:147` | `plugin.namespaces` (never-evicted lane) + symbols | clean |
+
+Every one carries an explicit "symbols-axis read only" comment. The discipline
+was applied when the lane landed; this is a confirmation, not a discovery.
+
+`matcher_view` (`resolve/refs.rs:321-348`) — the upgrade-to-whole decision that
+the "naive bag-strip loses 106 sites at Koha" note turns on — is also correct,
+including the part that looks wrong. Its `_ => false` arm is a target-kind
+allowlist, which reads like rule #10's partial enumeration, but:
+
+- `Ref::match_verdict_baked` is `true` for every ref kind except `MethodCall`
+  and `HashKeyAccess`, so no other kind can ever need the upgrade;
+- the only matcher arms that consult the bag are `(Sub|Method, MethodCall)`
+  (`method_call_invocant_class` when `method_target()` is `None` — exactly the
+  unbaked case) and `Handler` (`applicable_dispatches`, no-op when
+  `provisional_dispatches` is empty). Both are in the allowlist;
+- I specifically chased the delegation-alias path, where a name that is not
+  `target.name` can match and the pre-scan would miss it. `alias_matched`
+  excludes `RefKind::MethodCall` and short-circuits `matches_kind`, so an alias
+  match never reaches a bag-reading arm. No gap.
+- the closure gate (`file_sees_target_ids`) runs on the raw resident copy
+  *before* the view upgrade, which would be a hole if it read an evictable
+  axis. It reads `analysis.pack.include_closure` — the pack lane, which
+  `evict_axes` never touches. Safe.
+
+Still, `matcher_view` would be strictly better spelled as the general rule
+(upgrade when *any* name-matching ref is unbaked, `Handler` keeping its
+dispatch check), which is a superset of today's behavior at a cost of at most
+one extra decode per file, and stops the enumeration from having to be
+re-audited every time a matcher arm grows a bag read.
+
+### One latent hazard: `bag_present` is read for symbols
+
+`model/enrichment.rs:293-329` takes `idx.bag_present(&cached)` and then
+iterates `whole.symbols`. `bag_present` promises the bag axis only; the trait's
+own doc says a consumer reading more than one axis must take `whole_present`.
+This is safe **today** only because of an invariant held in the callers, not in
+the reader: every production strip site passes `(true, false)` or
+`(true, true)` to `evict_axes` — `index_perl.rs:188` computes `strip_rows =
+strip_bag && rows_ok`, `strip_import_copy` is bag-only, `pack_invalidator` is
+both — so "bag present, symbols evicted" is unreachable. The signature
+`evict_axes(strip_bag: bool, strip_rows: bool)` can express it, and the first
+site that writes `(false, true)` silently turns that loop into
+absence-by-eviction on every cross-file import enrichment. Either make the
+pairing unrepresentable (a closed `StripPlan` enum) or `debug_assert!(strip_bag
+|| !strip_rows)` in `evict_axes`; the reader should take `whole_present`
+either way.
+
+### `whole_copy_registration_sites_are_allowlisted`
+
+The test greps source lines for `name(` call sites and compares counts. It
+does what it claims (it catches a *new* whole-copy site) but three limits are
+worth writing down, since the gate split adds registration sites:
+
+- it counts **call sites, not residency** — an allowlisted site with count 1
+  can register N whole copies in a loop. The `residency_tripwire`
+  (`count_fully_resident` vs `expected_whole`) is the machine gate for that;
+  the allowlist is a human-review trigger. The two are complementary, and only
+  the tripwire runs on real data.
+- it skips `//`-prefixed lines only — a call inside a block comment or a string
+  counts.
+- it names six registration functions. `insert_cache` (whole by construction —
+  `persisted: false, strip: false`) is not among them; it is test-only today,
+  and a first production caller would pin whole copies without tripping the
+  allowlist. Worth adding with an empty expectation, the way
+  `register_workspace_module` already is.
+
+## 6. Invalidation and the enrichment writer: clean
+
+**`PackInvalidator`** — beyond finding #1, the coordination is sound. The H9-1
+generation guard claims *before* unregistering, so a stale re-analysis leaves
+the fresher registration intact rather than tearing it down; the surface gate
+(`skip_consumers`) refreshes consumers' `deps_stamp` on the Unchanged path,
+which is the non-obvious half (an unchanged header still moved every consumer's
+closure stamp, and skipping the refresh would make the next warm reject every
+consumer row). `is_consumer` stays the single include-closure rule.
+
+**`FileStore::enrich_open`** is the one open-doc writer and holds its
+contract. It clones off the store lock, enriches, and swaps under a short
+`Arc::ptr_eq` guard, so a concurrent rebuild wins and this derivation is
+dropped. Idempotency is real: `enrich_imported_types_with_keys` truncates
+`symbols`/`witnesses`/`refs` back to their sealed baselines before re-appending,
+and I checked that the enrichment body's appends land only in those three lanes
+(`enrichment.rs:151, 172, 180, 194, 347, 464, 540, 573, 581, 589` — symbols,
+witnesses, refs, and `push_type_constraint`, which is itself a witness push).
+`plugin.gated_emissions` is assigned wholesale rather than appended, so it
+cannot accumulate. Re-enriching an already-enriched clone is therefore stable
+rather than growing, which is the property that matters for a long-lived open
+doc.
+
+The concurrency residual is benign: two threads enriching one URL both derive
+from the same `base`, one wins the swap, and the loser returns its own equally
+valid derivation to its caller. Both were built from the same baseline.
+
+`Document::baseline_surface` being the freshness record — pre-enrichment, by
+construction — is what makes surface verdicts enrichment-invariant without any
+record-before-publish ordering. That is the load-bearing piece and it holds.
+
+## 7. Not a bug: `epoch.gen_stamp_missing = 1074`
+
+The hitlist's Tier 2 "a counter incrementing a thousand times unexplained".
+It is `IndexCore::stamp_missing_import_gens`, whose whole job is to stamp a
+generation for cache entries the @INC warm scan wrote without a registration
+front door. `or_insert_with` means it fires at most once per path, so 1074 is
+simply the number of warm-loaded providers that had no front-door generation —
+the function working. (`9d5e1cc0` closed this row; recording the mechanism here
+because it took thirty seconds to confirm from the code and the row's
+"correlated with nothing" reads as more mysterious than it is.)
+
+## 8. Unmeasured, lower confidence: `record_loader_shapes` in the parallel walk
+
+`IndexCore::record_loader_shapes` opens with
+
+```rust
+self.loader_config_shapes.retain(|_n, v| { v.retain(|(c, _)| c != contributor); !v.is_empty() });
+```
+
+and it is called once per file from inside `paths.par_iter().for_each(...)`
+(`index_perl.rs:399`) and again per file on the warm scan (`:181`).
+`DashMap::retain` takes a write guard on **every shard**, so every one of
+138,822 files puts a global write barrier in the middle of the parallel bulk
+index — even when the map is empty and there is nothing to retire. The
+per-call work is bounded by the number of distinct loader names (small), so
+this is a contention claim, not a complexity one, and I have **not measured
+it** — the corpora are not available here. If the cold-walk's 4.5 ms/file (vs
+3.0 at Koha) is ever re-attributed, this is a cheap thing to rule out: guard
+the retain on a non-empty map, or track contributors in a reverse map so a
+re-registration touches one key.
+
+## 9. 22 gold rows skip silently on a threaded Linux perl
+
+Found while building the substrate rather than by reading the seams, but it
+is the same failure shape the review is about. The DateTime fixtures spell
+their corpus path with a hardcoded arch triple:
+
+```
+gold-corpus/local/lib/perl5/x86_64-linux/DateTime.pm
+```
+
+Debian/Ubuntu's threaded perl installs into `x86_64-linux-gnu-thread-multi`,
+so on those hosts all 22 DateTime rows report `file not found` and land in
+`skip` — the run still exits 0 and still prints `0 FAIL / 0 XPASS / 0 CRASH`.
+A 469-row green and a 491-row green are indistinguishable at a glance, and the
+skipped set is exactly the cross-file hover / references / type-at rows that
+exercise a real XS-bearing dist.
+
+Confirmed by bridging the two spellings: with a symlink in place the same
+binary and the same substrate go 469 PASS / 22 skip → **491 PASS / 0 skip**.
+The fixture paths want to resolve the arch dir from `$Config{archname}` (or
+glob it) rather than assume one; failing that, `run.pl` should treat a nonzero
+skip count as something the summary shouts about.
+
+---
+
+# The gate split — adjudication
+
+The design, from `fc863769`'s Tier 1 #1: split `IndexReady.perl` into
+`attached` (opens at walk end) and `durable` (opens at drain end), plus
+worker-time registration of stripped copies behind a pending-blob overlay.
+Named failure lanes: commit-fail must replace a stripped registration with the
+whole-copy fallback; budget-overrun must UNREGISTER, "needing a removal path
+that does not currently exist".
+
+**Verdict: the gate split is safe. The worker-time registration it is bundled
+with is not, as specified — and the two are separable. Land the split; do not
+land register-before-commit until three things are true.**
+
+## Why the split alone is safe
+
+The gate is a `ReadyGate` that bounded waiters block on
+(`await_index_ready(language, WaitPolicy)`). Splitting it into two gates
+changes nothing about residency; it changes which verbs wait for what. The
+whole risk is per-verb classification, and it is a bounded, reviewable
+exercise: `attached` may gate only answers derivable from what exists at walk
+end (which files exist, which names they declare — the registration feed is
+extracted pre-strip and is complete at walk end), and `durable` must gate every
+answer that reads file *content* through a possibly-evicted axis, because
+content is what needs a committed blob to rehydrate from.
+
+The one thing to insist on: **there is no type-level enforcement of that
+split.** A `ReadyGate` is a runtime latch, so a verb wired to the wrong gate
+under-answers silently — the same failure class as everything else in this
+review. If the split lands, the classification wants to be a property a verb
+declares once (next to its `WaitPolicy`) rather than a call-site choice, and it
+wants a test that enumerates the verbs, the way
+`whole_copy_registration_sites_are_allowlisted` enumerates registration sites.
+
+## Why register-before-commit is the dangerous half
+
+**Today, "not yet registered" is the safe state, and every failure lane is a
+*decision not to register*.** `index_perl.rs:412-416` says it exactly: *"Until
+then the file reads as 'not yet indexed' — never wrong-empty."* That is why
+`on_fallback`'s drop-past-budget is honest — nothing was registered, so nothing
+has to be taken back.
+
+Worker-time registration inverts this. Both failure lanes stop being decisions
+and become **retractions**, which is a strictly harder problem, and it breaks
+three properties that the current design leans on:
+
+### (a) It retires the instrument that catches absence-as-answer
+
+`rehydrate_or_resident` documents its miss as *"ALWAYS an invariant break
+in-session: eviction is licensed only by a committed blob (persist-first)"*,
+and `PERL_LSP_STRICT_RESIDENCY` panics on it — the gold harness sets it, which
+is what makes a run that serves absence fail as a CRASH row instead of scoring
+wrong answers. With stripped copies registered before commit, a rehydration
+miss during the pending window is **normal**. That forces one of two things:
+
+- the overlay serves the pending blob, so misses stay invariant breaks — this
+  is the only acceptable option; or
+- misses become expected and strict mode must be relaxed for the window — which
+  retires the one instrument that catches absence-as-answer, in the same change
+  that introduces a new way to serve it.
+
+So the overlay is not an optimization; it is load-bearing for the crash canary.
+
+### (b) The overlay must WIN over the loader, not fall back to it
+
+This is the concrete flaw, and it is the same mechanism as finding #1.
+`load_one_diag` skips stamp validation for a single-row path. On any warm start
+of an edited tree, the previous session's row exists. So during the pending
+window a rehydration for a pending path would find a row, **succeed**, and
+serve last session's analysis — retained in the LRU, with no miss counted.
+`on_committed`'s `invalidate_bag_cache` would clear it afterwards, so the
+wrongness is bounded by the window; but the window is the 7–9 minute writer
+drain, i.e. exactly the first-time user's first ten minutes that Tier 1 #1
+exists to fix.
+
+Requirement: the overlay must be consulted **ahead of** the SQLite loader for
+pending paths, and the loader must refuse a row for a path with a pending
+registration. Fallback-on-miss (the R4 overlay's shape) is the wrong shape here.
+
+### (c) The ordering guarantee has nowhere to sit
+
+Today `on_committed` does `invalidate_bag_cache(path)` and *then* registers, so
+"an evicted copy is never reachable before its blob can rehydrate it" holds by
+construction. Register-before-commit removes the point in time where that
+sequence is expressible. The pending-blob overlay has to supply the guarantee
+instead, which means the overlay must be populated **before** the stripped copy
+is registered, and torn down **after** the LRU is invalidated at commit.
+That ordering should be minted by one function that owns both, the way
+`prepare_workspace_parts` owns reads-whole-before-evict — not spelled at the
+call sites.
+
+## The two failure lanes, adjudicated
+
+### Commit-fail → whole-copy fallback: **mechanically fine, and the memory is a wash**
+
+`run_persist_writer` already forks committed/fallback and the fallback already
+registers whole copies under `FALLBACK_WHOLE_BYTE_CAP`. Under
+register-before-commit the fallback becomes *replace the stripped registration
+with a whole one*, which is a re-registration — `register_workspace_resident`
+already replaces in place and re-picks the name-slot winner. No new machinery.
+
+On memory: the overlay holds the same `Vec<u8>` blobs the `WsFresh` channel
+entries already hold today, so it is roughly neutral against the ~7 GB drain
+backlog rather than additive — **provided the overlay holds encoded blobs, not
+decoded analyses.** An analysis-shaped overlay would multiply that backlog by
+the decode ratio and rebuild the wall this whole arc exists to avoid.
+
+### Budget-overrun → unregister: **the removal path exists; the brief's premise is slightly off, and what is actually missing is different**
+
+`ModuleIndex::unregister_workspace_path` (`registration.rs:692-733`) is a real
+inverse for the Perl workspace tier — `remove_surface`, `all_files`,
+`edges.remove_path_record`, `registered_names` → `all_defs` →
+`rebuild_name_registration` per affected name, with a cache-scan fallback for
+legacy doors. `unregister_file` (`:1248`) is the pack twin. The
+`registered_names` design exists precisely so the inverse is exact under symbol
+eviction (`docs/adr/storage-engine.md`, "Registration inverse under symbol
+eviction").
+
+What is genuinely missing is narrower, and worth having the real list:
+
+1. **`FileStore.workspace`** is not part of either unregister; the caller must
+   pair `files.remove_workspace(path)`. Today the only unregister callers are
+   deletion paths that do. A budget-overrun retraction is a new caller and will
+   forget unless the two are fused.
+2. **`IndexCore.loader_config_shapes` has no removal.** Entries are keyed by
+   contributor path string and retired *only* by that contributor
+   re-registering (`record_loader_shapes`'s opening `retain`). A retracted file
+   leaves its loader-config shapes in the index permanently — a phantom
+   contributor for `PluginLoad` config typing.
+3. **`ModuleIndex.loaded_modules` has no removal.** `record_workspace_projections`
+   inserts every import and plugin-load name; nothing takes them out. This
+   feeds the entrypoint-scan lint, so a retracted file leaves phantom
+   "module is loaded" facts.
+
+Both (2) and (3) are written at **worker time** by
+`record_workspace_projections`, which is exactly the point the design proposes
+to make reachable early. That is the real gap: not "no removal path" but
+"the removal path does not cover the two lanes worker-time registration
+writes".
+
+4. Not missing but load-bearing: **unregister has never run concurrently with
+   live queries.** Every existing caller is on the watcher path behind
+   `PackInvalidator`'s serialization lock, or is a delete. A budget-overrun
+   retraction fires from the persist writer thread while handlers are reading.
+   `unregister_workspace_path` does `all_files.remove` → `registered_names.remove`
+   → per-name `all_defs` mutation → `rebuild_name_registration`, all as separate
+   DashMap operations with no overall atomicity: a query interleaving mid-way
+   sees a file removed from `all_files` but still a candidate in `all_defs`, or
+   a name slot briefly pointing at a departed path. Today that window is
+   invisible because it is serialized; under the new caller it is not.
+
+## What must be true first
+
+1. **A test-mode `open_cache_db`** (finding #2). Both failure lanes are
+   persist-outcome lanes; without this they ship unexercised, and finding #1
+   is the proof that an unexercised persist lane rots.
+2. **Fix finding #1 first**, on its own. It is the same bug the commit-fail
+   lane must not reproduce, in code the gate split will sit on top of, and it
+   is a much smaller change to reason about in isolation.
+3. **The overlay wins over the loader for pending paths**, with the loader
+   refusing a row for a pending path — not fallback-on-miss (b). Otherwise the
+   stale-single-row path serves last session's analysis for the whole window.
+4. **The overlay holds encoded blobs**, byte-capped, so it is neutral against
+   today's channel backlog rather than additive; and overflow of *that* cap is
+   the budget-overrun lane, so cap and lane are one mechanism.
+5. **Retraction is one function** that fuses `unregister_workspace_path`,
+   `FileStore::remove_workspace`, and removal of the `loader_config_shapes` /
+   `loaded_modules` contributions — and its concurrency window is either closed
+   or explicitly bounded (4 above).
+6. **The `attached`/`durable` classification is declared, not chosen per call
+   site**, with an enumerating test.
+
+1, 2, 3 and 5 are prerequisites. 4 and 6 are shape constraints on the design
+itself. None of them is large; together they are most of the work, which is
+the honest reading — the hard part of this change was never the gate.
+
+**And a separability note that may be the most useful thing here:** the
+availability win the row is after comes from opening `attached` at walk end.
+Worker-time registration is what makes `attached` *useful* for content verbs —
+but a split where `attached` gates only existence/name answers needs **no**
+worker-time registration, no overlay, and neither failure lane. That is a
+strictly smaller change that banks part of the win and can land now, against
+seams that are already proven. Whether it banks enough is a measurement
+question (how much of the wedge is existence-shaped), and it is one the bench
+harness can answer before committing to the larger design.

--- a/src/index/module_index/mod.rs
+++ b/src/index/module_index/mod.rs
@@ -121,6 +121,23 @@ pub(crate) struct ResolveQueue {
     pub condvar: Condvar,
 }
 
+impl ResolveQueue {
+    /// Wake the drain after enqueueing. The notify is taken under `pending`
+    /// — the mutex `drain_next_batch` parks on — so it cannot land in the
+    /// window between the drain's queue checks and its park, where a condvar
+    /// has nobody to signal and the wakeup is simply lost. Free for a
+    /// `pending` push (that mutex already serializes it), load-bearing for a
+    /// `priority` one, whose own mutex gives no such ordering.
+    ///
+    /// The caller must have RELEASED `priority` first: the drain acquires
+    /// pending-then-priority, so holding both the other way round closes a
+    /// cycle.
+    pub fn notify_new_work(&self) {
+        let _pending = self.pending.lock().unwrap();
+        self.condvar.notify_one();
+    }
+}
+
 /// Signaled after each module is resolved.
 pub(crate) struct ResolveNotify {
     pub mu: Mutex<()>,

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -121,7 +121,10 @@ impl ModuleIndex {
             let mut pending = self.core.queue.pending.lock().unwrap();
             pending.push(module_name.to_string());
         }
-        self.core.queue.condvar.notify_one();
+        // Both guards are out of scope here — `notify_new_work` takes
+        // `pending`, and the drain's lock order forbids holding `priority`
+        // across it.
+        self.core.queue.notify_new_work();
     }
 
     /// Return the cached CachedModule for a module name. Never does I/O.

--- a/src/index/module_resolver/module_resolver_tests.rs
+++ b/src/index/module_resolver/module_resolver_tests.rs
@@ -239,3 +239,46 @@ fn import_tier_strip_gates_on_persistence() {
     assert!(strip_import_copy(&None, true, true).is_none());
 }
 
+
+/// The priority lane is guarded by its OWN mutex while the drain waits on the
+/// `pending` one, so a `request_resolve` for a stale module can land after the
+/// drain's priority check and before it parks — the notify reaches nobody and
+/// the wait loop, which only re-checked `pending`, never looks at priority
+/// again. In an all-stale workload (an `EXTRACT_VERSION` bump: every
+/// `request_resolve` takes the priority branch) nothing ever pushes `pending`,
+/// so the resolver sleeps for the rest of the session and cross-file
+/// resolution silently never completes.
+#[test]
+fn priority_push_wakes_a_parked_drain() {
+    use std::sync::mpsc;
+    use std::sync::{Condvar, Mutex};
+
+    let queue = Arc::new(ResolveQueue {
+        priority: Mutex::new(Vec::new()),
+        pending: Mutex::new(Vec::new()),
+        condvar: Condvar::new(),
+    });
+    let (tx, rx) = mpsc::channel();
+    let q = Arc::clone(&queue);
+    std::thread::spawn(move || {
+        let _ = tx.send(drain_next_batch(&q));
+    });
+
+    // Let the drain get past its priority check and park in `wait(pending)`.
+    // Generous: the drain reaches the park in microseconds, so an early push
+    // (which the first priority check would catch, hiding the bug) is not a
+    // realistic outcome here.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    // Exactly what `ModuleIndex::request_resolve` does for a stale module.
+    {
+        let mut p = queue.priority.lock().unwrap();
+        p.push("Stale::Module".to_string());
+    }
+    queue.condvar.notify_one();
+
+    let batch = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("a priority push must wake the parked drain");
+    assert_eq!(batch, vec!["Stale::Module".to_string()]);
+}

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -61,9 +61,11 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
         // re-resolve on demand (`request_resolve` queues stale names with
         // priority).
         if server.is_some() && !stale_names.is_empty() {
-            let mut pq = core.queue.priority.lock().unwrap();
-            pq.extend(stale_names);
-            core.queue.condvar.notify_one();
+            {
+                let mut pq = core.queue.priority.lock().unwrap();
+                pq.extend(stale_names);
+            }
+            core.queue.notify_new_work();
         }
         // Build reverse index from warmed cache.
         core.rebuild_reverse_index();
@@ -309,23 +311,28 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
 }
 
 /// Drain the next batch from the queue, checking priority first.
-fn drain_next_batch(queue: &ResolveQueue) -> Vec<String> {
-    // Check priority first
-    {
-        let mut priority = queue.priority.lock().unwrap();
-        if !priority.is_empty() {
-            return std::mem::take(&mut *priority);
-        }
-    }
-    // Wait for pending
+///
+/// Both checks live INSIDE the wait loop and `pending` is held across them.
+/// `priority` has its own mutex, so — unlike a `pending` push — a priority
+/// push is not serialized against this park by the condvar's mutex: a check
+/// made before taking `pending` could be overtaken by a push whose notify
+/// then reaches nobody, and the batch would sleep until unrelated `pending`
+/// traffic arrived (forever, in an all-stale workload where every
+/// `request_resolve` takes the priority branch). Producers close the other
+/// half by notifying under `pending` (`ResolveQueue::notify_new_work`).
+///
+/// Lock order here is pending-then-priority; producers must never hold
+/// `priority` while acquiring `pending`.
+pub(super) fn drain_next_batch(queue: &ResolveQueue) -> Vec<String> {
     let mut pending = queue.pending.lock().unwrap();
     loop {
-        if !pending.is_empty() {
-            // Before draining pending, re-check priority
+        {
             let mut priority = queue.priority.lock().unwrap();
             if !priority.is_empty() {
                 return std::mem::take(&mut *priority);
             }
+        }
+        if !pending.is_empty() {
             return std::mem::take(&mut *pending);
         }
         pending = queue.condvar.wait(pending).unwrap();

--- a/src/index/pack_bag_cache.rs
+++ b/src/index/pack_bag_cache.rs
@@ -47,6 +47,11 @@ pub struct PackBagCache {
     /// interleaving ever breaks that, because an over-count is a one-way
     /// ratchet that collapses the cache to a single entry.
     bytes: AtomicUsize,
+    /// How many times `resync_bytes` found the charge total actually wrong
+    /// and repaired it. The ghost-stats counter reports the same event but
+    /// only under `PERL_LSP_GHOST_STATS`; this one is always live so the
+    /// alarm is assertable.
+    resyncs: AtomicUsize,
     /// `maxCacheMb * 1 MiB`. `0` ⇒ never retain (rehydrate-and-drop).
     cap_bytes: usize,
     /// Per-path invalidation generation: `invalidate` bumps, a loading
@@ -85,6 +90,7 @@ impl PackBagCache {
             recency: DashMap::new(),
             clock: AtomicU64::new(0),
             bytes: AtomicUsize::new(0),
+            resyncs: AtomicUsize::new(0),
             cap_bytes,
             generation: DashMap::new(),
             loader: Box::new(loader),
@@ -233,14 +239,19 @@ impl PackBagCache {
     /// Recompute the charge total from the map. O(entries), and only reached
     /// when eviction has run out of victims while still reading over cap.
     ///
-    /// This is a self-heal for an invariant that should never break, so it
-    /// firing at all is the signal — a drifting counter is what collapsed this
-    /// LRU to a single entry and grew the process to 13.9 GB. Silent
-    /// self-healing would hide the next instance, hence the counter.
+    /// This is a self-heal for an invariant that should never break, so a
+    /// REPAIR is the signal — a drifting counter is what collapsed this LRU to
+    /// a single entry and grew the process to 13.9 GB. But running out of
+    /// victims does not imply drift: `evict_to_cap` never evicts `keep`, so an
+    /// entry bigger than the whole cap lands here every insert with the total
+    /// perfectly correct. Counting that would train the reader to ignore the
+    /// one number that names the ratchet, so only an actual correction reports.
     fn resync_bytes(&self) {
-        crate::util::ghost_stats::count("pack_bag_cache.resync_bytes_fired");
         let truth: usize = self.entries.iter().map(|e| e.value().1).sum();
-        self.bytes.store(truth, Ordering::Relaxed);
+        if self.bytes.swap(truth, Ordering::Relaxed) != truth {
+            crate::util::ghost_stats::count("pack_bag_cache.resync_bytes_fired");
+            self.resyncs.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// Drop `path`'s retained bag (a changed/saved file's bag is stale) so the
@@ -435,6 +446,58 @@ mod tests {
         let rows3 = cache.rows_for(&p).unwrap();
         assert!(Arc::ptr_eq(&whole, &rows3), "whole entry is a superset for rows readers");
         assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    /// `evict_to_cap` deliberately never evicts `keep`, so an entry larger
+    /// than the whole cap leaves the loop unable to get back under it — a
+    /// DESIGNED state ("a single oversized bag over the whole cap still
+    /// resolves the query it was loaded for"), not drift. It must not trip
+    /// the drift alarm: an alarm that fires on a benign, reachable case is
+    /// one the next real 13.9 GB ratchet gets to hide behind.
+    #[test]
+    fn an_oversized_entry_is_not_reported_as_drift() {
+        let one = empty_fa().heap_estimate().total();
+        assert!(one > 1);
+        // Cap below a single entry: the first insert is permanently over.
+        let cache = PackBagCache::new(one - 1, move |_p| Ok(empty_fa()));
+        let a = PathBuf::from("/x/a.h");
+        cache.bag_for(&a);
+        assert!(
+            cache.bytes.load(Ordering::Relaxed) > cache.cap_bytes,
+            "precondition: the entry alone exceeds the cap"
+        );
+        let truth: usize = cache.entries.iter().map(|e| e.value().1).sum();
+        assert_eq!(
+            cache.bytes.load(Ordering::Relaxed),
+            truth,
+            "precondition: nothing actually drifted"
+        );
+        assert_eq!(
+            cache.resyncs.load(Ordering::Relaxed),
+            0,
+            "the oversized-keep case is by design, not a byte-accounting drift"
+        );
+    }
+
+    /// The other half: a genuinely wrong counter MUST still raise the alarm.
+    #[test]
+    fn a_drifted_counter_is_reported() {
+        let one = empty_fa().heap_estimate().total();
+        let cache = PackBagCache::new(one * 8, move |_p| Ok(empty_fa()));
+        let paths: Vec<PathBuf> =
+            (0..4).map(|i| PathBuf::from(format!("/x/{i}.h"))).collect();
+        for p in &paths {
+            cache.bag_for(p);
+        }
+        assert_eq!(cache.resyncs.load(Ordering::Relaxed), 0);
+        // Poison the counter the way a lost concurrent credit would, then
+        // force an INSERT (a hit never reaches `evict_to_cap`).
+        cache.bytes.fetch_add(one * 1000, Ordering::Relaxed);
+        cache.bag_for(&PathBuf::from("/x/fresh.h"));
+        assert!(
+            cache.resyncs.load(Ordering::Relaxed) > 0,
+            "a real drift must still fire the alarm"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the **narrow seam review** row of "Validation still owed" in `docs/prompt-scale-validation-hitlist.md`, and delivers the adjudication the deferred `attached`/`durable` gate split was waiting on.

Branched from **`5cf44dfd`**. Base is `claude/project-rewrite-cpp-yqutwf`, not main.

The full review is `docs/review-narrow-seams.md` (nine findings, with the reasoning that decides each). This body is the part you need without reading it.

---

## What landed

Two fixes, both base-verified — each test fails on the commit before its fix and passes after, checked by running it both ways, not by inspection.

**`7febd2b` — a priority resolve could be lost forever.** `IndexCore`'s `ResolveQueue` guards two lanes with two mutexes but parks on one condvar, and a condvar is bound to the mutex it waits on: `pending`. A `priority` push therefore had no ordering against the drain at all.

1. drain locks `priority`, sees empty, unlocks
2. `request_resolve` locks `priority`, pushes a stale module, unlocks, `notify_one()` — **nobody is parked yet, so the notification is discarded**
3. drain locks `pending`, sees empty, parks in `wait(pending)`

and the wait loop only ever re-checked `pending`. The batch then slept until unrelated `pending` traffic arrived. On an `EXTRACT_VERSION` bump — the documented priority trigger — *every* `request_resolve` takes the priority branch, so nothing pushes `pending` and the resolver thread sleeps for the rest of the session: cross-file resolution silently never completes.

Both halves were required. Both checks moved inside the wait loop with `pending` held, and producers now notify through `ResolveQueue::notify_new_work`, which takes `pending` so a push can neither be missed by the check nor land its notify in the pre-park window. Lock order is pending-then-priority in the drain, so producers release `priority` first. `priority_push_wakes_a_parked_drain` hits its 5 s timeout before the change (exit 101) and returns in 0.3 s after.

**`841ef9e` — the alarm you just added fires on a designed state.** `evict_to_cap` never evicts `keep`, by design ("a single oversized bag over the whole cap still resolves the query it was loaded for"), so an entry larger than the cap reaches the out-of-victims arm on *every* insert — with the charge total perfectly correct — and that arm counted `resync_bytes_fired` unconditionally. That is the counter `5cf44dfd` added to name the drift that collapsed the LRU to one entry and grew the process to 13.9 GB, and an oversized entry is not exotic at 122×. An alarm with a benign, reachable trigger is one the next real instance hides behind. `resync_bytes` now recomputes first and reports only when the stored total actually needed correcting; the count is also readable off the cache rather than only under `PERL_LSP_GHOST_STATS`, so both halves are assertable.

## The finding I could not fix, and why

**`PackInvalidator::swap` strips against a persist it never checked** (`pack_invalidator.rs:413-484`). Already posted to #120 for `[C]`; ranked #1 here. The watcher's re-analysis path hand-rolls its own persist loop instead of using `run_persist_writer` and discards *both* signals that say a blob landed — `save_to_db`'s `bool` return and `tx.commit()`'s `Result` (`let _ = tx.commit()`, not even logged) — then sets `persisted = true` unconditionally and uses it as the strip license.

The part I did not expect: **the failure is stale, not empty.** A rollback leaves the previous generation's row intact, and `load_one_diag` deliberately skips stamp validation for a single-row path. So the loader *succeeds* and returns the pre-edit analysis. References, goto-def and types answer against the pre-edit generation of an edited file for the rest of the session — with no `REHYDRATION_MISSES` increment, no log line, and no `PERL_LSP_STRICT_RESIDENCY` panic. Every instrument you have for this class stays quiet.

`run_persist_writer` already gets this right, `save_module_generation` already returns "the strip-legality signal", and `conn.rs:58-61` already names the hazard in a comment. `PackInvalidator::swap` is the one persist site that opted out of all of it.

I did not land the fix (written out in the doc) because **`open_cache_db` is `#[cfg(test)] -> None` unconditionally**, so under `cargo test` `persisted` is always `false` and the strip branch never executes. The entire persist-then-strip path there has zero unit coverage by construction — which is also why the bug is comfortable in it. Base-verify-or-don't-ship was your bar and I held to it; the enabling change (a test-mode cache DB) is finding #2 and is a prerequisite for the gate split too.

## The gate split — verdict

**Safe to build, but the design bundles two separable halves and only one of them is safe on these seams as they stand.**

- The **`attached`/`durable` split itself is safe.** It changes which verbs wait for what, not residency. The risk is per-verb classification, which is bounded and reviewable — but it wants to be a property a verb *declares* (next to its `WaitPolicy`) with an enumerating test, because a `ReadyGate` is a runtime latch and a verb wired to the wrong gate under-answers silently.
- **Worker-time registration behind a pending-blob overlay is not safe as specified.** Today "not yet registered" is the safe state and every failure lane is a *decision not to register* — which is why the fallback's drop-past-budget is honest. Register-before-commit inverts that: both lanes become *retractions*.

Three things break under that inversion, in descending order of how much they cost you:

1. **It retires the instrument that catches absence-as-answer.** `rehydrate_or_resident` documents a miss as "ALWAYS an invariant break in-session", and `PERL_LSP_STRICT_RESIDENCY` panics on it — that is what makes gold fail as a CRASH row instead of scoring wrong answers. With stripped copies registered pre-commit, a miss during the window is *normal*. So the overlay is not an optimization; it is load-bearing for the crash canary.
2. **The overlay must WIN over the loader, not fall back to it** — same mechanism as finding #1. `load_one_diag` skips stamp validation for a single-row path, so on any warm start of an edited tree a pending-window rehydration finds the previous session's row, **succeeds**, and serves last session's analysis, uncounted. Bounded by the window — which is the 7–9 minute drain, i.e. exactly the first ten minutes this row exists to fix. Fallback-on-miss (the R4 overlay's shape) is the wrong shape here.
3. **The ordering guarantee has nowhere to sit.** `on_committed` does `invalidate_bag_cache` *then* registers, so "an evicted copy is never reachable before its blob can rehydrate it" holds by construction. Register-before-commit deletes the moment where that sequence is expressible; the overlay has to supply it, minted by one function that owns both ends.

On the two named lanes:

- **Commit-fail → whole-copy fallback: mechanically fine.** `run_persist_writer` already forks committed/fallback and `register_workspace_resident` already replaces in place. Memory is roughly a wash — the overlay holds the same blobs the `WsFresh` channel entries hold today — **provided it holds encoded blobs, not decoded analyses.** An analysis-shaped overlay rebuilds the wall this arc exists to avoid.
- **Budget-overrun → unregister: your premise is slightly off, and what's actually missing is more specific.** `ModuleIndex::unregister_workspace_path` *does* exist and is a real inverse (`remove_surface`, `all_files`, `edges.remove_path_record`, `registered_names` → `all_defs` → `rebuild_name_registration`); `unregister_file` is the pack twin. What is missing is narrower: it does not touch `FileStore.workspace` (callers pair it manually), and **neither `IndexCore.loader_config_shapes` nor `ModuleIndex.loaded_modules` has any removal path** — both are written by `record_workspace_projections` at worker time, exactly the point the design makes reachable early, and both retire only when the same contributor re-registers. Plus: unregister has never run concurrently with live queries (every caller today sits behind the invalidator's serialization lock), and its four DashMap operations have no overall atomicity.

**What must be true first:** a test-mode `open_cache_db`; finding #1 fixed on its own; overlay-wins-over-loader; encoded-blob byte-capped overlay whose overflow *is* the budget lane; retraction fused into one function covering all five lanes; declared gate classification. None is large; together they are most of the work — which is the honest reading, since the hard part was never the gate.

**The separability note may be the most useful thing here:** a split where `attached` gates only existence/name answers needs no worker-time registration, no overlay, and neither failure lane. That is a strictly smaller change against seams already proven, and whether it banks enough of the win is a question the bench harness can answer before committing to the larger design.

## Seams that are clean, and why

Stated as verdicts rather than silence, per your ask.

- **Two-flavors-one-byte-budget: clean, structurally.** The rows lane cannot drift the accounting because *no flavor-specific accounting exists* — the charge travels with the entry as `(Arc, usize)`, `insert` returns the displaced entry's own charge and credits exactly it in the same operation, and `heap_estimate()` is taken *after* `evict_witness_bag()` so a stripped entry is charged its stripped size. I walked the race interleavings (two threads decoding one path either order, `invalidate` racing an insert, eviction racing `invalidate`) and the counter stays exact in each. The real two-lane risk is **thrash, not drift** — two populations, one LRU, entry sizes differing ~2× — and it is invisible to every functional test and to a Perl-only soak. The pack-language soak you already have listed as owed is the instrument; suggest watching `refs.matcher_upgrade` vs `refs.matcher_rows_view` in it.
- **Residency: the invariant holds, checked exhaustively.** `b6312ea2` made this live by changing `symbols_present` from "whole copy" to "deliberately bag-stripped", so any consumer that read the bag off it was previously right by accident. I audited all eight sites — all symbols-only, each already carrying the comment saying so. `matcher_view`'s `_ => false` target-kind allowlist *reads* like rule #10 but is correct: `match_verdict_baked` is true for every ref kind but `MethodCall`/`HashKeyAccess`, and I specifically chased the delegation-alias path (where a non-`target.name` match could dodge the pre-scan) — `alias_matched` excludes `MethodCall` and short-circuits `matches_kind`, so it never reaches a bag-reading arm. The closure gate runs pre-upgrade on the raw resident copy but reads only `pack.include_closure`, which `evict_axes` never touches.
- **One latent hazard there:** `enrichment.rs:293` takes `bag_present` and then iterates `whole.symbols`. Safe *today* only because no production strip site passes `(false, true)` to `evict_axes` — the signature can express it, and the first site that does turns that loop into absence-by-eviction on every cross-file import enrichment. Worth making unrepresentable.
- **`IndexCore` locking, beyond the condvar bug: clean.** No guard held across `resolve()` (every handler snapshots and drops, with the reason at each site); no lock-order cycle into the queue (`on_resolved` fires outside `resolved.mu`, producers hold a queue mutex only across the push); `ensure_workspace_indexed` does no synchronous store work under the caller's guard.
- **`enrich_open` holds its contract.** Clone off-lock, `Arc::ptr_eq`-guarded swap, and idempotency is real — I checked that every enrichment append lands in the three lanes that get truncated back to baseline (`plugin.gated_emissions` is assigned wholesale, not appended). Re-enriching an already-enriched clone is stable, not growing.
- **`epoch.gen_stamp_missing = 1074` is not a mystery.** It is `stamp_missing_import_gens` doing its job — one stamp per warm-loaded @INC provider that had no registration front door, `or_insert_with` so at most once per path. (`9d5e1cc0` closed the row; recording the mechanism because "correlated with nothing" reads as stranger than it is.)

Two lower-confidence items I did *not* chase to ground, flagged as such in the doc: `record_loader_shapes`' per-file `DashMap::retain` puts an all-shard write barrier inside the parallel bulk walk (contention claim, **unmeasured** — no corpora here), and `PackBagCache`'s `generation`/`recency` maps accumulate path keys nothing removes.

## Verification

Ran at the full bar, true exit codes checked (`${PIPESTATUS[0]}`, never a piped `grep` status).

| | result |
|---|---|
| `cargo test` | **exit 0** |
| `cargo test --features cpp` | **exit 0** — 1514 unit (1511 baseline + my 3) |
| `./target/release/perl-lsp --languages` | `perl, cpp (beta)` — confirmed **before** gold |
| gold | **491 PASS / 15 xfail / 0 FAIL / 0 XPASS / 0 CRASH**, 3 prov?, 0 skip |
| e2e | **could not run** — `nvim` absent (rc=127). CI's. |

Substrate built here per CLAUDE.md's restricted-proxy recipe (cpm → cpan.org mirror → `Carton::Snapshot` → snapshot resolver); 174 dists.

**One thing that turned up doing it, and it is the same failure shape as the rest of this review** (finding #9): the DateTime fixtures spell their corpus path with a hardcoded `x86_64-linux`. Debian/Ubuntu's threaded perl installs to `x86_64-linux-gnu-thread-multi`, so on those hosts **22 gold rows report `file not found`, land in `skip`, and the run still exits 0 printing `0 FAIL / 0 XPASS / 0 CRASH`.** My first green was 469 PASS / 22 skip and looked identical to a real one. Bridging the two spellings with a symlink took the same binary and same substrate to 491 / 0 skip — the number above. The skipped set is exactly the cross-file hover / references / type-at rows over a real XS dist. The fixtures want the arch dir from `$Config{archname}`; failing that, `run.pl` should shout about a nonzero skip count instead of printing it below the fold.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_