### PR TITLE
obs: decompose the post-walk window, and say whether the queue bound engaged

### DIFF
--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -528,13 +528,18 @@ pub fn index_workspace_with_index(
 
     // Workspace-tier residency tripwire, mirroring the pack indexer's:
     // gated off under NO_EVICT (everything is deliberately whole there).
+    // Timed alongside the drain: it sweeps every registered file, so it is a
+    // second O(corpus) term between the walk and the readiness gate, and the
+    // window is only the drain's if the other terms are measured too.
     if let Some(idx) = module_index {
         if eviction_enabled() {
-            residency_tripwire(
-                "workspace",
-                idx.count_fully_resident(),
-                expected_whole.load(Ordering::Relaxed),
-            );
+            crate::util::timings::phase("index.residency_tripwire", || {
+                residency_tripwire(
+                    "workspace",
+                    idx.count_fully_resident(),
+                    expected_whole.load(Ordering::Relaxed),
+                );
+            });
         }
     }
 

--- a/src/index/module_resolver/persist.rs
+++ b/src/index/module_resolver/persist.rs
@@ -221,6 +221,12 @@ pub(crate) fn send_to_writer<E>(tx: &std::sync::mpsc::SyncSender<E>, entry: E) {
             }
             Err(TrySendError::Full(returned)) => entry = returned,
         }
+        // One per park INTERVAL, so `count * QUEUE_PARK` is roughly aggregate
+        // producer stall. Whether backpressure ever engaged is not inferable
+        // from wall time — a run where the walk never outran the writer looks
+        // identical to one where the depth did nothing — and a drain number
+        // from a run with zero parks says nothing about the depth.
+        crate::util::ghost_stats::count("persist_queue.producer_parked");
         std::thread::sleep(QUEUE_PARK);
         waited = waited.saturating_add(QUEUE_PARK);
         if !warned && waited >= QUEUE_STALL_WARN {

--- a/src/lsp/backend/indexing.rs
+++ b/src/lsp/backend/indexing.rs
@@ -210,6 +210,14 @@ impl Backend {
                     &crate::build::language_driver::LanguageScope::All,
                 )
             };
+            // Everything from here to `open_perl_gate_then_heal` is still
+            // inside the readiness gate, so it is part of the "100% walked,
+            // still not ready" window even though the walk and the writer are
+            // both done. Timed as one segment because the window's SIZE has
+            // been attributed to the writer drain, and an attribution is only
+            // worth anything if the other terms were measured rather than
+            // assumed.
+            let _to_gate = crate::util::timings::PhaseGuard::start("index.indexer_return_to_gate");
             // Drop the sender(s) so the emitter's channel closes, then drain it
             // — guarantees the final Report lands before End.
             drop(cb);


### PR DESCRIPTION
Branched from `ed7b21bb`. One commit, no behaviour change — three instruments on existing gates, plus the measurement they made possible.

## Why

The window between "100% walked" and the readiness gate opening has been attributed to the persist writer's drain. That attribution was never measured against the *other* terms in the same window, and apportioning by the wrong term is how several plans in this area have gone wrong.

## What

| instrument | what it answers |
|---|---|
| `index.residency_tripwire` | a **second** O(corpus) term in that window — it sweeps every registered file. **~1 ms at 2,265 files**, so the attribution to the drain survives, but it is measured now rather than assumed away |
| `index.indexer_return_to_gate` | the segment from the indexer returning to `open_perl_gate_then_heal`, which nothing timed at all. Server-path only |
| `persist_queue.producer_parked` | **whether backpressure ever engaged** |

The third is the one that matters, and it fixes a hole in my own previous work. Whether the bound engaged is **not inferable from wall time**: a run where the walk never outran the writer looks identical to one where the depth did nothing. A drain number from a zero-park run says nothing about the queue depth. One count per park interval, so `count × QUEUE_PARK` approximates aggregate producer stall.

All three ride existing gates (`PERL_LSP_PHASE_TIMING`, `PERL_LSP_GHOST_STATS`) and are inert when off.

## The measurement these made possible

The local corpus can't test the bounded-queue model — at 2,265 files the writer keeps up, so the depth never binds. So: **reproduce the regime, not the scale.** Throttle the writer below the walk's feed rate, vary the depth, and use the park counter to prove the bound actually engaged.

| `WRITE_QUEUE_DEPTH` | post-walk drain | producer parks | drain ÷ depth |
|---|---|---|---|
| 128 | 3,233 ms | 42,282 | 25.3 ms |
| 512 | 12,060 ms | 35,175 | 23.6 ms |
| 2048 | 42,132 ms | 11,662 | 20.6 ms |

Injected writer cost was 20 ms/file. 16× the depth, 13× the drain, and drain ÷ depth ≈ the injected cost at every point:

> **post-walk drain = queue depth × per-file writer cost — independent of corpus size.**

It reproduces the observed number too, which is why I believe it. At 138k (~122 files/s ⇒ 8.2 ms/file): unbounded ⇒ ~66k queued × 8.2 ms ≈ **9 min**, the measured pre-#130 window; bounded at 2048 ⇒ ≈ **17 s**.

**Two attempts at this experiment were invalid before one worked** — 400 µs/file and 2 ms/file both left the writer 7× faster than the walk's feed rate, so neither entered the writer-bound regime, and both produced non-monotonic noise (attempt 2 had the *unbounded* case fastest). Had either come out monotonic by luck I would have reported it as confirmation. That is exactly what the park counter now prevents, which is why it is in the tree rather than in a scratch file.

Detail in [#120](https://github.com/tree-sitter-perl/perl-lsp/issues/120#issuecomment-5342300272), including a correction to an earlier measurement of mine that was taken in a non-binding regime.

## Verification

| | result |
|---|---|
| `cargo test` | **exit 0** |
| `cargo test --features cpp` | **exit 0** — 1,554 unit, matching the baseline |
| `--languages` | `perl, cpp (beta)`, confirmed before gold |
| gold | **498 PASS / 15 xfail / 0 FAIL / 0 XPASS / 0 CRASH** |
| gold `skip` / `lang-skip` | **0 / 0**, grepped |
| e2e | **could not run** — `nvim` absent |

`--clear-cache` before gold. No test added: this commit adds no behaviour, only observation, and a test asserting a timer prints would pin the gate rather than the thing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_