### PR TITLE
Compile the combined query off the critical path, and attribute what is left

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,16 @@ cargo test                                    # 900+ unit tests
 cargo build --release && ./e2e/run.sh         # 10 nvim-driven e2e suites (requires nvim)
 ```
 
+The e2e harness needs **nvim 0.10+** (it calls `vim.lsp.get_clients`); CI pins
+v0.11.0. Distro packages are often older — Ubuntu 24.04 ships 0.9.5, which fails
+at harness startup rather than as a test failure. Prefer the release tarball:
+
+```bash
+curl -sSL -o nvim.tar.gz \
+  https://github.com/neovim/neovim/releases/download/v0.11.0/nvim-linux-x86_64.tar.gz
+tar xzf nvim.tar.gz && export PATH="$PWD/nvim-linux-x86_64/bin:$PATH"
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/src/build/builder/pattern_dispatch.rs
+++ b/src/build/builder/pattern_dispatch.rs
@@ -262,26 +262,32 @@ fn eligible_walk_specs<'p>(
 
 /// The combined query for a set of already-valid specs, plus the start
 /// pattern index of each spec within it.
-struct CombinedWalk {
+struct CombinedWalk<'r> {
     query: &'static Query,
     /// `starts[i]` = combined pattern index at which spec `i` begins. One
     /// source can contribute several patterns, so the owner of combined
     /// pattern `k` is the last `i` with `starts[i] <= k`.
+    starts: &'r [usize],
+}
+
+/// The owned form the registry stores; `CombinedWalk` is the borrowed view.
+struct OwnedCombinedWalk {
+    query: &'static Query,
     starts: Vec<usize>,
 }
 
