### PR TITLE
e2e: fail on an old nvim with the reason, not a traceback

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -8,6 +8,31 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 export PERL5LIB="${PERL5LIB:-$PWD/test_files/lib}"
 
+# Fail on an old nvim with the reason, not a traceback. The harness calls
+# `vim.lsp.get_clients` (0.10+); on 0.9.x that surfaces as
+# "attempt to call field 'get_clients' (a nil value)" inside lua/test/lsp.lua,
+# which reads as a broken harness rather than a stale editor — an hour lost to
+# it here, and Ubuntu 24.04 still ships 0.9.5.
+if ! command -v nvim >/dev/null 2>&1; then
+  echo "e2e: nvim not found. The harness needs nvim 0.10+ (CI pins v0.11.0)." >&2
+  exit 1
+fi
+nvim_ver=$(nvim --version | head -1 | sed -E 's/^NVIM v?//')
+nvim_major=${nvim_ver%%.*}
+nvim_minor=${nvim_ver#*.}; nvim_minor=${nvim_minor%%.*}
+if (( nvim_major == 0 && nvim_minor < 10 )); then
+  cat >&2 <<EOF
+e2e: nvim $nvim_ver is too old — the harness needs 0.10+ (it calls
+     vim.lsp.get_clients). CI pins v0.11.0. Distro packages lag: Ubuntu
+     24.04 ships 0.9.5. Use the release tarball:
+
+  curl -sSL -o nvim.tar.gz \\
+    https://github.com/neovim/neovim/releases/download/v0.11.0/nvim-linux-x86_64.tar.gz
+  tar xzf nvim.tar.gz && export PATH="\$PWD/nvim-linux-x86_64/bin:\$PATH"
+EOF
+  exit 1
+fi
+
 bin="${PERL_LSP_BIN:-./target/release/perl-lsp}"
 
 # Reap our own servers. nvim spawns perl-lsp and cleanly shuts it down when nvim


### PR DESCRIPTION
The harness calls `vim.lsp.get_clients`, which is nvim 0.10+. On 0.9.x that surfaces as:

```
E5113: Error while calling lua chunk: ./lua/test/lsp.lua:221:
       attempt to call field 'get_clients' (a nil value)
```

…from inside the harness, so the first read is *"the harness is broken"* rather than *"the editor is stale"*. That cost me an hour yesterday, and it is not an unlucky sandbox: Ubuntu 24.04 ships 0.9.5, so it is the default outcome of `apt-get install neovim`.

`run.sh` now checks up front and prints what is wrong, what is required, and the tarball command.

Documentation was the weaker fix. The README note added in `f9556339` only helps someone who thinks to look; the failure itself now says it. Same shape as the apt retry — put the fix where the failure surfaces.

## Base-verified both directions

With 0.9.5 on `PATH`:

```
e2e: nvim 0.9.5 is too old — the harness needs 0.10+ (it calls
     vim.lsp.get_clients). CI pins v0.11.0. Distro packages lag: Ubuntu
     24.04 ships 0.9.5. Use the release tarball:
  ...
TRUE_EXIT: 1
```

— exits before a single suite runs. With 0.11.0 it falls through and the suite runs normally.

## Full e2e on the merged tip

```
TOTAL: 113 passed, 0 failed  across 10 suites
```

**and the per-suite retry did not fire once.** Worth recording separately from the pass count: that retry exists to paper over the attach-then-hover readiness race, and `dbic_parametric.lua` was failing *through* it on CI before #136. Zero retries across ten suites is independent corroboration that the race is gone, on top of the 0/60 rate measurement.

`cargo test` also clean (no Rust changed; run as insurance).

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_