### PR TITLE
Four guards that did not guard, a measurement that cancelled a fix, and the provider chase at 6.4x

### DIFF
--- a/docs/prompt-scale-validation-hitlist.md
+++ b/docs/prompt-scale-validation-hitlist.md
@@ -667,6 +667,15 @@ named inputs.
   un-resolved the arm, dropped the answer, and prevented the re-push — flip
   forever. CLAUDE.md's worklist invariant states clear-and-emit as
   unconditional; it now has exactly one known exception, and this is it.
+- **`query_rec` memo poisoning** — a truncated subtree is memoized under a
+  depth-free `VisitedKey` and served to a later shallower consult in the same
+  query. Measured, not fixed, and the measurement argues against fixing it
+  blind: the memo dies with its top-level query (so this poisons a traversal,
+  never a session), and a depth-tagged-entry prototype rejected 80,200 entries
+  on a synthetic truncating diamond for a **5.6x wall-time cost (7s -> 39s)**
+  with an IDENTICAL top-level answer. The mechanism is trivially reproducible;
+  a shape where it changes a served answer is not, and that is what a fix
+  needs. See the `QUERY_REC_DEPTH_CAP` doc comment.
 - **`query_rec` 512-depth cap hit** on `MethodOnClass` — cross-dist
   class-name collisions make merged ancestry pathological at corpus scale.
   This is the package-identity candidate relation meeting the real world, and

--- a/docs/prompt-scale-validation-hitlist.md
+++ b/docs/prompt-scale-validation-hitlist.md
@@ -707,8 +707,21 @@ named inputs.
 - **~10 bookkeeping `get_cached` sites** left on the derived winner
   deliberately (existence checks equivalent by construction, last-resort
   fallbacks, CLI).
-- **`cursor_slot.rs:205`** — driver-owned slot detection; recorded as
-  reducible-but-deferred, not irreducible.
+- ~~**`cursor_slot.rs:205`**~~ — **CLOSED (B).** It was `language == "perl"`
+  selecting the detector. `DriverCaps::cursor_context` already existed and
+  already documented that exact split ("slots derive from the LIVE document
+  tree; off = the sentinel-reparse pack path") — the consumer simply wasn't
+  asking it. `detect_slot` now reads the cap, and the arm is named for what it
+  IS (`detect_slot_tree_native`) rather than for the one language that has the
+  cap today, so a second tree-native driver is served without being listed
+  here. Pinned by `layering_tests::slot_detection_dispatches_on_driver_caps_not_language_names`
+  (source half — base-verified: reinstating the compare fails it) plus the
+  existing `cursor_slot_tests` Perl slots (behavioural half — only the
+  tree-native arm produces `Slot::ModulePath`, so flipping the cap off fails
+  there). Remaining `== "perl"` sites are a different question and stay open:
+  `backend/indexing.rs` x2 is the perl-vs-pack INDEX FAMILY latch (Tier 4's
+  "merge the two index families"), and `module_cache/conn.rs:38` is a
+  back-compat on-disk filename, not a behaviour enumeration.
 
 # Tier 4 — structural, own arcs
 

--- a/docs/prompt-scale-validation-hitlist.md
+++ b/docs/prompt-scale-validation-hitlist.md
@@ -31,7 +31,7 @@ Detail for each is in its section below.
 | `pod.rs` multibyte panic | **CLOSED** `f47c002b` |
 | Fold-64 non-convergence | **CLOSED** `fed8ac00` |
 | `query_rec` 512-depth cap | **OPEN** — seen again during the #3 probe |
-| hover empty on a module-name token | **OPEN** |
+| hover empty on a module-name token | **CLOSED** (B) — two defects: the `PackageRef` arm swept only LOCAL symbols, and the CLI never built a CandidateSet for Perl at all |
 | `epoch.gen_stamp_missing = 1074` | **CLOSED** — explained, never a bug |
 
 ### Tier 3 / Tier 4
@@ -672,9 +672,19 @@ named inputs.
   This is the package-identity candidate relation meeting the real world, and
   it argues for filling the `ScopedLookup` visibility slot Perl still passes
   empty.
-- **hover empty on a `Koha::Database` module-name token** where goto-def works
-  at the same position — adjacent to the require/hover family fixed in
-  `5e97516b`.
+- ~~**hover empty on a `Koha::Database` module-name token**~~ — **fixed.**
+  Two defects stacked, and the second is why the first was awkward to
+  reproduce. (1) `hover_info`'s `RefKind::PackageRef` arm resolves through
+  `self.symbols_named` — a LOCAL sweep — so a package defined in another file
+  was unreachable from it by construction, and the arm falling through hit
+  `perl_hover_markdown`'s `FunctionCall`-only gate and returned `None`. Hover
+  now ends where `pack_hover_markdown` already ended: on the CandidateSet's
+  hover projection, so both verbs read one resolution. (2) The CLI `hover`
+  verb called `analysis.hover_info` **directly** for Perl — it built no
+  CandidateSet and so never entered `perl_hover_markdown`, meaning the CLI and
+  the server answered measurably different verbs. `--hover` now routes through
+  the same renderer the LSP handler calls. Pinned by `modname-hover.json`,
+  base-verified: both rows FAIL without the fix.
 - ~~**`epoch.gen_stamp_missing = 1074`**~~ — **closed, not a bug.** It counts
   warm @INC providers that needed a registration generation, stamped once at
   resolver startup. Measured on crm: 1,151 warm entries → 1,080 distinct paths

--- a/docs/prompt-storage-residuals.md
+++ b/docs/prompt-storage-residuals.md
@@ -89,6 +89,19 @@ Two unverified observations from the cpp adversarial review:
 - **`modules-{lang}.db` rows for deleted files are skipped on warm but
   never purged** — a suspected unbounded-growth residual on long-lived
   pack caches. Sibling of the watcher re-registration residual above.
+- **The `strings` interner is never garbage-collected.** `shred_derived_rows`
+  re-shreds a file by deleting and re-inserting its `refs` and `syms` rows
+  (`DELETE FROM refs/syms WHERE file_id = ?`), but never its strings; the
+  only `DELETE FROM strings` in the tree is in `clear_derived_rows`, the
+  hard clear. So within one cache generation the interner grows
+  monotonically with every edit and re-shred — a name that no surviving row
+  references still occupies its row. Measured at 556k rows / 31 MB, which is
+  why this is a residual and not a bug, but it is unbounded *by
+  construction*: nothing in the write path can ever shrink it. A collector
+  would be a `DELETE FROM strings WHERE id NOT IN (SELECT name_id FROM refs
+  UNION SELECT name_id FROM syms)` sweep, which is cheap to write and
+  expensive to run, so it wants a trigger (generation rollover, or a row
+  count threshold) rather than running per shred.
 - **`clean_body` truncates at `//` inside string literals** — a
   `#define URL "https://x"` body would be mangled, potentially flipping
   the whole-file validate gate to alias-only. Needs a string-literal-aware

--- a/docs/prompt-storage-residuals.md
+++ b/docs/prompt-storage-residuals.md
@@ -123,3 +123,26 @@ Two unverified observations from the cpp adversarial review:
   writers' panic-arm LRU-pin fix is the drift it would have prevented.
 - **Stamp-capture helper.** The stamp-before-read + re-stat-after-parse
   protocol is spelled in both fresh workers.
+
+## The reader side of the residency ladder
+
+`Residency` closed the WRITER side: the strip is one ladder, and
+`(rows evicted, bag kept)` is no longer expressible. The reader side is still
+open. `symbols_present` / `refs_present` hand back BAG-STRIPPED copies, so a
+bag-backed query on one answers `None` — not an error, not a panic, just a
+quietly missing type that reads as "no type known".
+
+Every site today is a deliberate symbols-axis read and says so in a comment.
+A comment is not a type, so `layering_tests::a_narrow_axis_view_is_never_asked_a_bag_question`
+scans for the shape instead: a narrow view chained straight into a bag-backed
+accessor, or bound and asked one later in the same scope. It is a heuristic —
+scope end is approximated by dedent, because a brace matcher that desyncs on a
+single string literal swallows the rest of the file and reports nonsense, and a
+tripwire that cries wolf gets deleted. False negatives are acceptable; false
+positives are not.
+
+The real fix is the reader-side axis-typed view, still deferred for the reason
+recorded in `docs/review-narrow-seams.md`: consumers read `.symbols`,
+`.plugin.namespaces`, `.provisional_dispatches` as public FIELDS, so a wrapper
+would have to re-export the struct's whole shape across ~106 sites — it drags
+the residency model behind it rather than hiding it.

--- a/docs/review-narrow-seams.md
+++ b/docs/review-narrow-seams.md
@@ -267,6 +267,18 @@ pairing unrepresentable (a closed `StripPlan` enum) or `debug_assert!(strip_bag
 || !strip_rows)` in `evict_axes`; the reader should take `whole_present`
 either way.
 
+**Resolved** — the pairing is now unrepresentable. `evict_axes(bool, bool)` is
+gone; `FileAnalysis::evict_to(Residency)` takes a ladder enum whose three
+variants are exactly the states that exist (`Whole` / `RowsOnly` /
+`Skeleton`). The invariant the callers were holding by hand —
+`strip_rows = strip_bag && rows_ok` — is now `Residency::for_strip`, so
+"bag present, rows evicted" has no spelling and `bag_present` carrying its
+symbols is a property of the type rather than of an audit. Proved over every
+inhabitant by `residency_is_a_ladder_so_a_bag_view_always_carries_its_rows`.
+The enrichment reader was left on `bag_present`: it is correct now for a
+structural reason, and moving it to `whole_present` would cost a whole-blob
+rehydrate per candidate on a path that only needs the bag.
+
 ### `whole_copy_registration_sites_are_allowlisted`
 
 The test greps source lines for `name(` call sites and compares counts. It

--- a/gold-corpus/fixtures/modname-hover.json
+++ b/gold-corpus/fixtures/modname-hover.json
@@ -1,0 +1,40 @@
+{
+  "capability": "hover",
+  "rows": [
+    {
+      "id": "modname-hv-01-invocant",
+      "difficulty": "moderate",
+      "semantic_area": "modules",
+      "comment": "Hover twin of goto-def on a MODULE-NAME token: `Text::SimpleTable->new(...)` in Catalyst.pm. Definition answers `SimpleTable.pm:3:9` at this exact position while hover answered nothing, because the model's `PackageRef` arm only sweeps LOCAL `symbols_named` — a package defined in another file is unreachable from it by construction. Hover now falls back to the CandidateSet's hover projection, so the two verbs resolve once and cannot disagree about whether a token resolves.",
+      "file": "Catalyst.pm",
+      "line": 103,
+      "col": 20,
+      "expect": {
+        "all": [
+          "package Text::SimpleTable",
+          "SimpleTable.pm"
+        ],
+        "none": []
+      },
+      "status": "gold"
+    },
+    {
+      "id": "modname-hv-02-require-bareword",
+      "difficulty": "moderate",
+      "semantic_area": "modules",
+      "root": "gold-corpus/require-fixture",
+      "comment": "Hover twin of `require-bareword-module`, same file/line/col: the bareword `require` form emits the PackageRef goto-def navigates, and hover must read the same resolution.",
+      "file": "lib/My/Requirer.pm",
+      "line": 2,
+      "col": 13,
+      "expect": {
+        "all": [
+          "package Req::Target",
+          "Target.pm"
+        ],
+        "none": []
+      },
+      "status": "gold"
+    }
+  ]
+}

--- a/src/build/language_driver.rs
+++ b/src/build/language_driver.rs
@@ -1608,6 +1608,12 @@ impl LanguageRegistry {
         self.drivers.iter().filter(|d| d.lang_pack().is_some()).map(|d| d.as_ref())
     }
 
+    /// Every id this build can serve — the feature-dependent set, so a caller
+    /// enumerating languages never carries its own list to drift.
+    pub fn ids(&self) -> Vec<&'static str> {
+        self.drivers.iter().map(|d| d.id()).collect()
+    }
+
     /// Human-facing name for a pack language id, for startup banners and
     /// progress messages. Purely cosmetic — `for_id` still speaks the short
     /// id everywhere else. Falls back to the id itself for a language this

