### PR TITLE
fix: the strip licence is a landed blob, and the lane that decides it is now testable

### DIFF
--- a/docs/review-narrow-seams.md
+++ b/docs/review-narrow-seams.md
@@ -12,10 +12,9 @@ reason is a result, and four of the five are mostly that.
 
 ---
 
-## 1. `PackInvalidator::swap` strips against a persist it never checked
+## 1. `PackInvalidator::swap` strips against a persist it never checked — **fixed, `586823d`**
 
-`src/index/pack_invalidator.rs:413-484`. **Reported, not fixed — see "why not
-landed".**
+`src/index/pack_invalidator.rs`.
 
 The watcher's re-analysis path hand-rolls its own persist loop instead of
 using `run_persist_writer`, and discards both signals that say whether a blob
@@ -60,47 +59,45 @@ resident copies were stripped is unrecoverable for the session"* — and
 mitigates only the BUSY lane with a 10 s `busy_timeout`. `PackInvalidator::swap`
 is the one persist site that opted out of all of it.
 
-Fix shape: thread the real signal per path.
+The persist collapses onto `run_persist_writer` rather than threading a
+second spelling of the same verdict through the hand-rolled loop: it already
+owns BEGIN IMMEDIATE / COMMIT / ROLLBACK and the committed/fallback fork, and
+two spellings of "did the blob land" is how the wrong one survives. Per-path
+truth rides `save_to_db`'s verdict into the committed lane, so one file's
+failure no longer licenses its siblings' strip; rows are no longer shredded
+for a blob that did not land. Registration is one method both writer lanes
+and the no-cache-DB path share — the writer's own no-connection arm drains
+its channel unregistered, which would otherwise have dropped those files.
 
-```rust
-let mut landed: HashSet<PathBuf> = HashSet::new();
-...
-    if module_cache::save_to_db(&conn, &p_str, &Some(cached), "workspace") {
-        landed.insert(p.clone());
-    }
-...
-    let committed = match tx {
-        Some(tx) => match tx.commit() {
-            Ok(()) => true,
-            Err(e) => { log::error!("pack swap: commit failed ({e}) — registering whole copies"); false }
-        },
-        None => true,   // autocommit: each save_to_db reported for itself
-    };
-    if !committed { landed.clear(); }
-```
-then gate the strip on `landed.contains(p)`.
+Base-verified on both lanes, which finding #2 made possible: a `RAISE(ROLLBACK)`
+trigger discards the whole transaction (every copy must stay whole) and a
+`RAISE(ABORT)` trigger scoped to one path fails that blob alone under a
+succeeding commit (that file stays whole, its sibling still strips). Both
+assertions fail against the previous `swap`. A third test is the control —
+with a healthy DB the copies DO strip, so "registered whole" is evidence
+about the failure lane rather than evidence the branch was never reached.
 
-**Why not landed.** `open_cache_db` is `#[cfg(test)] -> None` unconditionally
-(`module_cache/conn.rs:97-100`), so under `cargo test` `persisted` is always
-`false` and the strip branch never executes. The entire persist-then-strip path
-in `PackInvalidator::swap` has **zero unit coverage by construction** — which
-is also why the bug is comfortable there. A fix cannot be base-verified without
-first giving the harness a real cache DB, which is a larger change than the fix.
-That harness gap is finding #2.
+## 2. The persist/strip licence is untestable, and it is the one thing worth testing — **fixed, `3e14958`**
 
-## 2. The persist/strip licence is untestable, and it is the one thing worth testing
-
-`#[cfg(test)] open_cache_db -> None` makes every strip-licensing decision —
+`#[cfg(test)] open_cache_db -> None` made every strip-licensing decision —
 `persisted`, `strip_import_copy`'s gate, the writer's committed/fallback fork —
 unreachable from `cargo test`. Everything that decides whether a resident copy
 may be stripped is therefore exercised only by the gold harness and by
 corpus runs, and only when those happen to take the failure lane, which they
 essentially never do.
 