-impl CombinedWalk {
+impl CombinedWalk<'_> {
     /// Combine only specs that already compile on their own, so one malformed
     /// `.rhai` can never take dispatch out for the other twelve — it is
     /// dropped by `eligible_walk_specs` before it reaches the concatenation.
     /// `None` means "use the per-spec path", which is always correct.
-    fn build(specs: &[(&dyn plugin::FrameworkPlugin, &PatternSpec, &'static Query)]) -> Option<Self> {
-        if specs.is_empty() {
+    fn build(parts: Vec<(String, usize)>) -> Option<OwnedCombinedWalk> {
+        if parts.is_empty() {
             return None;
         }
-        let joined = specs
+        let joined = parts
             .iter()
-            .map(|(_, s, _)| s.query.as_str())
+            .map(|(src, _)| src.as_str())
             .collect::<Vec<_>>()
             .join("\n");
         let query = match cached_pattern_query(&joined) {
@@ -295,11 +301,11 @@ impl CombinedWalk {
                 return None;
             }
         };
-        let mut starts = Vec::with_capacity(specs.len());
+        let mut starts = Vec::with_capacity(parts.len());
         let mut acc = 0usize;
-        for (_, _, q) in specs {
+        for (_, count) in &parts {
             starts.push(acc);
-            acc += q.pattern_count();
+            acc += count;
         }
         if acc != query.pattern_count() {
             // Concatenation did not preserve pattern count, so routing by
@@ -314,7 +320,7 @@ impl CombinedWalk {
             crate::util::ghost_stats::count("pd.combine.pattern_count_mismatch");
             return None;
         }
-        Some(CombinedWalk { query, starts })
+        Some(OwnedCombinedWalk { query, starts })
     }
 
     fn owner_of(&self, pattern_index: usize) -> usize {
@@ -353,16 +359,35 @@ pub(crate) fn collection_equiv_enabled() -> bool {
     *ON.get_or_init(|| std::env::var("PERL_LSP_PD_EQUIV").as_deref() == Ok("1"))
 }
 
-/// Compiled combined query per registry shape, memoized process-wide on the
-/// joined source (via `cached_pattern_query`), so a build never pays a
-/// compile. `None` = fall back.
-fn combined_walk(
+/// The registry's combined query, derived once and cached ON the registry.
+///
+/// Deriving it means joining every spec source and hashing the result to look
+/// up the compiled-query memo — a per-PROCESS cost that reads as per-file if
+/// it lives at the call site. Measured there first: 1,903 ms across 3,520
+/// files, 49% of the whole dispatch phase, eating half the win the combined
+/// query had just bought. The registry owns the slot because the answer is a
+/// function of the registry's plugins and nothing else.
+///
+/// `None` = use the per-spec path.
+fn combined_walk<'r>(
+    registry: &'r crate::build::plugin::PluginRegistry,
     specs: &[(&dyn plugin::FrameworkPlugin, &PatternSpec, &'static Query)],
-) -> Option<CombinedWalk> {
+) -> Option<CombinedWalk<'r>> {
     if !combine_forced().unwrap_or(!combine_disabled()) {
         return None;
     }
-    CombinedWalk::build(specs)
+    // Owned, so the derivation can run on another thread: the source text
+    // plus each spec's pattern count is everything the concatenation needs.
+    let parts: Vec<(String, usize)> = specs
+        .iter()
+        .map(|(_, spec, q)| (spec.query.clone(), q.pattern_count()))
+        .collect();
+    registry
+        .combined_walk(move || {
+            crate::util::ghost_stats::count("pd.combine.built");
+            CombinedWalk::build(parts).map(|c| (c.query, c.starts))
+        })
+        .map(|(query, starts)| CombinedWalk { query, starts })
 }
 
 /// Matches for one spec in one round: `(pattern_index, captures)` in the
@@ -556,11 +581,15 @@ impl<'a> Builder<'a> {
         // bucket. Dispatch still runs spec-by-spec in exactly this order even
         // though the combined traversal yields matches interleaved in tree
         // order — the bucketing is what keeps emission order unchanged.
+        let su = crate::util::ghost_stats::ScopedNs::start("pd.setup.eligible");
         let specs = eligible_walk_specs(&plugins);
+        drop(su);
         if specs.is_empty() {
             return;
         }
-        let combined = combined_walk(&specs);
+        let sc = crate::util::ghost_stats::ScopedNs::start("pd.setup.combine");
+        let combined = combined_walk(&plugins, &specs);
+        drop(sc);
         let mut dispatched: HashSet<(String, String, Span)> = HashSet::new();
         let mut rounds_run = 0u64;
         for round in 0..16 {
@@ -572,8 +601,11 @@ impl<'a> Builder<'a> {
             // by the query engine here, since `matches` gets the
             // source text; unknown predicate names pass through
             // unfiltered (the deferred-predicate reservation).
-            let rounds_matches = self.collect_walk_matches(root, &specs, combined.as_ref());
+            let rounds_matches = crate::util::ghost_stats::timed("pd.collect", || {
+                self.collect_walk_matches(root, &specs, combined.as_ref())
+            });
             let mut progressed = false;
+            let lr = crate::util::ghost_stats::ScopedNs::start("pd.loop");
             for (ordinal, (p, spec, _)) in specs.iter().enumerate() {
                 let (query, collected) = &rounds_matches[ordinal];
                 let (p, spec, query) = (*p, *spec, *query);
@@ -591,10 +623,18 @@ impl<'a> Builder<'a> {
                 for (pattern_index, caps) in collected {
                     let pattern_index = *pattern_index;
                     let mspan = union_span(caps);
+                    crate::util::ghost_stats::count("pd.match.seen");
                     let key = (p.id().to_string(), spec.name.clone(), mspan);
                     if dispatched.contains(&key) {
+                        crate::util::ghost_stats::count("pd.match.dedup_skip");
                         continue;
                     }
+                    // The gate runs for EVERY collected match, dispatched or
+                    // not, and it is per-match work with per-package inputs:
+                    // an O(package_ranges) scan, two owned clones, and an
+                    // ancestry walk. Timed as one region because that is the
+                    // unit a caller would skip.
+                    let g = crate::util::ghost_stats::ScopedNs::start("pd.gate");
                     let pkg = self.package_at_point(mspan.start);
                     let uses = self.package_uses.get(&pkg).cloned().unwrap_or_default();
                     let parents = self.transitive_parents(&pkg);
@@ -603,6 +643,7 @@ impl<'a> Builder<'a> {
                         package_parents: &parents,
                     };
                     let fires = plugin::trigger_fires(p.triggers(), &tq);
+                    drop(g);
                     // Trigger didn't fire locally, but a `ClassIsa` gate may
                     // still hold CROSS-FILE (the package has ancestry the
                     // index-free builder can't resolve). Run `on_match` and
@@ -616,8 +657,14 @@ impl<'a> Builder<'a> {
                     };
                     let defer = !fires && !gate_prefixes.is_empty() && !parents.is_empty();
                     if !fires && !defer {
+                        crate::util::ghost_stats::count("pd.match.gated_out");
                         continue;
                     }
+                    crate::util::ghost_stats::count(if defer {
+                        "pd.match.deferred"
+                    } else {
+                        "pd.match.dispatched"
+                    });
                     dispatched.insert(key);
                     progressed = true;
                     crate::util::timings::record_pattern_dispatch(p.id(), &spec.name);
@@ -628,6 +675,7 @@ impl<'a> Builder<'a> {
                     let pkg_for_gate = pkg.clone();
                     let saved =
                         std::mem::replace(&mut self.current_package, Some(pkg.clone()));
+                    let c = crate::util::ghost_stats::ScopedNs::start("pd.context");
                     let mctx = self.build_match_context(
                         spec,
                         query,
@@ -639,7 +687,9 @@ impl<'a> Builder<'a> {
                         parents,
                         None,
                     );
-                    let actions = p.on_match(&spec.name, &mctx);
+                    drop(c);
+                    let actions =
+                        crate::util::ghost_stats::timed("pd.on_match", || p.on_match(&spec.name, &mctx));
                     if defer {
                         self.record_gated_pattern_emission(
                             p.id(),
@@ -673,6 +723,7 @@ impl<'a> Builder<'a> {
                     // (apply_emit_action stamps `current_package`
                     // onto symbols, so it must still be the match
                     // site's package here).
+                    let e = crate::util::ghost_stats::ScopedNs::start("pd.emit");
                     let match_scope = self.scope_at_point(mspan.start);
                     self.scope_stack.push(match_scope);
                     for a in actions {
@@ -722,9 +773,11 @@ impl<'a> Builder<'a> {
                         self.apply_emit_action(p.id().to_string(), a);
                     }
                     self.scope_stack.pop();
+                    drop(e);
                     self.current_package = saved;
                 }
             }
+            drop(lr);
             if !progressed {
                 break;
             }

--- a/src/build/builder/pattern_dispatch.rs
+++ b/src/build/builder/pattern_dispatch.rs
@@ -382,12 +382,20 @@ fn combined_walk<'r>(
         .iter()
         .map(|(_, spec, q)| (spec.query.clone(), q.pattern_count()))
         .collect();
-    registry
-        .combined_walk(move || {
-            crate::util::ghost_stats::count("pd.combine.built");
-            CombinedWalk::build(parts).map(|c| (c.query, c.starts))
-        })
-        .map(|(query, starts)| CombinedWalk { query, starts })
+    let ready = registry.combined_walk(move || {
+        crate::util::ghost_stats::count("pd.combine.built");
+        CombinedWalk::build(parts).map(|c| (c.query, c.starts))
+    });
+    // How many files ran before the background compile landed. The deferred
+    // compile is a startup-ORDERING change, so "how long was the window" is
+    // the question a large corpus actually answers; without this you can only
+    // infer it from a phase total.
+    crate::util::ghost_stats::count(if ready.is_some() {
+        "pd.combine.ready"
+    } else {
+        "pd.combine.pending"
+    });
+    ready.map(|(query, starts)| CombinedWalk { query, starts })
 }
 
 /// Matches for one spec in one round: `(pattern_index, captures)` in the

--- a/src/build/plugin/mod.rs
+++ b/src/build/plugin/mod.rs
@@ -1363,6 +1363,24 @@ pub enum CompletionKindHint {
 #[derive(Default)]
 pub struct PluginRegistry {
     plugins: Vec<Box<dyn FrameworkPlugin>>,
+    /// The registry's combined walk-phase query: the compiled query plus each
+    /// spec's start pattern index. A property of THIS plugin set, so it is
+    /// derived once per registry rather than per file.
+    ///
+    /// Filled on a BACKGROUND thread. Compiling it costs ~410 ms — comparable
+    /// to compiling all the individual specs, because the work is roughly
+    /// linear in total pattern source — and paying that synchronously puts it
+    /// on the critical path of the first build in the process: a one-shot CLI
+    /// verb on a small project went 686 ms to 1,101 ms, and under Rayon the
+    /// first file to arrive stalls the whole pool behind it. Since the
+    /// per-spec traversal is an always-correct fallback (and proven
+    /// equivalent), "not compiled yet" is simply another reason to take it.
+    combined_walk: std::sync::Arc<
+        std::sync::OnceLock<Option<(&'static tree_sitter::Query, Vec<usize>)>>,
+    >,
+    /// Whether the background compile has been kicked off. Separate from the
+    /// `OnceLock` because the lock is only *set* when the compile finishes.
+    combined_walk_started: std::sync::atomic::AtomicBool,
 }
 
 impl std::fmt::Debug for PluginRegistry {
@@ -1372,6 +1390,22 @@ impl std::fmt::Debug for PluginRegistry {
             .field("ids", &self.plugins.iter().map(|p| p.id()).collect::<Vec<_>>())
             .finish()
     }
+}
+
+/// Compile the combined query on the calling thread instead of a background
+/// one. True under `cargo test` so the combined path and its equivalence nets
+/// are actually exercised rather than racing a thread that never wins on a
+/// one-file build, and under `PERL_LSP_PD_COMBINE_SYNC=1` for a measurement
+/// that needs the same path on every file.
+fn combined_walk_is_synchronous() -> bool {
+    if cfg!(test) {
+        return true;
+    }
+    static SYNC: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SYNC.get_or_init(|| {
+        std::env::var("PERL_LSP_PD_COMBINE_SYNC").as_deref() == Ok("1")
+            || std::env::var("PERL_LSP_PD_EQUIV").as_deref() == Ok("1")
+    })
 }
 
 impl PluginRegistry {
@@ -1393,6 +1427,48 @@ impl PluginRegistry {
     /// has been processed, so filtering would prevent the plugin
     /// from ever hooking the statement that introduces the trigger.
     /// Plugins that use `on_use` should filter on `ctx.module_name`.
+    /// The combined walk-phase query if it is ready, kicking off the
+    /// background compile the first time it is asked for.
+    ///
+    /// `None` means "take the per-spec path" — either the compile is still
+    /// running or it produced no usable query. The caller cannot tell the two
+    /// apart, and must not: both mean the same thing to it.
+    ///
+    /// `derive` runs on the spawned thread, so it takes no borrow of the
+    /// registry; the builder side closes over owned spec sources.
+    pub(crate) fn combined_walk(
+        &self,
+        derive: impl FnOnce() -> Option<(&'static tree_sitter::Query, Vec<usize>)> + Send + 'static,
+    ) -> Option<(&'static tree_sitter::Query, &[usize])> {
+        use std::sync::atomic::Ordering;
+        if let Some(v) = self.combined_walk.get() {
+            return v.as_ref().map(|(q, s)| (*q, s.as_slice()));
+        }
+        if combined_walk_is_synchronous() {
+            // `get_or_init`, not `set`: under Rayon several threads arrive
+            // together, and `set` would have each of them compile the query
+            // only for one to win the slot. Blocking the losers is the point
+            // of the synchronous mode anyway.
+            return self
+                .combined_walk
+                .get_or_init(derive)
+                .as_ref()
+                .map(|(q, s)| (*q, s.as_slice()));
+        }
+        if !self.combined_walk_started.swap(true, Ordering::Relaxed) {
+            let slot = std::sync::Arc::clone(&self.combined_walk);
+            // Detached: nothing waits on it, and a registry outliving the
+            // process is the only way the thread outlives the slot.
+            std::thread::Builder::new()
+                .name("pd-combine".into())
+                .spawn(move || {
+                    let _ = slot.set(derive());
+                })
+                .ok();
+        }
+        None
+    }
+
     pub fn all(&self) -> impl Iterator<Item = &dyn FrameworkPlugin> {
         self.plugins.iter().map(|p| p.as_ref())
     }

--- a/src/build/plugin/mod.rs
+++ b/src/build/plugin/mod.rs
@@ -1459,12 +1459,20 @@ impl PluginRegistry {
             let slot = std::sync::Arc::clone(&self.combined_walk);
             // Detached: nothing waits on it, and a registry outliving the
             // process is the only way the thread outlives the slot.
-            std::thread::Builder::new()
+            let spawned = std::thread::Builder::new()
                 .name("pd-combine".into())
                 .spawn(move || {
                     let _ = slot.set(derive());
                 })
-                .ok();
+                .is_ok();
+            if !spawned {
+                // Releasing the flag matters: the slot is only ever filled by
+                // the thread, so a swallowed spawn failure would leave every
+                // later call taking the per-spec path forever — correct, but
+                // silently and permanently slower. Let the next caller retry.
+                self.combined_walk_started.store(false, Ordering::Relaxed);
+                crate::util::ghost_stats::count("pd.combine.spawn_failed");
+            }
         }
         None
     }


### PR DESCRIPTION
Attributing pattern dispatch's own residual found a **regression I shipped in #135**, and corrected the reading of what the residual even is.

## The regression

Building the combined query means joining every spec source and compiling the result. That is **~410 ms** — comparable to compiling all the individual specs, because the work is roughly linear in total pattern source. Measured per added spec: 49 ms at one, 411 ms at thirteen, no single pathological spec.

It was paid **synchronously on the first build in the process**, and under Rayon the first file to arrive stalled the whole pool behind it — 1,690 ms of blocked thread time across a 3,520-file walk. Single-threading identified it as one compile plus a convoy rather than a per-file cost.

| | pre-#135 | #135 | this PR |
|---|---:|---:|---:|
| one-shot `--check`, 6-file project | 686 ms | 1,101 ms | **697 ms** |
| cold single hover, 101-file root | 1,831 ms | 1,959 ms | **1,730 ms** |

The fix is to compile it on a background thread. The per-spec traversal is an always-correct, already-proven-equivalent fallback, so *"not compiled yet"* is simply another reason to take it — no new path and no new failure mode. The cold-hover case beats **both** prior arms because the compile lands mid-walk and later files still get the fast traversal.

Synchronous when determinism matters rather than latency: under `cargo test` (so the combined path and its equivalence nets are actually exercised instead of racing a thread that never wins on a one-file build), under `PERL_LSP_PD_EQUIV=1`, and under `PERL_LSP_PD_COMBINE_SYNC=1`. That mode uses `get_or_init` rather than `set`, so arriving threads block instead of each compiling a query only one of them can install (caught by `pd.combine.built` reading 4 instead of 1).

The slot lives on `PluginRegistry` because the answer is a function of the registry's plugins and nothing else; the derivation closes over owned spec sources so it can run on another thread.

## Corpus effect

| | per-spec | this PR | |
|---|---:|---:|---|
| `build::pattern_dispatch` | 19,253 ms | 3,101 ms | **6.2x** |
| `walk.build` | 29,701 ms | 15,173 ms | **−48.9%** |
| `pd.setup.combine` | — | 9.8 ms | was 1,690 ms at #135 |
| `--check` wall | 35.8 / 34.4 s | 26.6 / 28.2 s | |

## The attribution — which corrected my own inference

I reported after #135 that the residual was per-match gating and projection. **That was wrong**, and the instrumentation says so:

| region | ms | share | |
|---|---:|---:|---|
| `pd.collect` | 2,818 | 91% | tree traversal |
| `pd.loop` | 238 | 7.7% | per-spec/per-round bookkeeping |
| `pd.on_match` | 195 | 6.3% | Rhai plugin calls (851 at 229 µs) |
| `pd.context` | 31 | 1.0% | capture projections |
| `pd.gate` | 2 | 0.07% | the trigger gate (1,238 at 1.7 µs) |
| `pd.emit` | 1 | 0.04% | emissions |

**Gating is 0.07% of the phase.** What looked like a gating-and-projection residual was the compile convoy, which is now gone; the phase is still 91% traversal.

This also retires the pre-filter idea properly: a predicate that skips the ~91% of files matching nothing would be gating away 2 ms.

Counters (`pd.match.seen` 2,089, `dedup_skip` 851, `dispatched` 772, `gated_out` 387, `deferred` 79) are unchanged from before the fix, which is the equivalence evidence for it.

## Verification

- `cargo test` — 1,495 passed, 0 failed
- `cargo test --features cpp` — 1,555 passed, 0 failed, 3 ignored
- `PERL_LSP_PD_EQUIV=1 cargo test --features cpp` — 1,555 passed, 0 failed
- Corpus equivalence: **3,840 file-rounds, zero mismatches**, and 3,840 equals `build.pattern_rounds` exactly, so nothing was skipped
- `--languages` → `perl, cpp (beta)`; cache cleared then gold: **498 PASS, 16 xfail, 0 FAIL, 0 XPASS, 0 CRASH, 0 skip, 0 lang-skip**

All exit codes are the true ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_