### PR TITLE
perf: bound the persist queue, and pin the guard property that makes it safe

### DIFF
--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -1919,3 +1919,58 @@ fn for_strip_never_yields_rows_without_bag() {
     assert_eq!(Residency::for_strip(true, false), Residency::RowsOnly);
     assert_eq!(Residency::for_strip(true, true), Residency::Skeleton);
 }
+
+/// A deleted file's loader-config shapes must go with it. `record_workspace_projections`
+/// records them keyed by the contributor's path, and `record_loader_shapes`
+/// retracts a contributor's entries only when that SAME file re-registers — so a
+/// file that is deleted rather than edited never retracts, and its shapes type
+/// `$conf` in a plugin's `register` for the rest of the session from a
+/// contributor that no longer exists.
+///
+/// (`loaded_modules` deliberately has no inverse: several files may load one
+/// module, so removing on one file's deletion would wrongly un-suppress the
+/// entrypoint lint. Its reader is biased honest-quiet, so never-remove is the
+/// safe direction there — unlike here, where the stale value is a TYPE.)
+#[test]
+fn unregistering_a_workspace_file_retracts_its_loader_shapes() {
+    let dir = std::env::temp_dir().join(format!(
+        "qx-unreg-shapes-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("App.pm");
+    std::fs::write(
+        &path,
+        "package My::App;\nuse Mojolicious::Lite;\nplugin 'CloveApp', { minion => 1 };\n1;\n",
+    )
+    .unwrap();
+    let canon = std::fs::canonicalize(&path).unwrap();
+
+    let idx = ModuleIndex::new_for_test();
+    let fa = build_fa(&std::fs::read_to_string(&path).unwrap());
+    idx.record_workspace_projections(&canon, &fa);
+    let _ = idx.register_workspace_resident(canon.clone(), Arc::new(fa));
+
+    let shapes = |idx: &ModuleIndex| {
+        let mut out: Vec<String> = Vec::new();
+        idx.for_each_loader_shape(&mut |name, _t| out.push(name.to_string()));
+        out
+    };
+    assert!(
+        shapes(&idx).iter().any(|n| n == "CloveApp"),
+        "precondition: registration records the shape; got {:?}",
+        shapes(&idx)
+    );
+
+    idx.unregister_workspace_path(&canon);
+    assert!(
+        !shapes(&idx).iter().any(|n| n == "CloveApp"),
+        "a departed contributor's loader shape survived unregistration: {:?}",
+        shapes(&idx)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/index/module_index/parts.rs
+++ b/src/index/module_index/parts.rs
@@ -332,7 +332,7 @@ pub(crate) struct PackRegistrationParts {
     pub(super) arc: Arc<FileAnalysis>,
     pub(super) feed: Vec<(String, bool)>,
     pub(super) specs: Vec<(String, String)>,
-    pub(super) surface: crate::model::surface::Surface,
+    pub(super) surface: Option<crate::model::surface::Surface>,
 }
 
 impl PackRegistrationParts {
@@ -347,8 +347,15 @@ impl PackRegistrationParts {
     pub(crate) fn specs(&self) -> &[(String, String)] {
         &self.specs
     }
+    /// The projected surface — valid only BEFORE `record_surface` takes it.
+    /// Panics after, rather than handing back an empty one: the caller that
+    /// reads this encodes a warm stub, and an empty surface baked into a
+    /// persisted stub is served as valid on every later warm start. A loud
+    /// ordering failure beats a stub that is quietly wrong across sessions.
     pub(crate) fn surface(&self) -> &crate::model::surface::Surface {
-        &self.surface
+        self.surface
+            .as_ref()
+            .expect("read the surface before record_surface takes it")
     }
 
     /// A whole-copy token minted from an already-`Arc`'d analysis: the feed
@@ -358,7 +365,7 @@ impl PackRegistrationParts {
     pub(crate) fn whole(arc: Arc<FileAnalysis>) -> Self {
         let (feed, specs) = ModuleIndex::prepare_pack_feed(&arc);
         let surface = crate::model::surface::Surface::project(&arc);
-        PackRegistrationParts { arc, feed, specs, surface }
+        PackRegistrationParts { arc, feed, specs, surface: Some(surface) }
     }
 
     /// Rehydrate a token from a warm stub — the persisted form of a prior
@@ -370,7 +377,7 @@ impl PackRegistrationParts {
             arc: Arc::new(stub.skeleton),
             feed: stub.feed,
             specs: stub.specs,
-            surface: stub.surface,
+            surface: Some(stub.surface),
         }
     }
 
@@ -378,12 +385,18 @@ impl PackRegistrationParts {
     /// Separate from registration so the deferred-writer path can record
     /// pre-COMMIT (session-local) while the residency half waits for the
     /// commit; the sync front doors record then register in sequence.
+    ///
+    /// TAKES the surface rather than cloning it. Registration discards it
+    /// (`surface: _`), so a token that rides the bounded persist queue would
+    /// otherwise carry a payload whose only remaining use is to be dropped.
+    /// Calling this twice records an empty surface the second time — the one
+    /// caller shape is record-then-hand-off, and every call site does that.
     pub(crate) fn record_surface(
-        &self,
+        &mut self,
         idx: &ModuleIndex,
         path: &std::path::Path,
     ) -> crate::model::surface::SurfaceVerdict {
-        idx.record_surface_value(path, self.surface.clone())
+        idx.record_surface_value(path, self.surface.take().unwrap_or_default())
     }
 }
 
@@ -396,7 +409,7 @@ pub(crate) struct WorkspaceRegistrationParts {
     /// pre-strip — Perl allows any number of packages per file, and each
     /// one must be reachable by name (`docs/adr/file-store-and-resolve.md`).
     pub(super) names: Vec<(String, bool)>,
-    pub(super) surface: crate::model::surface::Surface,
+    pub(super) surface: Option<crate::model::surface::Surface>,
 }
 
 impl WorkspaceRegistrationParts {
@@ -404,13 +417,13 @@ impl WorkspaceRegistrationParts {
         &self.arc
     }
 
-    /// See `PackRegistrationParts::record_surface`.
+    /// See `PackRegistrationParts::record_surface` — takes, does not clone.
     pub(crate) fn record_surface(
-        &self,
+        &mut self,
         idx: &ModuleIndex,
         path: &std::path::Path,
     ) -> crate::model::surface::SurfaceVerdict {
-        idx.record_surface_value(path, self.surface.clone())
+        idx.record_surface_value(path, self.surface.take().unwrap_or_default())
     }
 }
 

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -761,6 +761,16 @@ impl ModuleIndex {
         });
         self.all_files.remove(&canon);
         self.core.edges.remove_path_record(&canon);
+        // The inverse of `record_workspace_projections`' shape half. Its own
+        // retraction only fires when the SAME file re-registers, so a deleted
+        // file would otherwise keep typing `$conf` in a plugin's `register`
+        // from a contributor that no longer exists. Keyed exactly as the
+        // recording side spells it.
+        self.core.purge_loader_shapes(&canon.display().to_string());
+        // `loaded_modules` deliberately has NO inverse: several files may load
+        // one module, so dropping on one file's deletion would wrongly
+        // un-suppress the entrypoint lint. Its reader is biased honest-quiet,
+        // so never-remove is the safe direction there.
         if let Some((_, names)) = self.registered_names.remove(&canon) {
             for (name, _) in &names {
                 if let Some(mut v) = self.core.all_defs.get_mut(name) {

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -735,7 +735,7 @@ impl ModuleIndex {
         fa: FileAnalysis,
         level: crate::model::file_analysis::Residency,
     ) -> Arc<FileAnalysis> {
-        let parts = self.prepare_workspace_parts(&path, fa, level);
+        let mut parts = self.prepare_workspace_parts(&path, fa, level);
         parts.record_surface(self, &path);
         let arc = Arc::clone(parts.arc());
         self.register_workspace_residency(path, parts);
@@ -1113,7 +1113,7 @@ impl ModuleIndex {
         // indexers that strip go through `register_symbols_stripping`.
         // `whole` mints the deliberate whole-copy token (feed + surface off
         // the unstripped arc) — the only door that pins a resident analysis.
-        let parts = PackRegistrationParts::whole(analysis);
+        let mut parts = PackRegistrationParts::whole(analysis);
         parts.record_surface(self, &path);
         self.register_symbols_inner(path, parts);
     }
@@ -1149,7 +1149,7 @@ impl ModuleIndex {
         let names = self.workspace_feed_prestrip(path, &fa);
         let surface = crate::model::surface::Surface::project(&fa);
         fa.evict_to(level);
-        WorkspaceRegistrationParts { arc: Arc::new(fa), names, surface }
+        WorkspaceRegistrationParts { arc: Arc::new(fa), names, surface: Some(surface) }
     }
 
     /// The ONE speller of the pack strip ordering: feed + specs + surface
@@ -1165,7 +1165,7 @@ impl ModuleIndex {
         let (feed, specs) = Self::prepare_pack_feed(&fa);
         let surface = crate::model::surface::Surface::project(&fa);
         fa.evict_to(level);
-        PackRegistrationParts { arc: Arc::new(fa), feed, specs, surface }
+        PackRegistrationParts { arc: Arc::new(fa), feed, specs, surface: Some(surface) }
     }
 
     pub fn register_symbols_stripping(
@@ -1174,7 +1174,7 @@ impl ModuleIndex {
         fa: FileAnalysis,
         level: crate::model::file_analysis::Residency,
     ) -> Arc<FileAnalysis> {
-        let parts = Self::prepare_pack_parts(fa, level);
+        let mut parts = Self::prepare_pack_parts(fa, level);
         parts.record_surface(self, &path);
         let arc = Arc::clone(parts.arc());
         self.register_symbols_inner(path, parts);

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -186,7 +186,7 @@ pub fn index_pack_languages(
                             }
                             // The stub IS a persisted `prepare_pack_parts`
                             // output — rehydrate the token, register through it.
-                            let parts =
+                            let mut parts =
                                 crate::index::module_index::PackRegistrationParts::from_warm_stub(stub);
                             parts.record_surface(&pack_index, &path);
                             pack_index.register_symbols_inner(path.clone(), parts);
@@ -205,7 +205,7 @@ pub fn index_pack_languages(
                     // The ladder that used to be `strip_bag && rows_ok`.
                     let level = crate::model::file_analysis::Residency::for_strip(eviction_enabled(), rows_ok);
                     let fully_stripped = level == crate::model::file_analysis::Residency::Skeleton;
-                    let parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
+                    let mut parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
                         fa,
                         level,
                     );
@@ -298,7 +298,7 @@ pub fn index_pack_languages(
             sym_seeds: Vec<crate::model::file_analysis::SymRowSeed>,
             stamp: (i64, i64),
         }
-        let (fresh_tx, fresh_rx) = std::sync::mpsc::channel::<FreshEntry>();
+        let (fresh_tx, fresh_rx) = bounded_persist_channel::<FreshEntry>();
         let persist = conn.is_some();
         let strip = persist && eviction_enabled();
         // Every DELIBERATE whole-copy registration under strip increments
@@ -437,7 +437,7 @@ pub fn index_pack_languages(
                         // the writer — it registers after the chunk COMMITS,
                         // so an evicted copy is never reachable before its blob
                         // can rehydrate it.
-                        let parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
+                        let mut parts = crate::index::module_index::ModuleIndex::prepare_pack_parts(
                             analysis, crate::model::file_analysis::Residency::Skeleton,
                         );
                         let stub_blob = module_cache::encode_stub(
@@ -451,7 +451,7 @@ pub fn index_pack_languages(
                         parts.record_surface(&pack_index, &canon);
                         let (blob, seeds, sym_seeds) = payload.unwrap();
                         let arc = Arc::clone(parts.arc());
-                        let _ = fresh_tx.send(FreshEntry {
+                        send_to_writer(&fresh_tx, FreshEntry {
                             path: canon.clone(),
                             arc,
                             parts: Some(parts),
@@ -469,7 +469,7 @@ pub fn index_pack_languages(
                         let arc = Arc::new(analysis);
                         pack_index.register_symbols(path.clone(), arc.clone());
                         if let Some((blob, seeds, sym_seeds)) = payload {
-                            let _ = fresh_tx.send(FreshEntry {
+                            send_to_writer(&fresh_tx, FreshEntry {
                                 path: canon.clone(),
                                 arc,
                                 parts: None,

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -497,7 +497,11 @@ pub fn index_pack_languages(
             });
 
             drop(fresh_tx);
-            let _ = writer.join();
+            // The pack twin of the workspace tier's drain window — see
+            // `index_perl`'s use of this label for what the number means.
+            crate::util::timings::phase("index.writer_drain_after_walk", || {
+                let _ = writer.join();
+            });
         });
         if strip {
             residency_tripwire(

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -510,7 +510,15 @@ pub fn index_workspace_with_index(
         if let Some(cb) = walk_done {
             cb();
         }
-        let _ = writer.join();
+        // The window the readiness gate is held open by AFTER every file has
+        // been analyzed — the "100% walked, still saving" phase. Bounding the
+        // persist queue makes this a function of the queue depth rather than
+        // of the corpus: the walk cannot outrun the writer by more than the
+        // depth, so only that much is left to drain here. Timed because that
+        // is the claim, and it is the number to check on a real tree.
+        crate::util::timings::phase("index.writer_drain_after_walk", || {
+            let _ = writer.join();
+        });
     });
 
     // Workspace-tier residency tripwire, mirroring the pack indexer's:

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -267,7 +267,7 @@ pub fn index_workspace_with_index(
         closure: crate::model::file_analysis::path_intern::ClosureList,
         stamp: (i64, i64),
     }
-    let (fresh_tx, fresh_rx) = std::sync::mpsc::channel::<WsFresh>();
+    let (fresh_tx, fresh_rx) = bounded_persist_channel::<WsFresh>();
     let timing = crate::util::timings::is_enabled();
 
     // Deliberate whole-copy accounting for the workspace-tier residency
@@ -426,8 +426,12 @@ pub fn index_workspace_with_index(
                         // "not yet indexed" — never wrong-empty.
                         let (arc, parts) = match module_index {
                             Some(idx) => {
-                                let parts =
+                                let mut parts =
                                     idx.prepare_workspace_parts(&canon, analysis, crate::model::file_analysis::Residency::Skeleton);
+                                // Takes the surface out rather than cloning it:
+                                // the writer's registration half discards it, so
+                                // it would otherwise ride the queue only to be
+                                // dropped.
                                 parts.record_surface(idx, &canon);
                                 (std::sync::Arc::clone(parts.arc()), Some(parts))
                             }
@@ -437,7 +441,7 @@ pub fn index_workspace_with_index(
                             }
                         };
                         let (blob, seeds, sym_seeds, closure) = payload.unwrap();
-                        let _ = fresh_tx.send(WsFresh {
+                        send_to_writer(&fresh_tx, WsFresh {
                             path: canon.clone(),
                             arc,
                             parts,
@@ -469,7 +473,7 @@ pub fn index_workspace_with_index(
                             None => std::sync::Arc::new(analysis),
                         };
                         if let Some((blob, seeds, sym_seeds, closure)) = payload {
-                            let _ = fresh_tx.send(WsFresh {
+                            send_to_writer(&fresh_tx, WsFresh {
                                 path: canon.clone(),
                                 arc: arc.clone(),
                                 parts: None,

--- a/src/index/module_resolver/module_resolver_tests.rs
+++ b/src/index/module_resolver/module_resolver_tests.rs
@@ -500,3 +500,101 @@ fn two_askers_with_different_use_lib_see_different_providers() {
          name means the t/lib copy",
     );
 }
+
+// ---- The bounded persist queue ----
+
+/// The cap has to be a property of the design, not of the corpus: an
+/// unbounded channel parks whatever the walk outruns, which at 138k files is
+/// about four fifths of the corpus in RAM. With a bound, a producer that gets
+/// ahead is throttled to writer rate, so peak in-flight can never exceed the
+/// depth however large the tree is.
+#[test]
+fn a_full_queue_throttles_the_producer_to_drain_rate() {
+    use std::sync::atomic::{AtomicUsize, Ordering as O};
+
+    // Depth is floored at one chunk, so ask for exactly that.
+    std::env::set_var("PERL_LSP_WRITE_QUEUE_DEPTH", "1");
+    let depth = write_queue_depth();
+    std::env::remove_var("PERL_LSP_WRITE_QUEUE_DEPTH");
+    assert_eq!(depth, PERSIST_CHUNK, "depth floors at one transaction");
+
+    let (tx, rx) = std::sync::mpsc::sync_channel::<usize>(depth);
+    let sent = Arc::new(AtomicUsize::new(0));
+    let received = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let total = depth * 4;
+    let (s, r, p) = (Arc::clone(&sent), Arc::clone(&received), Arc::clone(&peak));
+    let producer = std::thread::spawn(move || {
+        for i in 0..total {
+            send_to_writer(&tx, i);
+            // Sampled AFTER the send lands, so it can only over-report.
+            let in_flight = s.fetch_add(1, O::SeqCst) + 1 - r.load(O::SeqCst);
+            p.fetch_max(in_flight, O::SeqCst);
+        }
+    });
+
+    let mut drained = 0usize;
+    while let Ok(_e) = rx.recv() {
+        received.fetch_add(1, O::SeqCst);
+        drained += 1;
+        // Slow consumer: the producer must be the one that waits.
+        std::thread::sleep(std::time::Duration::from_micros(200));
+    }
+    producer.join().unwrap();
+
+    assert_eq!(drained, total, "every entry still reaches the writer");
+    let observed = peak.load(O::SeqCst);
+    assert!(
+        observed <= depth + 1,
+        "peak in-flight {observed} exceeded the {depth}-entry bound — the queue is not \
+         throttling the producer"
+    );
+}
+
+/// A writer that dies must not wedge the walk. `send_to_writer` returns on a
+/// disconnected receiver instead of parking forever, so the index degrades to
+/// "these files are not persisted this run" rather than hanging.
+#[test]
+fn a_dead_writer_releases_the_producer_instead_of_hanging() {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<usize>(PERSIST_CHUNK);
+    drop(rx);
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        // More entries than the depth: with a blocking send against a live
+        // but stalled receiver this would never return.
+        for i in 0..(PERSIST_CHUNK * 2) {
+            send_to_writer(&tx, i);
+        }
+        let _ = done_tx.send(());
+    });
+    done_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("a disconnected receiver must release the producer");
+}
+
+/// End-to-end over the real harness: more entries than the queue holds still
+/// all reach `on_committed`. Pins that bounding did not introduce a stall or
+/// drop between the throttled producer and the batching drain.
+#[test]
+fn the_writer_drains_more_entries_than_the_queue_holds() {
+    use std::sync::atomic::{AtomicUsize, Ordering as O};
+    std::env::set_var("PERL_LSP_WRITE_QUEUE_DEPTH", "1"); // → PERSIST_CHUNK
+    let (tx, rx) = bounded_persist_channel::<usize>();
+    std::env::remove_var("PERL_LSP_WRITE_QUEUE_DEPTH");
+
+    let committed = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&committed);
+    let total = PERSIST_CHUNK * 3 + 7;
+    let producer = std::thread::spawn(move || {
+        for i in 0..total {
+            send_to_writer(&tx, i);
+        }
+    });
+    // No connection: the harness drains unregistered, which is enough to
+    // prove the producer/consumer pairing. The committed lane is exercised by
+    // the persist-lane tests in `pack_invalidator_tests`.
+    run_persist_writer(rx, None, "test", |_c, _b: &[usize]| {}, |_e| { c.fetch_add(1, O::SeqCst); }, |_e| {});
+    producer.join().unwrap();
+    assert_eq!(committed.load(O::SeqCst), 0, "no connection ⇒ drained unregistered");
+}

--- a/src/index/module_resolver/persist.rs
+++ b/src/index/module_resolver/persist.rs
@@ -141,6 +141,98 @@ pub(super) fn analyze_stamped<T>(
 /// transient failure degrades gracefully, a permanent one can't OOM.
 pub(super) const FALLBACK_WHOLE_BYTE_CAP: usize = 128 * 1024 * 1024;
 
+/// Entries per persist transaction. The writer fills a batch with
+/// `try_recv` after its first blocking `recv`, so this is also the floor the
+/// bounded channel must clear for a chunk to be fillable without stalling.
+pub(crate) const PERSIST_CHUNK: usize = 128;
+
+/// Default depth of the bounded persist channel, in ENTRIES. A cold walk on
+/// 20 cores outruns SQLite's single writer roughly 4:1, so an unbounded
+/// channel parks about four fifths of the corpus in RAM — the cold-index
+/// spike. The cap is what makes peak in-flight a property of the design
+/// rather than of the corpus size: ~22 KB/entry at 138k Perl files puts this
+/// default near 44 MB.
+///
+/// It does NOT shorten time-to-ready. The writer is on the critical path for
+/// the whole run, so throttling the walk to writer rate finishes at about the
+/// same wall clock; what changes is the peak and the honesty of the progress
+/// bar. Only reducing the writer's WORK moves time-to-ready.
+const DEFAULT_WRITE_QUEUE_DEPTH: usize = 2048;
+
+/// `PERL_LSP_WRITE_QUEUE_DEPTH` overrides the default so the cap can be
+/// measured against a real corpus. Floored at one chunk: a channel shallower
+/// than a transaction would serialize the walk against every commit.
+pub(crate) fn write_queue_depth() -> usize {
+    std::env::var("PERL_LSP_WRITE_QUEUE_DEPTH")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_WRITE_QUEUE_DEPTH)
+        .max(PERSIST_CHUNK)
+}
+
+/// The bounded channel every bulk indexer hands to `run_persist_writer`.
+pub(crate) fn bounded_persist_channel<E>() -> (
+    std::sync::mpsc::SyncSender<E>,
+    std::sync::mpsc::Receiver<E>,
+) {
+    std::sync::mpsc::sync_channel(write_queue_depth())
+}
+
+/// How long a full-queue producer sleeps between attempts. Matched to the
+/// writer's drain rate (a slot frees every few ms at measured throughput), so
+/// the poll is cheap without adding meaningful latency to the walk.
+const QUEUE_PARK: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// A producer stalled this long has stopped being backpressure and started
+/// being a symptom; say so once rather than stalling mutely.
+const QUEUE_STALL_WARN: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Hand one entry to the persist writer, parking while the queue is full.
+///
+/// `try_send` + park rather than a blocking `send` so a stall is observable
+/// instead of silent, and so the disconnected case is handled explicitly
+/// rather than by whatever `send` happens to do.
+///
+/// **The deadlock this must not have**: a producer parked here while holding
+/// a lock the writer's `on_committed` needs would never be woken, because
+/// the writer cannot drain to free a slot. Every bulk send site therefore
+/// holds NO index or store guard at its call to this function — the
+/// registration tokens (`prepare_*_parts`) and surfaces are fully owned
+/// values by then, and the writer's lanes touch only `ModuleIndex` /
+/// `FileStore` / bag-cache maps that no producer holds across a send. That
+/// property is what makes the bound safe; it is not incidental, and a new
+/// send site has to preserve it — `filestore-guard-discipline`, the family
+/// that has already produced two deadlocks here.
+pub(crate) fn send_to_writer<E>(tx: &std::sync::mpsc::SyncSender<E>, entry: E) {
+    use std::sync::mpsc::TrySendError;
+    let mut entry = entry;
+    let mut waited = std::time::Duration::ZERO;
+    let mut warned = false;
+    loop {
+        match tx.try_send(entry) {
+            Ok(()) => return,
+            // The writer drains until every sender drops, so it never
+            // disconnects while work remains — this is the writer-thread-died
+            // case. Parking would hang the walk; dropping leaves the file
+            // unindexed, which the next run repairs.
+            Err(TrySendError::Disconnected(_)) => {
+                log::error!("persist writer is gone; dropping a queued entry");
+                return;
+            }
+            Err(TrySendError::Full(returned)) => entry = returned,
+        }
+        std::thread::sleep(QUEUE_PARK);
+        waited = waited.saturating_add(QUEUE_PARK);
+        if !warned && waited >= QUEUE_STALL_WARN {
+            warned = true;
+            log::warn!(
+                "persist queue full for {}s — the walk is throttled to writer rate",
+                waited.as_secs()
+            );
+        }
+    }
+}
+
 /// The persist-writer harness every persist site shares: batches entries off
 /// the channel (≤128 per txn), owns BEGIN IMMEDIATE / COMMIT / ROLLBACK
 /// (IMMEDIATE — a deferred txn that reads before writing can hit an
@@ -206,7 +298,7 @@ pub(crate) fn run_persist_writer<E>(
     };
     while let Ok(entry) = rx.recv() {
         batch.push(entry);
-        while batch.len() < 128 {
+        while batch.len() < PERSIST_CHUNK {
             match rx.try_recv() {
                 Ok(e) => batch.push(e),
                 Err(_) => break,

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -955,6 +955,75 @@ fn kind_comparisons_name_real_grammar_kinds() {
     );
 }
 
+/// Every producer that can PARK on the bounded persist queue is allowlisted,
+/// because parking is only safe while holding no lock the writer needs.
+///
+/// `run_persist_writer`'s committed and fallback lanes take `ModuleIndex`,
+/// `FileStore` and bag-cache guards. A producer that blocked on a full queue
+/// while holding one of those could never be woken — the writer cannot drain
+/// to free a slot. Today every site hands over fully-owned values
+/// (`prepare_*_parts` tokens, encoded blobs) with no guard live, which is the
+/// property that makes the bound safe. It is not self-evident from the call
+/// site, so a NEW one fails here until its author has answered the same
+/// question. This is the `filestore-guard-discipline` family, which has
+/// already produced two deadlocks in this codebase.
+#[test]
+fn persist_queue_producers_are_allowlisted() {
+    // file stem → (call sites, why parking there is safe)
+    // `source_files` reports the LAYER-directory stem, so both bulk
+    // indexers land under one key; the reasons are per file.
+    let allow: Vec<(&str, usize, &str)> = vec![(
+        "module_resolver",
+        4,
+        "index_perl's deferred + whole lanes (parts/blob owned; the FileStore write \
+         happens AFTER the send) and index_pack's two (register_symbols completes \
+         BEFORE the send)",
+    )];
+    let expected: HashMap<String, usize> =
+        allow.iter().map(|(f, n, _)| (f.to_string(), *n)).collect();
+
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    for (path, _layer, stem) in source_files() {
+        let text = fs::read_to_string(&path).unwrap();
+        let n = text
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !t.starts_with("//") && t.contains("send_to_writer(")
+            })
+            .count();
+        // The definition itself lives in `persist`; don't count it.
+        if n > 0 && !text.contains("pub(crate) fn send_to_writer") {
+            *seen.entry(stem.clone()).or_default() += n;
+        }
+    }
+
+    let mut violations: Vec<String> = Vec::new();
+    for (file, n) in &seen {
+        match expected.get(file) {
+            Some(exp) if exp == n => {}
+            Some(exp) => violations.push(format!(
+                "send_to_writer() call-site count changed in {file}: {n} (allowlisted {exp}) —                  state what guard, if any, is held at the new send"
+            )),
+            None => violations.push(format!(
+                "send_to_writer() called from {file} ({n} site(s)) — not allowlisted. A producer                  may park on a full queue, so it must hold NO index/store guard at the send"
+            )),
+        }
+    }
+    for (file, exp) in &expected {
+        if !seen.contains_key(file) {
+            violations.push(format!(
+                "send_to_writer() allowlisted in {file} ({exp}) but no call site found —                  update the allowlist"
+            ));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "persist-queue producer drift:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// A time-valued tunable must say its unit in its name.
 ///
 /// `BENCH_REQ_TIMEOUT` held seconds while `PERL_LSP_RESOLVE_BUDGET_MS` held

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -321,6 +321,19 @@ fn whole_copy_registration_sites_are_allowlisted() {
                 ("module_resolver", 2, "deferred writer halves — stripped arcs only"),
             ],
         ),
+        // `insert_cache` stores a WHOLE copy by construction (`persisted:
+        // false` — nothing was written, so the strip has no licence). Its one
+        // production reach is through `register_materialized_whole`, already
+        // bounded by that site's entry; a NEW caller would pin whole copies
+        // without tripping any other gate.
+        (
+            "insert_cache",
+            vec![(
+                "module_index",
+                1,
+                "register_materialized_whole’s cache-slot half",
+            )],
+        ),
         (
             "register_materialized_whole",
             vec![(

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -1037,6 +1037,121 @@ fn persist_queue_producers_are_allowlisted() {
     );
 }
 
+/// Every verb's readiness policy is enumerated here, because a wrong one is
+/// SILENT.
+///
+/// `WaitPolicy` is data at the call site and redirecting a verb is a one-word
+/// change — which is the strength and the hazard. `ReadyGate` is a runtime
+/// latch, so a verb that waits `Interactive` on the index gate when its answer
+/// must not be partial does not fail, warn, or look different; it just
+/// under-reports during a cold window, which is this arc's signature failure.
+/// Nothing else in the tree records the intended mapping, so this table is it:
+/// a policy change is deliberate or it is a test failure.
+///
+/// The rule the table encodes: an ACT-ON-ABLE answer (rename edits, a
+/// references sweep, a hierarchy) waits `Complete`; a latency-critical
+/// interactive answer that heals via a refresh channel stays `Interactive`.
+#[test]
+fn verb_readiness_policies_are_enumerated() {
+    // (verb, gate, policy)
+    let expected: &[(&str, &str, &str)] = &[
+        // Act-on-able: silently partial is worse than slow.
+        ("document_symbol", "await_open_ready", "Complete"),
+        ("goto_implementation", "await_index_ready", "Complete"),
+        ("goto_implementation", "await_open_full", "Complete"),
+        ("goto_implementation", "await_open_ready", "Complete"),
+        ("prepare_call_hierarchy", "await_index_ready", "Complete"),
+        ("prepare_call_hierarchy", "await_open_ready", "Complete"),
+        ("prepare_type_hierarchy", "await_index_ready", "Complete"),
+        ("prepare_type_hierarchy", "await_open_ready", "Complete"),
+        ("references", "await_index_ready", "Complete"),
+        ("references", "await_open_full", "Complete"),
+        ("references", "await_open_ready", "Complete"),
+        ("rename", "await_index_ready", "Complete"),
+        ("rename", "await_open_full", "Complete"),
+        ("rename", "await_open_ready", "Complete"),
+        // Latency-critical: best-effort now, healed by a refresh channel.
+        ("code_action", "await_open_ready", "Interactive"),
+        ("completion", "await_open_ready", "Interactive"),
+        ("document_highlight", "await_open_ready", "Interactive"),
+        ("folding_range", "await_open_ready", "Interactive"),
+        ("goto_definition", "await_index_ready", "Interactive"),
+        ("goto_definition", "await_open_ready", "Interactive"),
+        ("goto_type_definition", "await_index_ready", "Interactive"),
+        ("goto_type_definition", "await_open_ready", "Interactive"),
+        ("hover", "await_index_ready", "Interactive"),
+        ("hover", "await_open_ready", "Interactive"),
+        ("inlay_hint", "await_open_ready", "Interactive"),
+        // `prepare_rename` only validates the token; `rename` does the edits.
+        ("prepare_rename", "await_open_ready", "Interactive"),
+        ("selection_range", "await_open_ready", "Interactive"),
+        ("semantic_tokens_full", "await_open_ready", "Interactive"),
+        ("signature_help", "await_open_ready", "Interactive"),
+    ];
+
+    let text = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/lsp/backend/server.rs"),
+    )
+    .expect("read server.rs");
+
+    let mut found: Vec<(String, String, String)> = Vec::new();
+    let mut verb = String::new();
+    for line in text.lines() {
+        let t = line.trim_start();
+        // Method definitions sit at one indent level inside the impl.
+        if line.starts_with("    ") && !line.starts_with("     ") {
+            if let Some(rest) = t
+                .strip_prefix("pub async fn ")
+                .or_else(|| t.strip_prefix("async fn "))
+                .or_else(|| t.strip_prefix("pub fn "))
+                .or_else(|| t.strip_prefix("fn "))
+            {
+                verb = rest
+                    .split(|c: char| c == '(' || c == '<')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+            }
+        }
+        if t.starts_with("//") {
+            continue;
+        }
+        for gate in ["await_index_ready", "await_open_ready", "await_open_full"] {
+            if !t.contains(&format!("{gate}(")) {
+                continue;
+            }
+            let policy = t
+                .split("WaitPolicy::")
+                .nth(1)
+                .map(|r| {
+                    r.chars()
+                        .take_while(|c| c.is_alphabetic())
+                        .collect::<String>()
+                })
+                .unwrap_or_default();
+            found.push((verb.clone(), gate.to_string(), policy));
+        }
+    }
+    found.sort();
+    found.dedup();
+
+    let want: Vec<(String, String, String)> = expected
+        .iter()
+        .map(|(v, g, p)| (v.to_string(), g.to_string(), p.to_string()))
+        .collect();
+    let mut want_sorted = want.clone();
+    want_sorted.sort();
+
+    let missing: Vec<_> = want_sorted.iter().filter(|r| !found.contains(r)).collect();
+    let extra: Vec<_> = found.iter().filter(|r| !want_sorted.contains(r)).collect();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "verb readiness policy drift.\n  no longer present: {missing:?}\n  \
+         not enumerated:   {extra:?}\nA policy change is fine — say so here. \
+         An unnoticed one under-reports silently during a cold window."
+    );
+}
+
 /// A time-valued tunable must say its unit in its name.
 ///
 /// `BENCH_REQ_TIMEOUT` held seconds while `PERL_LSP_RESOLVE_BUDGET_MS` held


### PR DESCRIPTION
Hitlist row #7's backpressure half, plus the deadlock audit it was gated on. Branched from `0b3e2fc0`.

## What this does NOT do

**It does not shorten time-to-ready.** The writer is on the critical path for the whole run (walk ~10 min, writer ~19 min), so throttling the walk to writer rate finishes at roughly the same wall clock — the 20 cores that currently go idle at t=10 just go idle gradually instead. Only cutting the writer's *work* moves time-to-ready, and that is `[C]`'s dedup + interner (#128), which is complementary and already landed. Please don't let either be read as the other; I've put the same disclaimer in the `DEFAULT_WRITE_QUEUE_DEPTH` doc comment so it travels with the code.

What it buys is a **peak that is a property of the design rather than of the corpus** — bounded entries × entry size, not "whatever the walk got ahead by" — and an **honest progress bar**, which is the part of Tier 1 #1 that is still open.

## The deadlock audit

This is the reason the task was mine, so it's the part worth reading.

**The hazard:** a producer parked on a full queue while holding a lock the writer's `on_committed` needs can never be woken — the writer cannot drain to free a slot. `on_committed` / `on_fallback` take `ModuleIndex`, `FileStore` and bag-cache guards.

**Every send site, not just `index_perl`:**

| site | what runs before the send | guard live at the send? |
|---|---|---|
| `index_perl:442` (deferred) | `record_workspace_projections`, `prepare_workspace_parts`, `record_surface` — all return owned values | **no** |
| `index_perl:474` (whole) | `register_workspace_residency` completes; `files.insert_workspace_arc` happens **after** the send | **no** |
| `index_pack:454` (deferred) | `prepare_pack_parts`, `encode_stub`, `record_surface` — owned | **no** |
| `index_pack:472` (whole) | `pack_index.register_symbols` completes before the send | **no** |
| `pack_invalidator:446` | — | **deliberately left unbounded, see below** |

So the property holds, and it holds because the registration tokens (`prepare_*_parts`) are fully-owned values by the time they are handed over — which is the same design decision that made the persist-then-register ordering work. It is not incidental, but it is also not visible at the call site, which is exactly what the guard-discipline note exists to distrust. So it is now pinned: **`persist_queue_producers_are_allowlisted`** fails on a new `send_to_writer` call site until its author states what guard, if any, is live there. Same idiom as `whole_copy_registration_sites_are_allowlisted`.

Two more things that had to be true and are:

- **The writer is a real OS thread** (`std::thread::scope`), not a rayon worker, so all-workers-parked cannot starve the drain. If `on_committed` ever calls into rayon this stops being true — worth knowing.
- **`pack_invalidator`'s channel must stay unbounded.** It fills completely and *then* drains on the same thread; a bound there would deadlock against itself the moment a watcher event touched more files than the depth. It is not a backpressure site — its size is bounded by one event's consumer set.

**`try_send` + park, not blocking `send`**, as asked. Honest about the residual: retry is unbounded, so a writer that is alive but permanently wedged would still stall the walk — what `try_send` buys over `send` is that the stall is *announced* (warn after 30 s) and that a **dead** writer releases producers instead of wedging them. A permanent live wedge is implausible given the per-chunk panic guard and SQLite's 10 s busy timeout; if one is ever observed, the escalation is the byte-capped inline whole-copy fallback that `run_persist_writer` already implements, applied at the producer. I did not build that speculatively.

## The bound

`PERL_LSP_WRITE_QUEUE_DEPTH`, default **2048** entries, floored at `PERSIST_CHUNK` (128) — a channel shallower than a transaction would serialize the walk against every commit. 2048 is one order above the chunk (so the writer never starves between batches) and, at the ~22 KB/entry you measured, lands near 44 MB. It is env-tunable precisely because I can't measure it at 138k; `_DEPTH` is a count, so it's outside the `_SECONDS`/`_MILLISECONDS` rule (the park interval is a const, not a tunable, to avoid adding a time-named env var).

## Adjacent item: the discarded `parts.surface` — folded in

It turned out free after all, and slightly better than free: `record_surface` now **takes** the surface instead of cloning it, so the clone leaves the hot path *and* nothing rides the queue to be dropped.

One thing I did beyond the ask, because the trim created a real hazard: taking the surface leaves an ordering invariant — `encode_stub` reads `parts.surface()` and must run *before* `record_surface`. Both call sites are correct today, but a reorder would bake an **empty surface into a persisted warm stub**, which is then served as valid on every later warm start. That is the silent-across-sessions shape, so consumed-ness rides the token as an `Option` and `surface()` panics after the take rather than returning an empty one. Loud ordering failure over a quietly-wrong stub.

## Verification

True exit codes; `skip` grepped rather than read off the summary.

| | result |
|---|---|
| `cargo test` | **exit 0** |
| `cargo test --features cpp` | **exit 0** — 1541 unit (1537 baseline + 4) |
| `--languages` | `perl, cpp (beta)` — confirmed before gold |
| gold | **496 PASS / 15 xfail / 0 FAIL / 0 XPASS / 0 CRASH**, 3 prov? |
| gold `skip` / `lang-skip` | **0 / 0** |
| e2e | **could not run** — `nvim` absent. CI's. |

`--clear-cache` run before gold.

**Base-verified.** The throttle test is the one that had a meaningful "before": with the channel deep enough not to fill (i.e. the old unbounded behaviour) peak in-flight reaches **511 of 512** entries and the assertion fails; with the bound it stays ≤128. The other two are property tests for new code and I'm not claiming otherwise — `a_dead_writer_releases_the_producer_instead_of_hanging` (no hang on a dropped receiver) and `the_writer_drains_more_entries_than_the_queue_holds` (bounding introduced no stall or drop between the throttled producer and the batching drain).

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_