-This is the coverage shape that lets #1 exist and would let the gate split's
-two failure lanes (below) ship unexercised. A test-mode `open_cache_db` that
-opens a temp-dir DB (env-keyed, or a `#[cfg(test)]` override cell) is the
-enabling change for all of it.
+This is the coverage shape that let #1 exist and would let the gate split's
+two failure lanes (below) ship unexercised.
+
+The real writer open is now factored behind `open_cache_db_at`, so both
+profiles drive the same body — WAL, busy handling, schema init, the
+corruption-only recreate — rather than a test-shaped parallel one, and
+`with_test_cache_dir` installs a real DB for the current thread only. Unset
+(the default) `open_cache_db` still answers `None`, so no existing test
+changed behaviour; the short busy timeout it carries is what lets a test
+drive a contended writer without waiting out the production one. Failure
+lanes are injected with SQLite triggers rather than lock timing, which makes
+each one deterministic.
 
 ## 3. `ResolveQueue`'s priority lane can lose its wakeup — **fixed, `7febd2b`**
 

--- a/src/index/module_cache/conn.rs
+++ b/src/index/module_cache/conn.rs
@@ -34,9 +34,6 @@ pub fn cache_dir_for_workspace(workspace_root: Option<&str>) -> Option<PathBuf> 
 /// pack language gets its own `modules-{lang}.db` so names never comingle on
 /// disk (a Perl `Box` and a C++ class `Box` live in different files). The
 /// ONE spelling both openers share.
