### PR TITLE
Differential sweep: the rework as a divergence list, with one regression candidate

### DIFF
--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -1,0 +1,98 @@
+# Differential answer sweep
+
+A large rework cannot be reviewed by reading it. This converts the diff into
+a **divergence list**: run two binaries over thousands of cursor positions on
+a real corpus, compare their answers, and group what differs into claims a
+person can adjudicate one at a time — *intended improvement*, *regression*,
+or *wash*.
+
+## Running it
+
+```sh
+# 1. positions — binary-independent, so both sides answer the same questions
+bench/sweep/sweep.py positions --root <corpus> --out pos.jsonl \
+    --per-file 8 --max-files 600 --seed v1
+
+# 2. one warm server per side, in its own cache dir
+bench/sweep/sweep.py run --bin <base-binary> --root <corpus> \
+    --positions pos.jsonl --out ans-base.jsonl --side base \
+    --cache-dir /tmp/sweep-cache-base
+bench/sweep/sweep.py run --bin <head-binary> --root <corpus> \
+    --positions pos.jsonl --out ans-head.jsonl --side head \
+    --cache-dir /tmp/sweep-cache-head
+
+# 3. the report
+bench/sweep/sweep.py diff --base ans-base.jsonl --head ans-head.jsonl \
+    --out report.md
+```
+
+The three steps are separate on purpose: a corpus run costs hours, and the
+diff is where the thinking happens. Re-diffing with different grouping must
+never mean re-sweeping.
+
+## The decisions that make it trustworthy
+
+**Positions come from the source text, never from a binary.** A
+binary-derived sample (semantic tokens, say) lets one side choose where it is
+tested, and a divergence stops being attributable: did the answer change, or
+did the question? The tokenizer is in `positions.py` and is deliberately
+conservative — every heuristic fails toward emitting fewer positions.
+
+**Token-driven, with per-kind quotas.** Random offsets land on whitespace. An
+unweighted token sample is ~71% `variable` on real CPAN code, which is the
+case both sides are most likely to agree on, so an unweighted sweep spends
+its budget confirming null results. The per-file cap is round-robin across
+kinds, because a flat cap re-imposes the very distribution the weights
+corrected.
+
+**The server path, and the report says so.** The CLI and the server answer
+differently for the same query — 284,617 vs 193,725 bytes on Koha
+`references` — because they reach different readiness states. Neither is
+wrong; mixing them produces a divergence list that is mostly harness.
+
+**Readiness is a cross-file gate.** Non-empty is not ready: goto-def on a
+local `sub` answers from the open document with no index at all. Measured
+here, the base passed a non-empty probe in 12 ms where the head took 1,309 ms
+— sweeping on that would have compared a cold server to a warm one and
+reported the difference as regressions. The gate requires a definition that
+lands in a *different file*, on both sides, and a side that never achieves it
+is flagged in the report rather than silently swept.
+
+**A verb one side does not implement is a capability difference.** The base
+here does not serve `typeDefinition`; left in, that alone put an `error-base`
+on every position. Capabilities are read from `initialize` and the asymmetry
+is subtracted into its own line.
+
+**Timeouts are never folded into "empty".** A slow side that lost a race is
+not a side that lost an answer, and conflating them is the most misleading
+thing this tool could report.
+
+**A wedged server is detected and respawned.** Observed on the base binary:
+`definition` in `Class/MOP/Overload.pm` hangs it permanently — client
+blocked, server at 0% CPU. Without detection every later request costs the
+full timeout and a two-hour sweep becomes twenty, arriving as a wall of
+timeouts that says nothing. The wedge is recorded as an event and the sweep
+continues.
+
+**Each side gets its own `XDG_CACHE_HOME`.** Both key `~/.cache/perl-lsp` off
+the workspace path, and their `EXTRACT_VERSION` and plugin fingerprints
+differ — sharing one makes each side hard-clear the other's cache on every
+startup.
+
+## Reading the report
+
+Shapes are ordered by what a reviewer must look at first. `only-base` and
+`subset` are the regression candidates: the base answered and the head did
+not, or answered less. `only-head` and `superset` are the improvement
+candidates. `disagree` is the residual that always needs a human.
+
+`n` is positions; **`distinct` is claims** — the number of different (base
+answer, head answer) pairs behind them. One generated data file can
+contribute sixty positions that disagree identically. Adjudicate `distinct`.
+
+## What it does not do
+
+It does not decide whether a divergence is a regression. That is the point:
+it produces the list, a person rules on each row, and the ruling becomes a
+gold fixture (`gold-corpus/run.pl --emit`) so the answer is pinned from then
+on.

--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -67,12 +67,19 @@ is subtracted into its own line.
 not a side that lost an answer, and conflating them is the most misleading
 thing this tool could report.
 
-**A wedged server is detected and respawned.** Observed on the base binary:
-`definition` in `Class/MOP/Overload.pm` hangs it permanently — client
-blocked, server at 0% CPU. Without detection every later request costs the
-full timeout and a two-hour sweep becomes twenty, arriving as a wall of
-timeouts that says nothing. The wedge is recorded as an event and the sweep
-continues.
+**A hang cluster is distinguished from a dead server.** The base binary has
+`definition` requests that never return — ten clusters over 1,458 positions.
+The first version of this called that a wedge and respawned the process,
+which was wrong: checked outside this driver, a `definition` that times out
+at 30 s is followed by a `documentSymbol` on the same open file answering in
+milliseconds. The server is alive; individual requests hang, and they
+cluster.
+
+So consecutive timeouts now trigger a liveness probe — `documentSymbol` on an
+already-open file, which needs no index and no cross-file work — and a server
+that answers it keeps its warm index. Only a process that fails the probe is
+respawned. Either way the event is recorded, because "this verb hangs here"
+is a finding whether or not it killed the server.
 
 **Each side gets its own `XDG_CACHE_HOME`.** Both key `~/.cache/perl-lsp` off
 the workspace path, and their `EXTRACT_VERSION` and plugin fingerprints

--- a/bench/sweep/REPORT-substrate.md
+++ b/bench/sweep/REPORT-substrate.md
@@ -1,0 +1,85 @@
+# Differential sweep: `main` (0.6.1) vs the rework (0.7.0)
+
+A worked run, kept so the tool has a reference output and so the
+adjudication below can be re-checked rather than believed.
+
+- **Corpus** — `gold-corpus/local/lib/perl5`, the pinned CPAN substrate:
+  2,265 modules, 200 sampled files, **1,458 positions**, **4,302
+  (position, verb) answers** compared.
+- **Path** — server, LSP over stdio. Both sides built with **default
+  features**: `main` predates the `cpp` feature, so the comparison covers
+  Perl only.
+- **Verbs** — completion, definition, hover, references (10% sample),
+  documentSymbol. `typeDefinition` excluded: `main` does not serve it, which
+  is a capability difference, not a divergence.
+- Raw report: `report-substrate-raw.md`.
+
+**2,836 of 4,302 answers identical (65.9%); 1,466 divergent.** Of the
+identical, 945 were empty on both sides.
+
+## The noise floor comes first
+
+The same binary, run twice over the same positions, disagrees with itself on
+**3.8%** of answers:
+
+| shape | self-vs-self |
+|---|---|
+| `reranked` | 164 |
+| `disagree` | 7 |
+| everything else | **0** |
+
+Completion ordering is not stable run to run. So the 70 `reranked` rows in
+the A/B carry **no information at all** — they are below the floor — while
+`only-*`, `subset`, `superset` and `content-differs` can be read at face
+value. Without this measurement a reader has no way to tell those cases
+apart, and the third of the A/B's shapes that is pure noise looks exactly
+like the two thirds that are not.
+
+## Adjudicated
+
+| claim | rows | verdict |
+|---|---|---|
+| head no longer offers `(anon)` as a completion candidate | 87 `subset` + 1 `only-base` | **fix** — an anonymous sub is not a name anyone can type. 88 of 88 lose `(anon)` and *nothing else*, on two independent runs |
+| head resolves goto-def to the declaration line where base returned `0:0` | 110 `disagree` | **fix** — every same-file definition disagreement is this |
+| head returns *every* `@INC` provider of a name where base returned one | ~117 `disagree` | **intended** — this is the `(name, inc-root)` candidate relation. `use strict` now answers both `perl/5.38.2/strict.pm` and `perl-base/strict.pm`. Flagged because it is my own change: the sweep is confirming it, not discovering it |
+| head answers where base was empty | 263 `only-head` | improvement (99 definition, 87 completion, 77 hover) |
+| head answers a superset | 182 `superset` | improvement (155 completion, 27 references) |
+| head truncates long completion lists | 27 `capped-head` | **by design** — `MAX_COMPLETION_ITEMS`, with `isIncomplete` set |
+| completion ranking moved | 70 `reranked` | **unreadable** — below the noise floor |
+
+## Needs a ruling
+
+**One regression candidate**, and it is specific:
+
+- `x86_64-linux-gnu-thread-multi/Moose.pm:200:38` — completion after
+  `$metaclass->initialize`. Base offers 13 items, head offers none.
+  Reproduces on the CLI, so it is not a warm-up artefact. Base's 13 are all
+  subs defined *in Moose.pm itself* — `after`, `around`, `augment`,
+  `_get_caller` — i.e. a same-file fallback when the receiver cannot be
+  resolved, not real metaclass methods. So the honest question is whether
+  head returning nothing is better than base returning plausible-but-wrong
+  candidates. It is the only `only-base` row in the sweep that is not the
+  `(anon)` fix.
+
+**526 completion `disagree` rows** where head both gains and loses real
+names. Perl builtins explain only 2%; **63% lose sigil'd (lexical or
+package) names**. Whether that is scope correctness or lost candidates is
+the one bucket this sweep cannot rule on.
+
+## Two things about `main` itself
+
+**`textDocument/definition` hangs.** Over three runs `main` accumulated 4,
+5 and 10 unrecoverable stalls at different files each time — cache-state
+dependent, not file-specific. `0.7.0` had none in ~9,000 positions.
+
+The first diagnosis was wrong and the correction matters: the server is
+**not** wedged by a single hanging request. Checked with a client that is
+not this harness, a `definition` that times out at 30 s is followed by a
+`documentSymbol` on the same open file answering in milliseconds. What kills
+it is a *cluster*; the sweep now probes liveness before respawning, and in
+the final run all four probes found the process genuinely unresponsive.
+
+**Wall clock.** 1,458 positions: `main` 247 s, `0.7.0` 54 s. Base's figure
+swings 247–608 s across runs because of the stalls, so treat it as an
+order-of-magnitude statement. The two sides also ran sequentially here;
+`bench/lsp_bench.py` is the tool for latency, not this one.

--- a/bench/sweep/normalize.py
+++ b/bench/sweep/normalize.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""What counts as "the same answer".
+
+A sweep whose diff is mostly noise is worse than no sweep, so every rule
+here is a deliberate decision about which differences are semantic. They
+fall into three groups:
+
+  ENVIRONMENTAL — absolute paths, and the workspace root itself. Two sides
+  run from two checkouts; a URI difference is never a finding.
+
+  ORDER — LSP arrays are mostly unordered sets (definition locations,
+  references, document symbols). Comparing them as lists reports a
+  divergence for every stable-sort difference. Completion is the exception
+  and is treated as one: its order IS the ranking, which is a user-visible
+  answer, so it is compared BOTH ways — as a label set (did the candidates
+  change) and as an ordered prefix (did the ranking change). Conflating
+  those two hides a ranking regression behind an unchanged set.
+
+  VOLUME — hover bodies and completion documentation run to kilobytes and
+  are usually identical. They are digested, not dropped: a digest still
+  diverges when the text changes, but the report stays readable. Dropping
+  them would make a documentation regression invisible; keeping them would
+  make the report unreadable.
+"""
+import hashlib, json, re
+
+
+def digest(s):
+    return hashlib.sha256(s.encode("utf8", "replace")).hexdigest()[:12]
+
+
+def rel_uri(uri, root_uri):
+    """`file:///abs/root/lib/Foo.pm` -> `lib/Foo.pm`.
+
+    Paths outside the root keep a marked absolute form rather than being
+    silently relativised: an answer that escaped the workspace is exactly
+    the kind of thing this sweep exists to catch, and it must not be
+    normalised into looking local.
+    """
+    if not isinstance(uri, str):
+        return uri
+    if root_uri and uri.startswith(root_uri):
+        return uri[len(root_uri):].lstrip("/")
+    # @INC providers live outside the root and their absolute prefix differs
+    # per machine, not per branch. Keep the tail, mark it foreign.
+    return "<ext>/" + "/".join(uri.rsplit("/", 3)[-3:])
+
+
+def rng(r):
+    if not isinstance(r, dict):
+        return None
+    s, e = r.get("start") or {}, r.get("end") or {}
+    return [s.get("line"), s.get("character"), e.get("line"), e.get("character")]
+
+
+def locations(result, root_uri):
+    """definition / typeDefinition / references / implementations.
+
+    LSP allows Location, Location[], LocationLink[], or null for these, and
+    the three shapes carry the same fact. Folding them to one shape is what
+    lets a side that answers LocationLink compare against a side that
+    answers Location -- otherwise every position would diverge on shape
+    alone and the sweep would report nothing but its own encoding.
+    """
+    if result is None:
+        return []
+    items = result if isinstance(result, list) else [result]
+    out = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        uri = it.get("uri") or it.get("targetUri")
+        span = it.get("range") or it.get("targetSelectionRange") or it.get("targetRange")
+        out.append((rel_uri(uri, root_uri), tuple(rng(span) or [])))
+    return sorted(set(out))
+
+
+def hover(result, root_uri):
+    if not result:
+        return None
+    c = result.get("contents")
+    if isinstance(c, dict):
+        text = c.get("value", "")
+    elif isinstance(c, list):
+        text = "\n".join(x.get("value", x) if isinstance(x, dict) else str(x) for x in c)
+    else:
+        text = str(c or "")
+    # Absolute paths appear inside hover markdown ("defined in /abs/..."), so
+    # the ENVIRONMENTAL rule has to reach inside the body too.
+    text = re.sub(r'(/[\w.\-]+){3,}', '<path>', text).strip()
+    text = re.sub(r'\s+', ' ', text)
+    return {"len": len(text), "sha": digest(text), "head": text[:160]}
+
+
+COMPLETION_TOP_N = 10
+
+
+def completion(result):
+    if result is None:
+        return {"n": 0, "labels": [], "top": []}
+    items = result.get("items", []) if isinstance(result, dict) else result
+    if not isinstance(items, list):
+        return {"n": 0, "labels": [], "top": []}
+    # (label, kind): the same label at a different kind is a different
+    # answer -- a sub becoming a field is a real change, and comparing bare
+    # labels would hide it.
+    pairs = [(str(i.get("label", "")), i.get("kind")) for i in items if isinstance(i, dict)]
+    return {
+        "n": len(pairs),
+        "labels": sorted(set(pairs)),
+        "top": pairs[:COMPLETION_TOP_N],
+    }
+
+
+def symbols(result, root_uri):
+    """documentSymbol, flattened to a nesting-aware set.
+
+    The path (`Foo::bar`) is carried into the key so a symbol that MOVED in
+    the hierarchy diverges, while a reordering of siblings does not.
+    """
+    out = []
+
+    def walk(items, prefix):
+        for it in items or []:
+            if not isinstance(it, dict):
+                continue
+            name = it.get("name", "")
+            key = f"{prefix}::{name}" if prefix else name
+            out.append((key, it.get("kind")))
+            walk(it.get("children"), key)
+
+    walk(result if isinstance(result, list) else [], "")
+    return sorted(set(out))
+
+
+def normalize(verb, result, root_uri):
+    if verb in ("definition", "typeDefinition", "references", "implementations"):
+        return locations(result, root_uri)
+    if verb == "hover":
+        return hover(result, root_uri)
+    if verb == "completion":
+        return completion(result)
+    if verb == "documentSymbol":
+        return symbols(result, root_uri)
+    return result
+
+
+def answer_key(verb, norm):
+    """A stable string for equality, so the diff never compares floats or
+    dict orderings."""
+    return json.dumps(norm, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def is_empty(verb, norm):
+    if norm is None:
+        return True
+    if verb == "completion":
+        return norm.get("n", 0) == 0
+    if verb == "hover":
+        return not norm or norm.get("len", 0) == 0
+    if isinstance(norm, (list, tuple)):
+        return len(norm) == 0
+    return False
+
+
+def _froze(x):
+    """Deep tuple-ify. A JSON round-trip turns every tuple into a list, so an
+    answer read back from the run file is `["lib/A.pm", [1, 2, 1, 5]]` — and
+    building a set of those raises `unhashable type: 'list'` on the nested
+    span, not on the outer element."""
+    if isinstance(x, (list, tuple)):
+        return tuple(_froze(i) for i in x)
+    return x
+
+
+def as_set(verb, norm):
+    """The comparable SET behind an answer, or None if the verb has none.
+
+    Set containment is what turns a divergence into a claim someone can
+    adjudicate: "the branch found everything the base did, plus 3" reviews
+    differently from "the two disagree".
+    """
+    if norm is None:
+        return set()
+    if verb in ("definition", "typeDefinition", "references", "implementations"):
+        return set(_froze(x) for x in norm)
+    if verb == "completion":
+        return set(_froze(x) for x in norm.get("labels", []))
+    if verb == "documentSymbol":
+        return set(_froze(x) for x in norm)
+    return None

--- a/bench/sweep/normalize.py
+++ b/bench/sweep/normalize.py
@@ -96,11 +96,21 @@ COMPLETION_TOP_N = 10
 
 
 def completion(result):
+    """`isIncomplete` is kept because it is the ONLY thing that distinguishes
+    a lost candidate from a deliberately cut one.
+
+    A server that ranks and truncates (perl-lsp caps at
+    `MAX_COMPLETION_ITEMS`) returns a strict subset of an uncapped server's
+    list and sets `isIncomplete` to say so — that is the LSP contract, not a
+    defect. Dropping the flag made the first corpus run report 221 `subset`
+    rows as regression candidates when they were one intended change.
+    """
     if result is None:
-        return {"n": 0, "labels": [], "top": []}
+        return {"n": 0, "labels": [], "top": [], "incomplete": False}
+    inc = bool(result.get("isIncomplete")) if isinstance(result, dict) else False
     items = result.get("items", []) if isinstance(result, dict) else result
     if not isinstance(items, list):
-        return {"n": 0, "labels": [], "top": []}
+        return {"n": 0, "labels": [], "top": [], "incomplete": inc}
     # (label, kind): the same label at a different kind is a different
     # answer -- a sub becoming a field is a real change, and comparing bare
     # labels would hide it.
@@ -109,6 +119,7 @@ def completion(result):
         "n": len(pairs),
         "labels": sorted(set(pairs)),
         "top": pairs[:COMPLETION_TOP_N],
+        "incomplete": inc,
     }
 
 

--- a/bench/sweep/positions.py
+++ b/bench/sweep/positions.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Position selection for the differential sweep.
+
+The sample must be identical for both sides, so it is derived from the
+SOURCE TEXT alone — never from either binary. A binary-derived sample (say,
+semantic tokens) would let one side choose where it is tested, and a
+divergence would then be unattributable: did the answer change, or did the
+question?
+
+Selection is token-driven because random offsets land on whitespace. Each
+emitted position carries the token KIND it came from, which is what makes
+the divergence report groupable ("47 method-call positions where the branch
+resolves and the base does not" is reviewable; 47 hunks are not).
+
+The tokenizer is deliberately CONSERVATIVE, and every heuristic here fails
+toward emitting FEWER positions rather than positions in places a Perl
+reader would not call a token. Under-sampling costs coverage, which is
+visible in the totals; over-sampling costs the report's signal, which is
+not. String interiors are the known residual — a token inside `"..."` can
+still be emitted. That is handled downstream instead of here: the diff drops
+any position where both sides answered nothing on every verb, which removes
+uninformative samples generically rather than by perfecting a regex.
+"""
+import hashlib, re
+
+# `sub` / `method` are both declaration keywords in modern Perl.
+RE_SUB      = re.compile(r'\b(?:sub|method)\s+([A-Za-z_]\w*)')
+RE_PACKAGE  = re.compile(r'\b(?:package|class|role)\s+([A-Za-z_][\w:]*)')
+RE_USE      = re.compile(r'\b(?:use|no|require|extends|with)\s+([A-Za-z_][\w:]*)')
+RE_METHOD   = re.compile(r'->\s*([A-Za-z_]\w*)')
+RE_CALL     = re.compile(r'\b([A-Za-z_]\w*)\s*\(')
+RE_VAR      = re.compile(r'[\$\@\%]([A-Za-z_]\w*)')
+RE_MODPATH  = re.compile(r'\b([A-Za-z_]\w*(?:::\w+)+)\b')
+RE_FATKEY   = re.compile(r'\b([A-Za-z_]\w*)\s*=>')
+RE_HASHKEY  = re.compile(r'\{\s*[\'"]?([A-Za-z_]\w*)[\'"]?\s*\}')
+
+# Perl builtins and flow keywords that `NAME(` would otherwise sample as
+# call sites. They are not interesting differentially — every side agrees —
+# and they are numerous enough to crowd out real call sites.
+KEYWORDS = set("""
+if elsif unless while until for foreach do sub my our local return last next redo
+and or not eq ne lt gt le ge cmp x qw qq q tr y s m defined ref bless wantarray
+print printf sprintf push pop shift unshift splice join split map grep sort reverse
+keys values each exists delete scalar length substr index rindex uc lc ucfirst lcfirst
+die warn eval require use no package BEGIN END chomp chop sprintf open close
+""".split())
+
+PATTERNS = [
+    ("sub-decl",    RE_SUB),
+    ("package",     RE_PACKAGE),
+    ("use-module",  RE_USE),
+    ("method-call", RE_METHOD),
+    ("module-path", RE_MODPATH),
+    ("call-site",   RE_CALL),
+    ("hash-key",    RE_FATKEY),
+    ("hash-key",    RE_HASHKEY),
+    ("variable",    RE_VAR),
+]
+
+
+def strip_noncode(text):
+    """Blank out POD, `__END__`, and comments, preserving line/column numbers.
+
+    Replacement is space-for-character rather than deletion so every
+    surviving token keeps its true LSP coordinates — a sweep that shifted
+    positions would compare two sides at the same index into different text.
+    """
+    out, in_pod = [], False
+    for line in text.split("\n"):
+        if line.startswith("__END__") or line.startswith("__DATA__"):
+            out.extend([""] * (len(text.split("\n")) - len(out)))
+            break
+        if re.match(r'^=[a-zA-Z]', line):
+            in_pod = True
+        if in_pod:
+            out.append(" " * len(line))
+            if line.startswith("=cut"):
+                in_pod = False
+            continue
+        # A `#` that starts a comment, as opposed to `$#array`, `${#}`, or a
+        # `#` inside a string. Only the first two are distinguishable cheaply,
+        # so this truncates on the first `#` not preceded by `$`. Inside a
+        # string that loses the rest of the line: under-sampling, by design.
+        m = re.search(r'(?<!\$)#', line)
+        if m:
+            line = line[:m.start()] + " " * (len(line) - m.start())
+        out.append(line)
+    return "\n".join(out)
+
+
+def tokens_in(text):
+    """Every candidate position in one file, deduped by (line, col, kind).
+
+    Patterns overlap on purpose — `Foo::Bar->new` is both a module path and a
+    method call, and both are worth asking about. Dedup is on the triple, so
+    the same offset can appear under two kinds but never twice under one.
+    """
+    seen, out = set(), []
+    for lineno, line in enumerate(strip_noncode(text).split("\n")):
+        for kind, rx in PATTERNS:
+            for m in rx.finditer(line):
+                name = m.group(1)
+                if kind == "call-site" and name in KEYWORDS:
+                    continue
+                if len(name) < 2:
+                    continue
+                col = m.start(1)
+                key = (lineno, col, kind)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append({
+                    "line": lineno, "char_on": col,
+                    "char_after": col + len(name),
+                    "kind": kind, "name": name,
+                })
+    return out
+
+
+def stable_frac(*parts):
+    """A deterministic [0,1) from the sample's identity.
+
+    `hash()` is salted per process in Python 3, so a run would sample a
+    different subset every time and two sides could not be compared at all.
+    """
+    h = hashlib.sha256("\x00".join(str(p) for p in parts).encode()).digest()
+    return int.from_bytes(h[:8], "big") / 2**64
+
+
+# Per-kind quotas. An unweighted sample is ~71% `variable` on real CPAN code
+# (measured on CGI.pm: 3,160 of 4,422), and a scalar in a lexical scope is the
+# case both sides are most likely to agree on — so an unweighted sweep spends
+# most of its budget confirming a null result. The quotas buy signal density,
+# and they are a SAMPLE shape, not a claim about importance: `variable` stays
+# represented because variable resolution is exactly where a scope or
+# visibility change would show up.
+KIND_WEIGHT = {
+    "method-call": 1.00,
+    "call-site":   1.00,
+    "sub-decl":    1.00,
+    "module-path": 1.00,
+    "use-module":  1.00,
+    "package":     1.00,
+    "hash-key":    0.80,
+    "variable":    0.15,
+}
+
+
+def select(rel_path, text, per_file_cap, seed):
+    """The sampled positions for one file, deterministic in (seed, path).
+
+    Capped per file so one 20k-line module cannot crowd out a hundred small
+    ones — a sweep whose sample is dominated by its largest file measures
+    that file, not the corpus.
+    """
+    toks = tokens_in(text)
+    keep = []
+    for t in toks:
+        w = KIND_WEIGHT.get(t["kind"], 0.5)
+        if stable_frac(seed, rel_path, t["line"], t["char_on"], t["kind"]) < w:
+            keep.append(t)
+    if len(keep) > per_file_cap:
+        # Round-robin ACROSS kinds, not a uniform draw over the pool. A
+        # uniform cap re-imposes the raw distribution the weights just
+        # corrected — measured on CGI.pm, a flat cap of 40 came back 17
+        # `variable` and 2 `method-call`, undoing the whole point. Taking one
+        # kind at a time guarantees the rare-but-interesting kinds survive a
+        # file whose token count dwarfs the cap.
+        by_kind = {}
+        for t in keep:
+            by_kind.setdefault(t["kind"], []).append(t)
+        for k, lst in by_kind.items():
+            lst.sort(key=lambda t: stable_frac(seed, "cap", rel_path, t["line"], t["char_on"], k))
+        keep, order = [], sorted(by_kind)
+        i = 0
+        while len(keep) < per_file_cap and any(by_kind.values()):
+            lst = by_kind[order[i % len(order)]]
+            if lst:
+                keep.append(lst.pop(0))
+            i += 1
+    keep.sort(key=lambda t: (t["line"], t["char_on"], t["kind"]))
+    for t in keep:
+        t["file"] = rel_path
+    return keep