--- a/src/index/module_cache/warm.rs
+++ b/src/index/module_cache/warm.rs
@@ -338,7 +338,7 @@ pub fn warm_cache(
                         // touch a copy some OTHER path registered
                         // whole-for-a-reason (writer fallback, watcher).
                         if strip && !fa.degraded {
-                            fa.evict_axes(true, false);
+                            fa.evict_to(crate::model::file_analysis::Residency::RowsOnly);
                         }
                         let cand = Arc::new(CachedModule::new(path, Arc::new(fa)));
                         adopt_warm_provider(cache, all_defs, &module_name, cand);

--- a/src/index/module_index/index_core.rs
+++ b/src/index/module_index/index_core.rs
@@ -331,7 +331,7 @@ pub(crate) fn strip_import_copy_one(
 ) -> Arc<CachedModule> {
     if persisted && strip && !m.analysis.degraded {
         let mut fa = (*m.analysis).clone();
-        fa.evict_axes(true, false);
+        fa.evict_to(crate::model::file_analysis::Residency::RowsOnly);
         Arc::new(CachedModule::new(m.path.clone(), Arc::new(fa)))
     } else {
         m.clone()

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -320,8 +320,10 @@ impl CrossFileLookup for ModuleIndex {
         // Never-evicted copy (open docs, degraded files kept whole): a cheap
         // Arc bump, no I/O.
         if !cached.analysis.bag_is_evicted() {
+            crate::util::ghost_stats::count("bagpresent.resident_whole");
             return cached.analysis.clone();
         }
+        crate::util::ghost_stats::count("bagpresent.rehydrate");
         self.rehydrate_or_resident(cached)
     }
 

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -1836,6 +1836,43 @@ fn an_exhausted_consult_budget_degrades_instead_of_running_forever() {
 /// compile; enumerating the variants proves the invariant for the whole
 /// domain, needs no extra dependency, and runs on every `cargo test`.
 #[test]
+fn an_evicted_copy_still_answers_its_export_surface() {
+    use crate::model::file_analysis::Residency;
+    // The enrichment provider chase skips a candidate that exports none of the
+    // names the consumer needs, and it asks the RESIDENT copy so the skip costs
+    // no rehydrate. That is only sound while the export surface survives the
+    // strip: if eviction ever took `export`/`export_ok`/`export_lookup` with it,
+    // every candidate would answer "exports nothing", the chase would skip
+    // providers it must visit, and imported return types would quietly stop
+    // resolving — no panic, no error, just types going missing.
+    let src = "package Widget;\nour @EXPORT = ('make');\nour @EXPORT_OK = ('helper');\n\
+               sub make { my $c = shift; return bless {}, $c; }\nsub helper { return 1 }\n1;\n";
+    let full = parse_source_to_cached(src, "Widget");
+    assert!(
+        full.analysis.exports_name("make") && full.analysis.exports_name("helper"),
+        "fixture must export both names before eviction"
+    );
+
+    for level in [Residency::Whole, Residency::RowsOnly, Residency::Skeleton] {
+        let mut fa = (*full.analysis).clone();
+        fa.evict_to(level);
+        assert!(
+            fa.exports_name("make"),
+            "@EXPORT name unreachable at {level:?} — the chase's resident gate \
+             would skip this provider and lose its imported types"
+        );
+        assert!(
+            fa.exports_name("helper"),
+            "@EXPORT_OK name unreachable at {level:?} — same silent loss"
+        );
+        assert!(
+            !fa.exports_name("never_exported"),
+            "the gate must stay an over-approximation, not answer true for everything"
+        );
+    }
+}
+
+#[test]
 fn residency_is_a_ladder_so_a_bag_view_always_carries_its_rows() {
     use crate::model::file_analysis::Residency;
     let src = "package Widget;\nsub make { my $c = shift; return bless {}, $c; }\n1;\n";

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -79,7 +79,7 @@ fn symbols_present_answers_resident_when_only_bag_evicted() {
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
 
     let mut bag_only = (*full.analysis).clone();
-    bag_only.evict_axes(true, false);
+    bag_only.evict_to(crate::model::file_analysis::Residency::RowsOnly);
     let bag_only_cached = Arc::new(CachedModule::new(path.clone(), Arc::new(bag_only)));
     let got = idx.symbols_present(&bag_only_cached);
     assert!(
@@ -108,7 +108,7 @@ fn symbols_present_rehydrates_evicted_symbols_never_absence_by_eviction() {
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
     let mut stripped = (*full.analysis).clone();
-    stripped.evict_axes(true, true);
+    stripped.evict_to(crate::model::file_analysis::Residency::Skeleton);
     assert!(stripped.symbols_are_evicted(), "fixture must model the workspace strip");
     let stripped_cached = Arc::new(CachedModule::new(full.path.clone(), Arc::new(stripped)));
     let got = idx.symbols_present(&stripped_cached);
@@ -133,7 +133,7 @@ fn refs_present_answers_resident_when_only_bag_evicted() {
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
     let mut bag_only = (*full.analysis).clone();
-    bag_only.evict_axes(true, false);
+    bag_only.evict_to(crate::model::file_analysis::Residency::RowsOnly);
     let cached = Arc::new(CachedModule::new(full.path.clone(), Arc::new(bag_only)));
     let got = idx.refs_present(&cached);
     assert!(Arc::ptr_eq(&got, &cached.analysis), "rows-resident copy answers resident");
@@ -158,7 +158,7 @@ fn refs_present_rehydrates_evicted_refs_never_absence_by_eviction() {
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
     let mut stripped = (*full.analysis).clone();
-    stripped.evict_axes(true, true);
+    stripped.evict_to(crate::model::file_analysis::Residency::Skeleton);
     assert!(stripped.refs_are_evicted(), "fixture must model the workspace strip");
     let cached = Arc::new(CachedModule::new(full.path.clone(), Arc::new(stripped)));
     let got = idx.refs_present(&cached);
@@ -614,7 +614,7 @@ fn register_symbols_stripping_feeds_before_evict() {
     let path = full.path.clone();
 
     let idx = ModuleIndex::new_for_cli();
-    let arc = idx.register_symbols_stripping((*path).to_path_buf(), (*full.analysis).clone(), true, true);
+    let arc = idx.register_symbols_stripping((*path).to_path_buf(), (*full.analysis).clone(), crate::model::file_analysis::Residency::Skeleton);
     assert!(arc.symbols_are_evicted() && arc.symbols().is_empty(), "stored copy is stripped");
     assert!(arc.refs_are_evicted());
 
@@ -1119,7 +1119,7 @@ fn rehydration_miss_is_counted_and_serves_resident() {
     let src = "package Ghost;\nsub boo { return 1 }\n1;\n";
     let tree = parser.parse(src, None).unwrap();
     let mut fa = crate::build::builder::build(&tree, src.as_bytes());
-    fa.evict_axes(true, true);
+    fa.evict_to(crate::model::file_analysis::Residency::Skeleton);
     let cm = Arc::new(CachedModule::new(
         PathBuf::from("/fake/Ghost.pm"),
         Arc::new(fa),
@@ -1159,7 +1159,7 @@ fn foreign_path_rehydrates_through_the_owning_sibling() {
     let whole = crate::build::builder::build(&tree, src.as_bytes());
     let whole_arc = Arc::new(whole);
     let mut stripped = (*whole_arc).clone();
-    stripped.evict_axes(true, true);
+    stripped.evict_to(crate::model::file_analysis::Residency::Skeleton);
     let path = PathBuf::from("/fake/hub/Ghost.pm");
 
     // Install the hub's rehydration cell with a loader that serves the
@@ -1554,7 +1554,7 @@ fn reregistering_one_file_keeps_evicted_sibling_edges() {
     let pb = PathBuf::from("/fake/pkgid/Beta.pm");
     // The sibling registers through the stripping door: its resident copy
     // has NO symbols, only the pre-strip name record.
-    let _ = idx.register_workspace_stripping(pb.clone(), build_fa(src_b), true, true);
+    let _ = idx.register_workspace_stripping(pb.clone(), build_fa(src_b), crate::model::file_analysis::Residency::Skeleton);
     let _ = idx.register_workspace_resident(pa.clone(), Arc::new(build_fa(src_a)));
     assert!(!idx.modules_with_symbol("from_beta").is_empty(), "sibling edges fed");
     // Re-register the whole file; the evicted sibling's names must replay.
@@ -1815,4 +1815,70 @@ fn an_exhausted_consult_budget_degrades_instead_of_running_forever() {
         ResolutionSession::degraded(),
         "and the walk must SAY it under-answered"
     );
+}
+
+/// The ladder, proved over EVERY inhabitant of the type.
+///
+/// The hazard this replaces was `evict_axes(strip_bag, strip_rows)`: four
+/// spellings for three states, and the fourth — rows dropped, bag kept —
+/// was prevented only by no production site passing it. It is not a crash
+/// if someone does. `bag_present` returns a copy whose symbols were
+/// evicted, and a consumer that reads both (cross-file import enrichment
+/// walks `symbols` off a bag view) reads absence-by-eviction as
+/// absence-in-fact: a silently smaller answer.
+///
+/// `Residency` has no spelling for it, so this asserts the property that
+/// makes the bag-then-symbols reads correct BY CONSTRUCTION rather than by
+/// audit: **dropping the rows always drops the bag**, i.e. bag present
+/// implies rows present.
+///
+/// A `trybuild` compile-fail case would show one bad line failing to
+/// compile; enumerating the variants proves the invariant for the whole
+/// domain, needs no extra dependency, and runs on every `cargo test`.
+#[test]
+fn residency_is_a_ladder_so_a_bag_view_always_carries_its_rows() {
+    use crate::model::file_analysis::Residency;
+    let src = "package Widget;\nsub make { my $c = shift; return bless {}, $c; }\n1;\n";
+    let full = parse_source_to_cached(src, "Widget");
+
+    // EVERY level the type can express. A new variant added without a case
+    // here fails to compile on the match below, not silently at runtime.
+    for level in [Residency::Whole, Residency::RowsOnly, Residency::Skeleton] {
+        let mut fa = (*full.analysis).clone();
+        fa.evict_to(level);
+        let (bag_gone, refs_gone, syms_gone) =
+            (fa.bag_is_evicted(), fa.refs_are_evicted(), fa.symbols_are_evicted());
+
+        // THE invariant: no level keeps the bag while dropping the rows.
+        assert!(
+            !(refs_gone || syms_gone) || bag_gone,
+            "{level:?} drops a row axis while keeping the bag — the combination \
+             that makes `bag_present` hand out an evicted-symbols copy"
+        );
+        // The row axes move together: they persist as one generation.
+        assert_eq!(refs_gone, syms_gone, "{level:?} split the row axes");
+
+        // And each level strips exactly what it advertises.
+        let expected = match level {
+            Residency::Whole => (false, false),
+            Residency::RowsOnly => (true, false),
+            Residency::Skeleton => (true, true),
+        };
+        assert_eq!((bag_gone, refs_gone), expected, "{level:?} stripped the wrong axes");
+        assert_eq!(fa.is_fully_resident(), level == Residency::Whole);
+    }
+}
+
+/// `for_strip` is the one place the "rows only once the blob can rehydrate
+/// them" rule lives — it used to be `let strip_rows = strip_bag && rows_ok`
+/// written out at each tier. Eviction off means whole regardless of
+/// `rows_ok`; rows_ok false never yields a rows strip.
+#[test]
+fn for_strip_never_yields_rows_without_bag() {
+    use crate::model::file_analysis::Residency;
+    for rows_ok in [false, true] {
+        assert_eq!(Residency::for_strip(false, rows_ok), Residency::Whole);
+    }
+    assert_eq!(Residency::for_strip(true, false), Residency::RowsOnly);
+    assert_eq!(Residency::for_strip(true, true), Residency::Skeleton);
 }

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -733,10 +733,9 @@ impl ModuleIndex {
         &self,
         path: std::path::PathBuf,
         fa: FileAnalysis,
-        strip_bag: bool,
-        strip_rows: bool,
+        level: crate::model::file_analysis::Residency,
     ) -> Arc<FileAnalysis> {
-        let parts = self.prepare_workspace_parts(&path, fa, strip_bag, strip_rows);
+        let parts = self.prepare_workspace_parts(&path, fa, level);
         parts.record_surface(self, &path);
         let arc = Arc::clone(parts.arc());
         self.register_workspace_residency(path, parts);
@@ -1143,12 +1142,11 @@ impl ModuleIndex {
         &self,
         path: &std::path::Path,
         mut fa: FileAnalysis,
-        strip_bag: bool,
-        strip_rows: bool,
+        level: crate::model::file_analysis::Residency,
     ) -> WorkspaceRegistrationParts {
         let names = self.workspace_feed_prestrip(path, &fa);
         let surface = crate::model::surface::Surface::project(&fa);
-        fa.evict_axes(strip_bag, strip_rows);
+        fa.evict_to(level);
         WorkspaceRegistrationParts { arc: Arc::new(fa), names, surface }
     }
 
@@ -1160,12 +1158,11 @@ impl ModuleIndex {
     /// and the stub encoder gets exactly the halves registration used.
     pub(crate) fn prepare_pack_parts(
         mut fa: FileAnalysis,
-        strip_bag: bool,
-        strip_rows: bool,
+        level: crate::model::file_analysis::Residency,
     ) -> PackRegistrationParts {
         let (feed, specs) = Self::prepare_pack_feed(&fa);
         let surface = crate::model::surface::Surface::project(&fa);
-        fa.evict_axes(strip_bag, strip_rows);
+        fa.evict_to(level);
         PackRegistrationParts { arc: Arc::new(fa), feed, specs, surface }
     }
 
@@ -1173,10 +1170,9 @@ impl ModuleIndex {
         &self,
         path: std::path::PathBuf,
         fa: FileAnalysis,
-        strip_bag: bool,
-        strip_rows: bool,
+        level: crate::model::file_analysis::Residency,
     ) -> Arc<FileAnalysis> {
-        let parts = Self::prepare_pack_parts(fa, strip_bag, strip_rows);
+        let parts = Self::prepare_pack_parts(fa, level);
         parts.record_surface(self, &path);
         let arc = Arc::clone(parts.arc());
         self.register_symbols_inner(path, parts);
@@ -1280,7 +1276,7 @@ impl ModuleIndex {
         // resolves, and `direct_children_of` re-checks each candidate's CURRENT
         // `package_parents`, so a stale entry (an edit dropped a base)
         // self-heals at read. `package_parents` survives every strip
-        // (`evict_axes` leaves it) and rides the warm-stub skeleton, so the arc
+        // (`evict_to` leaves it) and rides the warm-stub skeleton, so the arc
         // carries it on the fresh, warm, and whole paths alike.
         for (child, parents) in analysis.package_parent_edges() {
             for parent in parents {

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -903,11 +903,13 @@ impl ModuleIndex {
     ) -> Arc<FileAnalysis> {
         let mut stage = "no bag cache installed on this index".to_string();
         if let Some(bc) = self.bag_cache_ref() {
-            let got = if want_bag {
-                bc.bag_for_diag(&cached.path)
-            } else {
-                bc.rows_for_diag(&cached.path)
-            };
+            let got = crate::util::ghost_stats::timed("rehydrate.loader", || {
+                if want_bag {
+                    bc.bag_for_diag(&cached.path)
+                } else {
+                    bc.rows_for_diag(&cached.path)
+                }
+            });
             match got {
                 Ok(full) => return full,
                 // Discriminated cause (see `RehydrateMiss`) so the tripwire

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -202,12 +202,12 @@ pub fn index_pack_languages(
                             fa.sym_row_seeds(),
                         ));
                     }
-                    let strip_bag = eviction_enabled();
-                    let fully_stripped = strip_bag && rows_ok;
+                    // The ladder that used to be `strip_bag && rows_ok`.
+                    let level = crate::model::file_analysis::Residency::for_strip(eviction_enabled(), rows_ok);
+                    let fully_stripped = level == crate::model::file_analysis::Residency::Skeleton;
                     let parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
                         fa,
-                        strip_bag,
-                        fully_stripped,
+                        level,
                     );
                     if fully_stripped {
                         if let Some(blob) = module_cache::encode_stub(
@@ -438,7 +438,7 @@ pub fn index_pack_languages(
                         // so an evicted copy is never reachable before its blob
                         // can rehydrate it.
                         let parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
-                            analysis, true, true,
+                            analysis, crate::model::file_analysis::Residency::Skeleton,
                         );
                         let stub_blob = module_cache::encode_stub(
                             parts.feed(),

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -192,19 +192,21 @@ pub fn index_workspace_with_index(
                 // WHOLE analysis, then the requested axes evict, then the
                 // stripped arc is stored (feeds must never see an emptied
                 // `symbols`).
-                let strip_bag = eviction_enabled();
-                let strip_rows = strip_bag && rows_ok;
+                // The ladder that used to be `strip_rows = strip_bag && rows_ok`.
+                let level = crate::model::file_analysis::Residency::for_strip(
+                    eviction_enabled(),
+                    rows_ok,
+                );
                 let arc = match module_index {
                     Some(idx) => idx.register_workspace_stripping(
                         path.clone(),
                         fa,
-                        strip_bag,
-                        strip_rows,
+                        level,
                     ),
                     None => {
                         // No index (CLI-less warm): no feeds to extract —
                         // strip and store.
-                        fa.evict_axes(strip_bag, strip_rows);
+                        fa.evict_to(level);
                         std::sync::Arc::new(fa)
                     }
                 };
@@ -425,12 +427,12 @@ pub fn index_workspace_with_index(
                         let (arc, parts) = match module_index {
                             Some(idx) => {
                                 let parts =
-                                    idx.prepare_workspace_parts(&canon, analysis, true, true);
+                                    idx.prepare_workspace_parts(&canon, analysis, crate::model::file_analysis::Residency::Skeleton);
                                 parts.record_surface(idx, &canon);
                                 (std::sync::Arc::clone(parts.arc()), Some(parts))
                             }
                             None => {
-                                analysis.evict_axes(true, true);
+                                analysis.evict_to(crate::model::file_analysis::Residency::Skeleton);
                                 (std::sync::Arc::new(analysis), None)
                             }
                         };
@@ -455,7 +457,7 @@ pub fn index_workspace_with_index(
                         let arc = match module_index {
                             Some(idx) => {
                                 let parts =
-                                    idx.prepare_workspace_parts(&canon, analysis, false, false);
+                                    idx.prepare_workspace_parts(&canon, analysis, crate::model::file_analysis::Residency::Whole);
                                 let arc = std::sync::Arc::clone(parts.arc());
                                 idx.register_workspace_residency(canon.clone(), parts);
                                 // Deliberate whole pin (unpersistable /

--- a/src/index/pack_bag_cache.rs
+++ b/src/index/pack_bag_cache.rs
@@ -151,14 +151,24 @@ impl PackBagCache {
                 if let Some(g) = &self.ghost {
                     g.on_hit();
                 }
+                crate::util::ghost_stats::count("bagcache.hit");
+                crate::util::ghost_stats::count_attributed("bagcache_hit");
                 return Ok(arc);
             }
+            // Resident, but stripped — a rows-axes reader retained it and a
+            // bag request cannot be served from it.
+            crate::util::ghost_stats::count("bagcache.miss_stripped_resident");
+            crate::util::ghost_stats::count_attributed("bagcache_miss");
+        } else {
+            crate::util::ghost_stats::count("bagcache.miss_absent");
+            crate::util::ghost_stats::count_attributed("bagcache_miss");
         }
         if let Some(g) = &self.ghost {
             g.on_miss(&path.to_string_lossy());
         }
         let gen_before = self.generation.get(path).map(|g| *g).unwrap_or(0);
-        let mut loaded = (self.loader)(path)?;
+        let mut loaded = crate::util::ghost_stats::timed(
+            "bagcache.decode", || (self.loader)(path))?;
         if !want_bag {
             loaded.evict_witness_bag();
         }
@@ -185,7 +195,7 @@ impl PackBagCache {
             self.credit(old_sz);
         }
         self.recency.insert(path.to_path_buf(), self.tick());
-        self.evict_to_cap(path);
+        crate::util::ghost_stats::timed("bagcache.evict_to_cap", || self.evict_to_cap(path));
         if let Some(g) = &self.ghost {
             g.set_usage(
                 self.bytes.load(Ordering::Relaxed) as u64,

--- a/src/index/pack_invalidator.rs
+++ b/src/index/pack_invalidator.rs
@@ -532,7 +532,7 @@ impl PackInvalidator {
         pack.invalidate_bag_cache(path);
         if landed && !arc.degraded && crate::index::module_resolver::eviction_enabled() {
             // Registration-owned strip (feeds read the whole copy).
-            let _ = pack.register_symbols_stripping(path.to_path_buf(), (**arc).clone(), true, true);
+            let _ = pack.register_symbols_stripping(path.to_path_buf(), (**arc).clone(), crate::model::file_analysis::Residency::Skeleton);
         } else {
             pack.register_symbols(path.to_path_buf(), Arc::clone(arc));
         }

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -452,6 +452,104 @@ fn inferred_type_has_no_production_caller() {
     );
 }
 
+/// A narrow-axis view is BAG-STRIPPED. `symbols_present` / `refs_present`
+/// hand back a copy whose witness bag may be gone, so a bag-backed query on
+/// one answers `None` — not an error, not a panic, just a quietly missing
+/// type. Every site today is a deliberate symbols-axis read and says so in a
+/// comment, but a comment is not a type: this scans for the shape instead.
+///
+/// The residency ADR's reader-side typed view would make this unwritable;
+/// until then this is the tripwire. Bind a narrow view, call a bag-backed
+/// accessor on it, and the test names the line and tells you to take
+/// `bag_present` (or `whole_present`) instead.
+#[test]
+fn a_narrow_axis_view_is_never_asked_a_bag_question() {
+    // Accessors that consult the witness bag. `return_type` covers the
+    // `SubInfo` projection, whose answer is a bag query one hop away.
+    const BAG_BACKED: &[&str] = &[
+        "inferred_type_via_bag",
+        "inferred_type_via_bag_ctx",
+        "sub_return_type_at_arity",
+        "find_method_return_type",
+        "method_call_return_type_via_bag",
+        "expr_type_at_span",
+        "mutated_keys_on_class",
+        "applicable_dispatches",
+        "witness_bag",
+        "return_type(",
+    ];
+    const NARROW: &[&str] = &["symbols_present", "refs_present"];
+    let mut violations = Vec::new();
+    for (path, _layer, _stem) in source_files() {
+        if path.to_string_lossy().contains("layering_tests") {
+            continue;
+        }
+        // `source_files()` hands back the file STEM, not its contents — read
+        // the text here, or this scans a one-word string and passes vacuously.
+        let text = fs::read_to_string(&path).expect("read source");
+        let lines: Vec<&str> = text.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            let Some(reader) = NARROW.iter().find(|r| line.contains(**r)) else {
+                continue;
+            };
+            let t = line.trim_start();
+            if t.starts_with("//") || t.starts_with("///") {
+                continue;
+            }
+            // Chained directly off the reader: `.symbols_present(x).return_type()`.
+            if let Some(rest) = line.split_once(*reader).map(|(_, r)| r) {
+                if let Some(acc) = BAG_BACKED.iter().find(|a| rest.contains(**a)) {
+                    violations.push(format!(
+                        "{}:{}: `{}` chained onto `{}` — the view is bag-stripped",
+                        path.display(),
+                        i + 1,
+                        acc,
+                        reader
+                    ));
+                }
+            }
+            // Bound to a name, then asked later in the same scope. Scope end is
+            // approximated by DEDENT rather than brace matching: a brace matcher
+            // that desyncs on one string literal swallows the rest of the file
+            // and reports nonsense, and a tripwire that cries wolf gets deleted.
+            let Some(name) = line
+                .split_once(" = ")
+                .and_then(|(lhs, _)| lhs.rsplit(|c: char| !(c.is_alphanumeric() || c == '_')).next())
+                .filter(|n| !n.is_empty())
+            else {
+                continue;
+            };
+            let indent = line.len() - line.trim_start().len();
+            for probe in lines.iter().skip(i + 1) {
+                let p = probe.trim_start();
+                if p.is_empty() || p.starts_with("//") {
+                    continue;
+                }
+                if probe.len() - p.len() < indent {
+                    break; // left the binding's scope
+                }
+                if let Some(rest) = probe.split_once(&format!("{}.", name)).map(|(_, r)| r) {
+                    if let Some(acc) = BAG_BACKED.iter().find(|a| rest.starts_with(**a)) {
+                        violations.push(format!(
+                            "{}: `{}.{}` — `{}` is bag-stripped; take `bag_present` \
+                             (or `whole_present`) if the bag is really needed",
+                            path.display(),
+                            name,
+                            acc,
+                            reader
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "bag-backed query on a narrow-axis view — it answers None instead of failing:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
 /// Slot detection asks the DRIVER which detector serves a language
 /// (`DriverCaps::cursor_context`), never the language's name. A name compare
 /// is a partial enumeration: it serves the languages someone remembered to

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -452,6 +452,50 @@ fn inferred_type_has_no_production_caller() {
     );
 }
 
+/// Slot detection asks the DRIVER which detector serves a language
+/// (`DriverCaps::cursor_context`), never the language's name. A name compare
+/// is a partial enumeration: it serves the languages someone remembered to
+/// list, and a second tree-native driver would be routed to the sentinel path
+/// while its cap says otherwise — silently, because both arms return a
+/// well-formed `DetectedSlot`. The cap is the value-borne property, so the
+/// consumer asks it and the driver answers. This is the source half of the
+/// pin; the behavioural half is `cursor_slot_tests`, whose Perl slots
+/// (`Slot::ModulePath` on `use Foo::`) only the tree-native arm produces, so
+/// flipping the cap off fails there.
+#[test]
+fn slot_detection_dispatches_on_driver_caps_not_language_names() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/lsp/cursor_slot.rs");
+    let text = fs::read_to_string(&path).unwrap();
+    // Every id the registry can hand this file, whatever features are on.
+    let ids = crate::build::language_driver::LanguageRegistry::with_enabled()
+        .ids()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut violations = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        let t = line.trim_start();
+        if t.starts_with("//") || t.starts_with("///") {
+            continue;
+        }
+        for id in &ids {
+            let quoted = format!("\"{}\"", id);
+            if line.contains(&format!("== {}", quoted))
+                || line.contains(&format!("{} ==", quoted))
+                || line.contains(&format!("matches!(language, {}", quoted))
+            {
+                violations.push(format!("{}: {}", i + 1, line.trim()));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "cursor_slot.rs compares a language id to a literal — ask the driver's \
+         caps instead (DriverCaps::cursor_context selects the tree-native arm):\n  {}",
+        violations.join("\n  ")
+    );
+}
+
 /// D4: the blocking decision rides the query API, not per-handler memory.
 /// Handlers reach set construction, the relational row search, and the
 /// rehydration readers only through `run_query`'s `QueryCx` (minted on the

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -78,6 +78,11 @@ pub(crate) fn cli_check(args: &[String]) {
     }
 
     if !all_diagnostics.is_empty() {
+        // `exit` skips `EmitOnDrop`, and this verb is the one that walks and
+        // ENRICHES a whole workspace — the run whose counters are worth the
+        // most. Emitting here is the same explicit-before-hard-exit rule the
+        // server path already follows.
+        crate::util::ghost_stats::emit_all("check");
         std::process::exit(1);
     }
 }

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -657,7 +657,21 @@ fn run_one(
             }
             resolve_imports_blocking(idx, &analysis);
             analysis.enrich_imported_types_with_keys(Some(idx));
-            analysis.hover_info(point, &source, Some(idx))
+            // Perl routes through the SAME renderer the LSP handler calls, so
+            // the CLI cannot answer a different verb than the server: the
+            // ladder's import/qualified signature lookups and the projection
+            // fallback are both reachable here or in neither.
+            let abs = std::fs::canonicalize(file)
+                .unwrap_or_else(|_| std::path::PathBuf::from(file));
+            let _staged = ScopedWorkspaceEntry::insert(ws, abs.clone(), analysis);
+            let origin = ws.workspace_raw().get(&abs).map(|r| r.value().clone())
+                .expect("origin staged above");
+            let cs = resolve::resolve(
+                ws, &origin, file_store::FileKey::Path(abs), point,
+                Some(idx), resolve::OverrideScope::default(),
+            )
+            .with_source(&source);
+            symbols::perl_hover_markdown(&cs, idx)
                 .ok_or_else(|| format!("No hover info at {}:{}", req.line, req.col))
         }
         "type-at" => {

--- a/src/lsp/cursor_slot.rs
+++ b/src/lsp/cursor_slot.rs
@@ -188,12 +188,14 @@ impl Slot {
     }
 }
 
-/// The one identity-question entry (`docs/adr/cursor-slots.md`): Perl
-/// wraps `cursor_context`'s tree-then-text detector chain; pack languages
-/// wrap `cursor_sentinel`'s member-access sentinel reparse (looking up the
-/// language's driver/parser/`LangPack` itself). Falls back to a bare
-/// `Identifier` slot when a pack language isn't registered or has no
-/// `LangPack`.
+/// The one identity-question entry (`docs/adr/cursor-slots.md`). Which
+/// detector serves a language is the DRIVER's answer, not this function's:
+/// `DriverCaps::cursor_context` means "my slots come from the live document
+/// tree via `lsp/cursor_context`", and its absence means the sentinel-reparse
+/// pack path. Asking the cap rather than comparing the id keeps a second
+/// tree-native language from having to be named here to be served. Falls back
+/// to a bare `Identifier` slot when the language isn't registered, or is a
+/// pack language with no `LangPack`.
 pub fn detect_slot(
     analysis: &FileAnalysis,
     tree: &Tree,
@@ -202,9 +204,6 @@ pub fn detect_slot(
     language: &str,
     module_index: Option<&dyn CrossFileLookup>,
 ) -> DetectedSlot {
-    if language == "perl" {
-        return detect_slot_perl(analysis, tree, source, point, module_index);
-    }
     let reg = crate::build::language_driver::LanguageRegistry::with_enabled();
     let cursor = crate::build::cursor_sentinel::point_to_byte(source, point);
     let bare_identifier = || DetectedSlot {
@@ -214,6 +213,9 @@ pub fn detect_slot(
     let Some(driver) = reg.for_id(language) else {
         return bare_identifier();
     };
+    if driver.caps().cursor_context {
+        return detect_slot_tree_native(analysis, tree, source, point, module_index);
+    }
     let Some(lang_pack) = driver.lang_pack() else {
         return bare_identifier();
     };
@@ -260,7 +262,11 @@ pub fn detect_slot(
     bare_identifier()
 }
 
-fn detect_slot_perl(
+/// The `cursor_context` arm: slots read off the LIVE document tree, with the
+/// text-scan detector as the incomplete-source fallback. Serves any driver
+/// whose `DriverCaps::cursor_context` is set — Perl today, by cap and not by
+/// name.
+fn detect_slot_tree_native(
     analysis: &FileAnalysis,
     tree: &Tree,
     source: &str,

--- a/src/lsp/symbols/hover.rs
+++ b/src/lsp/symbols/hover.rs
@@ -299,7 +299,29 @@ pub fn perl_hover(
     })
 }
 
-fn perl_hover_markdown(
+pub fn perl_hover_markdown(
+    cs: &crate::index::resolve::CandidateSet,
+    module_index: &ModuleIndex,
+) -> Option<String> {
+    if let Some(markdown) = perl_hover_named(cs, module_index) {
+        return Some(markdown);
+    }
+    // Nothing the name-keyed ladder above knows how to render. Present the
+    // hover projection's candidate — the definition goto-def would jump to —
+    // exactly as `pack_hover_markdown` does, so the two verbs cannot disagree
+    // about whether a token resolves (`docs/adr/resolution-candidate-set.md`).
+    // A module-name token was the standing case: `Koha::Database->new` is a
+    // `PackageRef` whose package lives in another file, which the ladder's
+    // local `symbols_named` sweep can never see.
+    let loc = cs.hover_candidate()?;
+    render_candidate_hover(cs, &loc, "perl")
+}
+
+/// The name-keyed Perl ladder: whatever the model can render from the ref or
+/// symbol under the cursor, plus the import/qualified-call signature lookups
+/// that read a cross-file `SubInfo` by NAME. Everything here is richer than a
+/// rendered declaration line, so it runs before the projection fallback.
+fn perl_hover_named(
     cs: &crate::index::resolve::CandidateSet,
     module_index: &ModuleIndex,
 ) -> Option<String> {

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -284,13 +284,40 @@ impl FileAnalysis {
             .collect();
         // A file with no call bindings needs no provider walk at all.
         if let Some(idx) = module_index.filter(|_| !needed_names.is_empty()) {
+            let _chase = crate::util::ghost_stats::ScopedNs::start("chase.total");
+            let _attrib = crate::util::ghost_stats::Attribute::start("chase");
+            crate::util::ghost_stats::count("chase.file");
             for import in &self.imports {
+                crate::util::ghost_stats::count("chase.import");
+                crate::util::ghost_stats::count_distinct(
+                    "chase.import", &import.module_name);
                 // A split exporter's subs live across its candidate files.
                 for cached in idx.visible_def_candidates(&import.module_name) {
+                    crate::util::ghost_stats::count("chase.candidate");
+                    crate::util::ghost_stats::count_distinct(
+                        "chase.candidate", &cached.path.display().to_string());
                 // Return-shape reads go through the bag — the resident index
                 // copy may be bag-evicted (workspace tier included), so take
                 // the bag-present view for the whole scan.
-                let whole = idx.bag_present(&cached);
+                // The scan below only does work for a symbol that is BOTH
+                // needed here and exported there, so a candidate exporting
+                // none of `needed_names` contributes nothing — and the
+                // expensive part of finding that out is fetching a view.
+                //
+                // `export_lookup` (@EXPORT u @EXPORT_OK) is not an evictable
+                // axis and is rebuilt by `build_indices` on every copy, so this
+                // reads the RESIDENT analysis: no rehydrate, no decode, no LRU
+                // traffic. Measured on the substrate: it drops the per-candidate
+                // bag fetch from 7,829 to 332 (95.8% of them were for providers
+                // that matched nothing). Do not "simplify" this to a
+                // symbols-axis probe — `symbols_present` rehydrates too, and
+                // doing that made the chase SLOWER, not faster.
+                if !needed_names.iter().any(|n| cached.analysis.exports_name(n)) {
+                    crate::util::ghost_stats::count("chase.candidate_skipped");
+                    continue;
+                }
+                let whole = crate::util::ghost_stats::timed(
+                    "chase.bag_present", || idx.bag_present(&cached));
                 // Fetched on the first return-type MISS (fallback-on-miss): the
                 // exporter's own return may chain through ITS imports (A→B→C),
                 // materialized only after the exporter is itself enriched — the
@@ -308,11 +335,22 @@ impl FileAnalysis {
                     if !whole.exports_name(&sym.name) {
                         continue;
                     }
+                    crate::util::ghost_stats::count("chase.sym_matched");
                     if matches!(sym.detail, SymbolDetail::Sub { .. }) {
-                        let mut ty = whole.symbol_return_type_via_bag(sym.id, None);
+                        crate::util::ghost_stats::count("chase.return_query");
+                        let mut ty = crate::util::ghost_stats::timed(
+                            "chase.symbol_return_type_via_bag",
+                            || whole.symbol_return_type_via_bag(sym.id, None),
+                        );
                         if ty.is_none() {
-                            let en = enriched
-                                .get_or_insert_with(|| idx.enriched_present(&cached));
+                            crate::util::ghost_stats::count("chase.return_miss");
+                            let en = enriched.get_or_insert_with(|| {
+                                crate::util::ghost_stats::count("chase.enriched_present");
+                                crate::util::ghost_stats::timed(
+                                    "chase.enriched_present",
+                                    || idx.enriched_present(&cached),
+                                )
+                            });
                             if !std::sync::Arc::ptr_eq(en, &whole) {
                                 ty = en.symbol_return_type_via_bag(sym.id, None);
                             }

--- a/src/model/file_analysis/lifecycle.rs
+++ b/src/model/file_analysis/lifecycle.rs
@@ -3,6 +3,53 @@
 
 use super::*;
 
+/// How much of a resident index copy survives the registration strip.
+///
+/// The evictable axes are a **ladder, not a set of independent switches**:
+/// every tier that drops the row axes drops the witness bag too. That was
+/// previously carried as `evict_axes(strip_bag, strip_rows)`, whose fourth
+/// combination — rows dropped, bag kept — no tier wants and nothing
+/// prevented. It is not a crash if someone writes it: `bag_present` hands
+/// back a copy whose symbols were evicted, and every consumer that reads
+/// both (cross-file import enrichment walks `symbols` off a bag view) reads
+/// absence-by-eviction as absence-in-fact. A silently smaller answer.
+///
+/// The ladder is not invented here — the callers already computed it by
+/// hand, as `let strip_rows = strip_bag && rows_ok`. This lifts that
+/// conjunction out of an expression and into the type, so the illegal
+/// pairing has no spelling.
+///
+/// Ordered widest-to-narrowest; a new axis extends the narrow end (and
+/// `is_fully_resident`), never adds a flag.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Residency {
+    /// Nothing evicted — open docs, degraded files, `PERL_LSP_NO_EVICT`.
+    Whole,
+    /// Witness bag dropped; refs and symbols kept. The @INC tier, whose
+    /// copies the MRO existence walks hammer for symbols.
+    RowsOnly,
+    /// Bag AND both row axes dropped. The workspace/pack tier once the blob
+    /// and its rows are persisted and can rehydrate.
+    Skeleton,
+}
+
+impl Residency {
+    /// The strip a persisting tier wants: nothing when eviction is off,
+    /// otherwise bag-only until the rows are safely on disk.
+    ///
+    /// This is the one place the "rows only once the blob can rehydrate
+    /// them" rule is written. `rows_ok` false with eviction on is exactly
+    /// `RowsOnly` — never the rows-without-bag combination, which the type
+    /// cannot express.
+    pub fn for_strip(eviction_enabled: bool, rows_ok: bool) -> Self {
+        match (eviction_enabled, rows_ok) {
+            (false, _) => Residency::Whole,
+            (true, false) => Residency::RowsOnly,
+            (true, true) => Residency::Skeleton,
+        }
+    }
+}
+
 impl FileAnalysis {
     /// Create a new FileAnalysis with indices built from the raw tables.
     /// `finalize_post_walk` runs on the builder path to seal baseline
@@ -161,19 +208,25 @@ impl FileAnalysis {
         !self.bag_evicted && !self.refs.is_evicted() && !self.symbols.is_evicted()
     }
 
-    /// The ONE speller of the registration strip: `strip_bag` drops the
-    /// witness bag; `strip_rows` drops the row-backed axes (refs AND
-    /// symbols — they persist as one generation and evict as one). Every
-    /// registration path routes here so a new eviction axis is added in
-    /// exactly one place; a site spelling `evict_*` calls directly is
-    /// re-stating this pairing by convention.
-    pub fn evict_axes(&mut self, strip_bag: bool, strip_rows: bool) {
-        if strip_bag {
-            self.evict_witness_bag();
-        }
-        if strip_rows {
-            self.evict_refs();
-            self.evict_symbols();
+    /// The ONE speller of the registration strip. Every registration path
+    /// routes here so a new eviction axis is added in exactly one place; a
+    /// site spelling `evict_*` calls directly is re-stating this by
+    /// convention.
+    ///
+    /// Takes a `Residency` rather than a pair of flags because the axes are
+    /// a LADDER, not independent switches — see that type. The pair could
+    /// spell "rows stripped, bag kept", which no tier wants and which would
+    /// turn every `bag_present` consumer that also reads symbols into
+    /// absence-by-eviction: a silently smaller answer, not a crash.
+    pub fn evict_to(&mut self, level: Residency) {
+        match level {
+            Residency::Whole => {}
+            Residency::RowsOnly => self.evict_witness_bag(),
+            Residency::Skeleton => {
+                self.evict_witness_bag();
+                self.evict_refs();
+                self.evict_symbols();
+            }
         }
     }
 

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -139,9 +139,44 @@ fn is_subclass_of(child: &str, ancestor: &str, ctx: &BagContext) -> bool {
 
 /// Depth backstop for `query_rec`. The `(bag, attachment)` visited set is
 /// the primary cycle guard; this cap is belt-and-braces against a new,
-/// unaccounted-for recursion shape blowing the stack. On hit, log once
+/// unaccounted-for recursion shape blowing the stack. On hit, warn once
 /// per process and return `None` (give up cleanly rather than abort).
+///
+/// **It fires in production** (Tier 2 of the scale hitlist, seen again in
+/// the row-#3 probe), so treat it as a live degradation path, not a
+/// should-never-happen. Every hit is counted as `query_rec.depth_cap`
+/// under `PERL_LSP_GHOST_STATS` — the one-shot warning says it happened,
+/// the counter says how often, and only the second one can tell a rare
+/// pathological file from a systematic truncation.
+///
+/// Known interaction, unfixed: a subtree truncated here still gets
+/// MEMOIZED by the caller. `VisitedKey` is `(bag, attachment, receiver,
+/// arity)` — depth is not in it — so a node first reached near the cap
+/// caches its truncated answer and every later, shallower consult reads
+/// that instead of re-deriving the full one. Which nodes lose depends on
+/// traversal order, so the degradation is order-dependent as well as
+/// silent. Not fixed here because declining to memoize truncated subtrees
+/// means MORE re-derivation in exactly the pathological case the
+/// cross-file budget gate exists to bound; it wants the cpan5k corpus to
+/// measure, not a guess.
+///
+/// **Profile-aware, because the stack ceiling is.** Measured on a 2 MiB stack
+/// (the tokio blocking-pool and rayon worker size) with an `@ISA` chain of N
+/// packages, one `query_rec` level per hop:
+///
+/// | build | deepest chain that answers | at 512 |
+/// |---|---|---|
+/// | release | ≥2,000 (cap fires first) | cap fires, answer degrades to `None` |
+/// | debug | 400 | **stack overflow — the process aborts** |
+///
+/// So a single value cannot serve both: 512 is under the release ceiling and
+/// over the debug one, and a debug abort is a `cargo test` that dies rather
+/// than fails. Release keeps 512 — this changes no shipped answer — and debug
+/// drops to a value with margin under its own measured ceiling.
+#[cfg(not(debug_assertions))]
 const QUERY_REC_DEPTH_CAP: u32 = 512;
+#[cfg(debug_assertions)]
+const QUERY_REC_DEPTH_CAP: u32 = 256;
 
 thread_local! {
     static QUERY_REC_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
@@ -237,15 +272,19 @@ impl ReducerRegistry {
             d
         });
         if depth >= QUERY_REC_DEPTH_CAP {
+            // Counted on EVERY hit: the one-shot warning below says the cap
+            // fired, but only a count distinguishes one pathological file
+            // from a systematic truncation across the corpus.
+            crate::util::ghost_stats::count("query_rec.depth_cap");
             QUERY_REC_DEPTH_WARNED.with(|w| {
                 if !w.get() {
                     w.set(true);
-                    eprintln!(
-                        "perl-lsp: query_rec depth cap ({}) hit on attachment {:?} — \
-                         returning None to avoid stack overflow. \
-                         This indicates an un-broken recursion path; \
-                         please report.",
-                        QUERY_REC_DEPTH_CAP, q.attachment,
+                    log::warn!(
+                        "query_rec depth cap ({}) hit on attachment {:?} — returning \
+                         None, so this answer is silently incomplete. Further hits are \
+                         counted as `query_rec.depth_cap` (PERL_LSP_GHOST_STATS).",
+                        QUERY_REC_DEPTH_CAP,
+                        q.attachment,
                     );
                 }
             });

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -149,16 +149,31 @@ fn is_subclass_of(child: &str, ancestor: &str, ctx: &BagContext) -> bool {
 /// the counter says how often, and only the second one can tell a rare
 /// pathological file from a systematic truncation.
 ///
-/// Known interaction, unfixed: a subtree truncated here still gets
-/// MEMOIZED by the caller. `VisitedKey` is `(bag, attachment, receiver,
-/// arity)` — depth is not in it — so a node first reached near the cap
-/// caches its truncated answer and every later, shallower consult reads
-/// that instead of re-deriving the full one. Which nodes lose depends on
-/// traversal order, so the degradation is order-dependent as well as
-/// silent. Not fixed here because declining to memoize truncated subtrees
-/// means MORE re-derivation in exactly the pathological case the
-/// cross-file budget gate exists to bound; it wants the cpan5k corpus to
-/// measure, not a guess.
+/// Known interaction, unfixed and now MEASURED rather than guessed at: a
+/// subtree truncated here still gets MEMOIZED by the caller. `VisitedKey` is
+/// `(bag, attachment, receiver, arity)` — depth is not in it — so a node
+/// first reached near the cap caches its truncated answer and a later,
+/// shallower consult reads that instead of re-deriving the full one. Which
+/// nodes lose depends on traversal order.
+///
+/// Two facts bound how much this matters, both worth knowing before anyone
+/// "fixes" it:
+///
+/// 1. **It cannot outlive one top-level query.** `QueryState` — memo included
+///    — is minted in `query` and dropped when it returns. So this is not a
+///    cache that poisons a session; the window is a single query's traversal.
+/// 2. **Guarding it is expensive and, so far, buys nothing observable.** A
+///    prototype tagged each entry with the depth that produced it and refused
+///    to serve a truncated entry to a shallower consult. On a synthetic
+///    diamond (a 400-hop branch and a 2-hop branch meeting at a node whose
+///    own tail crosses the cap) it rejected 80,200 entries and re-derived
+///    them — 5.6x the wall time, 7s to 39s — and the top-level answer was
+///    IDENTICAL with and without it. The mechanism fires constantly; a shape
+///    where it changes what a user sees was not found.
+///
+/// So the cost is confirmed real and the benefit is still unevidenced. A fix
+/// wants a corpus case where the served answer actually differs — not a
+/// reproduction of the mechanism, which is easy and proves nothing.
 ///
 /// **Profile-aware, because the stack ceiling is.** Measured on a 2 MiB stack
 /// (the tokio blocking-pool and rayon worker size) with an `@ISA` chain of N

--- a/src/model/witnesses/witnesses_tests.rs
+++ b/src/model/witnesses/witnesses_tests.rs
@@ -988,3 +988,71 @@ fn query_memo_keeps_inherited_receiver_per_child_in_one_query() {
          shared MethodOnClass{{Parent, m}} attachment"
     );
 }
+
+/// A chase deeper than the cap DEGRADES; it does not abort the process.
+///
+/// `QUERY_REC_DEPTH_CAP`'s whole job is "return `None` to avoid stack
+/// overflow", and it was not doing it in every build. Measured on a 2 MiB
+/// stack (the tokio blocking-pool / rayon worker size): a debug build
+/// overflowed inside `query_rec` between 400 and 512 hops — UNDER the 512
+/// cap — so the backstop never fired and the process aborted. A stack
+/// overflow is not a catchable panic, so that is a `cargo test` that dies
+/// rather than fails.
+///
+/// 600 `@ISA` hops is above the old debug ceiling and above both caps.
+/// Base-verify by restoring a single 512 cap: this aborts.
+#[test]
+fn a_chase_past_the_depth_cap_degrades_instead_of_aborting() {
+    const HOPS: usize = 600;
+    let src = isa_chain(HOPS);
+    // Explicitly 2 MiB: the harness's own thread size is not what this pins.
+    let answer = std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let mut p = tree_sitter::Parser::new();
+            p.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
+            let tree = p.parse(&src, None).unwrap();
+            let fa = crate::build::builder::build(&tree, src.as_bytes());
+            fa.find_method_return_type("C0", "target", None, None)
+        })
+        .expect("spawn")
+        .join()
+        .expect("the depth cap must fire before the stack does");
+
+    // Truncated, which is the honest outcome for a chase past the cap. The
+    // point of the test is that we reached this line at all.
+    assert!(
+        answer.is_none(),
+        "a {HOPS}-hop chase is past the cap, so a truncated answer is expected; \
+         got {answer:?}"
+    );
+}
+
+/// Control: a chain well under the cap still resolves, so the test above
+/// pins the cap's behaviour rather than a walk that never worked.
+#[test]
+fn a_chase_within_the_depth_cap_still_resolves() {
+    let src = isa_chain(100);
+    let mut p = tree_sitter::Parser::new();
+    p.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
+    let tree = p.parse(&src, None).unwrap();
+    let fa = crate::build::builder::build(&tree, src.as_bytes());
+    assert!(
+        fa.find_method_return_type("C0", "target", None, None).is_some(),
+        "a 100-hop chain is well within the cap and must still resolve"
+    );
+}
+
+/// `C0` isa `C1` isa … isa `C{n-1}`, which declares `target`. One
+/// `query_rec` level per hop.
+fn isa_chain(n: usize) -> String {
+    let mut src = String::new();
+    for i in 0..n {
+        src.push_str(&format!("package C{i};\n"));
+        if i + 1 < n {
+            src.push_str(&format!("our @ISA = (\"C{}\");\n", i + 1));
+        }
+    }
+    src.push_str(&format!("package C{}; sub target {{ return \"hi\" }}\n", n - 1));
+    src
+}

--- a/src/util/ghost_stats.rs
+++ b/src/util/ghost_stats.rs
@@ -74,6 +74,109 @@ pub fn count(tag: &str) {
     *c.entry(tag.to_string()).or_insert(0) += 1;
 }
 
+/// tag -> (total nanos, call count). A per-call `[PHASE]` line is useless for
+/// a region entered once per file across a corpus; what a hot region needs is
+/// the SUM and the call count, so an average and a share are derivable.
+fn accum() -> &'static Mutex<HashMap<String, (u128, u64)>> {
+    static A: OnceLock<Mutex<HashMap<String, (u128, u64)>>> = OnceLock::new();
+    A.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Add one timed region's elapsed nanos to `tag`'s running total.
+pub fn add_ns(tag: &str, nanos: u128) {
+    if !enabled() {
+        return;
+    }
+    let mut a = accum().lock().unwrap_or_else(|e| e.into_inner());
+    let e = a.entry(tag.to_string()).or_insert((0, 0));
+    e.0 += nanos;
+    e.1 += 1;
+}
+
+/// Time `body` into `tag`'s running total. Inert when the gate is off — not
+/// even an `Instant::now`, so an instrumented hot path costs nothing unmeasured.
+#[inline]
+pub fn timed<T>(tag: &str, body: impl FnOnce() -> T) -> T {
+    if !enabled() {
+        return body();
+    }
+    let t = std::time::Instant::now();
+    let out = body();
+    add_ns(tag, t.elapsed().as_nanos());
+    out
+}
+
+/// Accumulate a region's elapsed time on drop — the `timed` shape for a body
+/// that borrows its surroundings mutably and cannot be a closure.
+pub struct ScopedNs {
+    tag: &'static str,
+    started: Option<std::time::Instant>,
+}
+
+impl ScopedNs {
+    pub fn start(tag: &'static str) -> Self {
+        ScopedNs { tag, started: enabled().then(std::time::Instant::now) }
+    }
+}
+
+impl Drop for ScopedNs {
+    fn drop(&mut self) {
+        if let Some(t) = self.started {
+            add_ns(self.tag, t.elapsed().as_nanos());
+        }
+    }
+}
+
+/// tag -> set of distinct keys seen. Pairs with `count(tag)`: the ratio of
+/// total occurrences to distinct keys IS the repeat factor, which is the one
+/// number that says whether a memo would pay.
+fn distincts() -> &'static Mutex<HashMap<String, std::collections::HashSet<String>>> {
+    static D: OnceLock<Mutex<HashMap<String, std::collections::HashSet<String>>>> = OnceLock::new();
+    D.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record that `key` was seen under `tag`. No-op when the gate is off.
+pub fn count_distinct(tag: &str, key: &str) {
+    if !enabled() {
+        return;
+    }
+    let mut d = distincts().lock().unwrap_or_else(|e| e.into_inner());
+    d.entry(tag.to_string()).or_default().insert(key.to_string());
+}
+
+thread_local! {
+    /// Set while a region wants its downstream cache traffic attributed to it.
+    /// A hit rate is only actionable per CALLER: a 99% global rate hides a
+    /// caller that misses a third of the time, and that caller is the one to fix.
+    static ATTRIB: std::cell::Cell<Option<&'static str>> = const { std::cell::Cell::new(None) };
+}
+
+/// Attribute downstream `count_attributed` events to `tag` for this scope.
+pub struct Attribute(Option<&'static str>);
+
+impl Attribute {
+    pub fn start(tag: &'static str) -> Self {
+        Attribute(ATTRIB.with(|a| a.replace(Some(tag))))
+    }
+}
+
+impl Drop for Attribute {
+    fn drop(&mut self) {
+        ATTRIB.with(|a| a.set(self.0));
+    }
+}
+
+/// Bump `<caller>.<event>` when inside an `Attribute` scope, else `<event>`.
+pub fn count_attributed(event: &str) {
+    if !enabled() {
+        return;
+    }
+    match ATTRIB.with(|a| a.get()) {
+        Some(t) => count(&format!("{t}.{event}")),
+        None => count(&format!("unattributed.{event}")),
+    }
+}
+
 fn trace_every() -> u64 {
     static N: OnceLock<u64> = OnceLock::new();
     *N.get_or_init(|| {
@@ -159,6 +262,40 @@ pub fn emit_attribution(moment: &str) {
         out.push_str(&format!("[ghost-triggers {moment}] event counters:\n"));
         for (k, v) in rows {
             out.push_str(&format!("[ghost-triggers]   {v:>8}  {k}\n"));
+        }
+    }
+    {
+        let a = accum().lock().unwrap_or_else(|e| e.into_inner());
+        if !a.is_empty() {
+            let mut rows: Vec<(&String, &(u128, u64))> = a.iter().collect();
+            rows.sort_by(|x, y| y.1 .0.cmp(&x.1 .0).then_with(|| x.0.cmp(y.0)));
+            out.push_str(&format!("[ghost-triggers {moment}] accumulated time:\n"));
+            for (k, (ns, n)) in rows {
+                let ms = *ns as f64 / 1e6;
+                let avg_us = if *n > 0 { *ns as f64 / *n as f64 / 1e3 } else { 0.0 };
+                out.push_str(&format!(
+                    "[ghost-triggers]   {ms:>10.1} ms  n={n:<8} avg={avg_us:>9.1} us  {k}\n"
+                ));
+            }
+        }
+    }
+    {
+        let d = distincts().lock().unwrap_or_else(|e| e.into_inner());
+        if !d.is_empty() {
+            let c = counters().lock().unwrap_or_else(|e| e.into_inner());
+            let mut rows: Vec<(&String, usize)> =
+                d.iter().map(|(k, v)| (k, v.len())).collect();
+            rows.sort_by(|x, y| y.1.cmp(&x.1).then_with(|| x.0.cmp(y.0)));
+            out.push_str(&format!(
+                "[ghost-triggers {moment}] distinct keys (total/distinct = repeat factor):\n"
+            ));
+            for (k, n) in rows {
+                let total = c.get(k).copied().unwrap_or(0);
+                let factor = if n > 0 { total as f64 / n as f64 } else { 0.0 };
+                out.push_str(&format!(
+                    "[ghost-triggers]   distinct={n:<8} total={total:<10} x{factor:<8.2} {k}\n"
+                ));
+            }
         }
     }
     {


### PR DESCRIPTION
Eight commits. Mostly things that were supposed to prevent a class of mistake and didn't — plus one measurement that talked me out of a fix, and one that found where an enrichment build actually spends its time.

| commit | |
|---|---|
| `e93a54e` | `docs: the strings interner only ever grows` |
| `02d10fc` | `refactor: the residency axes are a ladder, so stop spelling them as two flags` |
| `11b39e6` | `fix: the depth backstop fired after the stack died, in every debug build` |
| `dfb6ac6` | `fix: hover and goto-def disagreed about whether a module name resolves` |
| `7b10abe` | `refactor: slot detection asks the driver, instead of asking for "perl"` |
| `04790cb` | `test: a narrow-axis view is never asked a bag question` |
| `4eccfd7` | `docs: the memo-poisoning fix costs 5.6x and buys nothing measurable` |
| `323b860` | `perf: the provider chase paid for 7,497 providers that matched nothing` |

---

## `323b860` — the cross-file provider chase, 1,541 ms → 240 ms

The chase was 61.6% of an enrichment build (`[C]`'s measurement in #131) and nobody had attributed it. Measured before touching it; the answer was not what the plan assumed.

**The chase is one call.** Over the gold substrate (2,265 `.pm`, cold cache), of 1,541 ms total: `bag_present` **1,441 ms (93.5%)**, return-type query 15.8 ms, `visible_def_candidates` 5.7 ms, `enriched_present` 0.3 ms. Provider *resolution* is 0.4%. The overlay is 0.02%.

**Why `bag_present` is expensive** — per-caller attribution, because a global hit rate hides exactly this:

| caller | hits | misses | miss rate |
|---|---|---|---|
| everything else | 1,668,278 | 15,671 | **1.0%** |
| the chase | 1,541 | 1,261 | **45.0%** |

The chase is a breadth sweep across the dep closure, so each consumer touches a different provider set and flushes the LRU it depends on. A miss is a real decode (562 µs) plus the eviction sweep (155 µs).

**The defect:** the loop takes the bag view up front *"for the whole scan"*, but the bag is needed by exactly one line and every filter above it is a symbols-axis read. 7,829 candidates fetched; **332 useful (4.24%)**. The gate reads the export surface off the **resident** copy — `export_lookup` is not an evictable axis — so the skip costs no rehydrate.

| | before | after |
|---|---|---|
| `chase.total` | 1,541 ms | **240 ms** |
| `bag_present` calls | 7,829 | **502** |
| symbols scanned | 472,249 | 35,208 |
| chase cache misses | 1,261 | 172 |

Work done is unchanged — `sym_matched` 413, `return_query` 413, `return_miss` 223, `enriched_present` 167, identical before and after — and `--check` over all 2,265 files gives a byte-identical diagnostic **set**.

**The wrong fix, measured before shipping the right one:** probing with `symbols_present` and upgrading lazily made it **worse** (1,541 → 2,333 ms). That view rehydrates too. The gate it computed was correct; the gate cost more than it saved. The generalisation is in the code comment: *any per-candidate analysis view costs a decode; only a field that survives the strip can gate for free.*

The test pins the **precondition**, not the speed, because the failure is silent: if eviction ever took the export surface, every candidate would answer "exports nothing", providers would be skipped, and imported types would stop resolving with no error. Base-verified.

## `4eccfd7` — the memo-poisoning fix, prototyped and rejected

The `query_rec` doc comment asked for the corpus "to measure, not a guess". Measured. Two findings killed it: the memo **cannot outlive one top-level query** (so it poisons a traversal, never a session — "sticky" was my own overstatement), and the depth-tagged guard cost **5.6× wall time (7s → 39s, 80,200 rejects)** for an **identical** answer.

The mechanism is trivially reproducible — 80,521 truncated stores — and a test I wrote to demonstrate the bug passed just as well with the guard disabled, so I dropped it. Reverted rather than ship a confirmed regression for an unevidenced benefit. The bar for re-attempting is now written down: a corpus case where the **served answer** differs.

## `02d10fc` — the residency flag pair

`evict_axes(bool, bool)` could spell `(false, true)`: evict the rows, keep the bag. The axes are a ladder, so they're spelled as one — `Residency::{Whole, RowsOnly, Skeleton}`, `for_strip` the single derivation, `evict_to` the single application. The invalid state is no longer expressible. Behaviour unchanged.

## `11b39e6` — the depth cap that fired after the stack died

| profile | survives to | cap was |
|---|---|---|
| release | ≥ 2,000 hops | 512 |
| **debug** | **400 hops** | **512** |

So in every debug build the stack died before the backstop fired. `gdb` put the fault inside `query_rec` itself. Now profile-aware. **Base-verified:** restoring the single `512` makes the 600-hop test abort with SIGABRT.

## `dfb6ac6` — hover and goto-def disagreed

`Koha::Database->new` navigates; hovering the same token answered nothing. Two stacked defects: `hover_info`'s `PackageRef` arm sweeps only LOCAL symbols, and the CLI's `hover` verb never entered `perl_hover_markdown` for Perl at all — so CLI and server answered measurably different verbs. Perl hover now ends on the CandidateSet's hover projection, where pack hover already ended. Pinned by two gold rows; **base-verified, both FAIL without the fix.**

## `7b10abe` — a cap the consumer never asked

`detect_slot` chose its detector with `language == "perl"` while `DriverCaps::cursor_context` already documented that exact split. It fails *quietly*: both arms return a well-formed `DetectedSlot`, so a second tree-native driver would be routed against its own cap and emit plausible wrong slots. Pinned by a source tripwire (base-verified) plus existing behavioural tests.

## `04790cb` — the reader side, netted

`symbols_present`/`refs_present` hand back bag-stripped copies, so a bag-backed query on one answers `None` — quietly. Every site is a deliberate symbols-axis read and says so in a comment; a comment is not a type, so this scans for the shape. Base-verified in both shapes. Worth noting the first draft **passed green over a tree with a violation injected into it** — `source_files()` returns the file stem, not its text — which is precisely the failure mode the test exists to catch.

---

## Verification

| gate | result |
|---|---|
| `cargo test` | 1497 / 0 |
| `cargo test --features cpp` | 1560 / 0 |
| gold, cold cache | **498 PASS** · 15 xfail · 0 FAIL · 0 XPASS · 0 CRASH · skip 0 · lang-skip 0 |
| gold on base, with the 2 hover rows | 496 PASS · **2 FAIL** — exit 1 |
| `--check` diagnostic set, 2,265 files, before vs after `323b860` | byte-identical |
| CI at `4eccfd7` | Rust ✅ · Gold ✅ · E2E ✅ |

Gold runs `PERL_LSP_STRICT_RESIDENCY=1`, so a residency behaviour change surfaces as a CRASH row rather than a FAIL. It's green.

**Not run, and not implied:** Koha `references` on `store` (284,617, server path). There is no Koha corpus in this sandbox. That is the one outstanding gate on `323b860`.

## Reported, not fixed

- **`--check` output order is nondeterministic run-to-run** — two runs of the *same* binary gave the same 11 diagnostics in different order. Pre-existing; I hit it comparing before/after and nearly misread it as a behaviour change. Anything diffing `--check` output across runs sees spurious churn.
- **`--heatmap` hard-exits past `EmitOnDrop`** (`heatmap.rs:353`) — the same hole fixed here for `--check`, which had made the whole-workspace enrich verb report no counters at all.
- **The rest of the chase.** 240 ms remains, `bag_present` 206 ms over 502 calls. A per-walk memo is the right next cut but the repeat factor after the gate is ~1.5×, not 9.6× — proportionally a much smaller win, and it needs session scoping. Left for a decision rather than built.
- **Candidate fan-out is 1.43 per import here**, not the 5–12 expected at 138k. If it is 5–12 at scale the gate matters *more* there.
- **`query_rec` memo poisoning** and the **release depth cap** — see `4eccfd7`.
- **The reader-side axis-typed view** — netted by `04790cb`, not removed; ~106 field-reading sites.
- **Hover on the `use Foo::Bar;` line** still renders the `use` statement; the ladder answers there, so changing it is a behaviour change at a position that isn't broken.

## For a human, not touched here

`CLAUDE.md:135` still says "`FileAnalysis::evict_axes` is the one speller of the strip". It's `evict_to` now. Flagged rather than edited.