-// Every consumer is a real-DB opener, itself `#[cfg(not(test))]` (tests
-// stub the opens out) — match their cfg so the test profile stays clean.
-#[cfg(not(test))]
 pub(super) fn db_path_for(dir: &std::path::Path, lang: &str) -> PathBuf {
     if lang == "perl" {
         dir.join("modules.db")
@@ -48,8 +45,26 @@ pub(super) fn db_path_for(dir: &std::path::Path, lang: &str) -> PathBuf {
 #[cfg(not(test))]
 pub fn open_cache_db(workspace_root: Option<&str>, lang: &str) -> Option<Connection> {
     let dir = cache_dir_for_workspace(workspace_root)?;
-    std::fs::create_dir_all(&dir).ok()?;
-    let db_path = db_path_for(&dir, lang);
+    open_cache_db_at(&dir, lang, WRITER_BUSY_TIMEOUT)
+}
+
+/// How long a writer waits on a busy DB before failing its statement. Two
+/// writers share the Perl DB (resolver thread + workspace indexer), and a
+/// failed commit after resident copies were stripped is unrecoverable for
+/// the session — so waiting beats failing.
+pub(super) const WRITER_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// The writer open, given the cache directory: WAL, busy handling, schema
+/// init, and the corruption-only recreate. Both the production opener and
+/// the test override (`with_test_cache_dir`) route here, so a test drives
+/// the real body rather than a parallel one.
+pub(super) fn open_cache_db_at(
+    dir: &std::path::Path,
+    lang: &str,
+    busy: std::time::Duration,
+) -> Option<Connection> {
+    std::fs::create_dir_all(dir).ok()?;
+    let db_path = db_path_for(dir, lang);
     log::info!("Module cache: {:?}", db_path);
 
     match Connection::open(&db_path) {
@@ -59,7 +74,7 @@ pub fn open_cache_db(workspace_root: Option<&str>, lang: &str) -> Option<Connect
             // indexer); a busy writer must wait, not fail its txn — a failed
             // commit after resident copies were stripped is unrecoverable
             // for the session.
-            let _ = conn.busy_timeout(std::time::Duration::from_secs(10));
+            let _ = conn.busy_timeout(busy);
             match init_schema(&conn) {
                 Ok(()) => Some(conn),
                 Err(e) => {
@@ -81,7 +96,7 @@ pub fn open_cache_db(workspace_root: Option<&str>, lang: &str) -> Option<Connect
                     let _ = std::fs::remove_file(&db_path);
                     let conn = Connection::open(&db_path).ok()?;
                     let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-                    let _ = conn.busy_timeout(std::time::Duration::from_secs(10));
+                    let _ = conn.busy_timeout(busy);
                     init_schema(&conn).ok()?;
                     Some(conn)
                 }
@@ -95,8 +110,40 @@ pub fn open_cache_db(workspace_root: Option<&str>, lang: &str) -> Option<Connect
 }
 
 #[cfg(test)]
-pub fn open_cache_db(_workspace_root: Option<&str>, _lang: &str) -> Option<Connection> {
-    None
+thread_local! {
+    /// Opt-in real cache DB for the current test thread: `(dir, busy timeout)`.
+    /// Unset — the default — keeps `open_cache_db` answering `None` exactly as
+    /// a stubbed-out open always did, so no existing test changes behaviour.
+    /// A test that needs the persist/strip lanes (whose whole point is a
+    /// *committed blob*, and which are otherwise unreachable from `cargo test`)
+    /// installs one with `with_test_cache_dir`.
+    static TEST_CACHE_DIR: std::cell::RefCell<Option<(PathBuf, std::time::Duration)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Run `f` with `open_cache_db` backed by a real SQLite DB under `dir` on
+/// THIS thread. Thread-local, so parallel tests can't see each other's; the
+/// short busy timeout is what lets a test drive a *contended* writer without
+/// waiting out the production `WRITER_BUSY_TIMEOUT`.
+#[cfg(test)]
+pub fn with_test_cache_dir<R>(dir: &std::path::Path, busy: std::time::Duration, f: impl FnOnce() -> R) -> R {
+    struct Restore(Option<(PathBuf, std::time::Duration)>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            let prev = self.0.take();
+            TEST_CACHE_DIR.with(|c| *c.borrow_mut() = prev);
+        }
+    }
+    let prev = TEST_CACHE_DIR.with(|c| c.borrow_mut().replace((dir.to_path_buf(), busy)));
+    let _restore = Restore(prev);
+    f()
+}
+
+#[cfg(test)]
+pub fn open_cache_db(_workspace_root: Option<&str>, lang: &str) -> Option<Connection> {
+    let installed = TEST_CACHE_DIR.with(|c| c.borrow().clone());
+    let (dir, busy) = installed?;
+    open_cache_db_at(&dir, lang, busy)
 }
 
 /// Read-only open for query-path consumers (the relational retrieval, bag

--- a/src/index/module_resolver/persist.rs
+++ b/src/index/module_resolver/persist.rs
@@ -141,7 +141,7 @@ pub(super) fn analyze_stamped<T>(
 /// transient failure degrades gracefully, a permanent one can't OOM.
 pub(super) const FALLBACK_WHOLE_BYTE_CAP: usize = 128 * 1024 * 1024;
 
-/// The persist-writer harness both bulk indexers share: batches entries off
+/// The persist-writer harness every persist site shares: batches entries off
 /// the channel (≤128 per txn), owns BEGIN IMMEDIATE / COMMIT / ROLLBACK
 /// (IMMEDIATE — a deferred txn that reads before writing can hit an
 /// unretryable SQLITE_BUSY_SNAPSHOT against a concurrent writer), and hands
@@ -152,7 +152,7 @@ pub(super) const FALLBACK_WHOLE_BYTE_CAP: usize = 128 * 1024 * 1024;
 /// unregistered. Registration runs inside the panic guard, mirroring the
 /// txn: entries a mid-batch registration panic leaves behind take the
 /// fallback lane instead of vanishing.
-pub(super) fn run_persist_writer<E>(
+pub(crate) fn run_persist_writer<E>(
     rx: std::sync::mpsc::Receiver<E>,
     conn: Option<&rusqlite::Connection>,
     label: &str,

--- a/src/index/pack_invalidator.rs
+++ b/src/index/pack_invalidator.rs
@@ -405,87 +405,139 @@ impl PackInvalidator {
         if let Some(fa) = changed_fa {
             results.push((canon.clone(), fa));
         }
-        // Persist the FULL analyses (bag present) FIRST so the on-disk blob can
-        // rehydrate, then register bag-STRIPPED resident copies and drop each
-        // file's now-stale entry from the rehydration LRU. `results` holds the
-        // full arcs; `save_to_db` encodes them whole. Strip only when we
-        // actually persisted — else the bag would be unrecoverable, so keep it.
-        let persisted = if let Some(conn) = module_cache::open_cache_db(root_uri, lang) {
+        // Persist FIRST so a stripped copy always has a blob to rehydrate
+        // from, then register. The fork is `run_persist_writer`'s: it owns
+        // BEGIN IMMEDIATE / COMMIT / ROLLBACK and routes every entry to the
+        // committed or the fallback lane. The strip licence is a LANDED blob
+        // for that path — `save_to_db`'s verdict, under a transaction that
+        // committed — and exactly one thing gets to decide it.
+        let conn = module_cache::open_cache_db(root_uri, lang);
+        if let Some(ref conn) = conn {
             if deleted {
-                module_cache::delete_ref_rows(&conn, &canon_str);
-            }
-            let tx = conn.unchecked_transaction().ok();
-            for (p, arc) in &results {
-                let p_str = p.to_string_lossy();
-                let cached = Arc::new(CachedModule::new(p.clone(), arc.clone()));
-                module_cache::save_to_db(&conn, &p_str, &Some(cached), "workspace");
-                if !arc.degraded {
-                    let seeds: Vec<_> = arc.ref_row_seeds();
-                    let sym_seeds = arc.sym_row_seeds();
-                    if let Err(e) = module_cache::shred_derived_rows(
-                        &conn, &p_str, "workspace", &seeds, &sym_seeds,
-                    ) {
-                        log::warn!("Failed to shred derived rows for {:?}: {}", p, e);
-                    }
-                }
+                module_cache::delete_ref_rows(conn, &canon_str);
             }
             if skip_consumers {
                 // Unchanged gate: the consumers' rows/blobs/stubs are still
                 // valid, but the edited header's mtime moved every consumer's
                 // closure stamp — refresh them or the next warm rejects every
-                // consumer row (the restart cold storm).
+                // consumer row (the restart cold storm). Outside the writer's
+                // transaction: these rows are already valid, so a refresh that
+                // lands while the changed file's blob does not costs nothing.
                 let mut memo = std::collections::HashMap::new();
                 for (p, closure) in &consumer_closures {
                     module_cache::refresh_deps_stamp(
-                        &conn,
+                        conn,
                         &p.to_string_lossy(),
                         closure,
                         &mut memo,
                     );
                 }
             }
-            if let Some(tx) = tx {
-                let _ = tx.commit();
-            }
-            true
-        } else {
-            false
-        };
-        if let Some(ref pack) = pack {
-            for (p, arc) in &results {
-                // H9-1 generation guard: claim BEFORE unregistering, so a rejected
-                // (strictly-older) result leaves the fresher registration intact
-                // rather than tearing it down. A stale re-analysis that read
-                // pre-save bytes loses to nothing — it simply isn't registered, and
-                // the writer that read post-save bytes (or a later save's event)
-                // wins. This also closes hazard 3: an under-invalidated consumer the
-                // bulk pass registered from pre-save bytes carries a lower generation
-                // than the reconcile that reads current disk, so the reconcile wins
-                // and no pre-save bytes are silently served.
-                if !self.claim_source_gen(p, event_gen) {
-                    log::debug!(
-                        "pack swap: skip stale re-register of {:?} (event gen {} < registered)",
-                        p,
-                        event_gen
-                    );
-                    continue;
+        }
+        match conn {
+            Some(ref conn) => {
+                // Paths whose blob row actually landed. Read by the committed
+                // lane only — the fallback lane's transaction is gone, so
+                // nothing in it landed whatever the per-file verdict said.
+                let landed: std::cell::RefCell<std::collections::HashSet<PathBuf>> =
+                    Default::default();
+                let (tx, rx) = std::sync::mpsc::channel();
+                for (p, arc) in &results {
+                    let _ = tx.send((p.clone(), Arc::clone(arc)));
                 }
-                pack.unregister_file(p);
-                // Drop the stale LRU pin BEFORE the new stripped copy becomes
-                // reachable — a query racing this re-register must not
-                // rehydrate the pre-edit generation against the new
-                // registration (the blob+rows committed above).
-                pack.invalidate_bag_cache(p);
-                if persisted && !arc.degraded && crate::index::module_resolver::eviction_enabled() {
-                    // Registration-owned strip (feeds read the whole copy).
-                    let _ = pack.register_symbols_stripping((*p).clone(), (**arc).clone(), true, true);
-                } else {
-                    pack.register_symbols(p.clone(), arc.clone());
+                drop(tx);
+                crate::index::module_resolver::run_persist_writer(
+                    rx,
+                    Some(conn),
+                    "pack swap persist",
+                    |conn, batch: &[(PathBuf, Arc<FileAnalysis>)]| {
+                        for (p, arc) in batch {
+                            let p_str = p.to_string_lossy();
+                            let cached = Arc::new(CachedModule::new(p.clone(), Arc::clone(arc)));
+                            if !module_cache::save_to_db(conn, &p_str, &Some(cached), "workspace") {
+                                // Shredding now would pair a new generation's
+                                // rows with a blob that isn't there — the same
+                                // write invariant `save_module_generation` holds.
+                                continue;
+                            }
+                            if !arc.degraded {
+                                let seeds: Vec<_> = arc.ref_row_seeds();
+                                let sym_seeds = arc.sym_row_seeds();
+                                if let Err(e) = module_cache::shred_derived_rows(
+                                    conn, &p_str, "workspace", &seeds, &sym_seeds,
+                                ) {
+                                    log::warn!("Failed to shred derived rows for {:?}: {}", p, e);
+                                }
+                            }
+                            landed.borrow_mut().insert(p.clone());
+                        }
+                    },
+                    |(p, arc): (PathBuf, Arc<FileAnalysis>)| {
+                        let ok = landed.borrow().contains(&p);
+                        self.register_after_swap(pack.as_ref(), &p, &arc, ok, event_gen);
+                    },
+                    |(p, arc): (PathBuf, Arc<FileAnalysis>)| {
+                        self.register_after_swap(pack.as_ref(), &p, &arc, false, event_gen);
+                    },
+                );
+            }
+            // No cache DB at all: nothing can land, so nothing may be
+            // stripped. (`run_persist_writer`'s own no-connection arm drains
+            // its channel unregistered, which would drop these files.)
+            None => {
+                for (p, arc) in &results {
+                    self.register_after_swap(pack.as_ref(), p, arc, false, event_gen);
                 }
             }
         }
         skip_consumers
     }
+
+    /// The registration half of a swap, for one file. `landed` is the strip
+    /// licence — a blob committed for THIS path — because a stripped copy
+    /// without one does not read as absent: `load_one_diag` skips stamp
+    /// validation on a single-row path, so it rehydrates the PREVIOUS
+    /// generation and the file answers pre-edit for the rest of the session,
+    /// with no rehydration miss counted and no strict-residency panic.
+    fn register_after_swap(
+        &self,
+        pack: Option<&Arc<ModuleIndex>>,
+        path: &Path,
+        arc: &Arc<FileAnalysis>,
+        landed: bool,
+        event_gen: i64,
+    ) {
+        let Some(pack) = pack else { return };
+        // H9-1 generation guard: claim BEFORE unregistering, so a rejected
+        // (strictly-older) result leaves the fresher registration intact rather
+        // than tearing it down. A stale re-analysis that read pre-save bytes
+        // loses to nothing — it simply isn't registered, and the writer that
+        // read post-save bytes (or a later save's event) wins. This also closes
+        // hazard 3: an under-invalidated consumer the bulk pass registered from
+        // pre-save bytes carries a lower generation than the reconcile that
+        // reads current disk, so the reconcile wins and no pre-save bytes are
+        // silently served.
+        if !self.claim_source_gen(path, event_gen) {
+            log::debug!(
+                "pack swap: skip stale re-register of {:?} (event gen {} < registered)",
+                path,
+                event_gen
+            );
+            return;
+        }
+        pack.unregister_file(path);
+        // Drop the stale LRU pin BEFORE the new copy becomes reachable — a
+        // query racing this re-register must not rehydrate the pre-edit
+        // generation against the new registration.
+        pack.invalidate_bag_cache(path);
+        if landed && !arc.degraded && crate::index::module_resolver::eviction_enabled() {
+            // Registration-owned strip (feeds read the whole copy).
+            let _ = pack.register_symbols_stripping(path.to_path_buf(), (**arc).clone(), true, true);
+        } else {
+            pack.register_symbols(path.to_path_buf(), Arc::clone(arc));
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/src/index/pack_invalidator_tests.rs
+++ b/src/index/pack_invalidator_tests.rs
@@ -248,3 +248,146 @@ fn file_changed_defers_during_bulk_index_and_reconciles() {
     assert_ne!(arc_of(&pack, &canon_hdr), before, "reconcile lands the deferred change");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ---- The persist/strip licence ----
+//
+// These three drive `swap`'s persist path with a REAL cache DB
+// (`with_test_cache_dir`), which `#[cfg(test)] open_cache_db -> None` made
+// unreachable. The failure lanes are injected with SQLite triggers rather
+// than lock timing, so each is deterministic: `RAISE(ROLLBACK)` discards the
+// whole transaction (the commit-fail lane), `RAISE(ABORT)` scoped to one path
+// fails that file's blob alone while the commit succeeds (the per-file lane).
+
+#[cfg(feature = "cpp")]
+struct SwapFixture {
+    dir: PathBuf,
+    hdr: PathBuf,
+    tu: PathBuf,
+    hub: ModuleIndex,
+    pack: Arc<ModuleIndex>,
+    inv: PackInvalidator,
+    files: FileStore,
+}
+
+#[cfg(feature = "cpp")]
+fn swap_fixture(tag: &str) -> SwapFixture {
+    let dir = std::env::temp_dir().join(format!("pack-persist-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let hdr = dir.join("box.h");
+    let tu = dir.join("use.cpp");
+    std::fs::write(&hdr, "class Box { public: int width() { return 1; } };\n").unwrap();
+    std::fs::write(&tu, "#include \"box.h\"\nint f() { Box b; return b.width(); }\n").unwrap();
+
+    let reg = crate::build::language_driver::LanguageRegistry::with_enabled();
+    let driver = reg.for_id("cpp").expect("cpp driver");
+    let hub = ModuleIndex::new_for_test();
+    let pack = Arc::new(ModuleIndex::new_for_test());
+    hub.attach_pack_index("cpp", pack.clone());
+    register_pair(driver, &pack, &[&hdr, &tu]);
+
+    SwapFixture { dir, hdr, tu, hub, pack, inv: PackInvalidator::default(), files: FileStore::new() }
+}
+
+/// The registered analysis for `path` — the residency question these tests
+/// ask ("was this copy stripped against a blob that landed?").
+#[cfg(feature = "cpp")]
+fn registered(pack: &ModuleIndex, path: &Path) -> Arc<FileAnalysis> {
+    let canon = std::fs::canonicalize(path).unwrap();
+    let mut found = None;
+    pack.for_each_registered_file(&mut |cm| {
+        if cm.path == canon {
+            found = Some(Arc::clone(&cm.analysis));
+        }
+    });
+    found.expect("registered")
+}
+
+#[cfg(feature = "cpp")]
+const TEST_BUSY: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Control for the two failure-lane tests below: with a healthy DB the swap
+/// DOES strip, so a "registered whole" assertion there is evidence about the
+/// failure lane rather than evidence the branch was never reached.
+#[cfg(feature = "cpp")]
+#[test]
+fn a_landed_persist_licenses_the_strip() {
+    let f = swap_fixture("ok");
+    std::fs::write(&f.hdr, "class Box { public: int width() { return 2; } int h() { return 3; } };\n").unwrap();
+    module_cache::with_test_cache_dir(&f.dir, TEST_BUSY, || {
+        f.inv.file_changed(None, &f.hub, &f.files, &f.hdr, false);
+    });
+    assert!(
+        registered(&f.pack, &f.hdr).symbols_are_evicted(),
+        "a committed blob licenses the strip — otherwise these tests prove nothing"
+    );
+    let _ = std::fs::remove_dir_all(&f.dir);
+}
+
+/// The commit-fail lane. The transaction is discarded, so no blob landed for
+/// ANY file in the batch and every copy must stay whole: a stripped copy
+/// whose blob was rolled back rehydrates from the PREVIOUS generation's row
+/// (`load_one_diag` skips stamp validation for a single-row path), so the
+/// file answers pre-edit for the rest of the session with no rehydration miss
+/// counted and no strict-residency panic.
+#[cfg(feature = "cpp")]
+#[test]
+fn a_rolled_back_transaction_leaves_every_copy_whole() {
+    let f = swap_fixture("rollback");
+    std::fs::write(&f.hdr, "class Box { public: int width() { return 2; } int h() { return 3; } };\n").unwrap();
+    module_cache::with_test_cache_dir(&f.dir, TEST_BUSY, || {
+        {
+            let conn = module_cache::open_cache_db(None, "cpp").expect("test cache db");
+            conn.execute_batch(
+                "CREATE TRIGGER kill_modules BEFORE INSERT ON modules \
+                 BEGIN SELECT RAISE(ROLLBACK, 'injected'); END;",
+            )
+            .unwrap();
+        }
+        f.inv.file_changed(None, &f.hub, &f.files, &f.hdr, false);
+    });
+    for p in [&f.hdr, &f.tu] {
+        let a = registered(&f.pack, p);
+        assert!(
+            !a.symbols_are_evicted() && !a.bag_is_evicted(),
+            "{p:?} was stripped against a transaction that rolled back"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&f.dir);
+}
+
+/// The per-file lane: one file's blob fails to land while the transaction
+/// commits. `save_to_db` reports it with its `bool` return; the strip licence
+/// is per PATH, so the failing file stays whole and its sibling still strips.
+#[cfg(feature = "cpp")]
+#[test]
+fn a_file_whose_blob_did_not_land_is_not_stripped() {
+    let f = swap_fixture("perfile");
+    std::fs::write(&f.hdr, "class Box { public: int width() { return 2; } int h() { return 3; } };\n").unwrap();
+    let canon_hdr = std::fs::canonicalize(&f.hdr).unwrap();
+    module_cache::with_test_cache_dir(&f.dir, TEST_BUSY, || {
+        {
+            let conn = module_cache::open_cache_db(None, "cpp").expect("test cache db");
+            // ABORT is statement-scoped: this file's INSERT fails, the
+            // transaction stays open and commits with its siblings' rows.
+            // Inlined, not bound — a trigger body cannot use parameters.
+            let target = canon_hdr.to_string_lossy().replace('\'', "''");
+            conn.execute_batch(&format!(
+                "CREATE TRIGGER kill_one BEFORE INSERT ON modules \
+                 WHEN NEW.path = '{target}' \
+                 BEGIN SELECT RAISE(ABORT, 'injected'); END;"
+            ))
+            .unwrap();
+        }
+        f.inv.file_changed(None, &f.hub, &f.files, &f.hdr, false);
+    });
+    assert!(
+        !registered(&f.pack, &f.hdr).symbols_are_evicted(),
+        "the file whose blob failed to save was stripped anyway"
+    );
+    assert!(
+        registered(&f.pack, &f.tu).symbols_are_evicted(),
+        "a sibling whose blob DID land must still strip — the licence is per path"
+    );
+    let _ = std::fs::remove_dir_all(&f.dir);
+}


### PR DESCRIPTION
Closes findings **#1** and **#2** of `docs/review-narrow-seams.md` — the one I had to leave in #121 because it could not be base-verified, and the harness gap that was why.

Branched from `71f75940`.

---

## Step 1 — `open_cache_db` is test-capable (`3e14958`)

It answered `None` unconditionally under `cfg(test)`, so every strip-licensing decision in the tree — `persisted`, `strip_import_copy`'s gate, `run_persist_writer`'s committed/fallback fork — was unreachable from `cargo test`. Everything deciding whether a resident copy may be stripped was exercised only by gold and corpus runs, and only if those happened to take a failure lane, which they essentially never do.

**This turned out to be smaller than step 2, not bigger** — you asked to hear early if it went the other way, and it didn't, so I just built it. The reason it's small is the shape: it is **opt-in, thread-local, and additive**.

- The real writer open is factored behind `open_cache_db_at(dir, lang, busy)`, so both profiles drive the *same* body — WAL, busy handling, schema init, the corruption-only recreate. A test that drove a parallel test-shaped opener would be testing a fake.
- `with_test_cache_dir(dir, busy, f)` installs a real DB **for the current thread only**, restoring on drop. Unset — the default — `open_cache_db` still returns `None`, byte-for-byte the old behaviour.
- Result: **1521 unit tests still pass, unchanged**, matching your baseline exactly. No existing test that assumes no DB exists had to learn anything.

The short busy timeout the override carries is the piece that lets a test drive a contended writer without waiting out the production 10 s. (It is a deliberate difference from production, and the only one.)

## Step 2 — the fix (`586823d`)

**I took the collapse onto `run_persist_writer`.** It was genuinely reachable and it is the better end state for the reason you gave — two spellings of "did the blob land" is how the wrong one survives. It also turned out to *enable* the testing rather than complicate it: BEGIN IMMEDIATE / COMMIT / ROLLBACK live in one place, so "the transaction did not land" is one observable fork rather than a subtlety of a hand-rolled DEFERRED transaction.

Three things beyond the mechanical move:

- **Per-path truth, not batch-wide.** `run_persist_writer`'s fork is per *chunk*, which alone would not have fixed the per-file lane. `write_batch` records which paths `save_to_db` actually accepted, and the committed lane reads that set — so one file's failure no longer licenses its siblings' strip, nor theirs its own.
- **Rows are no longer shredded for a blob that did not land.** The old loop shredded unconditionally. That is the write invariant `save_module_generation` already documents ("blob + rows describe the same generation or neither exists"); the swap was the site that didn't hold it.
- **The no-cache-DB path is handled explicitly.** `run_persist_writer`'s own no-connection arm drains its channel *unregistered*, which would have silently dropped every file when there is no DB — where today they register whole. Both writer lanes and that path now share one `register_after_swap`.

Two deliberate behaviour changes worth naming:

- The transaction is now BEGIN IMMEDIATE, not DEFERRED. That is `run_persist_writer`'s existing choice and its comment explains why (a deferred txn that reads before writing can hit an unretryable `SQLITE_BUSY_SNAPSHOT`).
- `refresh_deps_stamp` on the `skip_consumers` path moves *outside* the writer's transaction. Those consumer rows are already valid and were never touched, so a stamp refresh that lands while the changed file's blob does not is still correct — and it is not part of the strip licence, which is what the transaction now exists to decide.

## Base-verification

Both lanes, injected with **SQLite triggers rather than lock timing**, so each is deterministic rather than a race I'd be hoping to win:

| test | injection | before | after |
|---|---|---|---|
| `a_landed_persist_licenses_the_strip` | none — healthy DB | pass | pass |
| `a_rolled_back_transaction_leaves_every_copy_whole` | `RAISE(ROLLBACK)` on any `modules` insert — the whole txn is discarded | **FAIL** | pass |
| `a_file_whose_blob_did_not_land_is_not_stripped` | `RAISE(ABORT)` scoped to one path — statement-scoped, so that blob alone fails and the commit succeeds | **FAIL** | pass |

Verified by `git stash`-ing *only* `pack_invalidator.rs` back to `71f75940` and re-running: both failure-lane tests fail at their own assertions (`"was stripped against a transaction that rolled back"`, `"the file whose blob failed to save was stripped anyway"`), not at setup.

The first row is a **control, not a fix test** — it passes both ways on purpose. Without it, "registered whole" in the other two would be indistinguishable from "the strip branch was never reached", which is exactly the failure mode you caught by reverting a fix the other day. It is the assertion that makes the other two mean something.

One process note, since it bears on trusting the table: the per-file test initially "failed before" for the wrong reason — `RAISE(ABORT)` with a **bound parameter**, which SQLite rejects (`trigger cannot use variables`), so it panicked at trigger creation and never reached the swap. I only caught it because the post-fix run failed identically. The path is inlined now, and the before/after above was re-run from scratch after that.

## Verification

True exit codes, never a piped `grep` status.

| | result |
|---|---|
| `cargo test` | **exit 0** |
| `cargo test --features cpp` | **exit 0** — 1524 unit (1521 baseline + 3) |
| `./target/release/perl-lsp --languages` | `perl, cpp (beta)` — confirmed **before** gold |
| gold | **495 PASS / 15 xfail / 0 FAIL / 0 XPASS / 0 CRASH**, 3 prov? |
| gold `skip` | **0** — grepped explicitly, not read off the summary |
| e2e | **could not run** — `nvim` absent. CI's. |

`perl-lsp --clear-cache` run before gold, per your warning about the two-limits-at-once diagnostic — worth keeping in mind that the cache would hide a fix in exactly this area, since what this PR changes is *when a blob is allowed not to exist*.

`docs/review-narrow-seams.md` findings #1 and #2 are marked closed with the shape that actually landed, so the corpus record matches the code.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_