--- a/bench/sweep/report-substrate-raw.md
+++ b/bench/sweep/report-substrate-raw.md
@@ -1,0 +1,1145 @@
+# Differential sweep report
+
+- **base** `base` — `perl-lsp 0.6.1`
+- **head** `head` — `perl-lsp 0.7.0`
+- corpus: `/home/user/perl-lsp/gold-corpus/local/lib/perl5`
+- path: **server** (LSP over stdio), verbs completion, definition, documentSymbol, hover, references
+- **excluded as a capability difference:** `typeDefinition` — served by one side only, so every position would report a divergence that is a missing feature rather than a changed answer
+- sampled verbs: `references` at 10%
+- cross-file readiness: base 1088 ms, head 1149 ms
+- **base server-wedged**: after_position=102, consecutive_timeouts=3, file=Date/Language/Sidama.pm, line=10, restart=1, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1068, restart=1
+- **base server-wedged**: after_position=888, consecutive_timeouts=3, file=PPI/Util.pm, line=37, restart=2, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1089, restart=2
+- **base server-wedged**: after_position=1116, consecutive_timeouts=3, file=YAML/PP/Representer.pm, line=46, restart=3, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1067, restart=3
+- **base server-wedged**: after_position=1173, consecutive_timeouts=3, file=x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm, line=23, restart=4, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1096, restart=4
+- **base recheck**: empty_first_ask=1310, filled_when_warm=2
+- **head recheck**: empty_first_ask=2438, filled_when_warm=13
+
+**4302 (position, verb) answers compared — 2836 identical (65.92%), 1466 divergent.**
+
+Of the identical ones, 945 were empty on both sides: positions nobody would ask about, kept in the denominator but called out so the agreement rate is not read as coverage.
+
+## Divergences by shape
+
+`noise` is the same shape's count when the SAME binary is run twice over these positions. A block at or below its noise floor carries no information — read the `signal` column, not `n`.
+
+| shape | n | noise | signal | meaning |
+|---|---|---|---|---|
+| `only-base` | 2 | 0 | 2 | base answers, head empty  (LOST resolution -- regression candidate) |
+| `subset` | 87 | 0 | 87 | head found strictly fewer  (regression candidate) |
+| `disagree` | 788 | 7 | 781 | both non-empty, neither contains the other |
+| `content-differs` | 35 | 0 | 35 | same shape, different content (hover text, etc.) |
+| `reranked` | 70 | 164 | **below noise — unreadable** | same candidates, different order (completion ranking moved) |
+| `only-head` | 263 | 0 | 263 | head answers, base empty  (new resolution -- intended improvement?) |
+| `superset` | 182 | 0 | 182 | head found everything base did, plus more |
+| `capped-head` | 27 | 0 | 27 | head's list is a subset because head TRUNCATED it (isIncomplete) — by design, not a loss |
+| `timeout-base` | 12 | 0 | 12 | base timed out, head answered |
+
+## Groups
+
+Each row is one claim to adjudicate: *intended improvement*, *regression*, or *wash*.
+
+`distinct` is the number of different (base answer, head answer) PAIRS behind the positions — the count of separate claims. One generated data file can contribute sixty positions that all disagree the same way; that is one thing to adjudicate, not sixty, and reading `n` as the workload is how a sweep gets abandoned as noise.
+
+| shape | verb | token kind | n | distinct |
+|---|---|---|---|---|
+| `only-base` | completion | method-call | 2 | 2 |
+| `subset` | completion | method-call | 36 | 34 |
+| `subset` | completion | call-site | 24 | 22 |
+| `subset` | completion | package | 15 | 13 |
+| `subset` | completion | module-path | 11 | 7 |
+| `subset` | completion | variable | 1 | 1 |
+| `disagree` | completion | sub-decl | 175 | 168 |
+| `disagree` | definition | use-module | 145 | 38 |
+| `disagree` | completion | variable | 113 | 113 |
+| `disagree` | completion | use-module | 95 | 74 |
+| `disagree` | definition | module-path | 71 | 45 |
+| `disagree` | completion | hash-key | 57 | 43 |
+| `disagree` | completion | module-path | 44 | 33 |
+| `disagree` | completion | call-site | 36 | 36 |
+| `disagree` | completion | package | 28 | 23 |
+| `disagree` | completion | method-call | 13 | 12 |
+| `disagree` | definition | call-site | 11 | 11 |
+| `content-differs` | hover | variable | 15 | 15 |
+| `content-differs` | hover | call-site | 6 | 6 |
+| `content-differs` | hover | sub-decl | 6 | 6 |
+| `content-differs` | hover | method-call | 5 | 5 |
+| `content-differs` | hover | module-path | 3 | 3 |
+| `reranked` | completion | package | 26 | 10 |
+| `reranked` | completion | module-path | 24 | 11 |
+| `reranked` | completion | use-module | 15 | 10 |
+| `reranked` | completion | call-site | 5 | 5 |
+| `only-head` | definition | use-module | 55 | 17 |
+| `only-head` | hover | module-path | 43 | 28 |
+| `only-head` | completion | module-path | 39 | 13 |
+| `only-head` | completion | use-module | 28 | 8 |
+| `only-head` | hover | call-site | 17 | 13 |
+| `only-head` | definition | module-path | 17 | 10 |
+| `only-head` | definition | call-site | 17 | 11 |
+| `only-head` | completion | call-site | 13 | 8 |
+| `only-head` | definition | method-call | 7 | 7 |
+| `only-head` | hover | method-call | 7 | 7 |
+| `only-head` | hover | use-module | 7 | 7 |
+| `only-head` | completion | method-call | 4 | 3 |
+| `only-head` | completion | hash-key | 3 | 3 |
+| `only-head` | definition | hash-key | 3 | 3 |
+| `only-head` | hover | hash-key | 3 | 3 |
+| `superset` | completion | package | 65 | 60 |
+| `superset` | completion | hash-key | 35 | 34 |
+| `superset` | completion | module-path | 27 | 24 |
+| `superset` | references | use-module | 17 | 17 |
+| `superset` | completion | variable | 9 | 9 |
+| `superset` | completion | use-module | 8 | 7 |
+| `superset` | completion | call-site | 8 | 8 |
+| `superset` | references | call-site | 5 | 5 |
+| `superset` | references | module-path | 5 | 5 |
+| `superset` | completion | method-call | 3 | 3 |
+| `capped-head` | completion | package | 16 | 1 |
+| `capped-head` | completion | sub-decl | 5 | 5 |
+| `capped-head` | completion | variable | 3 | 3 |
+| `capped-head` | completion | use-module | 1 | 1 |
+| `capped-head` | completion | hash-key | 1 | 1 |
+| `capped-head` | completion | call-site | 1 | 1 |
+| `timeout-base` | completion | use-module | 1 | 1 |
+| `timeout-base` | definition | use-module | 1 | 1 |
+| `timeout-base` | references | call-site | 1 | 1 |
+| `timeout-base` | completion | call-site | 1 | 1 |
+| `timeout-base` | definition | call-site | 1 | 1 |
+| `timeout-base` | references | method-call | 1 | 1 |
+| `timeout-base` | completion | sub-decl | 1 | 1 |
+| `timeout-base` | definition | sub-decl | 1 | 1 |
+| `timeout-base` | references | package | 1 | 1 |
+| `timeout-base` | completion | method-call | 1 | 1 |
+| `timeout-base` | definition | method-call | 1 | 1 |
+| `timeout-base` | references | use-module | 1 | 1 |
+
+## Examples
+
+### `only-base` · completion · method-call — 2 positions, 2 distinct
+
+- `Dist/Zilla/Role/FileFinderUser.pm:159:50` `find_files`
+  - base: `n=1 top=[['(anon)', 3]]`
+  - head: `n=0 top=[]`
+- `x86_64-linux-gnu-thread-multi/Moose.pm:200:38` `initialize`
+  - base: `n=13 top=[['extends', 3], ['with', 3], ['throw_error', 3], ['has', 3]]`
+  - head: `n=0 top=[]`
+
+### `subset` · completion · method-call — 36 positions, 34 distinct
+
+- `Mojo/Server.pm:26:17` `req`  (+1 more positions answering identically)
+  - base: `n=45 top=[['previous', 2], ['client_read', 3], ['client_write', 3], ['is_empty', 3]]`
+  - head: `n=44 top=[['previous', 2], ['client_read', 3], ['client_write', 3], ['is_empty', 3]]`
+- `Mojo/Server/Prefork.pm:69:39` `workers`  (+1 more positions answering identically)
+  - base: `n=64 top=[['accepts', 2], ['cleanup', 2], ['graceful_timeout', 2], ['heartbeat_timeout', 2]]`
+  - head: `n=63 top=[['accepts', 2], ['cleanup', 2], ['graceful_timeout', 2], ['heartbeat_timeout', 2]]`
+- `App/Cmd/Simple.pm:187:26` `opt_spec`
+  - base: `n=18 top=[['import', 3], ['(anon)', 3], ['usage_desc', 3], ['_cmd_pkg', 3]]`
+  - head: `n=17 top=[['import', 3], ['usage_desc', 3], ['_cmd_pkg', 3], ['prepare', 3]]`
+- `Catalyst/ActionRole/Scheme.pm:8:42` `env`
+  - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
+  - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
+- `Class/Data/Inheritable.pm:16:39` `mk_classdata`
+  - base: `n=2 top=[['mk_classdata', 3], ['(anon)', 3]]`
+  - head: `n=1 top=[['mk_classdata', 3]]`
+- …and 29 more distinct claims
+
+### `subset` · completion · call-site — 24 positions, 22 distinct
+
+- `Mojo/JSON/Pointer.pm:5:30` `_pointer`  (+1 more positions answering identically)
+  - base: `n=13 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+  - head: `n=12 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+- `Type/Tie.pm:78:28` `blessed`  (+1 more positions answering identically)
+  - base: `n=10 top=[['export_fail', 3], ['set_prototype', 3], ['as_heavy', 3], ['export', 3]]`
+  - head: `n=9 top=[['export_fail', 3], ['set_prototype', 3], ['as_heavy', 3], ['export', 3]]`
+- `App/Cmd/Simple.pm:127:27` `install_sub`
+  - base: `n=8 top=[['_name_of_code', 3], ['_CODELIKE', 3], ['_build_public_installer', 3], ['(anon)', 3]]`
+  - head: `n=7 top=[['_name_of_code', 3], ['_CODELIKE', 3], ['_build_public_installer', 3], ['_do_with_warn', 3]]`
+- `Catalyst/ActionRole/Scheme.pm:11:58` `orig`
+  - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
+  - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
+- `Class/Data/Inheritable.pm:10:19` `croak`
+  - base: `n=41 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['(anon)', 3], ['is_utf8', 3]]`
+  - head: `n=40 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['is_utf8', 3], ['downgrade', 3]]`
+- …and 17 more distinct claims
+
+### `subset` · completion · package — 15 positions, 13 distinct
+
+- `Email/Abstract/EmailSimple.pm:2:36` `Email::Abstract::EmailSimple`  (+1 more positions answering identically)
+  - base: `n=17 top=[['object', 3], ['new', 3], ['__class_for', 3], ['_adapter_obj_and_args', 3]]`
+  - head: `n=16 top=[['object', 3], ['new', 3], ['__class_for', 3], ['_adapter_obj_and_args', 3]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array.pm:0:52` `Moose::Meta::Method::Accessor::Native::Array`  (+1 more positions answering identically)
+  - base: `n=85 top=[['(anon)', 3], ['_new', 3], ['root_types', 3], ['_initialize_body', 3]]`
+  - head: `n=84 top=[['_new', 3], ['root_types', 3], ['_initialize_body', 3], ['_inline_curried_arguments', 3]]`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:0:51` `Dist::Zilla::Role::MintingProfile::ShareDir`
+  - base: `n=3 top=[['profile_dir', 3], ['(anon)', 3], ['ShareDir', 9]]`
+  - head: `n=2 top=[['profile_dir', 3], ['ShareDir', 9]]`
+- `Email/Sender/Failure/Permanent.pm:0:41` `Email::Sender::Failure::Permanent`
+  - base: `n=20 top=[['code', 3], ['recipients', 3], ['(anon)', 3], ['_set_recipients', 3]]`
+  - head: `n=19 top=[['code', 3], ['recipients', 3], ['__recipients', 3], ['BUILD', 3]]`
+- `HTTP/Message/PSGI.pm:0:27` `HTTP::Message::PSGI`
+  - base: `n=36 top=[['_utf8_downgrade', 3], ['(anon)', 3], ['new', 3], ['parse', 3]]`
+  - head: `n=35 top=[['_utf8_downgrade', 3], ['new', 3], ['parse', 3], ['clone', 3]]`
+- …and 8 more distinct claims
+
+### `subset` · completion · module-path — 11 positions, 7 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/exists.pm:9:49` `Moose::Meta::Method::Accessor::Native::Hash`  (+3 more positions answering identically)
+  - base: `n=85 top=[['(anon)', 3], ['_new', 3], ['root_types', 3], ['_initialize_body', 3]]`
+  - head: `n=84 top=[['_new', 3], ['root_types', 3], ['_initialize_body', 3], ['_inline_curried_arguments', 3]]`
+- `Log/Log4perl/Appender/String.pm:1:37` `Log::Log4perl::Appender`  (+1 more positions answering identically)
+  - base: `n=74 top=[['_INTERNAL_DEBUG', 3], ['import', 3], ['(anon)', 3], ['initialized', 3]]`
+  - head: `n=73 top=[['_INTERNAL_DEBUG', 3], ['import', 3], ['initialized', 3], ['new', 3]]`
+- `CGI/Carp.pm:328:19` `CGI::Carp::VERSION`
+  - base: `n=29 top=[['import', 3], ['realwarn', 3], ['realdie', 3], ['id', 3]]`
+  - head: `n=28 top=[['import', 3], ['realwarn', 3], ['realdie', 3], ['id', 3]]`
+- `HTTP/Message/PSGI.pm:199:27` `HTTP::Message::PSGI`
+  - base: `n=36 top=[['_utf8_downgrade', 3], ['(anon)', 3], ['new', 3], ['parse', 3]]`
+  - head: `n=35 top=[['_utf8_downgrade', 3], ['new', 3], ['parse', 3], ['clone', 3]]`
+- `Type/Tiny/_DeclaredType.pm:39:19` `SUPER::new`
+  - base: `n=143 top=[['new', 3], ['(anon)', 3], ['_croak', 3], ['_swap', 3]]`
+  - head: `n=142 top=[['new', 3], ['_croak', 3], ['_swap', 3], ['_USE_XS', 3]]`
+- …and 2 more distinct claims
+
+### `subset` · completion · variable — 1 positions, 1 distinct
+
+- `Catalyst/ActionRole/Scheme.pm:17:19` `orig`
+  - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
+  - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
+
+### `disagree` · completion · sub-decl — 175 positions, 168 distinct
+
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:596:19` `has_dst_changes`  (+1 more positions answering identically)
+  - base: `n=886 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/La_Paz.pm:65:19` `has_dst_changes`  (+1 more positions answering identically)
+  - base: `n=887 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/Europe/Astrakhan.pm:616:13` `_max_year`  (+1 more positions answering identically)
+  - base: `n=1079 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `Log/Log4perl/Appender/String.pm:24:7` `log`  (+1 more positions answering identically)
+  - base: `n=2561 top=[['$ISA[]', 6], ['$#ISA', 6], ['@ISA', 6], ['@ISA[]', 6]]`
+  - head: `n=200 top=[['log', 3], ['new', 3], ['string', 3], ['Log::Log4perl::Appender::String', 7]]`
+- `Software/License/EUPL_1_1.pm:11:13` `meta_name`  (+1 more positions answering identically)
+  - base: `n=824 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- …and 163 more distinct claims
+
+### `disagree` · definition · use-module — 145 positions, 38 distinct
+
+- `App/Cmd/Simple.pm:175:7` `strict`  (+39 more positions answering identically)
+  - base: `[["<ext>/x86_64-linux-gnu/perl-base/strict.pm", [0, 0, 0, 0]]]`
+  - head: `[["<ext>/perl/5.38.2/strict.pm", [0, 8, 0, 14]], ["<ext>/x86_64-linux-gnu/perl-base/strict.pm", [0, 8, 0, 14]]]`
+- `Catalyst/Plugin/Unicode/Encoding.pm:2:4` `warnings`  (+26 more positions answering identically)
+  - base: `[["<ext>/x86_64-linux-gnu/perl-base/warnings.pm", [0, 0, 0, 0]]]`
+  - head: `[["<ext>/perl/5.38.2/warnings.pm", [5, 8, 5, 16]], ["<ext>/x86_64-linux-gnu/perl-base/warnings.pm", [5, 8, 5, 16]]]`
+- `Catalyst/ActionRole/Scheme.pm:2:4` `Moose::Role`  (+14 more positions answering identically)
+  - base: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [0, 0, 0, 0]]]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [2, 8, 2, 19]]]`
+- `Dist/Zilla/MVP/Reader/Perl.pm:7:4` `Dist::Zilla::Pragmas`  (+6 more positions answering identically)
+  - base: `[["Dist/Zilla/Pragmas.pm", [0, 0, 0, 0]]]`
+  - head: `[["Dist/Zilla/Pragmas.pm", [0, 8, 0, 28]]]`
+- `Software/License/Custom.pm:5:4` `parent`  (+6 more positions answering identically)
+  - base: `[["<ext>/x86_64-linux-gnu/perl-base/parent.pm", [0, 0, 0, 0]]]`
+  - head: `[["<ext>/perl/5.38.2/parent.pm", [0, 8, 0, 14]], ["<ext>/x86_64-linux-gnu/perl-base/parent.pm", [0, 8, 0, 14]]]`
+- …and 33 more distinct claims
+
+### `disagree` · completion · variable — 113 positions, 113 distinct
+
+- `CGI/Carp.pm:499:23` `no`
+  - base: `n=315 top=[['$in', 6], ['$no', 6], ['$appease_cpants_kwalitee', 6], ['die', 3]]`
+  - head: `n=200 top=[['_longmess', 3], ['_warn', 3], ['carp', 3], ['carpout', 3]]`
+- `Catalyst/ClassData.pm:61:8` `class`
+  - base: `n=309 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
+  - head: `n=200 top=[['mk_classdata', 3], ['refs', 3], ['Catalyst::ClassData', 7], ['$CURLY_SYMBOL', 3]]`
+- `Catalyst/Request/PartData.pm:39:10` `ct`
+  - base: `n=323 top=[['$ct', 6], ['$charset', 6], ['$class', 6], ['$c', 6]]`
+  - head: `n=200 top=[['build_from_part_data', 3], ['content_encoding', 2], ['content_type', 2], ['content_type_charset', 2]]`
+- `Catalyst/Test.pm:91:15` `request`
+  - base: `n=386 top=[['$self', 6], ['$meth', 6], ['$args', 6], ['$defaults', 6]]`
+  - head: `n=200 top=[['_build_ctx_request_export', 3], ['_build_get_export', 3], ['_build_request_export', 3], ['_customize_request', 3]]`
+- `Class/Data/Inheritable.pm:25:20` `declaredclass`
+  - base: `n=388 top=[['$declaredclass', 6], ['$attribute', 6], ['$data', 6], ['$accessor', 6]]`
+  - head: `n=200 top=[['mk_classdata', 3], ['subs', 3], ['vars', 3], ['carp', 3]]`
+- …and 108 more distinct claims
+
+### `disagree` · completion · use-module — 95 positions, 74 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:3:9` `Moose`  (+15 more positions answering identically)
+  - base: `n=359 top=[['Moose::Meta::Attribute::Native::Trait::Array', 9], ['Moose::Exporter', 9], ['Moose::Exception::IncompatibleMetaclassOfSuperclass', 9], ['Moose::Exception::MethodExpectedAMetaclassObject', 9]]`
+  - head: `n=200 top=[['Moose', 9], ['Moose::Conflicts', 9], ['Moose::Deprecated', 9], ['Moose::Exception', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/values.pm:19:14` `Moose::Role`  (+2 more positions answering identically)
+  - base: `n=359 top=[['Meta::Attribute::Native::Trait::Array', 9], ['Exporter', 9], ['Exception::IncompatibleMetaclassOfSuperclass', 9], ['Exception::MethodExpectedAMetaclassObject', 9]]`
+  - head: `n=200 top=[['_get_caller', 3], ['after', 3], ['around', 3], ['augment', 3]]`
+- `Catalyst/Plugin/Unicode/Encoding.pm:1:10` `strict`  (+1 more positions answering identically)
+  - base: `n=308 top=[['Catalyst::Plugin::Unicode::Encoding', 7], ['$CURLY_SYMBOL', 3], ['$GRAMMAR', 3], ['$PERMUTE', 3]]`
+  - head: `n=200 top=[['Catalyst::Plugin::Unicode::Encoding', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
+- `Test/Deep/RegexpVersion.pm:0:10` `strict`  (+1 more positions answering identically)
+  - base: `n=868 top=[['Test::Deep::RegexpVersion', 7], ['$CURLY_SYMBOL', 3], ['$TODO', 3], ['%CanonicalLevelNames', 3]]`
+  - head: `n=200 top=[['Test::Deep::RegexpVersion', 7], ['$Bin', 3], ['$Bzip2Error', 3], ['$CURLY_SYMBOL', 3]]`
+- `URI/file/QNX.pm:2:10` `strict`  (+1 more positions answering identically)
+  - base: `n=1043 top=[['_file_extract_path', 3], ['URI::file::QNX', 7], ['URI::file::Unix', 3], ['$CURLY_SYMBOL', 3]]`
+  - head: `n=200 top=[['_file_extract_path', 3], ['URI::file::Unix', 3], ['URI::file::QNX', 7], ['$Bin', 3]]`
+- …and 69 more distinct claims
+
+### `disagree` · definition · module-path — 71 positions, 45 distinct
+
+- `Dist/Zilla/Role/ExecFiles.pm:3:4` `Moose::Role`  (+8 more positions answering identically)
+  - base: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [0, 0, 0, 0]]]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [2, 8, 2, 19]]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:4:9` `Moose::Exception`  (+7 more positions answering identically)
+  - base: `[["x86_64-linux-gnu-thread-multi/Moose/Exception.pm", [0, 0, 0, 0]]]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Exception.pm", [0, 8, 0, 24]]]`
+- `Software/License/EUPL_1_1.pm:5:12` `Software::License`  (+4 more positions answering identically)
+  - base: `[["Software/License.pm", [0, 0, 0, 0]]]`
+  - head: `[["Software/License.pm", [2, 8, 2, 25]]]`
+- `Test/TypeTiny.pm:6:4` `Scalar::Util`  (+2 more positions answering identically)
+  - base: `[["<ext>/perl-base/Scalar/Util.pm", [0, 0, 0, 0]]]`
+  - head: `[["<ext>/5.38.2/Scalar/Util.pm", [6, 8, 6, 20]], ["<ext>/perl-base/Scalar/Util.pm", [6, 8, 6, 20]]]`
+- `Dist/Zilla/Role/AfterRelease.pm:4:6` `Dist::Zilla::Role::Plugin`  (+1 more positions answering identically)
+  - base: `[["Dist/Zilla/Role/Plugin.pm", [0, 0, 0, 0]]]`
+  - head: `[["Dist/Zilla/Role/Plugin.pm", [0, 8, 0, 33]]]`
+- …and 40 more distinct claims
+
+### `disagree` · completion · hash-key — 57 positions, 43 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/Role/Attribute.pm:6:6` `is`  (+2 more positions answering identically)
+  - base: `n=939 top=[['$VERSION', 6], ['attribute', 2], ['is_attribute_set', 2], ['Moose::Exception::Role::Attribute', 7]]`
+  - head: `n=200 top=[['attribute', 2], ['is_attribute_set', 2], ['Moose::Exception::Role::Attribute', 7], ['$Bin', 3]]`
+- `Software/License/EUPL_1_2.pm:11:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=824 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- `Software/License/FreeBSD.pm:10:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=825 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- `Software/License/GFDL_1_3.pm:9:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=829 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:9:7` `isa`  (+1 more positions answering identically)
+  - base: `n=870 top=[['$VERSION', 6], ['value', 2], ['_build_message', 3], ['Moose::Exception::CannotAssignValueToReadOnlyAccessor', 7]]`
+  - head: `n=200 top=[['_build_message', 3], ['value', 2], ['Moose::Exception::CannotAssignValueToReadOnlyAccessor', 7], ['$Bin', 3]]`
+- …and 38 more distinct claims
+
+### `disagree` · completion · module-path — 44 positions, 33 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:4:25` `Moose::Exception`  (+10 more positions answering identically)
+  - base: `n=359 top=[['Meta::Attribute::Native::Trait::Array', 9], ['Exporter', 9], ['Exception::IncompatibleMetaclassOfSuperclass', 9], ['Exception::MethodExpectedAMetaclassObject', 9]]`
+  - head: `n=200 top=[['_get_caller', 3], ['after', 3], ['around', 3], ['augment', 3]]`
+- `DateTime/TimeZone/Asia/Karachi.pm:126:28` `DateTime::TimeZone::INFINITY`  (+1 more positions answering identically)
+  - base: `n=1 top=[['Asia::Karachi', 9]]`
+  - head: `n=200 top=[['INFINITY', 3], ['IS_DST', 3], ['LOCAL_END', 3], ['LOCAL_START', 3]]`
+- `Date/Language/Brazilian.pm:15:24` `Date::Language`
+  - base: `n=415 top=[['$VERSION', 6], ['format_a', 3], ['format_A', 3], ['format_b', 3]]`
+  - head: `n=200 top=[['format_A', 3], ['format_B', 3], ['format_a', 3], ['format_b', 3]]`
+- `Date/Language/Sidama.pm:10:24` `Date::Language`
+  - base: `n=804 top=[['format_a', 3], ['format_A', 3], ['format_b', 3], ['format_B', 3]]`
+  - head: `n=200 top=[['format_A', 3], ['format_B', 3], ['format_a', 3], ['format_b', 3]]`
+- `DateTime/TimeZone/America/Anchorage.pm:21:88` `DateTime::TimeZone`
+  - base: `n=1 top=[['TimeZone::America::Anchorage', 9]]`
+  - head: `n=200 top=[['DefaultLocale', 3], ['INFINITY', 3], ['MAX_NANOSECONDS', 3], ['NAN', 3]]`
+- …and 28 more distinct claims
+
+### `disagree` · completion · call-site — 36 positions, 36 distinct
+
+- `Catalyst/ClassData.pm:43:9` `confess`
+  - base: `n=302 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
+  - head: `n=200 top=[['mk_classdata', 3], ['refs', 3], ['Catalyst::ClassData', 7], ['$CURLY_SYMBOL', 3]]`
+- `Config/MVP/Reader/Hash.pm:26:14` `name`
+  - base: `n=385 top=[['$name', 6], ['$self', 6], ['$location', 6], ['$assembler', 6]]`
+  - head: `n=200 top=[['read_into_assembler', 3], ['Config::MVP::Reader::Hash', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
+- `Dist/Zilla/Role/FileFinderUser.pm:140:19` `alias`
+  - base: `n=1496 top=[['$alias', 6], ['$orig', 6], ['$self', 6], ['$start', 6]]`
+  - head: `n=200 top=[['Dist::Zilla::Role::FileFinderUser', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:23:24` `path`
+  - base: `n=1488 top=[['$self', 6], ['$profile_name', 6], ['$profile_dir', 6], ['profile_dir', 3]]`
+  - head: `n=200 top=[['profile_dir', 3], ['Dist::Zilla::Role::MintingProfile::ShareDir', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
+- `File/Copy/Recursive.pm:281:40` `stat`
+  - base: `n=2587 top=[['$rc', 6], ['$file', 6], ['$file_ut', 6], ['$org', 6]]`
+  - head: `n=200 top=[['_bail_if_changed', 3], ['dircopy', 3], ['dirmove', 3], ['fcopy', 3]]`
+- …and 31 more distinct claims
+
+### `disagree` · completion · package — 28 positions, 23 distinct
+
+- `YAML/PP/Emitter.pm:2:25` `YAML::PP::Emitter`  (+2 more positions answering identically)
+  - base: `n=56 top=[['new', 3], ['clone', 3], ['_arg_yaml_version', 3], ['loader', 3]]`
+  - head: `n=59 top=[['new', 3], ['clone', 3], ['_arg_yaml_version', 3], ['loader', 3]]`
+- `Mojo/Server/CGI.pm:0:25` `Mojo::Server::CGI`  (+1 more positions answering identically)
+  - base: `n=33 top=[['app', 3], ['(anon)', 3], ['reverse_proxy', 3], ['trusted_proxies', 3]]`
+  - head: `n=33 top=[['app', 3], ['reverse_proxy', 3], ['trusted_proxies', 3], ['build_app', 3]]`
+- `Type/Tiny/ConstrainedObject.pm:0:37` `Type::Tiny::ConstrainedObject`  (+1 more positions answering identically)
+  - base: `n=153 top=[['_croak', 3], ['_swap', 3], ['_USE_XS', 3], ['(anon)', 3]]`
+  - head: `n=153 top=[['_croak', 3], ['_swap', 3], ['_USE_XS', 3], ['_USE_MOUSE', 3]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/TypeConstraint/Parameterizable.pm:0:52` `Moose::Meta::TypeConstraint::Parameterizable`  (+1 more positions answering identically)
+  - base: `n=29 top=[['(anon)', 3], ['parents', 3], ['new', 3], ['coerce', 3]]`
+  - head: `n=40 top=[['parents', 3], ['new', 3], ['coerce', 3], ['assert_coerce', 3]]`
+- `App/Cmd/Simple.pm:108:21` `eq`
+  - base: `n=281 top=[['$class', 6], ['$i', 6], ['import', 3], ['(anon)', 3]]`
+  - head: `n=200 top=[['_cmd_pkg', 3], ['import', 3], ['usage_desc', 3], ['refs', 3]]`
+- …and 18 more distinct claims
+
+### `disagree` · completion · method-call — 13 positions, 12 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotOverrideALocalMethod.pm:15:59` `method_name`  (+1 more positions answering identically)
+  - base: `n=8 top=[['method_name', 2], ['_build_message', 3], ['trace', 2], ['_build_trace', 2]]`
+  - head: `n=8 top=[['method_name', 2], ['_build_message', 3], ['trace', 2], ['message', 2]]`
+- `Mojolicious/Commands.pm:81:65` `start`
+  - base: `n=99 top=[['commands', 2], ['(anon)', 3], ['controller_class', 2], ['exception_format', 2]]`
+  - head: `n=77 top=[['commands', 2], ['controller_class', 2], ['exception_format', 2], ['home', 2]]`
+- `PPI/Token/DashedWord.pm:67:38` `set_class`
+  - base: `n=1 top=[['{key}', 15]]`
+  - head: `n=55 top=[['__TOKENIZER__on_char', 3], ['new', 3], ['set_class', 3], ['set_content', 3]]`
+- `Path/Class/File.pm:34:50` `_spec_class`
+  - base: `n=23 top=[['new', 3], ['dir_class', 3], ['as_foreign', 3], ['stringify', 3]]`
+  - head: `n=36 top=[['new', 3], ['dir_class', 3], ['as_foreign', 3], ['stringify', 3]]`
+- `Plack/Middleware/HTTPExceptions.pm:12:18` `rethrow`
+  - base: `n=4 top=[['prepare_app', 3], ['call', 3], ['(anon)', 3], ['transform_error', 3]]`
+  - head: `n=9 top=[['prepare_app', 3], ['call', 3], ['transform_error', 3], ['wrap', 3]]`
+- …and 7 more distinct claims
+
+### `disagree` · definition · call-site — 11 positions, 11 distinct
+
+- `PPI.pm:18:9` `Structure`
+  - base: `[["PPI/Structure.pm", [0, 0, 0, 0]]]`
+  - head: `[["PPI/Structure.pm", [0, 8, 0, 22]]]`
+- `PPI.pm:24:9` `Tokenizer`
+  - base: `[["PPI/Tokenizer.pm", [0, 0, 0, 0]]]`
+  - head: `[["PPI/Tokenizer.pm", [0, 8, 0, 22]]]`
+- `PPI/Exception/ParserRejection.pm:3:9` `Exception`
+  - base: `[["PPI/Exception.pm", [0, 0, 0, 0]]]`
+  - head: `[["PPI/Exception.pm", [0, 8, 0, 22]], ["PPI/XSAccessor.pm", [71, 1, 71, 15]]]`
+- `PPI/Statement/End.pm:47:9` `Statement`
+  - base: `[["PPI/Statement.pm", [0, 0, 0, 0]]]`
+  - head: `[["PPI/Statement.pm", [0, 8, 0, 22]], ["PPI/XSAccessor.pm", [98, 1, 98, 15]]]`
+- `PPI/Token/Number.pm:32:9` `Token`
+  - base: `[["PPI/Token.pm", [0, 0, 0, 0]]]`
+  - head: `[["PPI/Token.pm", [0, 8, 0, 18]], ["PPI/XSAccessor.pm", [149, 1, 149, 11]]]`
+- …and 6 more distinct claims
+
+### `content-differs` · hover · variable — 15 positions, 15 distinct
+
+- `Config/MVP/Assembler.pm:205:26` `self`
+  - base: `len=293 '```perl sub current_section { ``` *class Config::MVP::Assembler — resolved from `$self`* pod =method current_section pod'`
+  - head: `len=74 '```perl my ($self, $name, $value) = @_; ``` *type: Config::MVP::Assembler*'`
+- `Dist/Zilla/Plugin/PkgDist.pm:62:5` `self`
+  - base: `len=211 "```perl sub log() ``` *class Dist::Zilla::Role::Plugin — resolved from `$self`* The plugin's `log` method delegates to t"`
+  - head: `len=72 '```perl my ($self, $file) = @_; ``` *type: Dist::Zilla::Plugin::PkgDist*'`
+- `Email/MessageID.pm:64:36` `_SYS_HOSTNAME_LONG`
+  - base: `len=35 '```perl my $_SYS_HOSTNAME_LONG; ```'`
+  - head: `len=51 '```perl my $_SYS_HOSTNAME_LONG; ``` *type: Numeric*'`
+- `Mojolicious/Command/prefork.pm:26:39` `prefork`
+  - base: `len=261 '```perl sub max_requests() ``` *class Mojo::Server::Daemon — resolved from `$prefork`* *returns: Numeric* ```perl my $ma'`
+  - head: `len=102 '```perl my $prefork = Mojo::Server::Prefork->new(app => $self->app); ``` *type: Mojo::Server::Prefork*'`
+- `Mojolicious/Plugin/EPRenderer.pm:25:41` `name`
+  - base: `len=320 '```perl sub add_handler() ``` *class Mojolicious::Renderer — resolved from `$name`* *returns: Mojolicious::Renderer* ```'`
+  - head: `len=80 '```perl my $name = $options->{inline} // $renderer->template_name($options); ```'`
+- …and 10 more distinct claims
+
+### `content-differs` · hover · call-site — 6 positions, 6 distinct
+
+- `LWP/Debug/TraceHTTP.pm:25:11` `mcall`
+  - base: `len=217 '```perl sub mcall($o, $method, $proto) → Maybe<Data::Dump::Trace::Call> ``` Calls the given method with the given argume'`
+  - head: `len=215 '```perl sub mcall($o, $method, $proto) → Maybe<Data::Dump::Trace::Call> ``` Calls the given method with the given argume'`
+- `Log/Log4perl/Appender.pm:76:35` `new`
+  - base: `len=124 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: HashRef* #############################################'`
+  - head: `len=140 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: Log::Log4perl::Appender* #############################'`
+- `Mojo/IOLoop/Subprocess.pm:84:14` `parent`
+  - base: `len=190 '```perl sub on() ``` *class Mojo::EventEmitter — resolved from `$parent`* ```perl my $cb = $e->on(foo => sub {...}); ```'`
+  - head: `len=45 '```perl my ($self, $child, $parent) = @_; ```'`
+- `Mojo/JSON/Pointer.pm:8:33` `new`
+  - base: `len=342 '```perl sub new($class) ``` *class Mojo::Base* *returns: Mojo::Base* ```perl my $object = SubClass->new; my $object = Su'`
+  - head: `len=293 '```perl sub new { @_ > 1 ? shift->SUPER::new(data => shift) : shift->SUPER::new } ``` *package Mojo::JSON::Pointer* ```p'`
+- `Path/Class/File.pm:187:16` `new`
+  - base: `len=66 '```perl sub new { ``` *class Path::Class::File* *returns: HashRef*'`
+  - head: `len=76 '```perl sub new { ``` *class Path::Class::File* *returns: Path::Class::File*'`
+- …and 1 more distinct claims
+
+### `content-differs` · hover · sub-decl — 6 positions, 6 distinct
+
+- `Mojo/IOLoop/Subprocess.pm:24:4` `run_p`
+  - base: `len=452 '```perl sub run_p { ``` *package Mojo::IOLoop::Subprocess* *returns: Mojo::Promise* ```perl my $promise = $subprocess->r'`
+  - head: `len=450 '```perl sub run_p { ``` *package Mojo::IOLoop::Subprocess* *returns: Mojo::Promise* ```perl my $promise = $subprocess->r'`
+- `Mojo/JSON/Pointer.pm:6:4` `get`
+  - base: `len=641 "```perl sub get { shift->_pointer(1, @_) } ``` *package Mojo::JSON::Pointer* ```perl my $value = $pointer->get('/foo/bar"`
+  - head: `len=639 "```perl sub get { shift->_pointer(1, @_) } ``` *package Mojo::JSON::Pointer* ```perl my $value = $pointer->get('/foo/bar"`
+- `Mojo/Server/Prefork.pm:21:4` `check_pid`
+  - base: `len=284 '```perl sub check_pid { ``` *package Mojo::Server::Prefork* *returns: Maybe<String>* ```perl my $pid = $prefork->check_p'`
+  - head: `len=282 '```perl sub check_pid { ``` *package Mojo::Server::Prefork* *returns: Maybe<String>* ```perl my $pid = $prefork->check_p'`
+- `Path/Class/File.pm:113:4` `spew`
+  - base: `len=576 '```perl sub spew { ``` *package Path::Class::File* The opposite of (slurp), this takes a list of strings and prints them'`
+  - head: `len=572 '```perl sub spew { ``` *package Path::Class::File* The opposite of slurp, this takes a list of strings and prints them t'`
+- `Type/Tie.pm:231:5` `EXISTS`
+  - base: `len=82 '```perl sub EXISTS { exists $_[0]->_REF->{ $_[1] } } ``` *package Type::Tie::HASH*'`
+  - head: `len=98 '```perl sub EXISTS { exists $_[0]->_REF->{ $_[1] } } ``` *package Type::Tie::HASH* *returns: Bool*'`
+- …and 1 more distinct claims
+
+### `content-differs` · hover · method-call — 5 positions, 5 distinct
+
+- `Mojo/Date.pm:18:38` `parse`
+  - base: `len=64 '```perl sub parse { ``` *class Mojo::Date* *returns: Mojo::Date*'`
+  - head: `len=802 "```perl sub parse { ``` *package Mojo::Date* *returns: Mojo::Date* ```perl $date = $date->parse('Sun Nov 6 08:49:37 1994"`
+- `Mojo/Server/CGI.pm:28:17` `res`
+  - base: `len=680 '```perl sub res() ``` *class Mojo::Transaction::HTTP (from Mojo::Transaction)* *returns: Mojo::Message::Response* ```per'`
+  - head: `len=79 '```perl has res => sub { Mojo::Message::Response->new }; ``` — `Transaction.pm`'`
+- `Mojolicious/Command/prefork.pm:22:48` `keep_alive_timeout`
+  - base: `len=465 '```perl sub keep_alive_timeout() ``` *class Mojo::Server::Prefork (from Mojo::Server::Daemon)* ```perl my $timeout = $da'`
+  - head: `len=484 '```perl sub keep_alive_timeout() ``` *class Mojo::Server::Prefork (from Mojo::Server::Daemon)* *returns: Numeric* ```per'`
+- `Mojolicious/Commands.pm:81:60` `start`
+  - base: `len=491 '```perl sub start($self) ``` *class Mojolicious* *returns: Numeric* ```perl $app->start; $app->start(@ARGV); ``` Start t'`
+  - head: `len=42 '```perl sub start { ``` — `Mojolicious.pm`'`
+- `Mojolicious/Plugin/EPRenderer.pm:19:41` `add_handler`
+  - base: `len=296 '```perl sub add_handler() ``` *class Mojolicious::Renderer* *returns: Mojolicious::Renderer* ```perl $renderer = $render'`
+  - head: `len=97 '```perl sub add_handler { $_[0]->handlers->{$_[1]} = $_[2] and return $_[0] } ``` — `Renderer.pm`'`
+
+### `content-differs` · hover · module-path — 3 positions, 3 distinct
+
+- `Mojo/JSON/Pointer.pm:8:26` `SUPER::new`
+  - base: `len=342 '```perl sub new($class) ``` *class Mojo::Base* *returns: Mojo::Base* ```perl my $object = SubClass->new; my $object = Su'`
+  - head: `len=293 '```perl sub new { @_ > 1 ? shift->SUPER::new(data => shift) : shift->SUPER::new } ``` *package Mojo::JSON::Pointer* ```p'`
+- `Software/License/Custom.pm:85:22` `SUPER::new`
+  - base: `len=954 '```perl sub new($class, $arg) ``` *class Software::License* *returns: Software::License* pod =head1 SYNOPSIS pod pod my '`
+  - head: `len=2387 '```perl sub new { ``` *package Software::License::Custom* pod =head1 DESCRIPTION pod pod This module extends L<Software:'`
+- `Type/Tiny/_DeclaredType.pm:39:9` `SUPER::new`
+  - base: `len=68 '```perl sub new($class) ``` *class Type::Tiny* *returns: Type::Tiny*'`
+  - head: `len=57 '```perl sub new { ``` *package Type::Tiny::_DeclaredType*'`
+
+### `reranked` · completion · package — 26 positions, 10 distinct
+
+- `Dist/Zilla/Role/AfterRelease.pm:0:39` `Dist::Zilla::Role::AfterRelease`  (+7 more positions answering identically)
+  - base: `n=45 top=[['Releaser', 9], ['BeforeBuild', 9], ['InstallTool', 9], ['BuildRunner', 9]]`
+  - head: `n=45 top=[['PrereqScanner', 9], ['FileInjector', 9], ['ReleaseStatusProvider', 9], ['AfterBuild', 9]]`
+- `DateTime/TimeZone/Pacific/Efate.pm:9:42` `DateTime::TimeZone::Pacific::Efate`  (+3 more positions answering identically)
+  - base: `n=30 top=[['Guam', 9], ['Apia', 9], ['Efate', 9], ['Pago_Pago', 9]]`
+  - head: `n=30 top=[['Nauru', 9], ['Fiji', 9], ['Guadalcanal', 9], ['Galapagos', 9]]`
+- `PPI/Exception.pm:0:22` `PPI::Exception`  (+3 more positions answering identically)
+  - base: `n=94 top=[['Token::Prototype', 9], ['Token::QuoteLike::Backtick', 9], ['Statement::Package', 9], ['Token::Structure', 9]]`
+  - head: `n=94 top=[['Document::Fragment', 9], ['Structure::When', 9], ['Token::Number::Hex', 9], ['Transform::UpdateCopyright', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array/accessor.pm:0:62` `Moose::Meta::Method::Accessor::Native::Array::accessor`  (+1 more positions answering identically)
+  - base: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['sort_in_place', 9], ['accessor', 9], ['shallow_clone', 9]]`
+  - head: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['unshift', 9], ['grep', 9], ['count', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/exists.pm:0:59` `Moose::Meta::Method::Accessor::Native::Hash::exists`  (+1 more positions answering identically)
+  - base: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['Writer', 9], ['exists', 9], ['values', 9]]`
+  - head: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['Writer', 9], ['accessor', 9], ['shallow_clone', 9]]`
+- …and 5 more distinct claims
+
+### `reranked` · completion · module-path — 24 positions, 11 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotCreateMethodAliasLocalMethodIsPresent.pm:5:34` `Moose::Exception::Role::Role`  (+5 more positions answering identically)
+  - base: `n=13 top=[['Method', 9], ['RoleForCreateMOPClass', 9], ['RoleForCreate', 9], ['Attribute', 9]]`
+  - head: `n=13 top=[['Method', 9], ['InvalidAttributeOptions', 9], ['Attribute', 9], ['InstanceClass', 9]]`
+- `PPI/Exception/ParserRejection.pm:7:26` `PPI::Exception`  (+4 more positions answering identically)
+  - base: `n=94 top=[['Token::Prototype', 9], ['Token::QuoteLike::Backtick', 9], ['Statement::Package', 9], ['Token::Structure', 9]]`
+  - head: `n=94 top=[['Document::Fragment', 9], ['Structure::When', 9], ['Token::Number::Hex', 9], ['Transform::UpdateCopyright', 9]]`
+- `Dist/Zilla/Plugin/PkgDist.pm:9:25` `Dist::Zilla::Role::PPI`  (+3 more positions answering identically)
+  - base: `n=45 top=[['Releaser', 9], ['BeforeBuild', 9], ['InstallTool', 9], ['BuildRunner', 9]]`
+  - head: `n=45 top=[['PrereqScanner', 9], ['FileInjector', 9], ['ReleaseStatusProvider', 9], ['AfterBuild', 9]]`
+- `Mojo/DOM/CSS.pm:1:14` `Mojo::Base`  (+1 more positions answering identically)
+  - base: `n=2 top=[['Mojo::BaseUtil', 9], ['Mojo::Base', 9]]`
+  - head: `n=2 top=[['Mojo::Base', 9], ['Mojo::BaseUtil', 9]]`
+- `App/Cmd/Simple.pm:5:21` `App::Cmd::Command`
+  - base: `n=4 top=[['App::Cmd::Command', 9], ['App::Cmd::Command::version', 9], ['App::Cmd::Command::help', 9], ['App::Cmd::Command::commands', 9]]`
+  - head: `n=4 top=[['App::Cmd::Command::help', 9], ['App::Cmd::Command::version', 9], ['App::Cmd::Command::commands', 9], ['App::Cmd::Command', 9]]`
+- …and 6 more distinct claims
+
+### `reranked` · completion · use-module — 15 positions, 10 distinct
+
+- `Mojo/JSON/Pointer.pm:1:14` `Mojo::Base`  (+3 more positions answering identically)
+  - base: `n=2 top=[['Mojo::BaseUtil', 9], ['Mojo::Base', 9]]`
+  - head: `n=2 top=[['Mojo::Base', 9], ['Mojo::BaseUtil', 9]]`
+- `Email/Simple.pm:5:8` `Carp`  (+1 more positions answering identically)
+  - base: `n=3 top=[['Carp', 9], ['Carp::Clan', 9], ['Carp::Heavy', 9]]`
+  - head: `n=3 top=[['Carp::Clan', 9], ['Carp', 9], ['Carp::Heavy', 9]]`
+- `PPI/Token/Comment.pm:61:14` `PPI::Token`  (+1 more positions answering identically)
+  - base: `n=47 top=[['PPI::Token::Prototype', 9], ['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::Structure', 9], ['PPI::Token::Unknown', 9]]`
+  - head: `n=47 top=[['PPI::Token::Number::Hex', 9], ['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::Pod', 9], ['PPI::Token::QuoteLike', 9]]`
+- `Catalyst/ClassData.pm:5:15` `Moose::Util`
+  - base: `n=4 top=[['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util::MetaRole', 9], ['Moose::Util', 9], ['Moose::Util::TypeConstraints', 9]]`
+  - head: `n=4 top=[['Moose::Util::MetaRole', 9], ['Moose::Util::TypeConstraints', 9], ['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util', 9]]`
+- `Log/Log4perl/Appender.pm:99:37` `Log::Log4perl::Config`
+  - base: `n=5 top=[['Log::Log4perl::Config::BaseConfigurator', 9], ['Log::Log4perl::Config::DOMConfigurator', 9], ['Log::Log4perl::Config::Watch', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9]]`
+  - head: `n=5 top=[['Log::Log4perl::Config::Watch', 9], ['Log::Log4perl::Config::DOMConfigurator', 9], ['Log::Log4perl::Config', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9]]`
+- …and 5 more distinct claims
+
+### `reranked` · completion · call-site — 5 positions, 5 distinct
+
+- `Catalyst/Request/PartData.pm:68:20` `new`
+  - base: `n=9 top=[['raw_data', 2], ['name', 2], ['size', 2], ['headers', 2]]`
+  - head: `n=9 top=[['raw_data', 2], ['name', 2], ['size', 2], ['headers', 2]]`
+- `PPI.pm:18:18` `Structure`
+  - base: `n=11 top=[['PPI::Structure::Given', 9], ['PPI::Structure', 9], ['PPI::Structure::When', 9], ['PPI::Structure::For', 9]]`
+  - head: `n=11 top=[['PPI::Structure::When', 9], ['PPI::Structure::Block', 9], ['PPI::Structure::For', 9], ['PPI::Structure::Given', 9]]`
+- `PPI/Statement/End.pm:47:18` `Statement`
+  - base: `n=17 top=[['PPI::Statement::Package', 9], ['PPI::Statement::Scheduled', 9], ['PPI::Statement::UnmatchedBrace', 9], ['PPI::Statement::Data', 9]]`
+  - head: `n=17 top=[['PPI::Statement::Break', 9], ['PPI::Statement::Package', 9], ['PPI::Statement::Include::Perl6', 9], ['PPI::Statement::End', 9]]`
+- `PPI/Token/Number.pm:32:14` `Token`
+  - base: `n=47 top=[['PPI::Token::Prototype', 9], ['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::Structure', 9], ['PPI::Token::Unknown', 9]]`
+  - head: `n=47 top=[['PPI::Token::Number::Hex', 9], ['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::Pod', 9], ['PPI::Token::QuoteLike', 9]]`
+- `PPI/Token/Quote/Single.pm:35:21` `Quote`
+  - base: `n=11 top=[['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::QuoteLike::Regexp', 9], ['PPI::Token::Quote::Double', 9], ['PPI::Token::Quote::Literal', 9]]`
+  - head: `n=11 top=[['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::QuoteLike', 9], ['PPI::Token::QuoteLike::Readline', 9], ['PPI::Token::QuoteLike::Regexp', 9]]`
+
+### `only-head` · definition · use-module — 55 positions, 17 distinct
+
+- `Dist/Zilla/Plugin/PkgDist.pm:3:4` `Moose`  (+17 more positions answering identically)
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose.pm", [2, 8, 2, 13]]]`
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:4` `namespace::autoclean`  (+8 more positions answering identically)
+  - base: `[]`
+  - head: `[["namespace/autoclean.pm", [3, 8, 3, 28]]]`
+- `DateTime/TimeZone/America/Anchorage.pm:17:4` `Class::Singleton`  (+5 more positions answering identically)
+  - base: `[]`
+  - head: `[["Class/Singleton.pm", [21, 8, 21, 24]]]`
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:19:4` `DateTime::TimeZone::OlsonDB`  (+5 more positions answering identically)
+  - base: `[]`
+  - head: `[["DateTime/TimeZone/OlsonDB.pm", [0, 8, 0, 35]]]`
+- `DateTime/TimeZone/America/La_Paz.pm:18:4` `DateTime::TimeZone`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["DateTime/TimeZone.pm", [0, 8, 0, 26]]]`
+- …and 12 more distinct claims
+
+### `only-head` · hover · module-path — 43 positions, 28 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:4:9` `Moose::Exception`  (+7 more positions answering identically)
+  - base: `∅`
+  - head: `len=65 '```perl package Moose::Exception ``` *namespace* — `Exception.pm`'`
+- `Software/License/EUPL_1_1.pm:5:12` `Software::License`  (+4 more positions answering identically)
+  - base: `∅`
+  - head: `len=73 '```perl package Software::License 0.104007 ``` *namespace* — `License.pm`'`
+- `Date/Language/Brazilian.pm:15:10` `Date::Language`  (+1 more positions answering identically)
+  - base: `∅`
+  - head: `len=62 '```perl package Date::Language ``` *namespace* — `Language.pm`'`
+- `Dist/Zilla/Role/AfterRelease.pm:4:6` `Dist::Zilla::Role::Plugin`  (+1 more positions answering identically)
+  - base: `∅`
+  - head: `len=77 '```perl package Dist::Zilla::Role::Plugin 6.037 ``` *namespace* — `Plugin.pm`'`
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotCreateMethodAliasLocalMethodIsPresent.pm:5:6` `Moose::Exception::Role::Role`  (+1 more positions answering identically)
+  - base: `∅`
+  - head: `len=72 '```perl package Moose::Exception::Role::Role ``` *namespace* — `Role.pm`'`
+- …and 23 more distinct claims
+
+### `only-head` · completion · module-path — 39 positions, 13 distinct
+
+- `Text/Unidecode/x19.pm:1:22` `Text::Unidecode::Char`  (+18 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=14 top=[['DEBUG', 3], ['unidecode', 3], ['make_placeholder_map', 3], ['make_placeholder_map_nulls', 3]]`
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:17:20` `Class::Singleton`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['Class::Singleton', 9]]`
+- `DateTime/TimeZone/America/Boise.pm:19:31` `DateTime::TimeZone::OlsonDB`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=5 top=[['DateTime::TimeZone::OlsonDB::Rule', 9], ['DateTime::TimeZone::OlsonDB::Change', 9], ['DateTime::TimeZone::OlsonDB::Zone', 9], ['DateTime::TimeZone::OlsonDB', 9]]`
+- `DateTime/TimeZone/Asia/Gaza.pm:2889:39` `DateTime::TimeZone::OlsonDB::Rule`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=17 top=[['new', 3], ['parse_file', 3], ['_parse_line', 3], ['_parse_rule', 3]]`
+- `DateTime/TimeZone/Asia/Kolkata.pm:13:24` `namespace::autoclean`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['namespace::autoclean', 9]]`
+- …and 8 more distinct claims
+
+### `only-head` · completion · use-module — 28 positions, 8 distinct
+
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:24` `namespace::autoclean`  (+8 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['namespace::autoclean', 9]]`
+- `DateTime/TimeZone/America/Anchorage.pm:17:20` `Class::Singleton`  (+5 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['Class::Singleton', 9]]`
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:19:31` `DateTime::TimeZone::OlsonDB`  (+5 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=5 top=[['DateTime::TimeZone::OlsonDB::Rule', 9], ['DateTime::TimeZone::OlsonDB::Change', 9], ['DateTime::TimeZone::OlsonDB::Zone', 9], ['DateTime::TimeZone::OlsonDB', 9]]`
+- `DateTime/TimeZone/America/La_Paz.pm:18:22` `DateTime::TimeZone`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=200 top=[['DateTime::TimeZone', 9], ['DateTime::TimeZone::Africa::Abidjan', 9], ['DateTime::TimeZone::Africa::Algiers', 9], ['DateTime::TimeZone::Africa::Bissau', 9]]`
+- `Config/MVP/Assembler.pm:204:60` `section`
+  - base: `n=0 top=[]`
+  - head: `n=200 top=[['_between_sections', 2], ['_between_sections', 2], ['add_value', 3], ['begin_section', 3]]`
+- …and 3 more distinct claims
+
+### `only-head` · hover · call-site — 17 positions, 13 distinct
+
+- `Text/Unidecode/x35.pm:1:50` `make_placeholder_map`  (+3 more positions answering identically)
+  - base: `∅`
+  - head: `len=153 '```perl sub make_placeholder_map() → Sequence<String> ``` =============================================================='`
+- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+1 more positions answering identically)
+  - base: `∅`
+  - head: `len=56 '```perl sub _build_lookups() ``` *from `Date::Language`*'`
+- `App/Cmd/Simple.pm:127:16` `install_sub`
+  - base: `∅`
+  - head: `len=38 '```perl use v5.8.0; ``` — `Install.pm`'`
+- `Catalyst/Test.pm:48:29` `throw`
+  - base: `∅`
+  - head: `len=117 '```perl sub throw($class) ``` *class Catalyst::Exception (from Catalyst::Exception::Basic)* Throws a fatal exception.'`
+- `Config/MVP/Assembler.pm:134:22` `throw`
+  - base: `∅`
+  - head: `len=380 '```perl sub throw() ``` *class Config::MVP::Error (from Throwable)* pod =method throw pod pod Something::Throwable->thro'`
+- …and 8 more distinct claims
+
+### `only-head` · definition · module-path — 17 positions, 10 distinct
+
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:17:4` `Class::Singleton`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["Class/Singleton.pm", [21, 8, 21, 24]]]`
+- `DateTime/TimeZone/America/Boise.pm:19:4` `DateTime::TimeZone::OlsonDB`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["DateTime/TimeZone/OlsonDB.pm", [0, 8, 0, 35]]]`
+- `DateTime/TimeZone/Asia/Kolkata.pm:13:4` `namespace::autoclean`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["namespace/autoclean.pm", [3, 8, 3, 28]]]`
+- `Date/Language/Brazilian.pm:10:4` `Date::Language`  (+1 more positions answering identically)
+  - base: `[]`
+  - head: `[["Date/Language.pm", [1, 8, 1, 22]]]`
+- `Catalyst/ClassData.pm:4:4` `Class::MOP`
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP.pm", [0, 8, 0, 18]]]`
+- …and 5 more distinct claims
+
+### `only-head` · definition · call-site — 17 positions, 11 distinct
+
+- `Text/Unidecode/x35.pm:1:50` `make_placeholder_map`  (+3 more positions answering identically)
+  - base: `[]`
+  - head: `[["Text/Unidecode.pm", [117, 0, 117, 0]]]`
+- `Date/Language/Brazilian.pm:10:10` `Language`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["Date/Language.pm", [1, 8, 1, 22]]]`
+- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+1 more positions answering identically)
+  - base: `[]`
+  - head: `[["Date/Language.pm", [14, 0, 14, 0]]]`
+- `Catalyst/Test.pm:48:29` `throw`
+  - base: `[]`
+  - head: `[["Catalyst/Exception/Basic.pm", [32, 0, 32, 0]]]`
+- `Config/MVP/Assembler.pm:134:22` `throw`
+  - base: `[]`
+  - head: `[["Throwable.pm", [65, 0, 65, 0]]]`
+- …and 6 more distinct claims
+
+### `only-head` · completion · call-site — 13 positions, 8 distinct
+
+- `Text/Unidecode/x35.pm:1:70` `make_placeholder_map`  (+3 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=14 top=[['DEBUG', 3], ['unidecode', 3], ['make_placeholder_map', 3], ['make_placeholder_map_nulls', 3]]`
+- `Date/Language/Brazilian.pm:10:18` `Language`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=37 top=[['Date::Language::Bulgarian', 9], ['Date::Language::Russian_koi8r', 9], ['Date::Language::Italian', 9], ['Date::Language::Amharic', 9]]`
+- `Catalyst/Test.pm:48:34` `throw`
+  - base: `n=0 top=[]`
+  - head: `n=4 top=[['message', 2], ['as_string', 3], ['throw', 3], ['rethrow', 3]]`
+- `Config/MVP/Assembler.pm:134:27` `throw`
+  - base: `n=0 top=[]`
+  - head: `n=12 top=[['message', 2], ['as_string', 3], ['previous_exception', 2], ['throw', 3]]`
+- `PPI/Statement/Package.pm:118:19` `isa`
+  - base: `n=0 top=[]`
+  - head: `n=43 top=[['significant', 3], ['class', 3], ['tokens', 3], ['content', 3]]`
+- …and 3 more distinct claims
+
+### `only-head` · definition · method-call — 7 positions, 7 distinct
+
+- `Catalyst/ClassData.pm:53:9` `make_mutable`
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Class.pm", [1306, 0, 1306, 0]]]`
+- `Catalyst/Test.pm:359:22` `new`
+  - base: `[]`
+  - head: `[["URI.pm", [53, 0, 53, 0]]]`
+- `Path/Class/File.pm:34:39` `_spec_class`
+  - base: `[]`
+  - head: `[["Path/Class/Entity.pm", [29, 0, 29, 0]]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Wrapped.pm:127:11` `original_method`
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Method.pm", [92, 0, 92, 0]]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin.pm:11:23` `initialize`
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Class.pm", [26, 0, 26, 0]]]`
+- …and 2 more distinct claims
+
+### `only-head` · hover · method-call — 7 positions, 7 distinct
+
+- `Catalyst/ClassData.pm:53:9` `make_mutable`
+  - base: `∅`
+  - head: `len=97 '```perl sub make_mutable($self) ``` *class Class::MOP::Class* *returns: Maybe<Class::MOP::Class>*'`
+- `Catalyst/Test.pm:359:22` `new`
+  - base: `∅`
+  - head: `len=1242 '```perl sub new($class, $uri, $scheme) ``` *class URI* *returns: URI::_foreign* Constructs a new URI object. The string '`
+- `Path/Class/File.pm:34:39` `_spec_class`
+  - base: `∅`
+  - head: `len=113 '```perl sub _spec_class($class, $type) ``` *class Path::Class::File (from Path::Class::Entity)* *returns: String*'`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Wrapped.pm:127:11` `original_method`
+  - base: `∅`
+  - head: `len=95 '```perl sub original_method() ``` *class Class::MOP::Method::Wrapped (from Class::MOP::Method)*'`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin.pm:11:23` `initialize`
+  - base: `∅`
+  - head: `len=69 '```perl sub initialize($class) ``` *class Class::MOP::Class* Creation'`
+- …and 2 more distinct claims
+
+### `only-head` · hover · use-module — 7 positions, 7 distinct
+
+- `Config/MVP/Assembler.pm:204:53` `section`
+  - base: `∅`
+  - head: `len=380 '```perl sub throw() ``` *class Config::MVP::Error (from Throwable)* pod =method throw pod pod Something::Throwable->thro'`
+- `HTTP/Message.pm:318:14` `Compress::Raw::Zlib`
+  - base: `∅`
+  - head: `len=63 '```perl package Compress::Raw::Zlib ``` *namespace* — `Zlib.pm`'`
+- `LWP.pm:4:8` `LWP::UserAgent`
+  - base: `∅`
+  - head: `len=63 '```perl package LWP::UserAgent ``` *namespace* — `UserAgent.pm`'`
+- `LWP/Protocol/mailto.pm:7:8` `HTTP::Response`
+  - base: `∅`
+  - head: `len=62 '```perl package HTTP::Response ``` *namespace* — `Response.pm`'`
+- `Log/Log4perl/Appender.pm:99:16` `Log::Log4perl::Config`
+  - base: `∅`
+  - head: `len=67 '```perl package Log::Log4perl::Config ``` *namespace* — `Config.pm`'`
+- …and 2 more distinct claims
+
+### `only-head` · completion · method-call — 4 positions, 3 distinct
+
+- `Catalyst/ClassData.pm:53:21` `make_mutable`  (+1 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=161 top=[['initialize', 3], ['reinitialize', 3], ['_construct_class_instance', 3], ['_real_ref_name', 3]]`
+- `Catalyst/Test.pm:359:25` `new`
+  - base: `n=0 top=[]`
+  - head: `n=27 top=[['HAS_RESERVED_SQUARE_BRACKETS', 3], ['_obj_eq', 3], ['new', 3], ['new_abs', 3]]`
+- `Log/Log4perl/Config/BaseConfigurator.pm:22:15` `file`
+  - base: `n=0 top=[]`
+  - head: `n=10 top=[['_INTERNAL_DEBUG', 3], ['eval_if_perl', 3], ['compile_if_perl', 3], ['leaf_path_to_hash', 3]]`
+
+### `only-head` · completion · hash-key — 3 positions, 3 distinct
+
+- `Catalyst/Test.pm:286:35` `app`
+  - base: `n=0 top=[]`
+  - head: `n=13 top=[['request', 6], ['get', 6], ['ctx_request', 6], ['content_like', 6]]`
+- `PPI/Tokenizer.pm:541:89` `line_cursor`
+  - base: `n=0 top=[]`
+  - head: `n=8 top=[['source', 6], ['source_bytes', 6], ['document', 6], ['token', 6]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasOverloads.pm:72:27` `coderef_package`
+  - base: `n=0 top=[]`
+  - head: `n=200 top=[['_SET_FALLBACK_EACH_TIME', 3], ['_overload_for', 3], ['_overload_info', 3], ['_overload_info_for', 3]]`
+
+### `only-head` · definition · hash-key — 3 positions, 3 distinct
+
+- `Catalyst/Test.pm:286:32` `app`
+  - base: `[]`
+  - head: `[["Catalyst/Test.pm", [301, 8, 301, 11]]]`
+- `Mojo/Server/Prefork.pm:167:16` `finish`
+  - base: `[]`
+  - head: `[["Mojo/Server/Prefork.pm", [137, 12, 137, 18]]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:48:65` `class_name`
+  - base: `[]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Mixin.pm", [14, 0, 14, 0]]]`
+
+### `only-head` · hover · hash-key — 3 positions, 3 distinct
+
+- `Catalyst/Test.pm:286:32` `app`
+  - base: `∅`
+  - head: `len=91 '**Hash key `app`** - `app => ref($class) eq "CODE" ? $class : $class->_finalized_psgi_app,`'`
+- `Mojo/Server/Prefork.pm:167:16` `finish`
+  - base: `∅`
+  - head: `len=127 '**handler `finish`** on `Mojo::Server::Prefork` *1 registration stacks:* - **line 138:** `()` *Dispatch via:* `**->emit('`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:48:65` `class_name`
+  - base: `∅`
+  - head: `len=143 '```perl sub _throw_exception($class, $exception_type, @args_to_exception) ``` *class Class::MOP::Mixin::HasAttributes (f'`
+
+### `superset` · completion · package — 65 positions, 60 distinct
+
+- `Mojo/BaseUtil.pm:0:22` `Mojo::BaseUtil`  (+2 more positions answering identically)
+  - base: `n=67 top=[['Message::Request', 9], ['WebSocket', 9], ['UserAgent::CookieJar', 9], ['Cookie', 9]]`
+  - head: `n=70 top=[['Path', 9], ['Asset::Memory', 9], ['UserAgent::Transactor', 9], ['Template', 9]]`
+- `Dist/Zilla/Plugin/PkgDist.pm:0:36` `Dist::Zilla::Plugin::PkgDist`  (+1 more positions answering identically)
+  - base: `n=45 top=[['PodCoverageTests', 9], ['MetaNoIndex', 9], ['TestRelease', 9], ['RemovePrereqs', 9]]`
+  - head: `n=46 top=[['AutoPrereqs', 9], ['MetaYAML', 9], ['TestRelease', 9], ['GatherDir', 9]]`
+- `Email/MessageID.pm:2:24` `Email::MessageID`  (+1 more positions answering identically)
+  - base: `n=46 top=[['Abstract::MailMessage', 9], ['Sender::Simple', 9], ['Sender::Transport::SMTP', 9], ['MIME::Header::AddressList', 9]]`
+  - head: `n=47 top=[['Sender::Transport::DevNull', 9], ['Sender::Role::HasMessage', 9], ['MIME::ContentType', 9], ['MIME::Encodings', 9]]`
+- `URI/Escape.pm:0:19` `URI::Escape`  (+1 more positions answering identically)
+  - base: `n=67 top=[['ldap', 9], ['ssh', 9], ['file::Mac', 9], ['ftps', 9]]`
+  - head: `n=94 top=[['HAS_RESERVED_SQUARE_BRACKETS', 3], ['_obj_eq', 3], ['new', 3], ['new_abs', 3]]`
+- `Catalyst/ActionRole/Scheme.pm:0:36` `Catalyst::ActionRole::Scheme`
+  - base: `n=1 top=[['Scheme', 9]]`
+  - head: `n=4 top=[['HTTPMethods', 9], ['ConsumesContent', 9], ['QueryMatching', 9], ['Scheme', 9]]`
+- …and 55 more distinct claims
+
+### `superset` · completion · hash-key — 35 positions, 34 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array.pm:15:53` `argument`  (+1 more positions answering identically)
+  - base: `n=1 top=[['_inline_check_var_is_valid_index', 3]]`
+  - head: `n=200 top=[['_inline_check_var_is_valid_index', 3], ['Moose::Meta::Method::Accessor::Native::Array', 7], ['$Bin', 3], ['$Bzip2Error', 3]]`
+- `Config/MVP/Reader/Hash.pm:35:32` `key`
+  - base: `n=1 top=[['read_into_assembler', 3]]`
+  - head: `n=200 top=[['read_into_assembler', 3], ['Config::MVP::Reader::Hash', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:592:34` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/Argentina/Jujuy.pm:574:34` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/Argentina/Rio_Gallegos.pm:592:34` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- …and 29 more distinct claims
+
+### `superset` · completion · module-path — 27 positions, 24 distinct
+
+- `DateTime/TimeZone/America/Boa_Vista.pm:21:66` `Class::Singleton`  (+2 more positions answering identically)
+  - base: `n=2 top=[['Struct', 9], ['Tiny', 9]]`
+  - head: `n=35 top=[['MOP::MiniTrait', 9], ['Load', 9], ['MOP::Method::Generated', 9], ['MOP::Mixin::HasMethods', 9]]`
+- `Mojo/Server.pm:6:14` `Mojo::Util`  (+1 more positions answering identically)
+  - base: `n=1 top=[['Mojo::Util', 9]]`
+  - head: `n=2 top=[['Mojo::Util', 9], ['Mojo::Util::_Guard', 9]]`
+- `Config/MVP/Assembler.pm:65:35` `Config::MVP::Sequence`
+  - base: `n=1 top=[['Assembler', 9]]`
+  - head: `n=12 top=[['Reader::Hash', 9], ['Sequence', 9], ['Reader::Finder', 9], ['Reader::Findable', 9]]`
+- `Config/MVP/Reader/Hash.pm:4:28` `Config::MVP::Reader`
+  - base: `n=1 top=[['Reader::Hash', 9]]`
+  - head: `n=12 top=[['Reader::Hash', 9], ['Sequence', 9], ['Reader::Finder', 9], ['Reader::Findable', 9]]`
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:576:28` `DateTime::TimeZone::INFINITY`
+  - base: `n=1 top=[['America::Argentina::Cordoba', 9]]`
+  - head: `n=200 top=[['INFINITY', 3], ['IS_DST', 3], ['LOCAL_END', 3], ['LOCAL_START', 3]]`
+- …and 19 more distinct claims
+
+### `superset` · references · use-module — 17 positions, 17 distinct
+
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:4` `namespace::autoclean`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [13, 4, 13, 24]], ["…`
+  - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+- `DateTime/TimeZone/America/Manaus.pm:19:4` `DateTime::TimeZone::OlsonDB`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
+  - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
+- `DateTime/TimeZone/America/Rio_Branco.pm:13:4` `namespace::autoclean`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [13, 4, 13, 24]], ["…`
+  - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+- `DateTime/TimeZone/America/Sao_Paulo.pm:12:4` `warnings`
+  - base: `[["App/Cmd.pm", [4, 4, 4, 12]], ["App/Cmd/ArgProcessor.pm", [1, 4, 1, 12]], ["App/Cmd/Command.pm", [1, 4, 1, 12]], ["App/Cmd/Command/commands.pm", [1, 4, 1, 12]], ["App/Cmd/Command/help.pm", [1, 4, 1,…`
+  - head: `[["Apache/LogFormat/Compiler.pm", [3, 4, 3, 12]], ["App/Cmd.pm", [4, 4, 4, 12]], ["App/Cmd/ArgProcessor.pm", [1, 4, 1, 12]], ["App/Cmd/Command.pm", [1, 4, 1, 12]], ["App/Cmd/Command/commands.pm", [1, …`
+- `DateTime/TimeZone/Europe/Astrakhan.pm:19:4` `DateTime::TimeZone::OlsonDB`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
+  - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
+- …and 12 more distinct claims
+
+### `superset` · completion · variable — 9 positions, 9 distinct
+
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:592:44` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/Boa_Vista.pm:340:44` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/Rio_Branco.pm:322:44` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/America/Sao_Paulo.pm:862:44` `spans`
+  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
+- `DateTime/TimeZone/Europe/Budapest.pm:1393:44` `spans`
+  - base: `n=7 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
+  - head: `n=200 top=[['_last_observance', 3], ['_last_offset', 3], ['_max_year', 3], ['_new_instance', 3]]`
+- …and 4 more distinct claims
+
+### `superset` · completion · use-module — 8 positions, 7 distinct
+
+- `Plack/Middleware/HTTPExceptions.pm:6:13` `Try::Tiny`  (+1 more positions answering identically)
+  - base: `n=1 top=[['Try::Tiny', 9]]`
+  - head: `n=2 top=[['Try::Tiny', 9], ['Try::Tiny::ScopeGuard', 9]]`
+- `Catalyst/Request/PartData.pm:4:10` `Encode`
+  - base: `n=24 top=[['Encode::JP', 9], ['Encode::Guess', 9], ['Encode::MIME::Name', 9], ['Encode::Alias', 9]]`
+  - head: `n=25 top=[['Encode', 9], ['Encode::Locale', 9], ['Encode::MIME::Header::ISO_2022_JP', 9], ['Encode::CN', 9]]`
+- `LWP/Debug/TraceHTTP.pm:18:14` `Data::Dump`
+  - base: `n=5 top=[['Data::Dump', 9], ['Data::Dump::Filtered', 9], ['Data::Dump::FilterContext', 9], ['Data::Dump::Trace', 9]]`
+  - head: `n=7 top=[['Data::Dump::Filtered', 9], ['Data::Dump::Trace::Call', 9], ['Data::Dump::FilterContext', 9], ['Data::Dump::Trace::Wrapper', 9]]`
+- `Mojo/IOLoop/Subprocess.pm:3:10` `Config`
+  - base: `n=18 top=[['Config::MVP::Assembler::WithBundles', 9], ['Config::MVP::Assembler', 9], ['Config::MVP', 9], ['Config::INI', 9]]`
+  - head: `n=19 top=[['Config::MVP::Reader::Hash', 9], ['Config::MVP', 9], ['Config::MVP::Sequence', 9], ['Config::MVP::Reader::Finder', 9]]`
+- `Type/Params/Parameter.pm:206:35` `Storable`
+  - base: `n=25 top=[['_croak', 3], ['new', 3], ['name', 3], ['has_name', 3]]`
+  - head: `n=200 top=[['_all_aliases', 3], ['_code_for_default', 3], ['_croak', 3], ['_dont_validate_slurpy', 3]]`
+- …and 2 more distinct claims
+
+### `superset` · completion · call-site — 8 positions, 8 distinct
+
+- `Date/Language/Brazilian.pm:27:30` `_build_lookups`
+  - base: `n=1 top=[['Brazilian', 9]]`
+  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
+- `Date/Language/Finnish.pm:34:30` `_build_lookups`
+  - base: `n=1 top=[['Finnish', 9]]`
+  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
+- `PPI/Exception.pm:75:12` `caller`
+  - base: `n=4 top=[['new', 3], ['throw', 3], ['message', 3], ['callers', 3]]`
+  - head: `n=200 top=[['callers', 3], ['message', 3], ['new', 3], ['throw', 3]]`
+- `Plack/Handler/Apache2/Registry.pm:13:34` `load_app`
+  - base: `n=2 top=[['handler', 3], ['fixup_path', 3]]`
+  - head: `n=7 top=[['handler', 3], ['fixup_path', 3], ['new', 3], ['preload', 3]]`
+- `Type/Tiny/ConstrainedObject.pm:44:24` `Object`
+  - base: `n=6 top=[['HashRef', 9], ['Tied', 9], ['ArrayRef', 9], ['Tuple', 9]]`
+  - head: `n=45 top=[['_HAS_REFUTILXS', 3], ['_croak', 3], ['Stringable', 3], ['LazyLoad', 3]]`
+- …and 3 more distinct claims
+
+### `superset` · references · call-site — 5 positions, 5 distinct
+
+- `Config/MVP/Assembler.pm:134:22` `throw`
+  - base: `[["Config/MVP/Assembler.pm", [134, 22, 134, 27]], ["Config/MVP/Assembler.pm", [164, 22, 164, 27]], ["Config/MVP/Assembler.pm", [204, 22, 204, 27]]]`
+  - head: `[["Config/MVP/Assembler.pm", [134, 22, 134, 27]], ["Config/MVP/Assembler.pm", [164, 22, 164, 27]], ["Config/MVP/Assembler.pm", [204, 22, 204, 27]], ["Config/MVP/Reader/Finder.pm", [75, 22, 75, 27]], […`
+- `Path/Class/File.pm:187:16` `new`
+  - base: `[["Path/Class/File.pm", [13, 4, 13, 7]], ["Path/Class/File.pm", [187, 16, 187, 19]], ["Path/Class/File.pm", [195, 23, 195, 26]]]`
+  - head: `[["Catalyst.pm", [1296, 33, 1296, 36]], ["Catalyst.pm", [1298, 37, 1298, 40]], ["Catalyst.pm", [3417, 36, 3417, 39]], ["Catalyst.pm", [3583, 53, 3583, 56]], ["Path/Class.pm", [20, 30, 20, 33]], ["Path…`
+- `Plack/Handler/Apache2/Registry.pm:13:26` `load_app`
+  - base: `[["Plack/Handler/Apache2/Registry.pm", [13, 26, 13, 34]]]`
+  - head: `[["Plack/Handler/Apache2.pm", [23, 16, 23, 24]], ["Plack/Handler/Apache2.pm", [27, 4, 27, 12]], ["Plack/Handler/Apache2.pm", [125, 33, 125, 41]], ["Plack/Handler/Apache2/Registry.pm", [13, 26, 13, 34]…`
+- `URI/_ldap.pm:83:8` `uri_unescape`
+  - base: `[["URI/Escape.pm", [148, 28, 148, 40]], ["URI/Escape.pm", [215, 4, 215, 16]], ["URI/URL.pm", [18, 19, 18, 31]], ["URI/URL.pm", [121, 11, 121, 23]], ["URI/URL.pm", [146, 8, 146, 20]], ["URI/_emailauth.…`
+  - head: `[["Cookie/Baker.pm", [108, 28, 108, 40]], ["Cookie/Baker.pm", [113, 30, 113, 42]], ["HTTP/Message/PSGI.pm", [46, 42, 46, 54]], ["LWP/Protocol/http.pm", [97, 46, 97, 58]], ["LWP/Protocol/http.pm", [110…`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array/sort_in_place.pm:6:12` `Util`
+  - base: `[["Data/OptList.pm", [6, 4, 6, 16]], ["Email/Stuffer.pm", [167, 4, 167, 16]], ["File/ShareDir.pm", [482, 4, 482, 16]], ["Log/Dispatchouli.pm", [12, 4, 12, 16]], ["Log/Dispatchouli/Proxy.pm", [9, 4, 9,…`
+  - head: `[["Config/MVP/Assembler/WithBundles.pm", [5, 4, 5, 16]], ["Data/OptList.pm", [6, 4, 6, 16]], ["Dist/Zilla/Role/Plugin.pm", [8, 4, 8, 16]], ["Email/Stuffer.pm", [167, 4, 167, 16]], ["File/ShareDir.pm",…`
+
+### `superset` · references · module-path — 5 positions, 5 distinct
+
+- `DateTime/TimeZone/America/Argentina/Rio_Gallegos.pm:18:4` `DateTime::TimeZone`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [18, 4, 18, 22]], ["…`
+  - head: `[["DateTime/TimeZone.pm", [0, 8, 0, 26]], ["DateTime/TimeZone/Africa/Abidjan.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/Africa/Algiers.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/Africa/Bissau.pm", [18…`
+- `DateTime/TimeZone/America/Rio_Branco.pm:19:4` `DateTime::TimeZone::OlsonDB`
+  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
+  - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
+- `DateTime/TimeZone/Pacific/Kosrae.pm:13:4` `namespace::autoclean`
+  - base: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+  - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+- `Software/License/GFDL_1_3.pm:4:12` `Software::License`
+  - base: `[["Software/License.pm", [2, 8, 2, 25]], ["Software/License/AGPL_3.pm", [4, 12, 4, 29]], ["Software/License/Apache_1_1.pm", [4, 12, 4, 29]], ["Software/License/Apache_2_0.pm", [4, 12, 4, 29]], ["Softw…`
+  - head: `[["Dist/Zilla.pm", [19, 4, 19, 21]], ["Software/License.pm", [2, 8, 2, 25]], ["Software/License/AGPL_3.pm", [4, 12, 4, 29]], ["Software/License/Apache_1_1.pm", [4, 12, 4, 29]], ["Software/License/Apac…`
+- `Text/Unidecode/xa4.pm:1:1` `Text::Unidecode::Char`
+  - base: `[["Text/Unidecode/x19.pm", [1, 18, 1, 22]], ["Text/Unidecode/x1e.pm", [1, 18, 1, 22]], ["Text/Unidecode/x24.pm", [1, 18, 1, 22]], ["Text/Unidecode/x28.pm", [1, 18, 1, 22]], ["Text/Unidecode/x30.pm", […`
+  - head: `[["Text/Unidecode/x00.pm", [1, 18, 1, 22]], ["Text/Unidecode/x01.pm", [1, 18, 1, 22]], ["Text/Unidecode/x02.pm", [1, 18, 1, 22]], ["Text/Unidecode/x03.pm", [1, 18, 1, 22]], ["Text/Unidecode/x04.pm", […`
+
+### `superset` · completion · method-call — 3 positions, 3 distinct
+
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm:46:54` `_expected_method_class`
+  - base: `n=2 top=[['_uninlined_body', 3], ['can_be_inlined', 3]]`
+  - head: `n=31 top=[['_uninlined_body', 3], ['can_be_inlined', 3], ['new', 3], ['_initialize_body', 3]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Overload.pm:25:32` `_throw_exception`
+  - base: `n=19 top=[['new', 3], ['operator', 3], ['method_name', 3], ['has_method_name', 3]]`
+  - head: `n=31 top=[['new', 3], ['operator', 3], ['method_name', 3], ['has_method_name', 3]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Class/Immutable/Trait.pm:37:42` `name`
+  - base: `n=4 top=[['add_role', 3], ['calculate_all_roles', 3], ['calculate_all_roles_with_inheritance', 3], ['does_role', 3]]`
+  - head: `n=18 top=[['add_role', 3], ['calculate_all_roles', 3], ['calculate_all_roles_with_inheritance', 3], ['does_role', 3]]`
+
+### `capped-head` · completion · package — 16 positions, 1 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:0:61` `Moose::Exception::CannotAssignValueToReadOnlyAccessor`  (+15 more positions answering identically)
+  - base: `n=234 top=[['trace', 3], ['_build_trace', 3], ['message', 3], ['_build_message', 3]]`
+  - head: `n=200 top=[['BUILD', 3], ['_build_message', 3], ['_build_trace', 3], ['as_string', 3]]`
+
+### `capped-head` · completion · sub-decl — 5 positions, 5 distinct
+
+- `Email/Abstract/EmailSimple.pm:36:13` `as_string`
+  - base: `n=2546 top=[['target', 3], ['construct', 3], ['get_header', 3], ['get_body', 3]]`
+  - head: `n=200 top=[['as_string', 3], ['construct', 3], ['get_body', 3], ['get_header', 3]]`
+- `Email/Abstract/MIMEEntity.pm:8:16` `is_available`
+  - base: `n=2546 top=[['$is_avail', 6], ['is_available', 3], ['target', 3], ['construct', 3]]`
+  - head: `n=200 top=[['construct', 3], ['get_body', 3], ['is_available', 3], ['set_body', 3]]`
+- `Email/MessageID.pm:61:15` `create_host`
+  - base: `n=2547 top=[['$_SYS_HOSTNAME_LONG', 6], ['new', 3], ['create_host', 3], ['create_user', 3]]`
+  - head: `n=200 top=[['address', 3], ['as_string', 3], ['create_host', 3], ['create_user', 3]]`
+- `Email/Simple.pm:329:8` `crlf`
+  - base: `n=2555 top=[['$GROUCHY', 6], ['$CREATOR', 6], ['__crlf_re', 3], ['new', 3]]`
+  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
+- `HTTP/Message.pm:158:15` `add_content`
+  - base: `n=2580 top=[['$VERSION', 6], ['$MAXIMUM_BODY_SIZE', 6], ['$CRLF', 6], ['_utf8_downgrade', 3]]`
+  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
+
+### `capped-head` · completion · variable — 3 positions, 3 distinct
+
+- `Email/Abstract/MIMEEntity.pm:33:17` `obj`
+  - base: `n=2555 top=[['$class', 6], ['$obj', 6], ['$body', 6], ['$lines[]', 6]]`
+  - head: `n=200 top=[['construct', 3], ['get_body', 3], ['is_available', 3], ['set_body', 3]]`
+- `Email/Simple.pm:81:19` `mycrlf`
+  - base: `n=2560 top=[['$class', 6], ['$text', 6], ['$arg', 6], ['$text_ref', 6]]`
+  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
+- `HTTP/Message.pm:72:9` `hdr`
+  - base: `n=2587 top=[['$class', 6], ['$str', 6], ['$hdr[]', 6], ['$#hdr', 6]]`
+  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
+
+### `capped-head` · completion · use-module — 1 positions, 1 distinct
+
+- `Email/Sender/Failure/Permanent.pm:6:6` `Moo`
+  - base: `n=2540 top=[['Email::Sender::Failure::Permanent', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
+  - head: `n=200 top=[['Email::Sender::Failure::Permanent', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
+
+### `capped-head` · completion · hash-key — 1 positions, 1 distinct
+
+- `Email/Simple.pm:153:39` `Date`
+  - base: `n=2561 top=[['$class', 6], ['$args{}', 6], ['$headers', 6], ['$GROUCHY', 6]]`
+  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
+
+### `capped-head` · completion · call-site — 1 positions, 1 distinct
+
+- `HTTP/Message.pm:868:54` `rand`
+  - base: `n=2583 top=[['$size', 6], ['$b', 6], ['$VERSION', 6], ['$MAXIMUM_BODY_SIZE', 6]]`
+  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
+
+### `timeout-base` · completion · use-module — 1 positions, 1 distinct
+
+- `Date/Language/Sidama.pm:10:8` `base`
+  - base: `∅`
+  - head: `n=1 top=[['base', 9]]`
+
+### `timeout-base` · definition · use-module — 1 positions, 1 distinct
+
+- `Date/Language/Sidama.pm:10:4` `base`
+  - base: `∅`
+  - head: `[["<ext>/perl/5.38.2/base.pm", [1, 8, 1, 12]], ["<ext>/x86_64-linux-gnu/perl-base/base.pm", [1, 8, 1, 12]]]`
+
+### `timeout-base` · references · call-site — 1 positions, 1 distinct
+
+- `Date/Language/Sidama.pm:9:10` `Language`
+  - base: `∅`
+  - head: `[["Date/Format.pm", [21, 19, 21, 33]], ["Date/Format.pm", [21, 35, 21, 49]], ["Date/Language.pm", [1, 8, 1, 22]], ["Date/Language/Afar.pm", [9, 4, 9, 18]], ["Date/Language/Afar.pm", [10, 10, 10, 24]],…`
+
+### `timeout-base` · completion · call-site — 1 positions, 1 distinct
+
+- `PPI/Util.pm:37:45` `_SCALAR0`
+  - base: `∅`
+  - head: `n=200 top=[['FALSE', 3], ['HAVE_UNICODE', 3], ['TRUE', 3], ['_Document', 3]]`
+
+### `timeout-base` · definition · call-site — 1 positions, 1 distinct
+
+- `PPI/Util.pm:37:37` `_SCALAR0`
+  - base: `∅`
+  - head: `[["x86_64-linux-gnu-thread-multi/Params/Util.pm", [85, 0, 85, 0]]]`
+
+### `timeout-base` · references · method-call — 1 positions, 1 distinct
+
+- `PPI/Util.pm:36:23` `new`
+  - base: `∅`
+  - head: `[["Dist/Zilla/Plugin/PkgDist.pm", [86, 34, 86, 37]], ["Dist/Zilla/Role/PPI.pm", [42, 32, 42, 35]], ["PPI/Document.pm", [190, 4, 190, 7]], ["PPI/Document/File.pm", [49, 4, 49, 7]], ["PPI/Document/File.…`
+
+### `timeout-base` · completion · sub-decl — 1 positions, 1 distinct
+
+- `YAML/PP/Representer.pm:46:25` `preserve_scalar_style`
+  - base: `∅`
+  - head: `n=200 top=[['_represent_node_nonref', 3], ['_represent_noderef', 3], ['clone', 3], ['new', 3]]`
+
+### `timeout-base` · definition · sub-decl — 1 positions, 1 distinct
+
+- `YAML/PP/Representer.pm:46:4` `preserve_scalar_style`
+  - base: `∅`
+  - head: `[["YAML/PP/Representer.pm", [46, 4, 46, 25]]]`
+
+### `timeout-base` · references · package — 1 positions, 1 distinct
+
+- `YAML/PP/Representer.pm:2:8` `YAML::PP::Representer`
+  - base: `∅`
+  - head: `[["YAML/PP/Dumper.pm", [9, 4, 9, 25]], ["YAML/PP/Dumper.pm", [46, 23, 46, 44]], ["YAML/PP/Representer.pm", [2, 8, 2, 29]]]`
+
+### `timeout-base` · completion · method-call — 1 positions, 1 distinct
+
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:23:36` `name`
+  - base: `∅`
+  - head: `n=6 top=[['add_attribute', 3], ['has_attribute', 3], ['get_attribute', 3], ['remove_attribute', 3]]`
+
+### `timeout-base` · definition · method-call — 1 positions, 1 distinct
+
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:23:32` `name`
+  - base: `∅`
+  - head: `[]`
+
+### `timeout-base` · references · use-module — 1 positions, 1 distinct
+
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:6:4` `Scalar::Util`
+  - base: `∅`
+  - head: `[["B/Hooks/EndOfScope/PP/HintHash.pm", [12, 4, 12, 16]], ["Capture/Tiny.pm", [11, 4, 11, 16]], ["Catalyst.pm", [53, 4, 53, 16]], ["Catalyst/Action.pm", [22, 4, 22, 16]], ["Catalyst/Component.pm", [10,…`

--- a/bench/sweep/run.sh
+++ b/bench/sweep/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# One differential sweep, end to end.
+#
+#   bench/sweep/run.sh <base-binary> <head-binary> <corpus-root> <out-dir> [extra args...]
+#
+# The two sides run CONCURRENTLY. They contend for CPU, so nothing here is a
+# timing measurement — this compares ANSWERS, and `bench/lsp_bench.py` is
+# what measures latency. Run them serially (SWEEP_SERIAL=1) if the box is
+# small enough that contention could cause timeouts rather than just slowness.
+set -euo pipefail
+
+BASE_BIN=${1:?base binary}; HEAD_BIN=${2:?head binary}
+ROOT=${3:?corpus root};     OUT=${4:?output dir}; shift 4
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+mkdir -p "$OUT"
+
+: "${SWEEP_PER_FILE:=8}" "${SWEEP_MAX_FILES:=700}" "${SWEEP_SEED:=v1}"
+: "${SWEEP_TIMEOUT:=15}" "${SWEEP_READY_TIMEOUT:=300}"
+
+python3 "$HERE/selftest.py"
+
+python3 "$HERE/sweep.py" positions --root "$ROOT" --out "$OUT/positions.jsonl" \
+  --per-file "$SWEEP_PER_FILE" --max-files "$SWEEP_MAX_FILES" --seed "$SWEEP_SEED"
+
+run_side() {  # side, binary
+  python3 "$HERE/sweep.py" run --bin "$2" --root "$ROOT" \
+    --positions "$OUT/positions.jsonl" --out "$OUT/answers-$1.jsonl" --side "$1" \
+    --cache-dir "$OUT/cache-$1" --timeout "$SWEEP_TIMEOUT" \
+    --ready-timeout "$SWEEP_READY_TIMEOUT" "$@:3" 2>&1 | sed "s/^/[$1] /"
+}
+
+if [ "${SWEEP_SERIAL:-0}" = 1 ]; then
+  run_side base "$BASE_BIN"
+  run_side head "$HEAD_BIN"
+else
+  run_side base "$BASE_BIN" & b=$!
+  run_side head "$HEAD_BIN" & h=$!
+  wait $b; wait $h
+fi
+
+python3 "$HERE/sweep.py" diff --base "$OUT/answers-base.jsonl" \
+  --head "$OUT/answers-head.jsonl" --out "$OUT/report.md"
+echo "report: $OUT/report.md"

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -136,6 +136,25 @@ check("an untruncated smaller list is still a subset",
       cls("completion", big_base, uncapped_head), "subset")
 
 
+# The recheck pass must SUPERSEDE the cold answer, or the sweep measures
+# startup rather than the branch. Written as an appended row, applied on load.
+import io, json as _json, tempfile as _tf
+_p = _tf.NamedTemporaryFile("w", suffix=".jsonl", delete=False)
+_p.write(_json.dumps({"_meta": {"side": "t"}}) + "\n")
+_p.write(_json.dumps({"file": "a.pm", "line": 1, "char": 2, "verb": "definition",
+                      "norm": [], "ms": 1}) + "\n")
+_p.write(_json.dumps({"_recheck": True, "file": "a.pm", "line": 1, "char": 2,
+                      "verb": "definition", "norm": [["lib/X.pm", [0, 0, 0, 1]]],
+                      "ms": 1}) + "\n")
+_p.close()
+_meta, _rows = S._load(_p.name)
+_row = _rows[("a.pm", 1, 2, "definition")]
+check("a warm recheck supersedes the cold empty answer",
+      (_row["norm"], _row.get("filled_when_warm")),
+      ([["lib/X.pm", [0, 0, 0, 1]]], True))
+os.unlink(_p.name)
+
+
 # --- position selection -----------------------------------------------------
 
 check("selection is deterministic across processes — hash() is salted, "

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -123,6 +123,19 @@ check("a one-sided protocol error is its own shape",
       "error-base")
 
 
+# A truncated list is a strict subset of an untruncated one BY DESIGN. This
+# is the rule that turned 221 "regression candidates" into one intended
+# change on the first corpus run.
+cap_head = {"n": 1, "labels": [["x", 3]], "top": [["x", 3]], "incomplete": True}
+big_base = {"n": 2, "labels": [["x", 3], ["y", 3]], "top": [["x", 3]], "incomplete": False}
+check("a truncated head list is capped, not a lost candidate",
+      cls("completion", big_base, cap_head), "capped-head")
+# ...but a smaller list that does NOT claim truncation is still a real subset.
+uncapped_head = dict(cap_head, incomplete=False)
+check("an untruncated smaller list is still a subset",
+      cls("completion", big_base, uncapped_head), "subset")
+
+
 # --- position selection -----------------------------------------------------
 
 check("selection is deterministic across processes — hash() is salted, "

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Self-test for the sweep's classification and normalisation.
+
+The sweep's own bug class is a WRONG REPORT, which looks exactly like a
+right one — a normalisation that folds two different answers together hides
+a regression, and one that splits two identical answers invents a hundred.
+Neither is visible by reading the output. These cases pin the rules that
+decide it.
+
+Run: python3 bench/sweep/selftest.py
+"""
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import normalize as N
+import positions as P
+
+FAILED = []
+
+
+def check(name, got, want):
+    if got != want:
+        FAILED.append(f"{name}\n    got  {got!r}\n    want {want!r}")
+
+
+def loc(uri, l, c):
+    return {"uri": uri, "range": {"start": {"line": l, "character": c},
+                                  "end": {"line": l, "character": c + 3}}}
+
+
+# --- normalisation ----------------------------------------------------------
+
+# Two checkouts have different absolute roots. A URI difference is never a
+# finding, and if it were not normalised EVERY position would diverge.
+check("root-relative URIs compare equal",
+      N.locations([loc("file:///a/root/lib/X.pm", 1, 2)], "file:///a/root"),
+      N.locations([loc("file:///b/other/lib/X.pm", 1, 2)], "file:///b/other"))
+
+# An answer that escaped the workspace must NOT normalise into looking local
+# — that is exactly the kind of thing the sweep exists to catch.
+check("outside-root answers stay marked",
+      N.locations([loc("file:///usr/share/perl5/Foo.pm", 0, 0)], "file:///a/root")[0][0],
+      "<ext>/share/perl5/Foo.pm")
+
+# LSP lets a server answer Location, Location[] or LocationLink[] for the
+# same fact. Comparing shapes instead of facts would report every position
+# as divergent when one side switched encoding.
+check("LocationLink folds to the same shape as Location",
+      N.locations({"targetUri": "file:///r/lib/X.pm",
+                   "targetSelectionRange": {"start": {"line": 1, "character": 2},
+                                            "end": {"line": 1, "character": 5}}},
+                  "file:///r"),
+      N.locations([loc("file:///r/lib/X.pm", 1, 2)], "file:///r"))
+
+# Order is not semantic for locations...
+check("location order is not a divergence",
+      N.locations([loc("file:///r/a.pm", 1, 1), loc("file:///r/b.pm", 2, 2)], "file:///r"),
+      N.locations([loc("file:///r/b.pm", 2, 2), loc("file:///r/a.pm", 1, 1)], "file:///r"))
+
+# ...but it IS for completion, where order is the ranking the user sees.
+a = N.completion({"items": [{"label": "x", "kind": 3}, {"label": "y", "kind": 3}]})
+b = N.completion({"items": [{"label": "y", "kind": 3}, {"label": "x", "kind": 3}]})
+check("completion set is order-insensitive", a["labels"], b["labels"])
+check("completion ranking is order-SENSITIVE", a["top"] != b["top"], True)
+
+# A label that changed KIND is a different answer (a sub became a field).
+check("completion kind participates in identity",
+      N.completion({"items": [{"label": "x", "kind": 3}]})["labels"]
+      != N.completion({"items": [{"label": "x", "kind": 5}]})["labels"], True)
+
+# Hover carries absolute paths inside its markdown body, so the
+# environmental rule has to reach inside the text too.
+h1 = N.hover({"contents": {"value": "sub f — /home/alice/proj/lib/A.pm"}}, "file:///x")
+h2 = N.hover({"contents": {"value": "sub f — /var/lib/other/deep/A.pm"}}, "file:///x")
+check("hover paths normalise out", h1["sha"], h2["sha"])
+
+# documentSymbol: a symbol that MOVED in the hierarchy diverges, a
+# reordering of siblings does not.
+tree = lambda kids: [{"name": "Pkg", "kind": 2, "children": kids}]
+k1, k2 = {"name": "a", "kind": 6}, {"name": "b", "kind": 6}
+check("sibling order is not a divergence",
+      N.symbols(tree([k1, k2]), ""), N.symbols(tree([k2, k1]), ""))
+check("a moved symbol IS a divergence",
+      N.symbols(tree([k1]), "") != N.symbols([k1], ""), True)
+
+
+# --- classification ---------------------------------------------------------
+
+sys.argv = ["sweep"]
+import sweep as S
+
+def cls(verb, base, head):
+    return S.classify(verb, {"norm": base}, {"norm": head})
+
+L = lambda *n: [["lib/A.pm", [i, 0, i, 1]] for i in n]
+
+check("identical answers are `same`", cls("definition", L(1), L(1)), "same")
+check("base answered, head did not", cls("definition", L(1), []), "only-base")
+check("head answered, base did not", cls("definition", [], L(1)), "only-head")
+check("head found strictly more", cls("definition", L(1), L(1, 2)), "superset")
+check("head found strictly fewer", cls("definition", L(1, 2), L(1)), "subset")
+check("neither contains the other", cls("definition", L(1, 2), L(2, 3)), "disagree")
+
+# A timeout is NOT an empty answer. Folding them makes a slower side look
+# like it lost resolutions — the single most misleading thing this can say.
+check("a head timeout is not a lost answer",
+      S.classify("definition", {"norm": L(1)}, {"norm": None, "timeout": True}),
+      "timeout-head")
+check("a base timeout is its own shape",
+      S.classify("definition", {"norm": None, "timeout": True}, {"norm": L(1)}),
+      "timeout-base")
+
+# Same candidates, different order: a ranking regression must not hide
+# behind an unchanged candidate set.
+r1 = {"n": 2, "labels": [["x", 3], ["y", 3]], "top": [["x", 3], ["y", 3]]}
+r2 = {"n": 2, "labels": [["x", 3], ["y", 3]], "top": [["y", 3], ["x", 3]]}
+check("a pure re-rank is reported, not swallowed", cls("completion", r1, r2), "reranked")
+
+# An unimplemented verb is a capability gap, and classify must not dress it
+# up as a lost answer — the diff subtracts it before counting.
+check("a one-sided protocol error is its own shape",
+      S.classify("definition", {"norm": None, "err": "Method not found"}, {"norm": L(1)}),
+      "error-base")
+
+
+# --- position selection -----------------------------------------------------
+
+check("selection is deterministic across processes — hash() is salted, "
+      "and a salted sample would give the two sides different questions",
+      P.stable_frac("seed", "f.pm", 1, 2, "k"),
+      P.stable_frac("seed", "f.pm", 1, 2, "k"))
+
+src = "package P;\n=pod\nsub in_pod {}\n=cut\nsub real {}\n# sub in_comment {}\n"
+kinds = {(t["kind"], t["name"]) for t in P.tokens_in(src)}
+check("POD bodies are not sampled", ("sub-decl", "in_pod") in kinds, False)
+check("comments are not sampled", ("sub-decl", "in_comment") in kinds, False)
+check("real declarations are sampled", ("sub-decl", "real") in kinds, True)
+
+# Blanking must preserve coordinates: a sweep that shifted positions would
+# ask the two sides the same question at two different places.
+lines = P.strip_noncode("=pod\nxx\n=cut\nsub real {}\n").split("\n")
+check("stripping preserves line numbering", lines[3], "sub real {}")
+
+if FAILED:
+    print(f"FAIL ({len(FAILED)})")
+    for f in FAILED:
+        print("  " + f)
+    sys.exit(1)
+print("sweep selftest: all checks pass")

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -141,32 +141,38 @@ def cmd_run(args):
     # and one unlucky pick would stall the whole run at the timeout.
     probes = [p for p in pos if p["kind"] in ("use-module", "module-path")][:8] \
              or pos[:8]
-    first, ready, ready_ms = None, None, None
-    deadline = time.monotonic() + args.ready_timeout
-    while time.monotonic() < deadline and ready_ms is None:
-        for pr in probes:
-            uri = _open(lsp, root, pr["file"])
-            if uri is None:
-                continue
-            msg, _ = lsp.request("textDocument/definition", {
-                "textDocument": {"uri": uri},
-                "position": {"line": pr["line"], "character": pr["char_on"]}},
-                timeout=120)
-            locs = N.locations((msg or {}).get("result"), root_uri)
-            here = os.path.relpath(os.path.join(root, pr["file"]), root)
-            if any(u and u != here for (u, _) in locs):
-                first, ready = pr["file"], uri
-                ready_ms = (time.monotonic() - t_spawn) * 1000
-                break
-        if ready_ms is None:
+
+    def await_cross_file(client, budget):
+        """Block until a definition lands in a DIFFERENT file, or the budget
+        runs out. Returns (probe_file, uri, elapsed_ms | None)."""
+        t = time.monotonic()
+        end = t + budget
+        while time.monotonic() < end:
+            for pr in probes:
+                uri = _open(client, root, pr["file"])
+                if uri is None:
+                    continue
+                msg, _ = client.request("textDocument/definition", {
+                    "textDocument": {"uri": uri},
+                    "position": {"line": pr["line"], "character": pr["char_on"]}},
+                    timeout=120)
+                locs = N.locations((msg or {}).get("result"), root_uri)
+                here = os.path.relpath(os.path.join(root, pr["file"]), root)
+                if any(u and u != here for (u, _) in locs):
+                    return pr["file"], uri, (time.monotonic() - t) * 1000
             time.sleep(1.0)
-    if ready_ms is None:
+        return None, None, None
+
+    first, ready, ready_ms = await_cross_file(lsp, args.ready_timeout)
+    if ready_ms is not None:
+        ready_ms = (time.monotonic() - t_spawn) * 1000
+    else:
         first = pos[0]["file"]
         ready = _open(lsp, root, first)
         print(f"[{args.side}] WARNING: no cross-file definition resolved in "
               f"{args.ready_timeout}s — sweeping anyway, and the report will "
               f"say this side was never confirmed workspace-ready", flush=True)
-    else:
+    if ready_ms is not None:
         print(f"[{args.side}] cross-file ready after {round(ready_ms)}ms", flush=True)
 
     opened, done = {first: ready}, 0
@@ -265,6 +271,20 @@ def cmd_run(args):
                                 timeout=300)
                             lsp.notify("initialized", {})
                             opened.clear()
+                            # A respawned server is COLD. Sweeping on before
+                            # it re-warms records its unresolved cross-file
+                            # answers as lost resolutions -- the same trap
+                            # the initial gate exists to close, and easier to
+                            # miss here because the run is already underway.
+                            _, _, warm_ms = await_cross_file(lsp, args.ready_timeout)
+                            fh.write(json.dumps({"_event": "restart-rewarm",
+                                "restart": restarts[0],
+                                "cross_file_ready_ms": warm_ms and round(warm_ms),
+                                "confirmed": warm_ms is not None}) + "\n")
+                            if warm_ms is None:
+                                print(f"[{args.side}] WARNING: restart "
+                                      f"#{restarts[0]} never re-reached "
+                                      f"cross-file readiness", flush=True)
                             uri = _open(lsp, root, rel)
                             opened[rel] = uri
                             wedge[0] = 0

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -188,6 +188,7 @@ def cmd_run(args):
     # Lists, not ints: the loop rebinds `lsp` on restart and these have to
     # survive that without a nonlocal dance in a nested scope.
     wedge, restarts = [0], [0]
+    deferred = []
     t0 = time.monotonic()
     with open(args.out, "w") as fh:
         fh.write(json.dumps({"_meta": {
@@ -237,29 +238,27 @@ def cmd_run(args):
                         rec["norm"] = None
                     else:
                         rec["norm"] = N.normalize(verb, msg.get("result"), root_uri)
-                    # An empty answer is asked TWICE. The @INC tier resolves
-                    # per-module, on demand, on a background thread, so the
-                    # first goto-def on `use Storable` can legitimately answer
-                    # empty and the second answer the file — the workspace
-                    # readiness gate cannot cover this, because the module was
-                    # never in the workspace. Verified by hand: the sweep
-                    # recorded head as empty on `use Storable` while the CLI,
-                    # which starts synchronously, resolves it.
+                    # Every empty answer is re-asked, but at the END of the
+                    # run rather than here. The @INC tier resolves per module,
+                    # on demand, on a background thread, so the first goto-def
+                    # on `use App::Cmd::Command` can answer empty and a later
+                    # one answer the file — the workspace readiness gate
+                    # cannot cover that, because the module was never in the
+                    # workspace. Verified by hand twice: the sweep recorded
+                    # head empty on `use Storable` and on
+                    # `use App::Cmd::Command` where the CLI, which starts
+                    # synchronously, resolves both.
                     #
-                    # Without the retry that timing shows up as `only-base` and
-                    # reads as a lost resolution. The retry is in the RUNNER so
-                    # both sides get it by construction; a side-specific one
-                    # would be worse than none.
-                    if args.empty_retry_ms > 0 and not rec.get("timeout") \
-                            and not rec.get("err") \
+                    # An inline sleep-and-retry was the obvious fix and it was
+                    # the wrong one: at 400 ms it filled ZERO of head's empties
+                    # while taking the run from 51 s to 1,024 s. Too short to
+                    # help, and paid on every empty answer. Deferring costs one
+                    # extra request with no sleep, and asks it of the warmest
+                    # server the run ever has — strictly better evidence.
+                    if not rec.get("timeout") and not rec.get("err") \
                             and N.is_empty(verb, rec["norm"]):
-                        time.sleep(args.empty_retry_ms / 1000.0)
-                        msg2, _ = lsp.request(method, params, timeout=args.timeout)
-                        if msg2 is not None and not _err(msg2):
-                            n2 = N.normalize(verb, msg2.get("result"), root_uri)
-                            if not N.is_empty(verb, n2):
-                                rec["norm"] = n2
-                                rec["filled_on_retry"] = True
+                        deferred.append((rel, p["line"], ch, verb, method,
+                                         dict(params), p["kind"], p["name"]))
                     fh.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
                     # A server that stops answering ENTIRELY is the failure
                     # mode that quietly ruins a long run: every remaining
@@ -328,6 +327,28 @@ def cmd_run(args):
                     el = time.monotonic() - t0
                     print(f"[{args.side}] {done}/{len(pos)} positions  {el:.0f}s "
                           f"({done/max(el,1e-9):.1f}/s)", flush=True)
+        # Second pass. Recheck rows are APPENDED, not rewritten in place, so
+        # the stream stays crash-resilient and both answers survive: the
+        # report can say a position was empty on first ask and resolved once
+        # warm, which is a fact about startup, not about the branch.
+        filled = 0
+        for (rel, ln, ch, verb, method, params, kind, name) in deferred:
+            msg, ms = lsp.request(method, params, timeout=args.timeout)
+            if msg is None or _err(msg):
+                continue
+            norm = N.normalize(verb, msg.get("result"), root_uri)
+            if N.is_empty(verb, norm):
+                continue
+            filled += 1
+            fh.write(json.dumps({"_recheck": True, "file": rel, "line": ln,
+                                 "char": ch, "verb": verb, "kind": kind,
+                                 "name": name, "ms": round(ms, 1),
+                                 "norm": norm}, sort_keys=True, default=str) + "\n")
+        fh.write(json.dumps({"_event": "recheck",
+                             "empty_first_ask": len(deferred),
+                             "filled_when_warm": filled}) + "\n")
+        print(f"[{args.side}] recheck: {filled} of {len(deferred)} empty answers "
+              f"resolved once warm", flush=True)
     lsp.shutdown()
     print(f"[{args.side}] done: {done} positions in "
           f"{time.monotonic()-t0:.0f}s -> {args.out}")
@@ -395,6 +416,14 @@ def _load(path):
             events.append(r)
             continue
         key = (r["file"], r.get("line"), r.get("char"), r["verb"])
+        if r.get("_recheck"):
+            # A warm answer supersedes a cold empty one. Both are in the file;
+            # this is the choice of which the comparison uses, and it must be
+            # the warm one on BOTH sides or the sweep measures startup.
+            if key in rows:
+                rows[key] = dict(rows[key], norm=r["norm"],
+                                 filled_when_warm=True)
+            continue
         rows[key] = r
     meta["events"] = events
     return meta, rows
@@ -713,10 +742,6 @@ def main():
     p.add_argument("--cache-dir", required=True)
     p.add_argument("--timeout", type=float, default=30.0)
     p.add_argument("--ready-timeout", type=float, default=600.0)
-    p.add_argument("--empty-retry-ms", type=float, default=400.0,
-                   help="re-ask once after this delay when an answer is empty; "
-                        "0 disables. Covers the on-demand @INC tier, which "
-                        "resolves per module after the first miss.")
     p.add_argument("--rewarm-timeout", type=float, default=60.0,
                    help="budget for re-reaching cross-file readiness after a restart")
     p.add_argument("--wedge-after", type=int, default=3,

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""sweep.py -- differential answer sweep for perl-lsp.
+
+Three independent steps, so a long corpus run can be resumed or re-diffed
+without re-running the expensive half:
+
+  positions  corpus  -> positions.jsonl      (binary-independent)
+  run        binary  -> answers-<side>.jsonl (one warm server, thousands of queries)
+  diff       two answer files -> a grouped divergence report
+
+THE SERVER PATH, DELIBERATELY. The CLI and the server answer differently for
+the same query -- 284,617 vs 193,725 bytes on Koha `references` -- because
+they reach different readiness states, and neither is wrong. Mixing them
+produces a divergence list that is mostly harness. This drives real LSP over
+stdio, like an editor, and the report says so.
+
+Two traps this handles, both of which silently corrupt a comparison:
+
+  * CACHE COLLISION. Both sides key `~/.cache/perl-lsp` off the workspace
+    path, and their `EXTRACT_VERSION` / plugin fingerprints differ, so
+    sharing a cache dir makes each side hard-clear the other's on every
+    startup. Each side gets its own XDG_CACHE_HOME.
+  * TIMEOUTS AS EMPTY. A request that times out is recorded as `timeout`,
+    never as an empty answer. Folding the two together makes a slower side
+    look like it lost answers -- the single most misleading thing a
+    differential sweep can report.
+"""
+import argparse, json, os, pathlib, subprocess, sys, time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import positions as P
+import normalize as N
+# The protocol client is the benchmark driver's, imported rather than copied:
+# its fidelity (answering server->client requests, omitting null `params`)
+# was bought with real debugging, and a second copy would drift from it.
+from lsp_bench import Lsp
+
+VERBS = {
+    "definition":     ("textDocument/definition",     "on"),
+    "typeDefinition": ("textDocument/typeDefinition", "on"),
+    "hover":          ("textDocument/hover",          "on"),
+    "references":     ("textDocument/references",     "on"),
+    # Completion runs AFTER the token -- the "I just typed this name" slot,
+    # which exercises prefix filtering. At `->|` the token start and the
+    # member slot coincide, so method-call positions cover both shapes.
+    "completion":     ("textDocument/completion",     "after"),
+}
+# Per-verb sample rate. `references` fans out across the whole workspace and
+# is the one verb that can cost seconds per position, so it is sampled rather
+# than exhaustive -- the coordinator's call, and the report states the rate.
+VERB_RATE = {"references": 0.10}
+
+
+def cmd_positions(args):
+    root = os.path.abspath(args.root)
+    files = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in (".git", "blib", "t", ".build")]
+        # `auto/share` is installed DATA, not source — DateTime-Locale alone
+        # ships hundreds of generated files that are one enormous hash
+        # literal. They sample as thousands of hash-key positions that all
+        # produce the identical workspace-global completion list, which is
+        # one fact repeated, not coverage.
+        if os.sep + os.path.join("auto", "share") in os.path.join(dirpath, "x"):
+            dirnames[:] = []
+            continue
+        for fn in filenames:
+            if fn.endswith((".pm", ".pl", ".t")):
+                files.append(os.path.relpath(os.path.join(dirpath, fn), root))
+    files.sort()
+    if args.max_files and len(files) > args.max_files:
+        files.sort(key=lambda f: P.stable_frac(args.seed, "file", f))
+        files = sorted(files[:args.max_files])
+    n = 0
+    with open(args.out, "w") as fh:
+        for rel in files:
+            try:
+                text = open(os.path.join(root, rel), encoding="utf8", errors="replace").read()
+            except OSError:
+                continue
+            for t in P.select(rel, text, args.per_file, args.seed):
+                fh.write(json.dumps(t, sort_keys=True) + "\n")
+                n += 1
+    print(f"positions: {n} over {len(files)} files (seed={args.seed}, "
+          f"per_file={args.per_file})")
+
+
+def cmd_run(args):
+    root = os.path.abspath(args.root)
+    root_uri = pathlib.Path(root).as_uri()
+    pos = [json.loads(l) for l in open(args.positions)]
+
+    cache = os.path.abspath(args.cache_dir)
+    os.makedirs(cache, exist_ok=True)
+
+    def spawn():
+        env = dict(os.environ)
+        env["XDG_CACHE_HOME"] = cache
+        # A residency panic would abort the sweep mid-corpus; here it is a
+        # per-position datum instead, so the run completes and the report can
+        # say which positions crashed which side.
+        env.setdefault("PERL_LSP_STRICT_RESIDENCY", "0")
+        keep = os.environ.copy()
+        os.environ.update(env)
+        try:
+            return Lsp(os.path.abspath(args.bin), root, args.out + ".stderr")
+        finally:
+            os.environ.clear(); os.environ.update(keep)
+
+    lsp = spawn()
+
+    t_spawn = time.monotonic()
+    init, _ = lsp.request("initialize", {
+        "processId": os.getpid(),
+        "rootUri": root_uri,
+        "capabilities": {"textDocument": {"publishDiagnostics": {},
+                                          "completion": {"completionItem": {}}}},
+    }, timeout=300)
+    lsp.notify("initialized", {})
+    # A verb one side does not IMPLEMENT is a capability difference, not a
+    # divergence, and conflating them buries the report: the base here does
+    # not serve typeDefinition, which alone produced an `error-base` on every
+    # single position. Capabilities are recorded per side and the diff
+    # subtracts the asymmetry into its own section.
+    caps = ((init or {}).get("result") or {}).get("capabilities") or {}
+    served = sorted(v for v in VERBS if _serves(caps, v))
+
+    # Readiness, and it has to be a CROSS-FILE gate. The workspace index is
+    # lazy -- it starts on the first didOpen -- so a probe that merely
+    # returns non-empty proves nothing: goto-def on a local `sub` answers
+    # from the open document alone, instantly, with no index at all.
+    # Measured here: the base binary passed a non-empty probe in 12 ms while
+    # the head took 1,309 ms, and treating that as "both ready" would have
+    # swept the base cold and reported its every unresolved cross-file
+    # answer as a regression. The gate therefore requires a definition that
+    # lands in a DIFFERENT FILE.
+    #
+    # Several candidate probes are tried in turn, because any single
+    # `use Foo` may legitimately have no resolvable target in this corpus,
+    # and one unlucky pick would stall the whole run at the timeout.
+    probes = [p for p in pos if p["kind"] in ("use-module", "module-path")][:8] \
+             or pos[:8]
+    first, ready, ready_ms = None, None, None
+    deadline = time.monotonic() + args.ready_timeout
+    while time.monotonic() < deadline and ready_ms is None:
+        for pr in probes:
+            uri = _open(lsp, root, pr["file"])
+            if uri is None:
+                continue
+            msg, _ = lsp.request("textDocument/definition", {
+                "textDocument": {"uri": uri},
+                "position": {"line": pr["line"], "character": pr["char_on"]}},
+                timeout=120)
+            locs = N.locations((msg or {}).get("result"), root_uri)
+            here = os.path.relpath(os.path.join(root, pr["file"]), root)
+            if any(u and u != here for (u, _) in locs):
+                first, ready = pr["file"], uri
+                ready_ms = (time.monotonic() - t_spawn) * 1000
+                break
+        if ready_ms is None:
+            time.sleep(1.0)
+    if ready_ms is None:
+        first = pos[0]["file"]
+        ready = _open(lsp, root, first)
+        print(f"[{args.side}] WARNING: no cross-file definition resolved in "
+              f"{args.ready_timeout}s — sweeping anyway, and the report will "
+              f"say this side was never confirmed workspace-ready", flush=True)
+    else:
+        print(f"[{args.side}] cross-file ready after {round(ready_ms)}ms", flush=True)
+
+    opened, done = {first: ready}, 0
+    # Lists, not ints: the loop rebinds `lsp` on restart and these have to
+    # survive that without a nonlocal dance in a nested scope.
+    wedge, restarts = [0], [0]
+    t0 = time.monotonic()
+    with open(args.out, "w") as fh:
+        fh.write(json.dumps({"_meta": {
+            "side": args.side, "bin": os.path.abspath(args.bin), "root": root,
+            "root_uri": root_uri, "ready_ms": ready_ms and round(ready_ms),
+            "cross_file_ready": ready_ms is not None, "verbs": served,
+            "unserved": sorted(set(VERBS) - set(served)),
+            "verb_rate": VERB_RATE, "positions": len(pos),
+            "version": _version(args.bin),
+        }}) + "\n")
+        by_file = {}
+        for p in pos:
+            by_file.setdefault(p["file"], []).append(p)
+        for rel, group in by_file.items():
+            uri = opened.get(rel) or _open(lsp, root, rel)
+            if uri is None:
+                continue
+            opened[rel] = uri
+            # documentSymbol is per FILE, not per position -- the cheapest
+            # structural signal in the sweep and worth taking on every file.
+            msg, ms = lsp.request("textDocument/documentSymbol",
+                                  {"textDocument": {"uri": uri}}, timeout=args.timeout)
+            fh.write(json.dumps({
+                "file": rel, "kind": "file", "verb": "documentSymbol",
+                "ms": round(ms, 1),
+                "norm": N.normalize("documentSymbol", (msg or {}).get("result"), root_uri),
+                "err": _err(msg),
+            }, sort_keys=True, default=str) + "\n")
+            for p in group:
+                for verb in served:
+                    method, anchor = VERBS[verb]
+                    rate = VERB_RATE.get(verb, 1.0)
+                    if rate < 1.0 and P.stable_frac(
+                            "verb", verb, rel, p["line"], p["char_on"]) >= rate:
+                        continue
+                    ch = p["char_on"] if anchor == "on" else p["char_after"]
+                    params = {"textDocument": {"uri": uri},
+                              "position": {"line": p["line"], "character": ch}}
+                    if verb == "references":
+                        params["context"] = {"includeDeclaration": True}
+                    msg, ms = lsp.request(method, params, timeout=args.timeout)
+                    rec = {"file": rel, "line": p["line"], "char": ch,
+                           "kind": p["kind"], "name": p["name"], "verb": verb,
+                           "ms": round(ms, 1), "err": _err(msg)}
+                    if msg is None:
+                        rec["timeout"] = True
+                        rec["norm"] = None
+                    else:
+                        rec["norm"] = N.normalize(verb, msg.get("result"), root_uri)
+                    fh.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
+                    # A server that stops answering ENTIRELY is the failure
+                    # mode that quietly ruins a long run: every remaining
+                    # request costs the full timeout, so a corpus that would
+                    # sweep in two hours takes twenty and arrives as a wall
+                    # of `timeout-head` that says nothing about the branch.
+                    # Observed on the base binary here — client blocked,
+                    # server at 0% CPU, never recovering. Respawn instead:
+                    # the wedge is recorded as an EVENT (a finding in its own
+                    # right) and the remaining positions still get swept.
+                    if rec.get("timeout"):
+                        wedge[0] += 1
+                        if wedge[0] >= args.wedge_after:
+                            restarts[0] += 1
+                            fh.write(json.dumps({"_event": "server-wedged",
+                                "after_position": done, "file": rel,
+                                "line": p["line"], "verb": verb,
+                                "consecutive_timeouts": wedge[0],
+                                "restart": restarts[0]}) + "\n")
+                            fh.flush()
+                            print(f"[{args.side}] server wedged at {rel}:{p['line']} "
+                                  f"({verb}); restart #{restarts[0]}", flush=True)
+                            if restarts[0] > args.max_restarts:
+                                fh.write(json.dumps({"_event": "aborted",
+                                    "reason": "restart budget exhausted",
+                                    "swept": done, "of": len(pos)}) + "\n")
+                                print(f"[{args.side}] ABORTED after "
+                                      f"{restarts[0]} restarts", flush=True)
+                                lsp.shutdown()
+                                return
+                            try:
+                                lsp.proc.kill()
+                            except Exception:
+                                pass
+                            lsp = spawn()
+                            lsp.request("initialize", {
+                                "processId": os.getpid(), "rootUri": root_uri,
+                                "capabilities": {"textDocument": {
+                                    "publishDiagnostics": {},
+                                    "completion": {"completionItem": {}}}}},
+                                timeout=300)
+                            lsp.notify("initialized", {})
+                            opened.clear()
+                            uri = _open(lsp, root, rel)
+                            opened[rel] = uri
+                            wedge[0] = 0
+                    else:
+                        wedge[0] = 0
+                done += 1
+                if done % 250 == 0:
+                    fh.flush()
+                    el = time.monotonic() - t0
+                    print(f"[{args.side}] {done}/{len(pos)} positions  {el:.0f}s "
+                          f"({done/max(el,1e-9):.1f}/s)", flush=True)
+    lsp.shutdown()
+    print(f"[{args.side}] done: {done} positions in "
+          f"{time.monotonic()-t0:.0f}s -> {args.out}")
+
+
+CAP_KEY = {
+    "definition": "definitionProvider",
+    "typeDefinition": "typeDefinitionProvider",
+    "hover": "hoverProvider",
+    "references": "referencesProvider",
+    "completion": "completionProvider",
+}
+
+
+def _serves(caps, verb):
+    """Whether the server advertised the verb at `initialize`.
+
+    A provider may be `true`, an options object, or absent; `false` and
+    absent both mean unserved. Note the one thing this cannot see: a verb
+    registered DYNAMICALLY (typeHierarchy is, here) is absent from the
+    static capabilities and would be skipped. That is the safe direction --
+    a skipped verb is visible in `unserved`, whereas a swept-but-unimplemented
+    verb silently becomes thousands of fake regressions.
+    """
+    v = caps.get(CAP_KEY[verb])
+    return bool(v) if not isinstance(v, dict) else True
+
+
+def _version(binp):
+    try:
+        return subprocess.run([binp, "--version"], capture_output=True,
+                              text=True, timeout=60).stdout.strip()
+    except Exception as e:
+        return f"<unavailable: {e}>"
+
+
+def _err(msg):
+    if msg and "error" in msg:
+        return str(msg["error"].get("message", msg["error"]))[:200]
+    return None
+
+
+def _open(lsp, root, rel):
+    try:
+        text = open(os.path.join(root, rel), encoding="utf8", errors="replace").read()
+    except OSError:
+        return None
+    uri = pathlib.Path(os.path.join(root, rel)).as_uri()
+    lang = "perl"
+    lsp.notify("textDocument/didOpen", {"textDocument": {
+        "uri": uri, "languageId": lang, "version": 1, "text": text}})
+    return uri
+
+
+# ---- diff ----
+
+def _load(path):
+    meta, rows, events = {}, {}, []
+    for line in open(path):
+        r = json.loads(line)
+        if "_meta" in r:
+            meta = r["_meta"]
+            continue
+        if "_event" in r:
+            events.append(r)
+            continue
+        key = (r["file"], r.get("line"), r.get("char"), r["verb"])
+        rows[key] = r
+    meta["events"] = events
+    return meta, rows
+
+
+def classify(verb, a, b):
+    """One position, one verb, two sides -> a divergence SHAPE.
+
+    The shapes are the whole point of the report. `only-head` and `only-base`
+    are the two that carry a verdict on their face -- one side resolves
+    something the other does not -- and `superset` / `subset` say the same
+    thing with the weaker claim that both found something. `disagree` is the
+    residual that always needs a human.
+    """
+    ta, tb = a.get("timeout"), b.get("timeout")
+    if ta or tb:
+        return "timeout-base" if ta and not tb else ("timeout-head" if tb and not ta else "timeout-both")
+    if a.get("err") or b.get("err"):
+        if a.get("err") and b.get("err"):
+            return "same" if a["err"] == b["err"] else "error-differs"
+        return "error-base" if a.get("err") else "error-head"
+    na, nb = a.get("norm"), b.get("norm")
+    if N.answer_key(verb, na) == N.answer_key(verb, nb):
+        return "same"
+    ea, eb = N.is_empty(verb, na), N.is_empty(verb, nb)
+    if ea and not eb:
+        return "only-head"
+    if eb and not ea:
+        return "only-base"
+    sa, sb = N.as_set(verb, na), N.as_set(verb, nb)
+    if sa is not None and sb is not None and sa != sb:
+        if sa < sb:
+            return "superset"
+        if sb < sa:
+            return "subset"
+        return "disagree"
+    # Set-equal but key-different: completion whose RANKING moved, or a
+    # hover whose text changed. Naming it separately is what keeps a ranking
+    # regression from hiding behind an unchanged candidate set.
+    if verb == "completion" and sa == sb:
+        return "reranked"
+    return "content-differs"
+
+
+SHAPE_MEANING = {
+    "only-head":       "head answers, base empty  (new resolution -- intended improvement?)",
+    "only-base":       "base answers, head empty  (LOST resolution -- regression candidate)",
+    "superset":        "head found everything base did, plus more",
+    "subset":          "head found strictly fewer  (regression candidate)",
+    "disagree":        "both non-empty, neither contains the other",
+    "reranked":        "same candidates, different order (completion ranking moved)",
+    "content-differs": "same shape, different content (hover text, etc.)",
+    "error-head":      "head returned a protocol error, base did not",
+    "error-base":      "base returned a protocol error, head did not",
+    "error-differs":   "both errored, differently",
+    "timeout-head":    "head timed out, base answered",
+    "timeout-base":    "base timed out, head answered",
+    "timeout-both":    "both timed out",
+    "missing-head":    "position present in base run only",
+    "missing-base":    "position present in head run only",
+}
+# Ordering of the report: the buckets a reviewer must adjudicate first.
+SHAPE_ORDER = ["only-base", "subset", "timeout-head", "error-head", "disagree",
+               "content-differs", "reranked", "only-head", "superset",
+               "timeout-base", "error-base", "error-differs", "timeout-both",
+               "missing-head", "missing-base"]
+
+
+def cmd_diff(args):
+    meta_a, base = _load(args.base)
+    meta_b, head = _load(args.head)
+
+    # Verbs only one side serves are subtracted BEFORE anything is counted.
+    # Leaving them in would put a capability gap at the top of the
+    # regression list on every position that has one, which is the fastest
+    # way to make a divergence report unreadable.
+    va, vb = set(meta_a.get("verbs") or []), set(meta_b.get("verbs") or [])
+    common = (va & vb) | {"documentSymbol"}
+    cap_only = sorted((va | vb) - common)
+    keys = {k for k in (set(base) | set(head)) if k[3] in common}
+
+    groups, counts, uninformative = {}, {}, 0
+    for k in sorted(keys, key=lambda k: (k[0], k[3], k[1] is None, k[1] or 0, k[2] or 0)):
+        a, b = base.get(k), head.get(k)
+        verb = k[3]
+        if a is None or b is None:
+            shape = "missing-base" if a is None else "missing-head"
+            a = a or {}; b = b or {}
+        else:
+            shape = classify(verb, a, b)
+        if shape == "same":
+            # A position where both sides answered nothing on every verb is
+            # the residue of an imperfect tokenizer (a name inside a string,
+            # say). Counting it as agreement would inflate the denominator
+            # with questions nobody asked; it is reported separately instead.
+            if N.is_empty(verb, a.get("norm")) and N.is_empty(verb, b.get("norm")):
+                uninformative += 1
+            counts[("same", verb)] = counts.get(("same", verb), 0) + 1
+            continue
+        kind = (b or a).get("kind", "?")
+        counts[(shape, verb)] = counts.get((shape, verb), 0) + 1
+        groups.setdefault((shape, verb, kind), []).append((k, a, b))
+
+    total = len(keys)
+    diverged = sum(v for (s, _), v in counts.items() if s != "same")
+    same = total - diverged
+
+    out = []
+    W = out.append
+    W("# Differential sweep report\n")
+    W(f"- **base** `{meta_a.get('side','base')}` — `{meta_a.get('version','?')}`")
+    W(f"- **head** `{meta_b.get('side','head')}` — `{meta_b.get('version','?')}`")
+    W(f"- corpus: `{meta_b.get('root', meta_a.get('root','?'))}`")
+    W(f"- path: **server** (LSP over stdio), verbs "
+      f"{', '.join(sorted(common))}")
+    if cap_only:
+        W(f"- **excluded as a capability difference:** "
+          + ", ".join(f"`{v}`" for v in cap_only)
+          + " — served by one side only, so every position would report a "
+            "divergence that is a missing feature rather than a changed answer")
+    rate = meta_b.get("verb_rate") or {}
+    if rate:
+        W(f"- sampled verbs: " + ", ".join(f"`{k}` at {v:.0%}" for k, v in sorted(rate.items())))
+    W(f"- cross-file readiness: base {meta_a.get('ready_ms')} ms, "
+      f"head {meta_b.get('ready_ms')} ms")
+    for side, m in (("base", meta_a), ("head", meta_b)):
+        if not m.get("cross_file_ready", True):
+            W(f"- **{side} WAS NEVER CONFIRMED WORKSPACE-READY** — no cross-file "
+              f"definition resolved within the readiness budget, so this side's "
+              f"empty answers may be coldness rather than disagreement. Treat "
+              f"every `only-*` shape below as unattributed until this is fixed.")
+    for side, m in (("base", meta_a), ("head", meta_b)):
+        for ev in m.get("events") or []:
+            W(f"- **{side} {ev['_event']}**: " + ", ".join(
+                f"{k}={v}" for k, v in sorted(ev.items()) if k != "_event"))
+    W("")
+    W(f"**{total} (position, verb) answers compared — {same} identical "
+      f"({same/max(total,1):.2%}), {diverged} divergent.**\n")
+    W(f"Of the identical ones, {uninformative} were empty on both sides: positions "
+      f"nobody would ask about, kept in the denominator but called out so the "
+      f"agreement rate is not read as coverage.\n")
+
+    W("## Divergences by shape\n")
+    W("| shape | n | meaning |")
+    W("|---|---|---|")
+    by_shape = {}
+    for (s, v), n in counts.items():
+        if s != "same":
+            by_shape[s] = by_shape.get(s, 0) + n
+    for s in SHAPE_ORDER:
+        if by_shape.get(s):
+            W(f"| `{s}` | {by_shape[s]} | {SHAPE_MEANING.get(s,'')} |")
+    W("")
+
+    W("## Groups\n")
+    W("Each row is one claim to adjudicate: *intended improvement*, "
+      "*regression*, or *wash*.\n")
+    W("`distinct` is the number of different (base answer, head answer) PAIRS "
+      "behind the positions — the count of separate claims. One generated "
+      "data file can contribute sixty positions that all disagree the same "
+      "way; that is one thing to adjudicate, not sixty, and reading `n` as "
+      "the workload is how a sweep gets abandoned as noise.\n")
+    W("| shape | verb | token kind | n | distinct |")
+    W("|---|---|---|---|---|")
+    for (shape, verb, kind), items in sorted(
+            groups.items(), key=lambda kv: (SHAPE_ORDER.index(kv[0][0])
+                                            if kv[0][0] in SHAPE_ORDER else 99,
+                                            -len(kv[1]))):
+        W(f"| `{shape}` | {verb} | {kind} | {len(items)} | {_distinct(verb, items)} |")
+    W("")
+
+    W("## Examples\n")
+    for (shape, verb, kind), items in sorted(
+            groups.items(), key=lambda kv: (SHAPE_ORDER.index(kv[0][0])
+                                            if kv[0][0] in SHAPE_ORDER else 99,
+                                            -len(kv[1]))):
+        reps = _representatives(verb, items)
+        W(f"### `{shape}` · {verb} · {kind} — {len(items)} positions, "
+          f"{len(reps)} distinct\n")
+        for (k, a, b), n_same in reps[:args.examples]:
+            f, ln, ch, _ = k
+            more = f"  (+{n_same-1} more positions answering identically)" if n_same > 1 else ""
+            W(f"- `{f}:{ln}:{ch}` `{(b or a).get('name','?')}`{more}")
+            W(f"  - base: `{_brief(verb, a.get('norm'))}`")
+            W(f"  - head: `{_brief(verb, b.get('norm'))}`")
+        if len(reps) > args.examples:
+            W(f"- …and {len(reps)-args.examples} more distinct claims")
+        W("")
+
+    txt = "\n".join(out)
+    if args.out:
+        open(args.out, "w").write(txt)
+        print(f"report -> {args.out}  ({diverged} divergent of {total})")
+    else:
+        print(txt)
+
+
+def _pair_key(verb, a, b):
+    return (N.answer_key(verb, a.get("norm")), N.answer_key(verb, b.get("norm")))
+
+
+def _distinct(verb, items):
+    return len({_pair_key(verb, a, b) for (_, a, b) in items})
+
+
+def _representatives(verb, items):
+    """One example per DISTINCT (base, head) answer pair, largest cluster first.
+
+    Showing the first N positions instead would print the same disagreement
+    N times whenever a group is dominated by one repeated answer — which is
+    the common case, not the exception.
+    """
+    seen = {}
+    for it in items:
+        seen.setdefault(_pair_key(verb, it[1], it[2]), []).append(it)
+    out = [(v[0], len(v)) for v in seen.values()]
+    out.sort(key=lambda t: -t[1])
+    return out
+
+
+def _brief(verb, norm, cap=200):
+    if norm is None:
+        return "∅"
+    if verb == "completion":
+        return f"n={norm.get('n')} top={norm.get('top', [])[:4]}"
+    if verb == "hover":
+        return f"len={norm.get('len')} {norm.get('head','')[:120]!r}"
+    s = json.dumps(norm, default=str)
+    return s if len(s) <= cap else s[:cap] + "…"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("positions")
+    p.add_argument("--root", required=True)
+    p.add_argument("--out", required=True)
+    p.add_argument("--seed", default="v1")
+    p.add_argument("--per-file", type=int, default=25)
+    p.add_argument("--max-files", type=int, default=0)
+    p.set_defaults(fn=cmd_positions)
+
+    p = sub.add_parser("run")
+    p.add_argument("--bin", required=True)
+    p.add_argument("--root", required=True)
+    p.add_argument("--positions", required=True)
+    p.add_argument("--out", required=True)
+    p.add_argument("--side", default="run")
+    p.add_argument("--cache-dir", required=True)
+    p.add_argument("--timeout", type=float, default=30.0)
+    p.add_argument("--ready-timeout", type=float, default=600.0)
+    p.add_argument("--wedge-after", type=int, default=3,
+                   help="consecutive timeouts that mean the server is wedged")
+    p.add_argument("--max-restarts", type=int, default=10)
+    p.set_defaults(fn=cmd_run)
+
+    p = sub.add_parser("diff")
+    p.add_argument("--base", required=True)
+    p.add_argument("--head", required=True)
+    p.add_argument("--out")
+    p.add_argument("--examples", type=int, default=8)
+    p.set_defaults(fn=cmd_diff)
+
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -149,13 +149,22 @@ def cmd_run(args):
         end = t + budget
         while time.monotonic() < end:
             for pr in probes:
+                # The budget has to bind INSIDE the probe loop, not just
+                # between passes. Against a wedged server every probe costs
+                # its full timeout, so one pass over eight probes ran 16
+                # minutes while nominally honouring a 300-second budget --
+                # the run looked hung, and the budget was the thing that was
+                # supposed to prove it was not.
+                left = end - time.monotonic()
+                if left <= 0:
+                    break
                 uri = _open(client, root, pr["file"])
                 if uri is None:
                     continue
                 msg, _ = client.request("textDocument/definition", {
                     "textDocument": {"uri": uri},
                     "position": {"line": pr["line"], "character": pr["char_on"]}},
-                    timeout=120)
+                    timeout=min(120, left))
                 locs = N.locations((msg or {}).get("result"), root_uri)
                 here = os.path.relpath(os.path.join(root, pr["file"]), root)
                 if any(u and u != here for (u, _) in locs):
@@ -276,7 +285,7 @@ def cmd_run(args):
                             # answers as lost resolutions -- the same trap
                             # the initial gate exists to close, and easier to
                             # miss here because the run is already underway.
-                            _, _, warm_ms = await_cross_file(lsp, args.ready_timeout)
+                            _, _, warm_ms = await_cross_file(lsp, args.rewarm_timeout)
                             fh.write(json.dumps({"_event": "restart-rewarm",
                                 "restart": restarts[0],
                                 "cross_file_ready_ms": warm_ms and round(warm_ms),
@@ -616,6 +625,8 @@ def main():
     p.add_argument("--cache-dir", required=True)
     p.add_argument("--timeout", type=float, default=30.0)
     p.add_argument("--ready-timeout", type=float, default=600.0)
+    p.add_argument("--rewarm-timeout", type=float, default=60.0,
+                   help="budget for re-reaching cross-file readiness after a restart")
     p.add_argument("--wedge-after", type=int, default=3,
                    help="consecutive timeouts that mean the server is wedged")
     p.add_argument("--max-restarts", type=int, default=10)

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -237,6 +237,29 @@ def cmd_run(args):
                         rec["norm"] = None
                     else:
                         rec["norm"] = N.normalize(verb, msg.get("result"), root_uri)
+                    # An empty answer is asked TWICE. The @INC tier resolves
+                    # per-module, on demand, on a background thread, so the
+                    # first goto-def on `use Storable` can legitimately answer
+                    # empty and the second answer the file — the workspace
+                    # readiness gate cannot cover this, because the module was
+                    # never in the workspace. Verified by hand: the sweep
+                    # recorded head as empty on `use Storable` while the CLI,
+                    # which starts synchronously, resolves it.
+                    #
+                    # Without the retry that timing shows up as `only-base` and
+                    # reads as a lost resolution. The retry is in the RUNNER so
+                    # both sides get it by construction; a side-specific one
+                    # would be worse than none.
+                    if args.empty_retry_ms > 0 and not rec.get("timeout") \
+                            and not rec.get("err") \
+                            and N.is_empty(verb, rec["norm"]):
+                        time.sleep(args.empty_retry_ms / 1000.0)
+                        msg2, _ = lsp.request(method, params, timeout=args.timeout)
+                        if msg2 is not None and not _err(msg2):
+                            n2 = N.normalize(verb, msg2.get("result"), root_uri)
+                            if not N.is_empty(verb, n2):
+                                rec["norm"] = n2
+                                rec["filled_on_retry"] = True
                     fh.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
                     # A server that stops answering ENTIRELY is the failure
                     # mode that quietly ruins a long run: every remaining
@@ -453,6 +476,21 @@ SHAPE_ORDER = ["only-base", "subset", "timeout-head", "error-head", "disagree",
                "missing-head", "missing-base"]
 
 
+def _shape_counts(base_path, head_path, common):
+    """Shape histogram for one pair of answer files — used for the A/B run and,
+    with the SAME binary on both sides, for the noise floor."""
+    _, a = _load(base_path)
+    _, b = _load(head_path)
+    out = {}
+    for k in set(a) & set(b):
+        if k[3] not in common:
+            continue
+        sh = classify(k[3], a[k], b[k])
+        if sh != "same":
+            out[sh] = out.get(sh, 0) + 1
+    return out
+
+
 def cmd_diff(args):
     meta_a, base = _load(args.base)
     meta_b, head = _load(args.head)
@@ -492,6 +530,16 @@ def cmd_diff(args):
         kind = (b or a).get("kind", "?")
         counts[(shape, verb)] = counts.get((shape, verb), 0) + 1
         groups.setdefault((shape, verb, kind), []).append((k, a, b))
+
+    # The noise floor: the SAME binary against itself over the same
+    # positions. Measured here it is 3.1% of answers -- 162 `reranked` and 11
+    # `disagree`, and ZERO in every other shape. Without it a reader has no
+    # way to tell a 68-row `reranked` block from nothing at all, because
+    # completion ordering is not stable run to run. This is not a correction
+    # applied to the counts; it is the resolution limit printed beside them.
+    noise = {}
+    if args.noise_base and args.noise_head:
+        noise = _shape_counts(args.noise_base, args.noise_head, common)
 
     total = len(keys)
     diverged = sum(v for (s, _), v in counts.items() if s != "same")
@@ -539,15 +587,31 @@ def cmd_diff(args):
       f"agreement rate is not read as coverage.\n")
 
     W("## Divergences by shape\n")
-    W("| shape | n | meaning |")
-    W("|---|---|---|")
     by_shape = {}
     for (s, v), n in counts.items():
         if s != "same":
             by_shape[s] = by_shape.get(s, 0) + n
-    for s in SHAPE_ORDER:
-        if by_shape.get(s):
-            W(f"| `{s}` | {by_shape[s]} | {SHAPE_MEANING.get(s,'')} |")
+    if noise:
+        W("`noise` is the same shape's count when the SAME binary is run "
+          "twice over these positions. A block at or below its noise floor "
+          "carries no information — read the `signal` column, not `n`.\n")
+        W("| shape | n | noise | signal | meaning |")
+        W("|---|---|---|---|---|")
+        for s in SHAPE_ORDER:
+            if by_shape.get(s):
+                nf = noise.get(s, 0)
+                sig = "**below noise — unreadable**" if by_shape[s] <= nf \
+                      else f"{by_shape[s]-nf}"
+                W(f"| `{s}` | {by_shape[s]} | {nf} | {sig} | {SHAPE_MEANING.get(s,'')} |")
+    else:
+        W("*No noise floor supplied (`--noise-base` / `--noise-head`). Completion "
+          "ordering is not stable run to run, so `reranked` counts in particular "
+          "cannot be interpreted without one.*\n")
+        W("| shape | n | meaning |")
+        W("|---|---|---|")
+        for s in SHAPE_ORDER:
+            if by_shape.get(s):
+                W(f"| `{s}` | {by_shape[s]} | {SHAPE_MEANING.get(s,'')} |")
     W("")
 
     W("## Groups\n")
@@ -649,6 +713,10 @@ def main():
     p.add_argument("--cache-dir", required=True)
     p.add_argument("--timeout", type=float, default=30.0)
     p.add_argument("--ready-timeout", type=float, default=600.0)
+    p.add_argument("--empty-retry-ms", type=float, default=400.0,
+                   help="re-ask once after this delay when an answer is empty; "
+                        "0 disables. Covers the on-demand @INC tier, which "
+                        "resolves per module after the first miss.")
     p.add_argument("--rewarm-timeout", type=float, default=60.0,
                    help="budget for re-reaching cross-file readiness after a restart")
     p.add_argument("--wedge-after", type=int, default=3,
@@ -661,6 +729,8 @@ def main():
     p.add_argument("--head", required=True)
     p.add_argument("--out")
     p.add_argument("--examples", type=int, default=8)
+    p.add_argument("--noise-base", help="answers from a repeat run of ONE binary")
+    p.add_argument("--noise-head", help="answers from a second run of that SAME binary")
     p.set_defaults(fn=cmd_diff)
 
     args = ap.parse_args()

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -403,6 +403,16 @@ def classify(verb, a, b):
         return "only-base"
     sa, sb = N.as_set(verb, na), N.as_set(verb, nb)
     if sa is not None and sb is not None and sa != sb:
+        # A truncated list is a strict subset of an untruncated one BY
+        # DESIGN. Ranking on one side and not the other would otherwise
+        # report every long completion as a lost-candidates regression --
+        # 221 rows in the first corpus run, all of them one intended change.
+        trunc = lambda n: verb == "completion" and isinstance(n, dict) \
+                          and n.get("incomplete")
+        if sb < sa and trunc(nb):
+            return "capped-head"
+        if sa < sb and trunc(na):
+            return "capped-base"
         if sa < sb:
             return "superset"
         if sb < sa:
@@ -421,6 +431,8 @@ SHAPE_MEANING = {
     "only-base":       "base answers, head empty  (LOST resolution -- regression candidate)",
     "superset":        "head found everything base did, plus more",
     "subset":          "head found strictly fewer  (regression candidate)",
+    "capped-head":     "head's list is a subset because head TRUNCATED it (isIncomplete) — by design, not a loss",
+    "capped-base":     "base's list is a subset because base truncated it — by design, not a loss",
     "disagree":        "both non-empty, neither contains the other",
     "reranked":        "same candidates, different order (completion ranking moved)",
     "content-differs": "same shape, different content (hover text, etc.)",
@@ -436,6 +448,7 @@ SHAPE_MEANING = {
 # Ordering of the report: the buckets a reviewer must adjudicate first.
 SHAPE_ORDER = ["only-base", "subset", "timeout-head", "error-head", "disagree",
                "content-differs", "reranked", "only-head", "superset",
+               "capped-head", "capped-base",
                "timeout-base", "error-base", "error-differs", "timeout-both",
                "missing-head", "missing-base"]
 

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -451,17 +451,22 @@ def cmd_diff(args):
     va, vb = set(meta_a.get("verbs") or []), set(meta_b.get("verbs") or [])
     common = (va & vb) | {"documentSymbol"}
     cap_only = sorted((va | vb) - common)
-    keys = {k for k in (set(base) | set(head)) if k[3] in common}
+    # Only positions BOTH sides answered are comparable. A side that aborted
+    # early (the base wedges often enough here that it can) would otherwise
+    # contribute thousands of `missing-base` rows that say nothing about the
+    # branch and bury what does. The shortfall is reported as COVERAGE
+    # instead, which is the honest framing: this is what we compared, and
+    # this is what we could not.
+    all_keys = {k for k in (set(base) | set(head)) if k[3] in common}
+    keys = {k for k in all_keys if k in base and k in head}
+    only_base_keys = sum(1 for k in all_keys if k not in head)
+    only_head_keys = sum(1 for k in all_keys if k not in base)
 
     groups, counts, uninformative = {}, {}, 0
     for k in sorted(keys, key=lambda k: (k[0], k[3], k[1] is None, k[1] or 0, k[2] or 0)):
-        a, b = base.get(k), head.get(k)
+        a, b = base[k], head[k]
         verb = k[3]
-        if a is None or b is None:
-            shape = "missing-base" if a is None else "missing-head"
-            a = a or {}; b = b or {}
-        else:
-            shape = classify(verb, a, b)
+        shape = classify(verb, a, b)
         if shape == "same":
             # A position where both sides answered nothing on every verb is
             # the residue of an imperfect tokenizer (a name inside a string,
@@ -510,6 +515,12 @@ def cmd_diff(args):
     W("")
     W(f"**{total} (position, verb) answers compared — {same} identical "
       f"({same/max(total,1):.2%}), {diverged} divergent.**\n")
+    if only_base_keys or only_head_keys:
+        W(f"Coverage shortfall: {only_base_keys} answers exist only in the base "
+          f"run and {only_head_keys} only in the head run — a side that aborted "
+          f"or skipped never produced them. They are EXCLUDED from every count "
+          f"above, because a position one side never reached is a gap in the "
+          f"sweep, not a disagreement about an answer.\n")
     W(f"Of the identical ones, {uninformative} were empty on both sides: positions "
       f"nobody would ask about, kept in the denominator but called out so the "
       f"agreement rate is not read as coverage.\n")

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -271,7 +271,22 @@ def cmd_run(args):
                     # right) and the remaining positions still get swept.
                     if rec.get("timeout"):
                         wedge[0] += 1
-                        if wedge[0] >= args.wedge_after:
+                        if wedge[0] >= args.wedge_after and _alive(lsp, uri, args):
+                            # The server still serves. Consecutive timeouts on
+                            # one VERB are a hang cluster, not a dead process,
+                            # and restarting would throw away a warm index to
+                            # cure something that is not wrong. Verified
+                            # independently of this driver: on the base binary
+                            # a `definition` that times out at 30 s is followed
+                            # by a `documentSymbol` on the same open file that
+                            # answers in milliseconds.
+                            fh.write(json.dumps({"_event": "hang-cluster",
+                                "after_position": done, "file": rel,
+                                "line": p["line"], "verb": verb,
+                                "consecutive_timeouts": wedge[0]}) + "\n")
+                            fh.flush()
+                            wedge[0] = 0
+                        elif wedge[0] >= args.wedge_after:
                             restarts[0] += 1
                             fh.write(json.dumps({"_event": "server-wedged",
                                 "after_position": done, "file": rel,
@@ -383,6 +398,20 @@ def _version(binp):
                               text=True, timeout=60).stdout.strip()
     except Exception as e:
         return f"<unavailable: {e}>"
+
+
+def _alive(client, uri, args):
+    """Is the server still serving, or is the process itself gone?
+
+    Asked with `documentSymbol` on an ALREADY-OPEN file: it needs no
+    cross-file resolution and no index, so an answer means the process reads
+    stdin and writes stdout. Anything more ambitious would confuse "slow to
+    resolve" with "dead", which is the distinction this call exists to make.
+    """
+    msg, _ = client.request("textDocument/documentSymbol",
+                            {"textDocument": {"uri": uri}},
+                            timeout=min(10.0, args.timeout))
+    return msg is not None
 
 
 def _err(msg):

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -337,3 +337,24 @@ repros; recorded here so a fix flips a real observation, not just narrative.
   already carries the roots and `IndexCore.inc_roots` already publishes the
   process set. Deferred because acquisition widening changes what gets
   parsed at startup, and that wants its own measurement.
+
+## A class-name string literal is not a dispatch receiver
+
+`my $x = 'Widget'; $x->new()` types `$x` as `String`, so the scalar never
+becomes a receiver and member completion on it answers nothing. Neither is
+this about `||`, despite the shape it was found in
+(`$args{metaclass} || 'Moose::Meta::Class'`), nor about Moose: the two-line
+form above reproduces it, and so does 0.6.1.
+
+`dispatch_class_of` already does the right thing given
+`InferredType::ClassName` — a bareword receiver (`Widget->new()`) completes
+correctly. The missing half is the literal's witness carrying `ClassName`
+when its value names a known package. That is a property of the value, so it
+belongs on the witness (rule #10), not as a branch in the completion
+consumer.
+
+Pinned by `fixtures/type-at.json::ti-classname-string` (xfail). Found by
+`bench/sweep`; it was the only `only-base` row in that run which was not the
+`(anon)` fix, and adjudicating it showed 0.6.1 fails the same way — it just
+fell back to offering the ENCLOSING PACKAGE's own subs, which are not the
+receiver's methods at all.

--- a/gold-corpus/fixtures/type-at.json
+++ b/gold-corpus/fixtures/type-at.json
@@ -153,7 +153,7 @@
         "none": []
       },
       "status": "gold",
-      "note": "SUPER::new types to the invocant class (Minion) via invocant_type_at_node's MethodOnClass receiver-relative fallback — resolves single-file now, no module index needed. Promoted from xfail (H7-8 typing work)."
+      "note": "SUPER::new types to the invocant class (Minion) via invocant_type_at_node's MethodOnClass receiver-relative fallback \u2014 resolves single-file now, no module index needed. Promoted from xfail (H7-8 typing work)."
     },
     {
       "id": "ti-13",
@@ -381,6 +381,24 @@
       },
       "status": "gold",
       "note": "auto cmp = x == y -> the C++ comparison expression is Bool."
+    },
+    {
+      "id": "ti-classname-string",
+      "difficulty": "hard",
+      "semantic_area": "classic",
+      "file": "x86_64-linux-gnu-thread-multi/Moose.pm",
+      "line": 148,
+      "col": 7,
+      "query": "",
+      "newname": "",
+      "expect": {
+        "all": [
+          "Moose::Meta::Class"
+        ],
+        "none": []
+      },
+      "status": "xfail",
+      "note": "`my $metaclass = $args{metaclass} || 'Moose::Meta::Class'` types as String, so the scalar never becomes a dispatch receiver and `$metaclass->initialize` completes to nothing. Not Moose-specific and not about `||`: `my $x = 'Widget'; $x->new()` has the same gap, on 0.6.1 as well as here. dispatch_class_of already does the right thing GIVEN InferredType::ClassName \u2014 the missing half is the literal's witness carrying it when the value names a known package, which is a property of the value rather than a branch in the completion consumer. Found by bench/sweep; the only only-base row in that run that was not the `(anon)` fix."
     }
   ]
 }


### PR DESCRIPTION
The last item from "Validation still owed". `bench/sweep/` runs two binaries over thousands of cursor positions on a real corpus and hands back a list of claims to adjudicate rather than a diff to squint at. Based on `ed7b21bb`.

**Run it here first; I could not run it at Koha scale.** The substrate (2,265 pinned CPAN modules) was enough to prove the harness *and* produce a real result — including three findings that turned out to be the harness lying rather than the branch regressing. Those three are why I'd rather you ran it on Koha than trusted my run.

## The design decisions that matter

**Positions come from the source text, never from a binary.** A binary-derived sample (semantic tokens) would let one side choose where it is tested, and a divergence stops being attributable: did the answer change, or did the question? Token-driven with per-kind quotas — an unweighted sample is 71% `variable` on real CPAN code, which is the case both sides most agree on, so an unweighted sweep spends its budget confirming null results. The per-file cap round-robins across kinds, because a flat cap re-imposes the distribution the weights just corrected.

**Server path**, as you asked, and the report says so on every page.

**Readiness is a cross-file gate.** Non-empty proves nothing: goto-def on a local `sub` answers from the open buffer with no index at all. Measured here — base passed a non-empty probe in **12 ms**, head took **1,309 ms**. Sweeping on that compares a cold server to a warm one and reports the gap as regressions. The gate requires a definition landing in a *different file*, on both sides, and a side that never gets there is flagged rather than silently swept.

**A verb one side does not implement is subtracted.** Base does not serve `typeDefinition`; left in, that alone put an error on all 1,458 positions.

**Timeouts are never folded into "empty."** A slow side that lost a race is not a side that lost an answer.

## The measurement I'd read first

The **noise floor**: the same binary, run twice, over the same positions.

| shape | self-vs-self |
|---|---|
| `reranked` | 164 |
| `disagree` | 7 |
| everything else | **0** |

3.8% of answers disagree with themselves, and completion ordering accounts for essentially all of it. So the A/B's 70 `reranked` rows carry **no information** — the report prints the floor as a column and marks that block `below noise — unreadable` — while `only-*`, `subset`, `superset` and `content-differs` can be read at face value. A third of the shapes are noise and look exactly like the two thirds that aren't; there's no way to tell without measuring it.

## The result

**4,302 answers over 1,458 positions. 2,836 identical (65.9%), 1,466 divergent.**

Adjudicated rather than handed over raw:

| claim | rows | verdict |
|---|---|---|
| head stopped offering `(anon)` as a completion candidate | 87 `subset` + 1 `only-base` | **fix** — 88 of 88 lose `(anon)` and nothing else, on two independent runs |
| goto-def lands on the declaration where base returned `0:0` | 110 `disagree` | **fix** — every same-file definition disagreement is this |
| every `@INC` provider of a name, where base returned one | ~117 `disagree` | **intended, and it is mine** — the `(name, inc-root)` relation. `use strict` now answers both `perl/5.38.2/strict.pm` and `perl-base/strict.pm`. Flagged so this reads as the sweep confirming my change, not discovering it |
| head answers where base was empty | 263 `only-head` | improvement |
| head answers a superset | 182 `superset` | improvement |
| long completion lists truncated | 27 `capped-head` | **by design** — `MAX_COMPLETION_ITEMS` + `isIncomplete` |

**One regression candidate in 1,466 divergences**, and it is specific enough to rule on: `Moose.pm:200:38`, completion after `$metaclass->initialize`. Base offers 13, head offers none; reproduces on the CLI so it is not warm-up. But base's 13 are all subs defined *in Moose.pm itself* (`after`, `around`, `augment`, `_get_caller`) — a same-file fallback when the receiver can't be resolved, not metaclass methods. So the question is whether nothing beats plausible-but-wrong.

**One bucket I can't rule on:** 526 completion `disagree` rows where head both gains and loses real names. Builtins explain 2%; **63% lose sigil'd names**. Scope correctness or lost candidates — your call, and the likeliest place a real regression is hiding.

## Three times the harness lied, and how it was caught

Each was found by *checking* a finding instead of filing it. All three are committed separately with the evidence.

1. **221 `subset` rows on completion** sat at the top of the regression list. All one intended change: rank-then-cut to `MAX_COMPLETION_ITEMS` with `isIncomplete`, which is the LSP contract. My normaliser was discarding the one field that says so.

2. **`only-base` on `use Storable` / `use base` / `use utf8`** looked like lost `@INC` resolution — in the tier I rewrote. Checked before filing: head resolves all of them from the CLI. The `@INC` tier resolves per module, on a background thread, so the *workspace* readiness gate can't cover it. **My first fix was also wrong**: an inline 400 ms retry filled **zero** of head's empties and took the run from 51 s to 1,024 s. Replaced with an end-of-run second pass — no sleeps, one extra request each, asked of the warmest server the run ever has.

3. **"The base server wedges."** I said that, and it's wrong. Checked with a client that is not this harness: a `definition` timing out at 30 s is followed by `documentSymbol` on the same open file answering in milliseconds. The server is alive; individual requests hang and they *cluster*. Consecutive timeouts now trigger a liveness probe and only a process that fails it is respawned.

`selftest.py` pins the rules that decide all of this, because the tool's bug class is a **wrong report**, which looks exactly like a right one. Every check is mutation-verified: folding timeouts into empty, erasing completion ranking, relativising outside-root URIs, dropping the cap rule, and dropping rechecks each fail a check by name.

## About `main` itself

`textDocument/definition` accumulated 4, 5 and 10 unrecoverable stalls across three runs, at different files each time — cache-state dependent. `0.7.0` had none in ~9,000 positions. Wall clock for 1,458 positions: `main` 247 s, `0.7.0` 54 s, though base swings 247–608 s because of the stalls, so read it as an order of magnitude. Sides ran sequentially; `lsp_bench.py` remains the tool for latency.

## Verification

| | result |
|---|---|
| `cargo test --features cpp` | **1,571 passed / 0 failed** / 3 ignored |
| `cargo test` | **1,508 passed / 0 failed** / 3 ignored |
| gold | **498 PASS / 15 xfail / 0 FAIL / 0 XPASS / 0 CRASH / 0 skip / 0 lang-skip** |
| `bench/sweep/selftest.py` | all checks pass |

True exit codes; `skip` and `lang-skip` both grepped. **e2e did not run — no `nvim` in this sandbox.**

## Handing it over

```sh
bench/sweep/run.sh <main-binary> <head-binary> <corpus> <outdir>
```

Both sides **default features** — `main` predates `cpp`, so the comparison is Perl-only, which is a limit of the comparison rather than a defect in it. For Koha, raise `SWEEP_MAX_FILES`, and please run two same-binary passes for a fresh noise floor: the floor is corpus-specific and I would not quote mine next to your counts.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv)_