### PR TITLE
Make completion deterministic — an instrument fix that happens to correct a ranking bug

### DIFF
--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -86,6 +86,19 @@ the workspace path, and their `EXTRACT_VERSION` and plugin fingerprints
 differ — sharing one makes each side hard-clear the other's cache on every
 startup.
 
+**A run's answers file does not exist until the run finishes.** Answers are
+written to `<out>.partial` and renamed only on clean completion, so an
+aborted or still-running side is never mistakable for a finished one. This is
+the fix for the root cause behind three separate wrong results in one
+evening: a measurement reading a file that is not yet what it will be.
+
+**A side that stopped is not a side that found less.** The header records how
+many positions a complete run would answer, and a completion marker is
+written at the very end; `diff` refuses (exit 3) when either check fails.
+`--allow-short` compares anyway and stamps the report TRUNCATED — because
+every ratio over a short side is a ratio over the positions it reached before
+stopping, which are the cheap ones.
+
 **All four inputs are cross-checked for provenance.** The diff verifies that
 the noise pair answered the same positions (by content hash) and did not run
 before the A/B, and refuses the floor otherwise. This is not defensive

--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -86,6 +86,22 @@ the workspace path, and their `EXTRACT_VERSION` and plugin fingerprints
 differ — sharing one makes each side hard-clear the other's cache on every
 startup.
 
+**The noise floor is measured over exactly the answers compared.** It is a
+per-answer rate, so it is only subtractable from a count taken over the same
+answers. Measured on Koha: the base wedged repeatedly and produced 1,184
+comparable answers where the two noise runs produced ~21,790. Quoting the
+larger population's floor beside the smaller count is not a correction, it is
+a different measurement — and a biased one, because the answers a stalling
+side reaches first are the cheap ones, which is exactly where two runs agree.
+The report says what fraction of the comparison the floor could cover.
+
+**A re-warmed server is not the same server.** Every row records the server
+generation that answered it. Answers from a generation that never
+re-confirmed cross-file readiness after a restart are HELD OUT of every count
+— on Koha 3 of 8 restarts never re-warmed, and an unconfirmed empty cannot be
+told apart from a lost resolution. Answers from a generation that did re-warm
+are counted but reported, because a rebuilt index is not the same index.
+
 ## Reading the report
 
 Shapes are ordered by what a reviewer must look at first. `only-base` and
@@ -96,6 +112,19 @@ candidates. `disagree` is the residual that always needs a human.
 `n` is positions; **`distinct` is claims** — the number of different (base
 answer, head answer) pairs behind them. One generated data file can
 contribute sixty positions that disagree identically. Adjudicate `distinct`.
+
+## Testing the harness
+
+`selftest.py` covers the rules that decide the report — normalisation,
+classification, the floor's intersection, the recheck supersede. `run.sh` is
+covered by `selftest-shell.sh` instead, which invokes it for real against a
+throwaway two-file corpus and asserts the same binary agrees with itself.
+
+That split is not tidiness. `run.sh` was once completely non-functional —
+`"$@:3"` is not slice syntax, so both sides died on `unrecognized arguments`
+— while the Python suite stayed green throughout, because it never invoked
+the entry point. A unit suite that passes says nothing about whether the
+thing runs.
 
 ## What it does not do
 

--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -108,6 +108,15 @@ like a floor from this one. It happened, and it published wrong numbers —
 a report generated the moment the head side finished, while the two noise
 runs the script had not yet started sat on disk from the previous invocation.
 
+**The floor is a distribution, not a number, so give `--noise` more than two
+runs.** Four head runs on the substrate yield six pairs, and on identical
+inputs `disagree` came out 14, 15, 17, 19, 25, 25 — nearly 2x between the
+luckiest and unluckiest pair. A two-run floor reports whichever one happened
+to run. The tool measures every pair and reports the WORST, because a shape
+earns "signal" by clearing the worst self-disagreement observed; the range is
+printed alongside so the estimate's stability is visible. `reranked` is tight
+(158-168); `disagree` is not.
+
 **The floor is sliced per verb as well as per shape.** An aggregate is the
 wrong baseline for a single-verb block, and it errs in both directions:
 measured here, every one of the `disagree` floor's occurrences is on

--- a/bench/sweep/README.md
+++ b/bench/sweep/README.md
@@ -86,6 +86,21 @@ the workspace path, and their `EXTRACT_VERSION` and plugin fingerprints
 differ — sharing one makes each side hard-clear the other's cache on every
 startup.
 
+**All four inputs are cross-checked for provenance.** The diff verifies that
+the noise pair answered the same positions (by content hash) and did not run
+before the A/B, and refuses the floor otherwise. This is not defensive
+paranoia: four well-formed answer files produce a well-formed report whether
+or not they belong together, and a floor from a previous run reads exactly
+like a floor from this one. It happened, and it published wrong numbers —
+a report generated the moment the head side finished, while the two noise
+runs the script had not yet started sat on disk from the previous invocation.
+
+**The floor is sliced per verb as well as per shape.** An aggregate is the
+wrong baseline for a single-verb block, and it errs in both directions:
+measured here, every one of the `disagree` floor's occurrences is on
+completion, so a `definition` block read against the aggregate is handed
+noise it does not have.
+
 **The noise floor is measured over exactly the answers compared.** It is a
 per-answer rate, so it is only subtractable from a count taken over the same
 answers. Measured on Koha: the base wedged repeatedly and produced 1,184

--- a/bench/sweep/REPORT-substrate.md
+++ b/bench/sweep/REPORT-substrate.md
@@ -19,19 +19,28 @@ identical, 945 were empty on both sides.
 
 ## The noise floor comes first
 
-The same binary, run twice over the same positions, disagrees with itself on
-**3.8%** of answers:
+> **The figures in this section were re-measured.** They were originally
+> taken over every answer the two noise runs produced, while the A/B counts
+> came from the smaller set the wedging base got through. Same defect
+> `[coordinator]` found at Koha scale, an order of magnitude smaller here,
+> and it moved real numbers: `disagree` 7 → **22**, `only-head` 0 → **11**,
+> `capped-head` 0 → **3**. The floor is now measured over exactly the
+> compared answers, and the report states what fraction of them it covers
+> (87.5% on this corpus — the noise runs reach positions the base never did).
+
+The same binary, run twice over the same positions, disagrees with itself:
 
 | shape | self-vs-self |
 |---|---|
-| `reranked` | 164 |
-| `disagree` | 7 |
+| `reranked` | 127 |
+| `disagree` | 22 |
+| `only-head` | 11 |
+| `capped-head` | 3 |
 | everything else | **0** |
 
-Completion ordering is not stable run to run. So the 70 `reranked` rows in
-the A/B carry **no information at all** — they are below the floor — while
-`only-*`, `subset`, `superset` and `content-differs` can be read at face
-value. Without this measurement a reader has no way to tell those cases
+Completion ordering is not stable run to run. So the `reranked` block carries
+**no information at all** — it sits below the floor — while `only-base`,
+`subset`, `superset` and `content-differs` can be read at face value. Without this measurement a reader has no way to tell those cases
 apart, and the third of the A/B's shapes that is pure noise looks exactly
 like the two thirds that are not.
 

--- a/bench/sweep/REPORT-substrate.md
+++ b/bench/sweep/REPORT-substrate.md
@@ -19,24 +19,34 @@ identical, 945 were empty on both sides.
 
 ## The noise floor comes first
 
-> **The figures in this section were re-measured.** They were originally
-> taken over every answer the two noise runs produced, while the A/B counts
-> came from the smaller set the wedging base got through. Same defect
-> `[coordinator]` found at Koha scale, an order of magnitude smaller here,
-> and it moved real numbers: `disagree` 7 → **22**, `only-head` 0 → **11**,
-> `capped-head` 0 → **3**. The floor is now measured over exactly the
-> compared answers, and the report states what fraction of them it covers
-> (87.5% on this corpus — the noise runs reach positions the base never did).
+> **These figures were published wrong once, and the retraction is the
+> useful part.** An earlier amendment here claimed the intersected floor rose
+> sharply (`disagree` 7 → 22, `only-head` 0 → 11, `capped-head` 0 → 3). It did
+> not. That report was generated the moment the head side finished, while the
+> two noise runs the script had yet to start were still on disk from the
+> PREVIOUS invocation — so a fresh A/B was diffed against a stale floor. Four
+> well-formed files produce a well-formed report whether or not they belong
+> together, which is why `sweep.py diff` now cross-checks the positions hash
+> and start time of all four inputs and refuses a floor that fails either.
+>
+> Intersecting the floor is still right — a rate is only subtractable from a
+> count over the same answers — but on THIS corpus it barely moves anything,
+> because the base's stalls cost few answers. At Koha's 7.1% coverage it may
+> matter a great deal; that remains unmeasured by me.
 
 The same binary, run twice over the same positions, disagrees with itself:
 
-| shape | self-vs-self |
-|---|---|
-| `reranked` | 127 |
-| `disagree` | 22 |
-| `only-head` | 11 |
-| `capped-head` | 3 |
-| everything else | **0** |
+| shape | self-vs-self | of which |
+|---|---|---|
+| `reranked` | 152 | all completion |
+| `disagree` | 5 | all completion |
+| everything else | **0** | |
+
+Measured over 4,017 of 4,017 compared answers — full coverage, matched run.
+The per-verb slice matters: **all** of the `disagree` floor is completion, so
+a `definition` block read against the aggregate would be handed noise it does
+not have. The groups table now carries a per-verb floor column for this
+reason.
 
 Completion ordering is not stable run to run. So the `reranked` block carries
 **no information at all** — it sits below the floor — while `only-base`,

--- a/bench/sweep/REPORT-substrate.md
+++ b/bench/sweep/REPORT-substrate.md
@@ -14,39 +14,39 @@ adjudication below can be re-checked rather than believed.
   is a capability difference, not a divergence.
 - Raw report: `report-substrate-raw.md`.
 
-**2,836 of 4,302 answers identical (65.9%); 1,466 divergent.** Of the
-identical, 945 were empty on both sides.
+**2,747 of 4,302 answers identical (63.9%); 1,555 divergent.** Of the
+identical, 895 were empty on both sides.
 
 ## The noise floor comes first
 
-> **These figures were published wrong once, and the retraction is the
-> useful part.** An earlier amendment here claimed the intersected floor rose
-> sharply (`disagree` 7 → 22, `only-head` 0 → 11, `capped-head` 0 → 3). It did
-> not. That report was generated the moment the head side finished, while the
-> two noise runs the script had yet to start were still on disk from the
-> PREVIOUS invocation — so a fresh A/B was diffed against a stale floor. Four
-> well-formed files produce a well-formed report whether or not they belong
-> together, which is why `sweep.py diff` now cross-checks the positions hash
-> and start time of all four inputs and refuses a floor that fails either.
->
-> Intersecting the floor is still right — a rate is only subtractable from a
-> count over the same answers — but on THIS corpus it barely moves anything,
-> because the base's stalls cost few answers. At Koha's 7.1% coverage it may
-> matter a great deal; that remains unmeasured by me.
+> **Re-measured end to end with the guarded harness.** Every figure below
+> comes from one verified set: five runs (base + four head) on one position
+> set, each renamed from `.partial` only on clean completion, each carrying
+> its position-set hash and a completion marker, and cross-checked by
+> `diff` before use. The earlier figures in this section were published
+> twice and wrong twice — first from a floor measured over a different
+> population, then from noise files belonging to the *previous* invocation.
+> Neither error was visible in the output.
 
-The same binary, run twice over the same positions, disagrees with itself:
+The same binary, run twice, disagrees with itself — but **the floor is not a
+number, it is a distribution.** Four head runs give six pairs, and on
+identical inputs they disagree by nearly 2× in one shape:
 
-| shape | self-vs-self | of which |
+| shape | across 6 pairs | reported floor (worst) |
 |---|---|---|
-| `reranked` | 152 | all completion |
-| `disagree` | 5 | all completion |
-| everything else | **0** | |
+| `reranked` | 158, 163, 164, 164, 167, 168 | **168** |
+| `disagree` | 14, 15, 17, 19, 25, 25 | **25** |
+| everything else | all zero | **0** |
 
-Measured over 4,017 of 4,017 compared answers — full coverage, matched run.
-The per-verb slice matters: **all** of the `disagree` floor is completion, so
-a `definition` block read against the aggregate would be handed noise it does
-not have. The groups table now carries a per-verb floor column for this
-reason.
+A two-run floor is one draw from that. Whichever pair happened to run would
+have been quoted as "the floor", and for `disagree` that is anywhere from 14
+to 25 — so a block sitting in that band cannot be called signal on a two-run
+measurement. The reported floor is the **worst** pair, because a shape earns
+"signal" by clearing the worst self-disagreement observed, not the luckiest.
+`--noise` takes as many runs as you give it.
+
+All of the `disagree` floor is on completion; `definition` contributes zero
+in all six pairs. The groups table carries a per-verb floor for that reason.
 
 Completion ordering is not stable run to run. So the `reranked` block carries
 **no information at all** — it sits below the floor — while `only-base`,
@@ -58,13 +58,13 @@ like the two thirds that are not.
 
 | claim | rows | verdict |
 |---|---|---|
-| head no longer offers `(anon)` as a completion candidate | 87 `subset` + 1 `only-base` | **fix** — an anonymous sub is not a name anyone can type. 88 of 88 lose `(anon)` and *nothing else*, on two independent runs |
-| head resolves goto-def to the declaration line where base returned `0:0` | 110 `disagree` | **fix** — every same-file definition disagreement is this |
+| head no longer offers `(anon)` as a completion candidate | 52 `subset` + 1 `only-base` | **fix** — an anonymous sub is not a name anyone can type. 53 of 53 lose `(anon)` and *nothing else*, and this has now reproduced on four independent runs |
+| head resolves goto-def to the declaration line where base returned `0:0` | 56 `disagree` | **fix** — every same-file definition disagreement is this, in every run |
 | head returns *every* `@INC` provider of a name where base returned one | ~117 `disagree` | **intended** — this is the `(name, inc-root)` candidate relation. `use strict` now answers both `perl/5.38.2/strict.pm` and `perl-base/strict.pm`. Flagged because it is my own change: the sweep is confirming it, not discovering it |
-| head answers where base was empty | 263 `only-head` | improvement (99 definition, 87 completion, 77 hover) |
-| head answers a superset | 182 `superset` | improvement (155 completion, 27 references) |
-| head truncates long completion lists | 27 `capped-head` | **by design** — `MAX_COMPLETION_ITEMS`, with `isIncomplete` set |
-| completion ranking moved | 70 `reranked` | **unreadable** — below the noise floor |
+| head answers where base was empty | 417 `only-head` | improvement |
+| head answers a superset | 254 `superset` | improvement |
+| head truncates long completion lists | 16 `capped-head` | **by design** — `MAX_COMPLETION_ITEMS`, with `isIncomplete` set |
+| completion ranking moved | 41 `reranked` | **unreadable** — floor is 168 |
 
 ## Needs a ruling
 
@@ -80,9 +80,10 @@ like the two thirds that are not.
   candidates. It is the only `only-base` row in the sweep that is not the
   `(anon)` fix.
 
-**526 completion `disagree` rows** where head both gains and loses real
-names. Perl builtins explain only 2%; **63% lose sigil'd (lexical or
-package) names**. Whether that is scope correctness or lost candidates is
+**531 completion `disagree` rows** where head both gains and loses real
+names (of 560 completion disagreements). Perl builtins explain only ~2% of
+what head gains; **341 — 64% — lose sigil'd (lexical or package) names**,
+against a `disagree`/completion floor of 25. Whether that is scope correctness or lost candidates is
 the one bucket this sweep cannot rule on.
 
 ## Two things about `main` itself

--- a/bench/sweep/report-substrate-raw.md
+++ b/bench/sweep/report-substrate-raw.md
@@ -1,42 +1,56 @@
 # Differential sweep report
 
 - **base** `base` — `perl-lsp 0.6.1`
-- **head** `head` — `perl-lsp 0.7.0`
+- **head** `h1` — `perl-lsp 0.7.0`
 - corpus: `/home/user/perl-lsp/gold-corpus/local/lib/perl5`
 - path: **server** (LSP over stdio), verbs completion, definition, documentSymbol, hover, references
 - **excluded as a capability difference:** `typeDefinition` — served by one side only, so every position would report a divergence that is a missing feature rather than a changed answer
 - sampled verbs: `references` at 10%
-- cross-file readiness: base 1088 ms, head 1149 ms
-- **base server-wedged**: after_position=102, consecutive_timeouts=3, file=Date/Language/Sidama.pm, line=10, restart=1, verb=definition
-- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1068, restart=1
-- **base server-wedged**: after_position=888, consecutive_timeouts=3, file=PPI/Util.pm, line=37, restart=2, verb=definition
-- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1089, restart=2
-- **base server-wedged**: after_position=1116, consecutive_timeouts=3, file=YAML/PP/Representer.pm, line=46, restart=3, verb=definition
-- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1067, restart=3
-- **base server-wedged**: after_position=1173, consecutive_timeouts=3, file=x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm, line=23, restart=4, verb=definition
-- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1096, restart=4
-- **base recheck**: empty_first_ask=1310, filled_when_warm=2
-- **head recheck**: empty_first_ask=2438, filled_when_warm=13
+- cross-file readiness: base 96 ms, head 2457 ms
+- **base server-wedged**: after_position=165, consecutive_timeouts=3, file=DateTime/TimeZone/America/Boise.pm, line=17, restart=1, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=90, epoch=1, restart=1
+- **base server-wedged**: after_position=479, consecutive_timeouts=3, file=Dist/Zilla/Role/MintingProfile/ShareDir.pm, line=20, restart=2, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1087, epoch=2, restart=2
+- **base server-wedged**: after_position=528, consecutive_timeouts=3, file=Email/MessageID.pm, line=63, restart=3, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=95, epoch=3, restart=3
+- **base server-wedged**: after_position=679, consecutive_timeouts=3, file=Mojo/Server.pm, line=19, restart=4, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1073, epoch=4, restart=4
+- **base server-wedged**: after_position=899, consecutive_timeouts=3, file=Plack/HTTPParser.pm, line=0, restart=5, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1076, epoch=5, restart=5
+- **base server-wedged**: after_position=1008, consecutive_timeouts=3, file=Test/TypeTiny.pm, line=2, restart=6, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1092, epoch=6, restart=6
+- **base server-wedged**: after_position=1147, consecutive_timeouts=3, file=x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm, line=17, restart=7, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1088, epoch=7, restart=7
+- **base server-wedged**: after_position=1452, consecutive_timeouts=3, file=x86_64-linux-gnu-thread-multi/oose.pm, line=6, restart=8, verb=definition
+- **base restart-rewarm**: confirmed=True, cross_file_ready_ms=1093, epoch=8, restart=8
+- **base recheck**: empty_first_ask=1483, filled_when_warm=4
+- **base complete**: positions_answered=1458
+- **head recheck**: empty_first_ask=2437, filled_when_warm=12
+- **head complete**: positions_answered=1458
 
-**4302 (position, verb) answers compared — 2836 identical (65.92%), 1466 divergent.**
+**4302 (position, verb) answers compared — 2747 identical (63.85%), 1555 divergent.**
 
-Of the identical ones, 945 were empty on both sides: positions nobody would ask about, kept in the denominator but called out so the agreement rate is not read as coverage.
+Of the 4302 compared, 3817 were answered after at least one side restarted (by a generation that did re-warm). A rebuilt index is not the same index.
+
+Of the identical ones, 944 were empty on both sides: positions nobody would ask about, kept in the denominator but called out so the agreement rate is not read as coverage.
 
 ## Divergences by shape
 
-`noise` is the same shape's count when the SAME binary is run twice over these positions. A block at or below its noise floor carries no information — read the `signal` column, not `n`.
+`noise` is the WORST self-disagreement across all 6 pairs of same-binary runs, measured over EXACTLY the answers compared here. A shape earns `signal` only by clearing the worst floor observed, not the luckiest.
+
+> The floor is not one number. Across those pairs: `disagree` ranged 14–25. A single pair would have reported any one of those, so a block sitting between the low and high figures cannot be called signal from a two-run floor.
 
 | shape | n | noise | signal | meaning |
 |---|---|---|---|---|
 | `only-base` | 2 | 0 | 2 | base answers, head empty  (LOST resolution -- regression candidate) |
-| `subset` | 87 | 0 | 87 | head found strictly fewer  (regression candidate) |
-| `disagree` | 788 | 7 | 781 | both non-empty, neither contains the other |
-| `content-differs` | 35 | 0 | 35 | same shape, different content (hover text, etc.) |
-| `reranked` | 70 | 164 | **below noise — unreadable** | same candidates, different order (completion ranking moved) |
-| `only-head` | 263 | 0 | 263 | head answers, base empty  (new resolution -- intended improvement?) |
-| `superset` | 182 | 0 | 182 | head found everything base did, plus more |
-| `capped-head` | 27 | 0 | 27 | head's list is a subset because head TRUNCATED it (isIncomplete) — by design, not a loss |
-| `timeout-base` | 12 | 0 | 12 | base timed out, head answered |
+| `subset` | 52 | 0 | 52 | head found strictly fewer  (regression candidate) |
+| `disagree` | 730 | 25 | 705 | both non-empty, neither contains the other |
+| `content-differs` | 21 | 0 | 21 | same shape, different content (hover text, etc.) |
+| `reranked` | 41 | 168 | **below noise — unreadable** | same candidates, different order (completion ranking moved) |
+| `only-head` | 417 | 0 | 417 | head answers, base empty  (new resolution -- intended improvement?) |
+| `superset` | 254 | 0 | 254 | head found everything base did, plus more |
+| `capped-head` | 16 | 0 | 16 | head's list is a subset because head TRUNCATED it (isIncomplete) — by design, not a loss |
+| `timeout-base` | 22 | 0 | 22 | base timed out, head answered |
 
 ## Groups
 
@@ -44,77 +58,76 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 
 `distinct` is the number of different (base answer, head answer) PAIRS behind the positions — the count of separate claims. One generated data file can contribute sixty positions that all disagree the same way; that is one thing to adjudicate, not sixty, and reading `n` as the workload is how a sweep gets abandoned as noise.
 
-| shape | verb | token kind | n | distinct |
-|---|---|---|---|---|
-| `only-base` | completion | method-call | 2 | 2 |
-| `subset` | completion | method-call | 36 | 34 |
-| `subset` | completion | call-site | 24 | 22 |
-| `subset` | completion | package | 15 | 13 |
-| `subset` | completion | module-path | 11 | 7 |
-| `subset` | completion | variable | 1 | 1 |
-| `disagree` | completion | sub-decl | 175 | 168 |
-| `disagree` | definition | use-module | 145 | 38 |
-| `disagree` | completion | variable | 113 | 113 |
-| `disagree` | completion | use-module | 95 | 74 |
-| `disagree` | definition | module-path | 71 | 45 |
-| `disagree` | completion | hash-key | 57 | 43 |
-| `disagree` | completion | module-path | 44 | 33 |
-| `disagree` | completion | call-site | 36 | 36 |
-| `disagree` | completion | package | 28 | 23 |
-| `disagree` | completion | method-call | 13 | 12 |
-| `disagree` | definition | call-site | 11 | 11 |
-| `content-differs` | hover | variable | 15 | 15 |
-| `content-differs` | hover | call-site | 6 | 6 |
-| `content-differs` | hover | sub-decl | 6 | 6 |
-| `content-differs` | hover | method-call | 5 | 5 |
-| `content-differs` | hover | module-path | 3 | 3 |
-| `reranked` | completion | package | 26 | 10 |
-| `reranked` | completion | module-path | 24 | 11 |
-| `reranked` | completion | use-module | 15 | 10 |
-| `reranked` | completion | call-site | 5 | 5 |
-| `only-head` | definition | use-module | 55 | 17 |
-| `only-head` | hover | module-path | 43 | 28 |
-| `only-head` | completion | module-path | 39 | 13 |
-| `only-head` | completion | use-module | 28 | 8 |
-| `only-head` | hover | call-site | 17 | 13 |
-| `only-head` | definition | module-path | 17 | 10 |
-| `only-head` | definition | call-site | 17 | 11 |
-| `only-head` | completion | call-site | 13 | 8 |
-| `only-head` | definition | method-call | 7 | 7 |
-| `only-head` | hover | method-call | 7 | 7 |
-| `only-head` | hover | use-module | 7 | 7 |
-| `only-head` | completion | method-call | 4 | 3 |
-| `only-head` | completion | hash-key | 3 | 3 |
-| `only-head` | definition | hash-key | 3 | 3 |
-| `only-head` | hover | hash-key | 3 | 3 |
-| `superset` | completion | package | 65 | 60 |
-| `superset` | completion | hash-key | 35 | 34 |
-| `superset` | completion | module-path | 27 | 24 |
-| `superset` | references | use-module | 17 | 17 |
-| `superset` | completion | variable | 9 | 9 |
-| `superset` | completion | use-module | 8 | 7 |
-| `superset` | completion | call-site | 8 | 8 |
-| `superset` | references | call-site | 5 | 5 |
-| `superset` | references | module-path | 5 | 5 |
-| `superset` | completion | method-call | 3 | 3 |
-| `capped-head` | completion | package | 16 | 1 |
-| `capped-head` | completion | sub-decl | 5 | 5 |
-| `capped-head` | completion | variable | 3 | 3 |
-| `capped-head` | completion | use-module | 1 | 1 |
-| `capped-head` | completion | hash-key | 1 | 1 |
-| `capped-head` | completion | call-site | 1 | 1 |
-| `timeout-base` | completion | use-module | 1 | 1 |
-| `timeout-base` | definition | use-module | 1 | 1 |
-| `timeout-base` | references | call-site | 1 | 1 |
-| `timeout-base` | completion | call-site | 1 | 1 |
-| `timeout-base` | definition | call-site | 1 | 1 |
-| `timeout-base` | references | method-call | 1 | 1 |
-| `timeout-base` | completion | sub-decl | 1 | 1 |
-| `timeout-base` | definition | sub-decl | 1 | 1 |
-| `timeout-base` | references | package | 1 | 1 |
-| `timeout-base` | completion | method-call | 1 | 1 |
-| `timeout-base` | definition | method-call | 1 | 1 |
-| `timeout-base` | references | use-module | 1 | 1 |
+The `verb noise` column is the floor for that shape ON THAT VERB, which is the only baseline a single-verb block can be read against. It is summed over the verb's kinds, so a block covering one kind sits well under it.
+
+| shape | verb | token kind | n | distinct | verb noise |
+|---|---|---|---|---|---|
+| `only-base` | completion | method-call | 2 | 2 | 0 |
+| `subset` | completion | method-call | 24 | 24 | 0 |
+| `subset` | completion | call-site | 12 | 11 | 0 |
+| `subset` | completion | module-path | 10 | 6 | 0 |
+| `subset` | completion | package | 5 | 3 | 0 |
+| `subset` | completion | variable | 1 | 1 | 0 |
+| `disagree` | completion | sub-decl | 180 | 171 | 25 |
+| `disagree` | definition | use-module | 119 | 29 | 0 |
+| `disagree` | completion | variable | 115 | 115 | 25 |
+| `disagree` | completion | use-module | 91 | 72 | 25 |
+| `disagree` | completion | hash-key | 59 | 51 | 25 |
+| `disagree` | definition | module-path | 42 | 25 | 0 |
+| `disagree` | completion | module-path | 41 | 30 | 25 |
+| `disagree` | completion | call-site | 40 | 39 | 25 |
+| `disagree` | completion | package | 17 | 17 | 25 |
+| `disagree` | completion | method-call | 17 | 16 | 25 |
+| `disagree` | definition | call-site | 9 | 9 | 0 |
+| `content-differs` | hover | variable | 13 | 13 | 0 |
+| `content-differs` | hover | sub-decl | 6 | 6 | 0 |
+| `content-differs` | hover | call-site | 2 | 2 | 0 |
+| `reranked` | completion | module-path | 14 | 5 | 168 |
+| `reranked` | completion | package | 13 | 9 | 168 |
+| `reranked` | completion | use-module | 8 | 7 | 168 |
+| `reranked` | completion | call-site | 6 | 6 | 168 |
+| `only-head` | definition | use-module | 80 | 26 | 0 |
+| `only-head` | completion | module-path | 56 | 24 | 0 |
+| `only-head` | completion | use-module | 55 | 19 | 0 |
+| `only-head` | definition | module-path | 49 | 31 | 0 |
+| `only-head` | hover | module-path | 43 | 28 | 0 |
+| `only-head` | definition | call-site | 32 | 24 | 0 |
+| `only-head` | hover | call-site | 28 | 23 | 0 |
+| `only-head` | completion | call-site | 20 | 15 | 0 |
+| `only-head` | definition | method-call | 15 | 15 | 0 |
+| `only-head` | hover | method-call | 14 | 14 | 0 |
+| `only-head` | completion | method-call | 7 | 6 | 0 |
+| `only-head` | hover | use-module | 7 | 7 | 0 |
+| `only-head` | completion | hash-key | 3 | 3 | 0 |
+| `only-head` | definition | hash-key | 3 | 3 | 0 |
+| `only-head` | hover | hash-key | 3 | 3 | 0 |
+| `only-head` | references | method-call | 1 | 1 | 0 |
+| `only-head` | documentSymbol | file | 1 | 1 | 0 |
+| `superset` | completion | package | 109 | 107 | 0 |
+| `superset` | completion | hash-key | 35 | 34 | 0 |
+| `superset` | completion | module-path | 30 | 28 | 0 |
+| `superset` | references | use-module | 21 | 21 | 0 |
+| `superset` | completion | use-module | 11 | 8 | 0 |
+| `superset` | completion | call-site | 11 | 10 | 0 |
+| `superset` | completion | variable | 10 | 10 | 0 |
+| `superset` | completion | method-call | 8 | 8 | 0 |
+| `superset` | references | call-site | 7 | 7 | 0 |
+| `superset` | references | module-path | 6 | 6 | 0 |
+| `superset` | references | sub-decl | 4 | 4 | 0 |
+| `superset` | references | method-call | 1 | 1 | 0 |
+| `superset` | references | package | 1 | 1 | 0 |
+| `capped-head` | completion | package | 16 | 1 | 0 |
+| `timeout-base` | completion | use-module | 3 | 3 | 0 |
+| `timeout-base` | definition | use-module | 3 | 3 | 0 |
+| `timeout-base` | references | use-module | 3 | 2 | 0 |
+| `timeout-base` | completion | call-site | 3 | 3 | 0 |
+| `timeout-base` | definition | call-site | 3 | 3 | 0 |
+| `timeout-base` | references | package | 2 | 2 | 0 |
+| `timeout-base` | completion | sub-decl | 1 | 1 | 0 |
+| `timeout-base` | definition | sub-decl | 1 | 1 | 0 |
+| `timeout-base` | references | sub-decl | 1 | 1 | 0 |
+| `timeout-base` | references | hash-key | 1 | 1 | 0 |
+| `timeout-base` | references | call-site | 1 | 1 | 0 |
 
 ## Examples
 
@@ -127,64 +140,33 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
   - base: `n=13 top=[['extends', 3], ['with', 3], ['throw_error', 3], ['has', 3]]`
   - head: `n=0 top=[]`
 
-### `subset` · completion · method-call — 36 positions, 34 distinct
+### `subset` · completion · method-call — 24 positions, 24 distinct
 
-- `Mojo/Server.pm:26:17` `req`  (+1 more positions answering identically)
-  - base: `n=45 top=[['previous', 2], ['client_read', 3], ['client_write', 3], ['is_empty', 3]]`
-  - head: `n=44 top=[['previous', 2], ['client_read', 3], ['client_write', 3], ['is_empty', 3]]`
-- `Mojo/Server/Prefork.pm:69:39` `workers`  (+1 more positions answering identically)
-  - base: `n=64 top=[['accepts', 2], ['cleanup', 2], ['graceful_timeout', 2], ['heartbeat_timeout', 2]]`
-  - head: `n=63 top=[['accepts', 2], ['cleanup', 2], ['graceful_timeout', 2], ['heartbeat_timeout', 2]]`
-- `App/Cmd/Simple.pm:187:26` `opt_spec`
-  - base: `n=18 top=[['import', 3], ['(anon)', 3], ['usage_desc', 3], ['_cmd_pkg', 3]]`
-  - head: `n=17 top=[['import', 3], ['usage_desc', 3], ['_cmd_pkg', 3], ['prepare', 3]]`
 - `Catalyst/ActionRole/Scheme.pm:8:42` `env`
   - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
   - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
 - `Class/Data/Inheritable.pm:16:39` `mk_classdata`
   - base: `n=2 top=[['mk_classdata', 3], ['(anon)', 3]]`
   - head: `n=1 top=[['mk_classdata', 3]]`
-- …and 29 more distinct claims
+- `Config/MVP/Assembler.pm:205:47` `current_section`
+  - base: `n=13 top=[['sequence_class', 2], ['section_class', 2], ['sequence', 2], ['(anon)', 3]]`
+  - head: `n=12 top=[['sequence_class', 2], ['section_class', 2], ['sequence', 2], ['_between_sections', 2]]`
+- …and 21 more distinct claims
 
-### `subset` · completion · call-site — 24 positions, 22 distinct
+### `subset` · completion · call-site — 12 positions, 11 distinct
 
-- `Mojo/JSON/Pointer.pm:5:30` `_pointer`  (+1 more positions answering identically)
-  - base: `n=13 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
-  - head: `n=12 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
 - `Type/Tie.pm:78:28` `blessed`  (+1 more positions answering identically)
   - base: `n=10 top=[['export_fail', 3], ['set_prototype', 3], ['as_heavy', 3], ['export', 3]]`
   - head: `n=9 top=[['export_fail', 3], ['set_prototype', 3], ['as_heavy', 3], ['export', 3]]`
-- `App/Cmd/Simple.pm:127:27` `install_sub`
-  - base: `n=8 top=[['_name_of_code', 3], ['_CODELIKE', 3], ['_build_public_installer', 3], ['(anon)', 3]]`
-  - head: `n=7 top=[['_name_of_code', 3], ['_CODELIKE', 3], ['_build_public_installer', 3], ['_do_with_warn', 3]]`
 - `Catalyst/ActionRole/Scheme.pm:11:58` `orig`
   - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
   - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
-- `Class/Data/Inheritable.pm:10:19` `croak`
-  - base: `n=41 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['(anon)', 3], ['is_utf8', 3]]`
-  - head: `n=40 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['is_utf8', 3], ['downgrade', 3]]`
-- …and 17 more distinct claims
-
-### `subset` · completion · package — 15 positions, 13 distinct
-
-- `Email/Abstract/EmailSimple.pm:2:36` `Email::Abstract::EmailSimple`  (+1 more positions answering identically)
-  - base: `n=17 top=[['object', 3], ['new', 3], ['__class_for', 3], ['_adapter_obj_and_args', 3]]`
-  - head: `n=16 top=[['object', 3], ['new', 3], ['__class_for', 3], ['_adapter_obj_and_args', 3]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array.pm:0:52` `Moose::Meta::Method::Accessor::Native::Array`  (+1 more positions answering identically)
-  - base: `n=85 top=[['(anon)', 3], ['_new', 3], ['root_types', 3], ['_initialize_body', 3]]`
-  - head: `n=84 top=[['_new', 3], ['root_types', 3], ['_initialize_body', 3], ['_inline_curried_arguments', 3]]`
-- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:0:51` `Dist::Zilla::Role::MintingProfile::ShareDir`
-  - base: `n=3 top=[['profile_dir', 3], ['(anon)', 3], ['ShareDir', 9]]`
-  - head: `n=2 top=[['profile_dir', 3], ['ShareDir', 9]]`
-- `Email/Sender/Failure/Permanent.pm:0:41` `Email::Sender::Failure::Permanent`
-  - base: `n=20 top=[['code', 3], ['recipients', 3], ['(anon)', 3], ['_set_recipients', 3]]`
-  - head: `n=19 top=[['code', 3], ['recipients', 3], ['__recipients', 3], ['BUILD', 3]]`
-- `HTTP/Message/PSGI.pm:0:27` `HTTP::Message::PSGI`
-  - base: `n=36 top=[['_utf8_downgrade', 3], ['(anon)', 3], ['new', 3], ['parse', 3]]`
-  - head: `n=35 top=[['_utf8_downgrade', 3], ['new', 3], ['parse', 3], ['clone', 3]]`
+- `Email/Simple.pm:166:25` `new`
+  - base: `n=22 top=[['__crlf_re', 3], ['new', 3], ['_split_head_from_body', 3], ['create', 3]]`
+  - head: `n=21 top=[['__crlf_re', 3], ['new', 3], ['_split_head_from_body', 3], ['create', 3]]`
 - …and 8 more distinct claims
 
-### `subset` · completion · module-path — 11 positions, 7 distinct
+### `subset` · completion · module-path — 10 positions, 6 distinct
 
 - `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/exists.pm:9:49` `Moose::Meta::Method::Accessor::Native::Hash`  (+3 more positions answering identically)
   - base: `n=85 top=[['(anon)', 3], ['_new', 3], ['root_types', 3], ['_initialize_body', 3]]`
@@ -195,13 +177,19 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `CGI/Carp.pm:328:19` `CGI::Carp::VERSION`
   - base: `n=29 top=[['import', 3], ['realwarn', 3], ['realdie', 3], ['id', 3]]`
   - head: `n=28 top=[['import', 3], ['realwarn', 3], ['realdie', 3], ['id', 3]]`
-- `HTTP/Message/PSGI.pm:199:27` `HTTP::Message::PSGI`
-  - base: `n=36 top=[['_utf8_downgrade', 3], ['(anon)', 3], ['new', 3], ['parse', 3]]`
-  - head: `n=35 top=[['_utf8_downgrade', 3], ['new', 3], ['parse', 3], ['clone', 3]]`
-- `Type/Tiny/_DeclaredType.pm:39:19` `SUPER::new`
-  - base: `n=143 top=[['new', 3], ['(anon)', 3], ['_croak', 3], ['_swap', 3]]`
-  - head: `n=142 top=[['new', 3], ['_croak', 3], ['_swap', 3], ['_USE_XS', 3]]`
-- …and 2 more distinct claims
+- …and 3 more distinct claims
+
+### `subset` · completion · package — 5 positions, 3 distinct
+
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array.pm:0:52` `Moose::Meta::Method::Accessor::Native::Array`  (+1 more positions answering identically)
+  - base: `n=85 top=[['(anon)', 3], ['_new', 3], ['root_types', 3], ['_initialize_body', 3]]`
+  - head: `n=84 top=[['_new', 3], ['root_types', 3], ['_initialize_body', 3], ['_inline_curried_arguments', 3]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/TypeConstraint/Parameterizable.pm:0:52` `Moose::Meta::TypeConstraint::Parameterizable`  (+1 more positions answering identically)
+  - base: `n=41 top=[['(anon)', 3], ['parents', 3], ['new', 3], ['coerce', 3]]`
+  - head: `n=40 top=[['parents', 3], ['new', 3], ['coerce', 3], ['assert_coerce', 3]]`
+- `Log/Log4perl/Appender.pm:1:31` `Log::Log4perl::Appender`
+  - base: `n=74 top=[['_INTERNAL_DEBUG', 3], ['import', 3], ['(anon)', 3], ['initialized', 3]]`
+  - head: `n=73 top=[['_INTERNAL_DEBUG', 3], ['import', 3], ['initialized', 3], ['new', 3]]`
 
 ### `subset` · completion · variable — 1 positions, 1 distinct
 
@@ -209,197 +197,137 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
   - base: `n=4 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2], ['(anon)', 3]]`
   - head: `n=3 top=[['match', 2], ['match_captures', 2], ['list_extra_info', 2]]`
 
-### `disagree` · completion · sub-decl — 175 positions, 168 distinct
+### `disagree` · completion · sub-decl — 180 positions, 171 distinct
 
 - `DateTime/TimeZone/America/Argentina/San_Luis.pm:596:19` `has_dst_changes`  (+1 more positions answering identically)
-  - base: `n=886 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+  - base: `n=252 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
   - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
 - `DateTime/TimeZone/America/La_Paz.pm:65:19` `has_dst_changes`  (+1 more positions answering identically)
-  - base: `n=887 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+  - base: `n=471 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
   - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `DateTime/TimeZone/Europe/Astrakhan.pm:616:13` `_max_year`  (+1 more positions answering identically)
-  - base: `n=1079 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
+- `DateTime/TimeZone/America/Paramaribo.pm:76:13` `_max_year`  (+1 more positions answering identically)
+  - base: `n=471 top=[['$VERSION', 6], ['$spans', 6], ['olson_version', 3], ['has_dst_changes', 3]]`
   - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `Log/Log4perl/Appender/String.pm:24:7` `log`  (+1 more positions answering identically)
-  - base: `n=2561 top=[['$ISA[]', 6], ['$#ISA', 6], ['@ISA', 6], ['@ISA[]', 6]]`
-  - head: `n=200 top=[['log', 3], ['new', 3], ['string', 3], ['Log::Log4perl::Appender::String', 7]]`
-- `Software/License/EUPL_1_1.pm:11:13` `meta_name`  (+1 more positions answering identically)
-  - base: `n=824 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
-  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
-- …and 163 more distinct claims
+- …and 168 more distinct claims
 
-### `disagree` · definition · use-module — 145 positions, 38 distinct
+### `disagree` · definition · use-module — 119 positions, 29 distinct
 
-- `App/Cmd/Simple.pm:175:7` `strict`  (+39 more positions answering identically)
+- `App/Cmd/Simple.pm:175:7` `strict`  (+38 more positions answering identically)
   - base: `[["<ext>/x86_64-linux-gnu/perl-base/strict.pm", [0, 0, 0, 0]]]`
   - head: `[["<ext>/perl/5.38.2/strict.pm", [0, 8, 0, 14]], ["<ext>/x86_64-linux-gnu/perl-base/strict.pm", [0, 8, 0, 14]]]`
 - `Catalyst/Plugin/Unicode/Encoding.pm:2:4` `warnings`  (+26 more positions answering identically)
   - base: `[["<ext>/x86_64-linux-gnu/perl-base/warnings.pm", [0, 0, 0, 0]]]`
   - head: `[["<ext>/perl/5.38.2/warnings.pm", [5, 8, 5, 16]], ["<ext>/x86_64-linux-gnu/perl-base/warnings.pm", [5, 8, 5, 16]]]`
-- `Catalyst/ActionRole/Scheme.pm:2:4` `Moose::Role`  (+14 more positions answering identically)
+- `Dist/Zilla/Role/Plugin.pm:3:4` `Moose::Role`  (+10 more positions answering identically)
   - base: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [0, 0, 0, 0]]]`
   - head: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [2, 8, 2, 19]]]`
-- `Dist/Zilla/MVP/Reader/Perl.pm:7:4` `Dist::Zilla::Pragmas`  (+6 more positions answering identically)
-  - base: `[["Dist/Zilla/Pragmas.pm", [0, 0, 0, 0]]]`
-  - head: `[["Dist/Zilla/Pragmas.pm", [0, 8, 0, 28]]]`
-- `Software/License/Custom.pm:5:4` `parent`  (+6 more positions answering identically)
-  - base: `[["<ext>/x86_64-linux-gnu/perl-base/parent.pm", [0, 0, 0, 0]]]`
-  - head: `[["<ext>/perl/5.38.2/parent.pm", [0, 8, 0, 14]], ["<ext>/x86_64-linux-gnu/perl-base/parent.pm", [0, 8, 0, 14]]]`
-- …and 33 more distinct claims
+- …and 26 more distinct claims
 
-### `disagree` · completion · variable — 113 positions, 113 distinct
+### `disagree` · completion · variable — 115 positions, 115 distinct
 
 - `CGI/Carp.pm:499:23` `no`
-  - base: `n=315 top=[['$in', 6], ['$no', 6], ['$appease_cpants_kwalitee', 6], ['die', 3]]`
+  - base: `n=76 top=[['$in', 6], ['$no', 6], ['$appease_cpants_kwalitee', 6], ['die', 3]]`
   - head: `n=200 top=[['_longmess', 3], ['_warn', 3], ['carp', 3], ['carpout', 3]]`
 - `Catalyst/ClassData.pm:61:8` `class`
-  - base: `n=309 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
+  - base: `n=91 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
   - head: `n=200 top=[['mk_classdata', 3], ['refs', 3], ['Catalyst::ClassData', 7], ['$CURLY_SYMBOL', 3]]`
 - `Catalyst/Request/PartData.pm:39:10` `ct`
-  - base: `n=323 top=[['$ct', 6], ['$charset', 6], ['$class', 6], ['$c', 6]]`
+  - base: `n=93 top=[['$ct', 6], ['$charset', 6], ['$class', 6], ['$c', 6]]`
   - head: `n=200 top=[['build_from_part_data', 3], ['content_encoding', 2], ['content_type', 2], ['content_type_charset', 2]]`
-- `Catalyst/Test.pm:91:15` `request`
-  - base: `n=386 top=[['$self', 6], ['$meth', 6], ['$args', 6], ['$defaults', 6]]`
-  - head: `n=200 top=[['_build_ctx_request_export', 3], ['_build_get_export', 3], ['_build_request_export', 3], ['_customize_request', 3]]`
-- `Class/Data/Inheritable.pm:25:20` `declaredclass`
-  - base: `n=388 top=[['$declaredclass', 6], ['$attribute', 6], ['$data', 6], ['$accessor', 6]]`
-  - head: `n=200 top=[['mk_classdata', 3], ['subs', 3], ['vars', 3], ['carp', 3]]`
-- …and 108 more distinct claims
+- …and 112 more distinct claims
 
-### `disagree` · completion · use-module — 95 positions, 74 distinct
+### `disagree` · completion · use-module — 91 positions, 72 distinct
 
-- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:3:9` `Moose`  (+15 more positions answering identically)
-  - base: `n=359 top=[['Moose::Meta::Attribute::Native::Trait::Array', 9], ['Moose::Exporter', 9], ['Moose::Exception::IncompatibleMetaclassOfSuperclass', 9], ['Moose::Exception::MethodExpectedAMetaclassObject', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/IllegalInheritedOptions.pm:3:9` `Moose`  (+10 more positions answering identically)
+  - base: `n=407 top=[['Moose::Exception::InvalidArgPassedToMooseUtilMetaRole', 9], ['Moose::Exception::InvalidNameForType', 9], ['Moose::Exception::NoAttributeFoundInSuperClass', 9], ['Moose::Meta::Instance', 9]]`
+  - head: `n=200 top=[['Moose', 9], ['Moose::Conflicts', 9], ['Moose::Deprecated', 9], ['Moose::Exception', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:3:9` `Moose`  (+3 more positions answering identically)
+  - base: `n=400 top=[['Moose::Exception::InvalidArgPassedToMooseUtilMetaRole', 9], ['Moose::Exception::InvalidNameForType', 9], ['Moose::Exception::NoAttributeFoundInSuperClass', 9], ['Moose::Meta::Instance', 9]]`
   - head: `n=200 top=[['Moose', 9], ['Moose::Conflicts', 9], ['Moose::Deprecated', 9], ['Moose::Exception', 9]]`
 - `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/values.pm:19:14` `Moose::Role`  (+2 more positions answering identically)
-  - base: `n=359 top=[['Meta::Attribute::Native::Trait::Array', 9], ['Exporter', 9], ['Exception::IncompatibleMetaclassOfSuperclass', 9], ['Exception::MethodExpectedAMetaclassObject', 9]]`
+  - base: `n=359 top=[['Exception::InvalidArgPassedToMooseUtilMetaRole', 9], ['Exception::InvalidNameForType', 9], ['Exception::NoAttributeFoundInSuperClass', 9], ['Meta::Instance', 9]]`
   - head: `n=200 top=[['_get_caller', 3], ['after', 3], ['around', 3], ['augment', 3]]`
-- `Catalyst/Plugin/Unicode/Encoding.pm:1:10` `strict`  (+1 more positions answering identically)
-  - base: `n=308 top=[['Catalyst::Plugin::Unicode::Encoding', 7], ['$CURLY_SYMBOL', 3], ['$GRAMMAR', 3], ['$PERMUTE', 3]]`
-  - head: `n=200 top=[['Catalyst::Plugin::Unicode::Encoding', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
-- `Test/Deep/RegexpVersion.pm:0:10` `strict`  (+1 more positions answering identically)
-  - base: `n=868 top=[['Test::Deep::RegexpVersion', 7], ['$CURLY_SYMBOL', 3], ['$TODO', 3], ['%CanonicalLevelNames', 3]]`
-  - head: `n=200 top=[['Test::Deep::RegexpVersion', 7], ['$Bin', 3], ['$Bzip2Error', 3], ['$CURLY_SYMBOL', 3]]`
-- `URI/file/QNX.pm:2:10` `strict`  (+1 more positions answering identically)
-  - base: `n=1043 top=[['_file_extract_path', 3], ['URI::file::QNX', 7], ['URI::file::Unix', 3], ['$CURLY_SYMBOL', 3]]`
-  - head: `n=200 top=[['_file_extract_path', 3], ['URI::file::Unix', 3], ['URI::file::QNX', 7], ['$Bin', 3]]`
 - …and 69 more distinct claims
 
-### `disagree` · definition · module-path — 71 positions, 45 distinct
+### `disagree` · completion · hash-key — 59 positions, 51 distinct
 
-- `Dist/Zilla/Role/ExecFiles.pm:3:4` `Moose::Role`  (+8 more positions answering identically)
-  - base: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [0, 0, 0, 0]]]`
-  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [2, 8, 2, 19]]]`
+- `Software/License/EUPL_1_2.pm:11:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=861 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- `Software/License/FreeBSD.pm:10:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=861 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- `Software/License/GFDL_1_3.pm:9:29` `open_source`  (+1 more positions answering identically)
+  - base: `n=861 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
+  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
+- …and 48 more distinct claims
+
+### `disagree` · definition · module-path — 42 positions, 25 distinct
+
 - `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:4:9` `Moose::Exception`  (+7 more positions answering identically)
   - base: `[["x86_64-linux-gnu-thread-multi/Moose/Exception.pm", [0, 0, 0, 0]]]`
   - head: `[["x86_64-linux-gnu-thread-multi/Moose/Exception.pm", [0, 8, 0, 24]]]`
-- `Software/License/EUPL_1_1.pm:5:12` `Software::License`  (+4 more positions answering identically)
-  - base: `[["Software/License.pm", [0, 0, 0, 0]]]`
-  - head: `[["Software/License.pm", [2, 8, 2, 25]]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array.pm:25:3` `Moose::Role`  (+6 more positions answering identically)
+  - base: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [0, 0, 0, 0]]]`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Role.pm", [2, 8, 2, 19]]]`
 - `Test/TypeTiny.pm:6:4` `Scalar::Util`  (+2 more positions answering identically)
   - base: `[["<ext>/perl-base/Scalar/Util.pm", [0, 0, 0, 0]]]`
   - head: `[["<ext>/5.38.2/Scalar/Util.pm", [6, 8, 6, 20]], ["<ext>/perl-base/Scalar/Util.pm", [6, 8, 6, 20]]]`
-- `Dist/Zilla/Role/AfterRelease.pm:4:6` `Dist::Zilla::Role::Plugin`  (+1 more positions answering identically)
-  - base: `[["Dist/Zilla/Role/Plugin.pm", [0, 0, 0, 0]]]`
-  - head: `[["Dist/Zilla/Role/Plugin.pm", [0, 8, 0, 33]]]`
-- …and 40 more distinct claims
+- …and 22 more distinct claims
 
-### `disagree` · completion · hash-key — 57 positions, 43 distinct
-
-- `x86_64-linux-gnu-thread-multi/Moose/Exception/Role/Attribute.pm:6:6` `is`  (+2 more positions answering identically)
-  - base: `n=939 top=[['$VERSION', 6], ['attribute', 2], ['is_attribute_set', 2], ['Moose::Exception::Role::Attribute', 7]]`
-  - head: `n=200 top=[['attribute', 2], ['is_attribute_set', 2], ['Moose::Exception::Role::Attribute', 7], ['$Bin', 3]]`
-- `Software/License/EUPL_1_2.pm:11:29` `open_source`  (+1 more positions answering identically)
-  - base: `n=824 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
-  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
-- `Software/License/FreeBSD.pm:10:29` `open_source`  (+1 more positions answering identically)
-  - base: `n=825 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
-  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
-- `Software/License/GFDL_1_3.pm:9:29` `open_source`  (+1 more positions answering identically)
-  - base: `n=829 top=[['name', 3], ['url', 3], ['meta_name', 3], ['meta2_name', 3]]`
-  - head: `n=200 top=[['meta2_name', 3], ['meta_name', 3], ['name', 3], ['spdx_expression', 3]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:9:7` `isa`  (+1 more positions answering identically)
-  - base: `n=870 top=[['$VERSION', 6], ['value', 2], ['_build_message', 3], ['Moose::Exception::CannotAssignValueToReadOnlyAccessor', 7]]`
-  - head: `n=200 top=[['_build_message', 3], ['value', 2], ['Moose::Exception::CannotAssignValueToReadOnlyAccessor', 7], ['$Bin', 3]]`
-- …and 38 more distinct claims
-
-### `disagree` · completion · module-path — 44 positions, 33 distinct
+### `disagree` · completion · module-path — 41 positions, 30 distinct
 
 - `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm:4:25` `Moose::Exception`  (+10 more positions answering identically)
-  - base: `n=359 top=[['Meta::Attribute::Native::Trait::Array', 9], ['Exporter', 9], ['Exception::IncompatibleMetaclassOfSuperclass', 9], ['Exception::MethodExpectedAMetaclassObject', 9]]`
+  - base: `n=359 top=[['Exception::InvalidArgPassedToMooseUtilMetaRole', 9], ['Exception::InvalidNameForType', 9], ['Exception::NoAttributeFoundInSuperClass', 9], ['Meta::Instance', 9]]`
   - head: `n=200 top=[['_get_caller', 3], ['after', 3], ['around', 3], ['augment', 3]]`
 - `DateTime/TimeZone/Asia/Karachi.pm:126:28` `DateTime::TimeZone::INFINITY`  (+1 more positions answering identically)
   - base: `n=1 top=[['Asia::Karachi', 9]]`
   - head: `n=200 top=[['INFINITY', 3], ['IS_DST', 3], ['LOCAL_END', 3], ['LOCAL_START', 3]]`
 - `Date/Language/Brazilian.pm:15:24` `Date::Language`
-  - base: `n=415 top=[['$VERSION', 6], ['format_a', 3], ['format_A', 3], ['format_b', 3]]`
+  - base: `n=154 top=[['$VERSION', 6], ['format_a', 3], ['format_A', 3], ['format_b', 3]]`
   - head: `n=200 top=[['format_A', 3], ['format_B', 3], ['format_a', 3], ['format_b', 3]]`
-- `Date/Language/Sidama.pm:10:24` `Date::Language`
-  - base: `n=804 top=[['format_a', 3], ['format_A', 3], ['format_b', 3], ['format_B', 3]]`
-  - head: `n=200 top=[['format_A', 3], ['format_B', 3], ['format_a', 3], ['format_b', 3]]`
-- `DateTime/TimeZone/America/Anchorage.pm:21:88` `DateTime::TimeZone`
-  - base: `n=1 top=[['TimeZone::America::Anchorage', 9]]`
-  - head: `n=200 top=[['DefaultLocale', 3], ['INFINITY', 3], ['MAX_NANOSECONDS', 3], ['NAN', 3]]`
-- …and 28 more distinct claims
+- …and 27 more distinct claims
 
-### `disagree` · completion · call-site — 36 positions, 36 distinct
+### `disagree` · completion · call-site — 40 positions, 39 distinct
 
+- `Class/Data/Inheritable.pm:10:19` `croak`  (+1 more positions answering identically)
+  - base: `n=40 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['(anon)', 3], ['is_utf8', 3]]`
+  - head: `n=40 top=[['_fetch_sub', 3], ['UTF8_REGEXP_PROBLEM', 3], ['is_utf8', 3], ['downgrade', 3]]`
 - `Catalyst/ClassData.pm:43:9` `confess`
-  - base: `n=302 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
+  - base: `n=84 top=[['$class', 6], ['$attribute', 6], ['$warn_on_instance', 6], ['$slot', 6]]`
   - head: `n=200 top=[['mk_classdata', 3], ['refs', 3], ['Catalyst::ClassData', 7], ['$CURLY_SYMBOL', 3]]`
 - `Config/MVP/Reader/Hash.pm:26:14` `name`
-  - base: `n=385 top=[['$name', 6], ['$self', 6], ['$location', 6], ['$assembler', 6]]`
+  - base: `n=153 top=[['$name', 6], ['$self', 6], ['$location', 6], ['$assembler', 6]]`
   - head: `n=200 top=[['read_into_assembler', 3], ['Config::MVP::Reader::Hash', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
-- `Dist/Zilla/Role/FileFinderUser.pm:140:19` `alias`
-  - base: `n=1496 top=[['$alias', 6], ['$orig', 6], ['$self', 6], ['$start', 6]]`
-  - head: `n=200 top=[['Dist::Zilla::Role::FileFinderUser', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
-- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:23:24` `path`
-  - base: `n=1488 top=[['$self', 6], ['$profile_name', 6], ['$profile_dir', 6], ['profile_dir', 3]]`
-  - head: `n=200 top=[['profile_dir', 3], ['Dist::Zilla::Role::MintingProfile::ShareDir', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
-- `File/Copy/Recursive.pm:281:40` `stat`
-  - base: `n=2587 top=[['$rc', 6], ['$file', 6], ['$file_ut', 6], ['$org', 6]]`
-  - head: `n=200 top=[['_bail_if_changed', 3], ['dircopy', 3], ['dirmove', 3], ['fcopy', 3]]`
-- …and 31 more distinct claims
+- …and 36 more distinct claims
 
-### `disagree` · completion · package — 28 positions, 23 distinct
+### `disagree` · completion · package — 17 positions, 17 distinct
 
-- `YAML/PP/Emitter.pm:2:25` `YAML::PP::Emitter`  (+2 more positions answering identically)
-  - base: `n=56 top=[['new', 3], ['clone', 3], ['_arg_yaml_version', 3], ['loader', 3]]`
-  - head: `n=59 top=[['new', 3], ['clone', 3], ['_arg_yaml_version', 3], ['loader', 3]]`
-- `Mojo/Server/CGI.pm:0:25` `Mojo::Server::CGI`  (+1 more positions answering identically)
-  - base: `n=33 top=[['app', 3], ['(anon)', 3], ['reverse_proxy', 3], ['trusted_proxies', 3]]`
-  - head: `n=33 top=[['app', 3], ['reverse_proxy', 3], ['trusted_proxies', 3], ['build_app', 3]]`
-- `Type/Tiny/ConstrainedObject.pm:0:37` `Type::Tiny::ConstrainedObject`  (+1 more positions answering identically)
-  - base: `n=153 top=[['_croak', 3], ['_swap', 3], ['_USE_XS', 3], ['(anon)', 3]]`
-  - head: `n=153 top=[['_croak', 3], ['_swap', 3], ['_USE_XS', 3], ['_USE_MOUSE', 3]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/TypeConstraint/Parameterizable.pm:0:52` `Moose::Meta::TypeConstraint::Parameterizable`  (+1 more positions answering identically)
-  - base: `n=29 top=[['(anon)', 3], ['parents', 3], ['new', 3], ['coerce', 3]]`
-  - head: `n=40 top=[['parents', 3], ['new', 3], ['coerce', 3], ['assert_coerce', 3]]`
 - `App/Cmd/Simple.pm:108:21` `eq`
-  - base: `n=281 top=[['$class', 6], ['$i', 6], ['import', 3], ['(anon)', 3]]`
+  - base: `n=39 top=[['$class', 6], ['$i', 6], ['import', 3], ['(anon)', 3]]`
   - head: `n=200 top=[['_cmd_pkg', 3], ['import', 3], ['usage_desc', 3], ['refs', 3]]`
-- …and 18 more distinct claims
+- `CGI/Carp.pm:0:17` `CGI::Carp`
+  - base: `n=1 top=[['Carp', 9]]`
+  - head: `n=200 top=[['Accept', 3], ['Area', 3], ['CLEAR', 3], ['DELETE', 3]]`
+- `CGI/Struct.pm:0:19` `CGI::Struct`
+  - base: `n=1 top=[['Struct', 9]]`
+  - head: `n=200 top=[['Accept', 3], ['Area', 3], ['CLEAR', 3], ['DELETE', 3]]`
+- …and 14 more distinct claims
 
-### `disagree` · completion · method-call — 13 positions, 12 distinct
+### `disagree` · completion · method-call — 17 positions, 16 distinct
 
 - `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotOverrideALocalMethod.pm:15:59` `method_name`  (+1 more positions answering identically)
   - base: `n=8 top=[['method_name', 2], ['_build_message', 3], ['trace', 2], ['_build_trace', 2]]`
   - head: `n=8 top=[['method_name', 2], ['_build_message', 3], ['trace', 2], ['message', 2]]`
-- `Mojolicious/Commands.pm:81:65` `start`
-  - base: `n=99 top=[['commands', 2], ['(anon)', 3], ['controller_class', 2], ['exception_format', 2]]`
-  - head: `n=77 top=[['commands', 2], ['controller_class', 2], ['exception_format', 2], ['home', 2]]`
-- `PPI/Token/DashedWord.pm:67:38` `set_class`
-  - base: `n=1 top=[['{key}', 15]]`
-  - head: `n=55 top=[['__TOKENIZER__on_char', 3], ['new', 3], ['set_class', 3], ['set_content', 3]]`
-- `Path/Class/File.pm:34:50` `_spec_class`
-  - base: `n=23 top=[['new', 3], ['dir_class', 3], ['as_foreign', 3], ['stringify', 3]]`
-  - head: `n=36 top=[['new', 3], ['dir_class', 3], ['as_foreign', 3], ['stringify', 3]]`
-- `Plack/Middleware/HTTPExceptions.pm:12:18` `rethrow`
-  - base: `n=4 top=[['prepare_app', 3], ['call', 3], ['(anon)', 3], ['transform_error', 3]]`
-  - head: `n=9 top=[['prepare_app', 3], ['call', 3], ['transform_error', 3], ['wrap', 3]]`
-- …and 7 more distinct claims
+- `App/Cmd/Simple.pm:187:26` `opt_spec`
+  - base: `n=4 top=[['import', 3], ['(anon)', 3], ['usage_desc', 3], ['_cmd_pkg', 3]]`
+  - head: `n=17 top=[['import', 3], ['usage_desc', 3], ['_cmd_pkg', 3], ['prepare', 3]]`
+- `Dist/Zilla/Role/Plugin.pm:57:46` `plugin_name`
+  - base: `n=11 top=[['plugin_name', 2], ['zilla', 2], ['logger', 2], ['(anon)', 3]]`
+  - head: `n=11 top=[['plugin_name', 2], ['zilla', 2], ['logger', 2], ['mvp_multivalue_args', 3]]`
+- …and 13 more distinct claims
 
-### `disagree` · definition · call-site — 11 positions, 11 distinct
+### `disagree` · definition · call-site — 9 positions, 9 distinct
 
 - `PPI.pm:18:9` `Structure`
   - base: `[["PPI/Structure.pm", [0, 0, 0, 0]]]`
@@ -410,51 +338,20 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `PPI/Exception/ParserRejection.pm:3:9` `Exception`
   - base: `[["PPI/Exception.pm", [0, 0, 0, 0]]]`
   - head: `[["PPI/Exception.pm", [0, 8, 0, 22]], ["PPI/XSAccessor.pm", [71, 1, 71, 15]]]`
-- `PPI/Statement/End.pm:47:9` `Statement`
-  - base: `[["PPI/Statement.pm", [0, 0, 0, 0]]]`
-  - head: `[["PPI/Statement.pm", [0, 8, 0, 22]], ["PPI/XSAccessor.pm", [98, 1, 98, 15]]]`
-- `PPI/Token/Number.pm:32:9` `Token`
-  - base: `[["PPI/Token.pm", [0, 0, 0, 0]]]`
-  - head: `[["PPI/Token.pm", [0, 8, 0, 18]], ["PPI/XSAccessor.pm", [149, 1, 149, 11]]]`
 - …and 6 more distinct claims
 
-### `content-differs` · hover · variable — 15 positions, 15 distinct
+### `content-differs` · hover · variable — 13 positions, 13 distinct
 
 - `Config/MVP/Assembler.pm:205:26` `self`
   - base: `len=293 '```perl sub current_section { ``` *class Config::MVP::Assembler — resolved from `$self`* pod =method current_section pod'`
   - head: `len=74 '```perl my ($self, $name, $value) = @_; ``` *type: Config::MVP::Assembler*'`
-- `Dist/Zilla/Plugin/PkgDist.pm:62:5` `self`
-  - base: `len=211 "```perl sub log() ``` *class Dist::Zilla::Role::Plugin — resolved from `$self`* The plugin's `log` method delegates to t"`
-  - head: `len=72 '```perl my ($self, $file) = @_; ``` *type: Dist::Zilla::Plugin::PkgDist*'`
 - `Email/MessageID.pm:64:36` `_SYS_HOSTNAME_LONG`
   - base: `len=35 '```perl my $_SYS_HOSTNAME_LONG; ```'`
   - head: `len=51 '```perl my $_SYS_HOSTNAME_LONG; ``` *type: Numeric*'`
-- `Mojolicious/Command/prefork.pm:26:39` `prefork`
-  - base: `len=261 '```perl sub max_requests() ``` *class Mojo::Server::Daemon — resolved from `$prefork`* *returns: Numeric* ```perl my $ma'`
-  - head: `len=102 '```perl my $prefork = Mojo::Server::Prefork->new(app => $self->app); ``` *type: Mojo::Server::Prefork*'`
-- `Mojolicious/Plugin/EPRenderer.pm:25:41` `name`
-  - base: `len=320 '```perl sub add_handler() ``` *class Mojolicious::Renderer — resolved from `$name`* *returns: Mojolicious::Renderer* ```'`
-  - head: `len=80 '```perl my $name = $options->{inline} // $renderer->template_name($options); ```'`
+- `Mojo/IOLoop/Subprocess.pm:63:40` `stream`
+  - base: `len=72 '```perl my $stream = Mojo::IOLoop::Stream->new($reader)->timeout(0); ```'`
+  - head: `len=101 '```perl my $stream = Mojo::IOLoop::Stream->new($reader)->timeout(0); ``` *type: Mojo::IOLoop::Stream*'`
 - …and 10 more distinct claims
-
-### `content-differs` · hover · call-site — 6 positions, 6 distinct
-
-- `LWP/Debug/TraceHTTP.pm:25:11` `mcall`
-  - base: `len=217 '```perl sub mcall($o, $method, $proto) → Maybe<Data::Dump::Trace::Call> ``` Calls the given method with the given argume'`
-  - head: `len=215 '```perl sub mcall($o, $method, $proto) → Maybe<Data::Dump::Trace::Call> ``` Calls the given method with the given argume'`
-- `Log/Log4perl/Appender.pm:76:35` `new`
-  - base: `len=124 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: HashRef* #############################################'`
-  - head: `len=140 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: Log::Log4perl::Appender* #############################'`
-- `Mojo/IOLoop/Subprocess.pm:84:14` `parent`
-  - base: `len=190 '```perl sub on() ``` *class Mojo::EventEmitter — resolved from `$parent`* ```perl my $cb = $e->on(foo => sub {...}); ```'`
-  - head: `len=45 '```perl my ($self, $child, $parent) = @_; ```'`
-- `Mojo/JSON/Pointer.pm:8:33` `new`
-  - base: `len=342 '```perl sub new($class) ``` *class Mojo::Base* *returns: Mojo::Base* ```perl my $object = SubClass->new; my $object = Su'`
-  - head: `len=293 '```perl sub new { @_ > 1 ? shift->SUPER::new(data => shift) : shift->SUPER::new } ``` *package Mojo::JSON::Pointer* ```p'`
-- `Path/Class/File.pm:187:16` `new`
-  - base: `len=66 '```perl sub new { ``` *class Path::Class::File* *returns: HashRef*'`
-  - head: `len=76 '```perl sub new { ``` *class Path::Class::File* *returns: Path::Class::File*'`
-- …and 1 more distinct claims
 
 ### `content-differs` · hover · sub-decl — 6 positions, 6 distinct
 
@@ -467,137 +364,120 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `Mojo/Server/Prefork.pm:21:4` `check_pid`
   - base: `len=284 '```perl sub check_pid { ``` *package Mojo::Server::Prefork* *returns: Maybe<String>* ```perl my $pid = $prefork->check_p'`
   - head: `len=282 '```perl sub check_pid { ``` *package Mojo::Server::Prefork* *returns: Maybe<String>* ```perl my $pid = $prefork->check_p'`
-- `Path/Class/File.pm:113:4` `spew`
-  - base: `len=576 '```perl sub spew { ``` *package Path::Class::File* The opposite of (slurp), this takes a list of strings and prints them'`
-  - head: `len=572 '```perl sub spew { ``` *package Path::Class::File* The opposite of slurp, this takes a list of strings and prints them t'`
-- `Type/Tie.pm:231:5` `EXISTS`
-  - base: `len=82 '```perl sub EXISTS { exists $_[0]->_REF->{ $_[1] } } ``` *package Type::Tie::HASH*'`
-  - head: `len=98 '```perl sub EXISTS { exists $_[0]->_REF->{ $_[1] } } ``` *package Type::Tie::HASH* *returns: Bool*'`
-- …and 1 more distinct claims
+- …and 3 more distinct claims
 
-### `content-differs` · hover · method-call — 5 positions, 5 distinct
+### `content-differs` · hover · call-site — 2 positions, 2 distinct
 
-- `Mojo/Date.pm:18:38` `parse`
-  - base: `len=64 '```perl sub parse { ``` *class Mojo::Date* *returns: Mojo::Date*'`
-  - head: `len=802 "```perl sub parse { ``` *package Mojo::Date* *returns: Mojo::Date* ```perl $date = $date->parse('Sun Nov 6 08:49:37 1994"`
-- `Mojo/Server/CGI.pm:28:17` `res`
-  - base: `len=680 '```perl sub res() ``` *class Mojo::Transaction::HTTP (from Mojo::Transaction)* *returns: Mojo::Message::Response* ```per'`
-  - head: `len=79 '```perl has res => sub { Mojo::Message::Response->new }; ``` — `Transaction.pm`'`
-- `Mojolicious/Command/prefork.pm:22:48` `keep_alive_timeout`
-  - base: `len=465 '```perl sub keep_alive_timeout() ``` *class Mojo::Server::Prefork (from Mojo::Server::Daemon)* ```perl my $timeout = $da'`
-  - head: `len=484 '```perl sub keep_alive_timeout() ``` *class Mojo::Server::Prefork (from Mojo::Server::Daemon)* *returns: Numeric* ```per'`
-- `Mojolicious/Commands.pm:81:60` `start`
-  - base: `len=491 '```perl sub start($self) ``` *class Mojolicious* *returns: Numeric* ```perl $app->start; $app->start(@ARGV); ``` Start t'`
-  - head: `len=42 '```perl sub start { ``` — `Mojolicious.pm`'`
-- `Mojolicious/Plugin/EPRenderer.pm:19:41` `add_handler`
-  - base: `len=296 '```perl sub add_handler() ``` *class Mojolicious::Renderer* *returns: Mojolicious::Renderer* ```perl $renderer = $render'`
-  - head: `len=97 '```perl sub add_handler { $_[0]->handlers->{$_[1]} = $_[2] and return $_[0] } ``` — `Renderer.pm`'`
+- `Log/Log4perl/Appender.pm:76:35` `new`
+  - base: `len=124 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: HashRef* #############################################'`
+  - head: `len=140 '```perl sub new { ``` *package Log::Log4perl::Appender* *returns: Log::Log4perl::Appender* #############################'`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/TypeConstraint/Parameterizable.pm:66:41` `find_or_create_isa_type_constraint`
+  - base: `len=121 '```perl sub find_or_create_isa_type_constraint($type_constraint_name, $options) ``` *from `Moose::Util::TypeConstraints`'`
+  - head: `len=158 '```perl sub find_or_create_isa_type_constraint($type_constraint_name, $options) → Moose::Meta::TypeConstraint::Class ```'`
 
-### `content-differs` · hover · module-path — 3 positions, 3 distinct
-
-- `Mojo/JSON/Pointer.pm:8:26` `SUPER::new`
-  - base: `len=342 '```perl sub new($class) ``` *class Mojo::Base* *returns: Mojo::Base* ```perl my $object = SubClass->new; my $object = Su'`
-  - head: `len=293 '```perl sub new { @_ > 1 ? shift->SUPER::new(data => shift) : shift->SUPER::new } ``` *package Mojo::JSON::Pointer* ```p'`
-- `Software/License/Custom.pm:85:22` `SUPER::new`
-  - base: `len=954 '```perl sub new($class, $arg) ``` *class Software::License* *returns: Software::License* pod =head1 SYNOPSIS pod pod my '`
-  - head: `len=2387 '```perl sub new { ``` *package Software::License::Custom* pod =head1 DESCRIPTION pod pod This module extends L<Software:'`
-- `Type/Tiny/_DeclaredType.pm:39:9` `SUPER::new`
-  - base: `len=68 '```perl sub new($class) ``` *class Type::Tiny* *returns: Type::Tiny*'`
-  - head: `len=57 '```perl sub new { ``` *package Type::Tiny::_DeclaredType*'`
-
-### `reranked` · completion · package — 26 positions, 10 distinct
-
-- `Dist/Zilla/Role/AfterRelease.pm:0:39` `Dist::Zilla::Role::AfterRelease`  (+7 more positions answering identically)
-  - base: `n=45 top=[['Releaser', 9], ['BeforeBuild', 9], ['InstallTool', 9], ['BuildRunner', 9]]`
-  - head: `n=45 top=[['PrereqScanner', 9], ['FileInjector', 9], ['ReleaseStatusProvider', 9], ['AfterBuild', 9]]`
-- `DateTime/TimeZone/Pacific/Efate.pm:9:42` `DateTime::TimeZone::Pacific::Efate`  (+3 more positions answering identically)
-  - base: `n=30 top=[['Guam', 9], ['Apia', 9], ['Efate', 9], ['Pago_Pago', 9]]`
-  - head: `n=30 top=[['Nauru', 9], ['Fiji', 9], ['Guadalcanal', 9], ['Galapagos', 9]]`
-- `PPI/Exception.pm:0:22` `PPI::Exception`  (+3 more positions answering identically)
-  - base: `n=94 top=[['Token::Prototype', 9], ['Token::QuoteLike::Backtick', 9], ['Statement::Package', 9], ['Token::Structure', 9]]`
-  - head: `n=94 top=[['Document::Fragment', 9], ['Structure::When', 9], ['Token::Number::Hex', 9], ['Transform::UpdateCopyright', 9]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array/accessor.pm:0:62` `Moose::Meta::Method::Accessor::Native::Array::accessor`  (+1 more positions answering identically)
-  - base: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['sort_in_place', 9], ['accessor', 9], ['shallow_clone', 9]]`
-  - head: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['unshift', 9], ['grep', 9], ['count', 9]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/exists.pm:0:59` `Moose::Meta::Method::Accessor::Native::Hash::exists`  (+1 more positions answering identically)
-  - base: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['Writer', 9], ['exists', 9], ['values', 9]]`
-  - head: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['Writer', 9], ['accessor', 9], ['shallow_clone', 9]]`
-- …and 5 more distinct claims
-
-### `reranked` · completion · module-path — 24 positions, 11 distinct
+### `reranked` · completion · module-path — 14 positions, 5 distinct
 
 - `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotCreateMethodAliasLocalMethodIsPresent.pm:5:34` `Moose::Exception::Role::Role`  (+5 more positions answering identically)
-  - base: `n=13 top=[['Method', 9], ['RoleForCreateMOPClass', 9], ['RoleForCreate', 9], ['Attribute', 9]]`
-  - head: `n=13 top=[['Method', 9], ['InvalidAttributeOptions', 9], ['Attribute', 9], ['InstanceClass', 9]]`
+  - base: `n=13 top=[['ParamsHash', 9], ['Class', 9], ['AttributeName', 9], ['EitherAttributeOrAttributeName', 9]]`
+  - head: `n=13 top=[['Instance', 9], ['Method', 9], ['Role', 9], ['Class', 9]]`
 - `PPI/Exception/ParserRejection.pm:7:26` `PPI::Exception`  (+4 more positions answering identically)
-  - base: `n=94 top=[['Token::Prototype', 9], ['Token::QuoteLike::Backtick', 9], ['Statement::Package', 9], ['Token::Structure', 9]]`
-  - head: `n=94 top=[['Document::Fragment', 9], ['Structure::When', 9], ['Token::Number::Hex', 9], ['Transform::UpdateCopyright', 9]]`
-- `Dist/Zilla/Plugin/PkgDist.pm:9:25` `Dist::Zilla::Role::PPI`  (+3 more positions answering identically)
-  - base: `n=45 top=[['Releaser', 9], ['BeforeBuild', 9], ['InstallTool', 9], ['BuildRunner', 9]]`
-  - head: `n=45 top=[['PrereqScanner', 9], ['FileInjector', 9], ['ReleaseStatusProvider', 9], ['AfterBuild', 9]]`
-- `Mojo/DOM/CSS.pm:1:14` `Mojo::Base`  (+1 more positions answering identically)
-  - base: `n=2 top=[['Mojo::BaseUtil', 9], ['Mojo::Base', 9]]`
-  - head: `n=2 top=[['Mojo::Base', 9], ['Mojo::BaseUtil', 9]]`
+  - base: `n=94 top=[['Token::Pod', 9], ['Statement::Include::Perl6', 9], ['Document::File', 9], ['Statement::Variable', 9]]`
+  - head: `n=94 top=[['Structure::Constructor', 9], ['Transform', 9], ['Token::_QuoteEngine::Full', 9], ['Token::QuoteLike::Words', 9]]`
 - `App/Cmd/Simple.pm:5:21` `App::Cmd::Command`
-  - base: `n=4 top=[['App::Cmd::Command', 9], ['App::Cmd::Command::version', 9], ['App::Cmd::Command::help', 9], ['App::Cmd::Command::commands', 9]]`
-  - head: `n=4 top=[['App::Cmd::Command::help', 9], ['App::Cmd::Command::version', 9], ['App::Cmd::Command::commands', 9], ['App::Cmd::Command', 9]]`
+  - base: `n=4 top=[['App::Cmd::Command::help', 9], ['App::Cmd::Command::version', 9], ['App::Cmd::Command', 9], ['App::Cmd::Command::commands', 9]]`
+  - head: `n=4 top=[['App::Cmd::Command::version', 9], ['App::Cmd::Command::help', 9], ['App::Cmd::Command', 9], ['App::Cmd::Command::commands', 9]]`
+- …and 2 more distinct claims
+
+### `reranked` · completion · package — 13 positions, 9 distinct
+
+- `PPI/Structure.pm:0:22` `PPI::Structure`  (+2 more positions answering identically)
+  - base: `n=94 top=[['Token::Pod', 9], ['Statement::Include::Perl6', 9], ['Document::File', 9], ['Statement::Variable', 9]]`
+  - head: `n=94 top=[['Structure::Constructor', 9], ['Transform', 9], ['Token::_QuoteEngine::Full', 9], ['Token::QuoteLike::Words', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array/accessor.pm:0:62` `Moose::Meta::Method::Accessor::Native::Array::accessor`  (+1 more positions answering identically)
+  - base: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['pop', 9], ['sort_in_place', 9], ['natatime', 9]]`
+  - head: `n=28 top=[['_inline_check_var_is_valid_index', 3], ['uniq', 9], ['Writer', 9], ['pop', 9]]`
+- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Hash/exists.pm:0:59` `Moose::Meta::Method::Accessor::Native::Hash::exists`  (+1 more positions answering identically)
+  - base: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['exists', 9], ['set', 9], ['is_empty', 9]]`
+  - head: `n=16 top=[['_inline_check_var_is_valid_key', 3], ['clear', 9], ['Writer', 9], ['shallow_clone', 9]]`
 - …and 6 more distinct claims
 
-### `reranked` · completion · use-module — 15 positions, 10 distinct
+### `reranked` · completion · use-module — 8 positions, 7 distinct
 
-- `Mojo/JSON/Pointer.pm:1:14` `Mojo::Base`  (+3 more positions answering identically)
-  - base: `n=2 top=[['Mojo::BaseUtil', 9], ['Mojo::Base', 9]]`
-  - head: `n=2 top=[['Mojo::Base', 9], ['Mojo::BaseUtil', 9]]`
-- `Email/Simple.pm:5:8` `Carp`  (+1 more positions answering identically)
-  - base: `n=3 top=[['Carp', 9], ['Carp::Clan', 9], ['Carp::Heavy', 9]]`
-  - head: `n=3 top=[['Carp::Clan', 9], ['Carp', 9], ['Carp::Heavy', 9]]`
 - `PPI/Token/Comment.pm:61:14` `PPI::Token`  (+1 more positions answering identically)
-  - base: `n=47 top=[['PPI::Token::Prototype', 9], ['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::Structure', 9], ['PPI::Token::Unknown', 9]]`
-  - head: `n=47 top=[['PPI::Token::Number::Hex', 9], ['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::Pod', 9], ['PPI::Token::QuoteLike', 9]]`
+  - base: `n=47 top=[['PPI::Token::Pod', 9], ['PPI::Token::Regexp::Substitute', 9], ['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::QuoteLike::Words', 9]]`
+  - head: `n=47 top=[['PPI::Token::_QuoteEngine::Full', 9], ['PPI::Token::QuoteLike::Words', 9], ['PPI::Tokenizer', 9], ['PPI::Token::Attribute', 9]]`
 - `Catalyst/ClassData.pm:5:15` `Moose::Util`
-  - base: `n=4 top=[['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util::MetaRole', 9], ['Moose::Util', 9], ['Moose::Util::TypeConstraints', 9]]`
-  - head: `n=4 top=[['Moose::Util::MetaRole', 9], ['Moose::Util::TypeConstraints', 9], ['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util', 9]]`
+  - base: `n=4 top=[['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util::MetaRole', 9], ['Moose::Util::TypeConstraints', 9], ['Moose::Util', 9]]`
+  - head: `n=4 top=[['Moose::Util', 9], ['Moose::Util::TypeConstraints', 9], ['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util::MetaRole', 9]]`
 - `Log/Log4perl/Appender.pm:99:37` `Log::Log4perl::Config`
-  - base: `n=5 top=[['Log::Log4perl::Config::BaseConfigurator', 9], ['Log::Log4perl::Config::DOMConfigurator', 9], ['Log::Log4perl::Config::Watch', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9]]`
-  - head: `n=5 top=[['Log::Log4perl::Config::Watch', 9], ['Log::Log4perl::Config::DOMConfigurator', 9], ['Log::Log4perl::Config', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9]]`
-- …and 5 more distinct claims
+  - base: `n=5 top=[['Log::Log4perl::Config::Watch', 9], ['Log::Log4perl::Config::BaseConfigurator', 9], ['Log::Log4perl::Config', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9]]`
+  - head: `n=5 top=[['Log::Log4perl::Config', 9], ['Log::Log4perl::Config::BaseConfigurator', 9], ['Log::Log4perl::Config::PropertyConfigurator', 9], ['Log::Log4perl::Config::DOMConfigurator', 9]]`
+- …and 4 more distinct claims
 
-### `reranked` · completion · call-site — 5 positions, 5 distinct
+### `reranked` · completion · call-site — 6 positions, 6 distinct
 
 - `Catalyst/Request/PartData.pm:68:20` `new`
   - base: `n=9 top=[['raw_data', 2], ['name', 2], ['size', 2], ['headers', 2]]`
   - head: `n=9 top=[['raw_data', 2], ['name', 2], ['size', 2], ['headers', 2]]`
 - `PPI.pm:18:18` `Structure`
-  - base: `n=11 top=[['PPI::Structure::Given', 9], ['PPI::Structure', 9], ['PPI::Structure::When', 9], ['PPI::Structure::For', 9]]`
-  - head: `n=11 top=[['PPI::Structure::When', 9], ['PPI::Structure::Block', 9], ['PPI::Structure::For', 9], ['PPI::Structure::Given', 9]]`
-- `PPI/Statement/End.pm:47:18` `Statement`
-  - base: `n=17 top=[['PPI::Statement::Package', 9], ['PPI::Statement::Scheduled', 9], ['PPI::Statement::UnmatchedBrace', 9], ['PPI::Statement::Data', 9]]`
-  - head: `n=17 top=[['PPI::Statement::Break', 9], ['PPI::Statement::Package', 9], ['PPI::Statement::Include::Perl6', 9], ['PPI::Statement::End', 9]]`
-- `PPI/Token/Number.pm:32:14` `Token`
-  - base: `n=47 top=[['PPI::Token::Prototype', 9], ['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::Structure', 9], ['PPI::Token::Unknown', 9]]`
-  - head: `n=47 top=[['PPI::Token::Number::Hex', 9], ['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::Pod', 9], ['PPI::Token::QuoteLike', 9]]`
-- `PPI/Token/Quote/Single.pm:35:21` `Quote`
-  - base: `n=11 top=[['PPI::Token::QuoteLike::Backtick', 9], ['PPI::Token::QuoteLike::Regexp', 9], ['PPI::Token::Quote::Double', 9], ['PPI::Token::Quote::Literal', 9]]`
-  - head: `n=11 top=[['PPI::Token::Quote::Interpolate', 9], ['PPI::Token::QuoteLike', 9], ['PPI::Token::QuoteLike::Readline', 9], ['PPI::Token::QuoteLike::Regexp', 9]]`
+  - base: `n=11 top=[['PPI::Structure::For', 9], ['PPI::Structure::Block', 9], ['PPI::Structure::Subscript', 9], ['PPI::Structure::Condition', 9]]`
+  - head: `n=11 top=[['PPI::Structure::Constructor', 9], ['PPI::Structure::Block', 9], ['PPI::Structure::For', 9], ['PPI::Structure::List', 9]]`
+- `PPI/Exception/ParserRejection.pm:3:18` `Exception`
+  - base: `n=2 top=[['PPI::Exception', 9], ['PPI::Exception::ParserRejection', 9]]`
+  - head: `n=2 top=[['PPI::Exception::ParserRejection', 9], ['PPI::Exception', 9]]`
+- …and 3 more distinct claims
 
-### `only-head` · definition · use-module — 55 positions, 17 distinct
+### `only-head` · definition · use-module — 80 positions, 26 distinct
 
 - `Dist/Zilla/Plugin/PkgDist.pm:3:4` `Moose`  (+17 more positions answering identically)
   - base: `[]`
   - head: `[["x86_64-linux-gnu-thread-multi/Moose.pm", [2, 8, 2, 13]]]`
-- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:4` `namespace::autoclean`  (+8 more positions answering identically)
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:4` `namespace::autoclean`  (+11 more positions answering identically)
   - base: `[]`
   - head: `[["namespace/autoclean.pm", [3, 8, 3, 28]]]`
-- `DateTime/TimeZone/America/Anchorage.pm:17:4` `Class::Singleton`  (+5 more positions answering identically)
+- `Dist/Zilla/MVP/Reader/Perl.pm:7:4` `Dist::Zilla::Pragmas`  (+6 more positions answering identically)
   - base: `[]`
-  - head: `[["Class/Singleton.pm", [21, 8, 21, 24]]]`
-- `DateTime/TimeZone/America/Argentina/Cordoba.pm:19:4` `DateTime::TimeZone::OlsonDB`  (+5 more positions answering identically)
+  - head: `[["Dist/Zilla/Pragmas.pm", [0, 8, 0, 28]]]`
+- …and 23 more distinct claims
+
+### `only-head` · completion · module-path — 56 positions, 24 distinct
+
+- `Text/Unidecode/x19.pm:1:22` `Text::Unidecode::Char`  (+18 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=14 top=[['DEBUG', 3], ['unidecode', 3], ['make_placeholder_map', 3], ['make_placeholder_map_nulls', 3]]`
+- `DateTime/TimeZone/Asia/Kolkata.pm:13:24` `namespace::autoclean`  (+3 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['namespace::autoclean', 9]]`
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:17:20` `Class::Singleton`  (+2 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['Class::Singleton', 9]]`
+- …and 21 more distinct claims
+
+### `only-head` · completion · use-module — 55 positions, 19 distinct
+
+- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:24` `namespace::autoclean`  (+11 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['namespace::autoclean', 9]]`
+- `Dist/Zilla/MVP/Reader/Perl.pm:7:24` `Dist::Zilla::Pragmas`  (+6 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=1 top=[['Dist::Zilla::Pragmas', 9]]`
+- `DateTime/TimeZone/America/Argentina/Cordoba.pm:19:31` `DateTime::TimeZone::OlsonDB`  (+5 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=5 top=[['DateTime::TimeZone::OlsonDB::Zone', 9], ['DateTime::TimeZone::OlsonDB::Rule', 9], ['DateTime::TimeZone::OlsonDB', 9], ['DateTime::TimeZone::OlsonDB::Observance', 9]]`
+- …and 16 more distinct claims
+
+### `only-head` · definition · module-path — 49 positions, 31 distinct
+
+- `Software/License/EUPL_1_1.pm:5:12` `Software::License`  (+4 more positions answering identically)
   - base: `[]`
-  - head: `[["DateTime/TimeZone/OlsonDB.pm", [0, 8, 0, 35]]]`
-- `DateTime/TimeZone/America/La_Paz.pm:18:4` `DateTime::TimeZone`  (+2 more positions answering identically)
+  - head: `[["Software/License.pm", [2, 8, 2, 25]]]`
+- `DateTime/TimeZone/Asia/Kolkata.pm:13:4` `namespace::autoclean`  (+3 more positions answering identically)
   - base: `[]`
-  - head: `[["DateTime/TimeZone.pm", [0, 8, 0, 26]]]`
-- …and 12 more distinct claims
+  - head: `[["namespace/autoclean.pm", [3, 8, 3, 28]]]`
+- `Date/Language/Brazilian.pm:10:4` `Date::Language`  (+2 more positions answering identically)
+  - base: `[]`
+  - head: `[["Date/Language.pm", [1, 8, 1, 22]]]`
+- …and 28 more distinct claims
 
 ### `only-head` · hover · module-path — 43 positions, 28 distinct
 
@@ -610,91 +490,9 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `Date/Language/Brazilian.pm:15:10` `Date::Language`  (+1 more positions answering identically)
   - base: `∅`
   - head: `len=62 '```perl package Date::Language ``` *namespace* — `Language.pm`'`
-- `Dist/Zilla/Role/AfterRelease.pm:4:6` `Dist::Zilla::Role::Plugin`  (+1 more positions answering identically)
-  - base: `∅`
-  - head: `len=77 '```perl package Dist::Zilla::Role::Plugin 6.037 ``` *namespace* — `Plugin.pm`'`
-- `x86_64-linux-gnu-thread-multi/Moose/Exception/CannotCreateMethodAliasLocalMethodIsPresent.pm:5:6` `Moose::Exception::Role::Role`  (+1 more positions answering identically)
-  - base: `∅`
-  - head: `len=72 '```perl package Moose::Exception::Role::Role ``` *namespace* — `Role.pm`'`
-- …and 23 more distinct claims
+- …and 25 more distinct claims
 
-### `only-head` · completion · module-path — 39 positions, 13 distinct
-
-- `Text/Unidecode/x19.pm:1:22` `Text::Unidecode::Char`  (+18 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=14 top=[['DEBUG', 3], ['unidecode', 3], ['make_placeholder_map', 3], ['make_placeholder_map_nulls', 3]]`
-- `DateTime/TimeZone/America/Argentina/San_Luis.pm:17:20` `Class::Singleton`  (+2 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=1 top=[['Class::Singleton', 9]]`
-- `DateTime/TimeZone/America/Boise.pm:19:31` `DateTime::TimeZone::OlsonDB`  (+2 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=5 top=[['DateTime::TimeZone::OlsonDB::Rule', 9], ['DateTime::TimeZone::OlsonDB::Change', 9], ['DateTime::TimeZone::OlsonDB::Zone', 9], ['DateTime::TimeZone::OlsonDB', 9]]`
-- `DateTime/TimeZone/Asia/Gaza.pm:2889:39` `DateTime::TimeZone::OlsonDB::Rule`  (+2 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=17 top=[['new', 3], ['parse_file', 3], ['_parse_line', 3], ['_parse_rule', 3]]`
-- `DateTime/TimeZone/Asia/Kolkata.pm:13:24` `namespace::autoclean`  (+2 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=1 top=[['namespace::autoclean', 9]]`
-- …and 8 more distinct claims
-
-### `only-head` · completion · use-module — 28 positions, 8 distinct
-
-- `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:24` `namespace::autoclean`  (+8 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=1 top=[['namespace::autoclean', 9]]`
-- `DateTime/TimeZone/America/Anchorage.pm:17:20` `Class::Singleton`  (+5 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=1 top=[['Class::Singleton', 9]]`
-- `DateTime/TimeZone/America/Argentina/Cordoba.pm:19:31` `DateTime::TimeZone::OlsonDB`  (+5 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=5 top=[['DateTime::TimeZone::OlsonDB::Rule', 9], ['DateTime::TimeZone::OlsonDB::Change', 9], ['DateTime::TimeZone::OlsonDB::Zone', 9], ['DateTime::TimeZone::OlsonDB', 9]]`
-- `DateTime/TimeZone/America/La_Paz.pm:18:22` `DateTime::TimeZone`  (+2 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=200 top=[['DateTime::TimeZone', 9], ['DateTime::TimeZone::Africa::Abidjan', 9], ['DateTime::TimeZone::Africa::Algiers', 9], ['DateTime::TimeZone::Africa::Bissau', 9]]`
-- `Config/MVP/Assembler.pm:204:60` `section`
-  - base: `n=0 top=[]`
-  - head: `n=200 top=[['_between_sections', 2], ['_between_sections', 2], ['add_value', 3], ['begin_section', 3]]`
-- …and 3 more distinct claims
-
-### `only-head` · hover · call-site — 17 positions, 13 distinct
-
-- `Text/Unidecode/x35.pm:1:50` `make_placeholder_map`  (+3 more positions answering identically)
-  - base: `∅`
-  - head: `len=153 '```perl sub make_placeholder_map() → Sequence<String> ``` =============================================================='`
-- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+1 more positions answering identically)
-  - base: `∅`
-  - head: `len=56 '```perl sub _build_lookups() ``` *from `Date::Language`*'`
-- `App/Cmd/Simple.pm:127:16` `install_sub`
-  - base: `∅`
-  - head: `len=38 '```perl use v5.8.0; ``` — `Install.pm`'`
-- `Catalyst/Test.pm:48:29` `throw`
-  - base: `∅`
-  - head: `len=117 '```perl sub throw($class) ``` *class Catalyst::Exception (from Catalyst::Exception::Basic)* Throws a fatal exception.'`
-- `Config/MVP/Assembler.pm:134:22` `throw`
-  - base: `∅`
-  - head: `len=380 '```perl sub throw() ``` *class Config::MVP::Error (from Throwable)* pod =method throw pod pod Something::Throwable->thro'`
-- …and 8 more distinct claims
-
-### `only-head` · definition · module-path — 17 positions, 10 distinct
-
-- `DateTime/TimeZone/America/Argentina/San_Luis.pm:17:4` `Class::Singleton`  (+2 more positions answering identically)
-  - base: `[]`
-  - head: `[["Class/Singleton.pm", [21, 8, 21, 24]]]`
-- `DateTime/TimeZone/America/Boise.pm:19:4` `DateTime::TimeZone::OlsonDB`  (+2 more positions answering identically)
-  - base: `[]`
-  - head: `[["DateTime/TimeZone/OlsonDB.pm", [0, 8, 0, 35]]]`
-- `DateTime/TimeZone/Asia/Kolkata.pm:13:4` `namespace::autoclean`  (+2 more positions answering identically)
-  - base: `[]`
-  - head: `[["namespace/autoclean.pm", [3, 8, 3, 28]]]`
-- `Date/Language/Brazilian.pm:10:4` `Date::Language`  (+1 more positions answering identically)
-  - base: `[]`
-  - head: `[["Date/Language.pm", [1, 8, 1, 22]]]`
-- `Catalyst/ClassData.pm:4:4` `Class::MOP`
-  - base: `[]`
-  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP.pm", [0, 8, 0, 18]]]`
-- …and 5 more distinct claims
-
-### `only-head` · definition · call-site — 17 positions, 11 distinct
+### `only-head` · definition · call-site — 32 positions, 24 distinct
 
 - `Text/Unidecode/x35.pm:1:50` `make_placeholder_map`  (+3 more positions answering identically)
   - base: `[]`
@@ -702,37 +500,38 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `Date/Language/Brazilian.pm:10:10` `Language`  (+2 more positions answering identically)
   - base: `[]`
   - head: `[["Date/Language.pm", [1, 8, 1, 22]]]`
-- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+1 more positions answering identically)
+- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+2 more positions answering identically)
   - base: `[]`
   - head: `[["Date/Language.pm", [14, 0, 14, 0]]]`
-- `Catalyst/Test.pm:48:29` `throw`
-  - base: `[]`
-  - head: `[["Catalyst/Exception/Basic.pm", [32, 0, 32, 0]]]`
-- `Config/MVP/Assembler.pm:134:22` `throw`
-  - base: `[]`
-  - head: `[["Throwable.pm", [65, 0, 65, 0]]]`
-- …and 6 more distinct claims
+- …and 21 more distinct claims
 
-### `only-head` · completion · call-site — 13 positions, 8 distinct
+### `only-head` · hover · call-site — 28 positions, 23 distinct
+
+- `Text/Unidecode/x35.pm:1:50` `make_placeholder_map`  (+3 more positions answering identically)
+  - base: `∅`
+  - head: `len=153 '```perl sub make_placeholder_map() → Sequence<String> ``` =============================================================='`
+- `Date/Language/Brazilian.pm:27:16` `_build_lookups`  (+2 more positions answering identically)
+  - base: `∅`
+  - head: `len=56 '```perl sub _build_lookups() ``` *from `Date::Language`*'`
+- `App/Cmd/Simple.pm:127:16` `install_sub`
+  - base: `∅`
+  - head: `len=38 '```perl use v5.8.0; ``` — `Install.pm`'`
+- …and 20 more distinct claims
+
+### `only-head` · completion · call-site — 20 positions, 15 distinct
 
 - `Text/Unidecode/x35.pm:1:70` `make_placeholder_map`  (+3 more positions answering identically)
   - base: `n=0 top=[]`
   - head: `n=14 top=[['DEBUG', 3], ['unidecode', 3], ['make_placeholder_map', 3], ['make_placeholder_map_nulls', 3]]`
 - `Date/Language/Brazilian.pm:10:18` `Language`  (+2 more positions answering identically)
   - base: `n=0 top=[]`
-  - head: `n=37 top=[['Date::Language::Bulgarian', 9], ['Date::Language::Russian_koi8r', 9], ['Date::Language::Italian', 9], ['Date::Language::Amharic', 9]]`
-- `Catalyst/Test.pm:48:34` `throw`
+  - head: `n=37 top=[['Date::Language::French', 9], ['Date::Language', 9], ['Date::Language::Czech', 9], ['Date::Language::Bulgarian', 9]]`
+- `App/Cmd/Simple.pm:127:27` `install_sub`
   - base: `n=0 top=[]`
-  - head: `n=4 top=[['message', 2], ['as_string', 3], ['throw', 3], ['rethrow', 3]]`
-- `Config/MVP/Assembler.pm:134:27` `throw`
-  - base: `n=0 top=[]`
-  - head: `n=12 top=[['message', 2], ['as_string', 3], ['previous_exception', 2], ['throw', 3]]`
-- `PPI/Statement/Package.pm:118:19` `isa`
-  - base: `n=0 top=[]`
-  - head: `n=43 top=[['significant', 3], ['class', 3], ['tokens', 3], ['content', 3]]`
-- …and 3 more distinct claims
+  - head: `n=7 top=[['_name_of_code', 3], ['_CODELIKE', 3], ['_build_public_installer', 3], ['_do_with_warn', 3]]`
+- …and 12 more distinct claims
 
-### `only-head` · definition · method-call — 7 positions, 7 distinct
+### `only-head` · definition · method-call — 15 positions, 15 distinct
 
 - `Catalyst/ClassData.pm:53:9` `make_mutable`
   - base: `[]`
@@ -740,18 +539,12 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `Catalyst/Test.pm:359:22` `new`
   - base: `[]`
   - head: `[["URI.pm", [53, 0, 53, 0]]]`
-- `Path/Class/File.pm:34:39` `_spec_class`
+- `Dist/Zilla/Role/ExecFiles.pm:18:16` `zilla`
   - base: `[]`
-  - head: `[["Path/Class/Entity.pm", [29, 0, 29, 0]]]`
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Wrapped.pm:127:11` `original_method`
-  - base: `[]`
-  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Method.pm", [92, 0, 92, 0]]]`
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin.pm:11:23` `initialize`
-  - base: `[]`
-  - head: `[["x86_64-linux-gnu-thread-multi/Class/MOP/Class.pm", [26, 0, 26, 0]]]`
-- …and 2 more distinct claims
+  - head: `[["Dist/Zilla/Role/Plugin.pm", [37, 0, 37, 0]]]`
+- …and 12 more distinct claims
 
-### `only-head` · hover · method-call — 7 positions, 7 distinct
+### `only-head` · hover · method-call — 14 positions, 14 distinct
 
 - `Catalyst/ClassData.pm:53:9` `make_mutable`
   - base: `∅`
@@ -759,16 +552,23 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `Catalyst/Test.pm:359:22` `new`
   - base: `∅`
   - head: `len=1242 '```perl sub new($class, $uri, $scheme) ``` *class URI* *returns: URI::_foreign* Constructs a new URI object. The string '`
-- `Path/Class/File.pm:34:39` `_spec_class`
+- `Dist/Zilla/Role/ExecFiles.pm:18:16` `zilla`
   - base: `∅`
-  - head: `len=113 '```perl sub _spec_class($class, $type) ``` *class Path::Class::File (from Path::Class::Entity)* *returns: String*'`
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Wrapped.pm:127:11` `original_method`
-  - base: `∅`
-  - head: `len=95 '```perl sub original_method() ``` *class Class::MOP::Method::Wrapped (from Class::MOP::Method)*'`
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin.pm:11:23` `initialize`
-  - base: `∅`
-  - head: `len=69 '```perl sub initialize($class) ``` *class Class::MOP::Class* Creation'`
-- …and 2 more distinct claims
+  - head: `len=175 '```perl sub zilla() ``` *class Dist::Zilla::Role::ExecFiles (from Dist::Zilla::Role::Plugin)* This attribute contains th'`
+- …and 11 more distinct claims
+
+### `only-head` · completion · method-call — 7 positions, 6 distinct
+
+- `Catalyst/ClassData.pm:53:21` `make_mutable`  (+1 more positions answering identically)
+  - base: `n=0 top=[]`
+  - head: `n=161 top=[['initialize', 3], ['reinitialize', 3], ['_construct_class_instance', 3], ['_real_ref_name', 3]]`
+- `Catalyst/Test.pm:359:25` `new`
+  - base: `n=0 top=[]`
+  - head: `n=27 top=[['HAS_RESERVED_SQUARE_BRACKETS', 3], ['_obj_eq', 3], ['new', 3], ['new_abs', 3]]`
+- `LWP/Protocol/mailto.pm:161:31` `new`
+  - base: `n=0 top=[]`
+  - head: `n=52 top=[['new', 3], ['parse', 3], ['clone', 3], ['code', 3]]`
+- …and 3 more distinct claims
 
 ### `only-head` · hover · use-module — 7 positions, 7 distinct
 
@@ -781,25 +581,7 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `LWP.pm:4:8` `LWP::UserAgent`
   - base: `∅`
   - head: `len=63 '```perl package LWP::UserAgent ``` *namespace* — `UserAgent.pm`'`
-- `LWP/Protocol/mailto.pm:7:8` `HTTP::Response`
-  - base: `∅`
-  - head: `len=62 '```perl package HTTP::Response ``` *namespace* — `Response.pm`'`
-- `Log/Log4perl/Appender.pm:99:16` `Log::Log4perl::Config`
-  - base: `∅`
-  - head: `len=67 '```perl package Log::Log4perl::Config ``` *namespace* — `Config.pm`'`
-- …and 2 more distinct claims
-
-### `only-head` · completion · method-call — 4 positions, 3 distinct
-
-- `Catalyst/ClassData.pm:53:21` `make_mutable`  (+1 more positions answering identically)
-  - base: `n=0 top=[]`
-  - head: `n=161 top=[['initialize', 3], ['reinitialize', 3], ['_construct_class_instance', 3], ['_real_ref_name', 3]]`
-- `Catalyst/Test.pm:359:25` `new`
-  - base: `n=0 top=[]`
-  - head: `n=27 top=[['HAS_RESERVED_SQUARE_BRACKETS', 3], ['_obj_eq', 3], ['new', 3], ['new_abs', 3]]`
-- `Log/Log4perl/Config/BaseConfigurator.pm:22:15` `file`
-  - base: `n=0 top=[]`
-  - head: `n=10 top=[['_INTERNAL_DEBUG', 3], ['eval_if_perl', 3], ['compile_if_perl', 3], ['leaf_path_to_hash', 3]]`
+- …and 4 more distinct claims
 
 ### `only-head` · completion · hash-key — 3 positions, 3 distinct
 
@@ -837,24 +619,30 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
   - base: `∅`
   - head: `len=143 '```perl sub _throw_exception($class, $exception_type, @args_to_exception) ``` *class Class::MOP::Mixin::HasAttributes (f'`
 
-### `superset` · completion · package — 65 positions, 60 distinct
+### `only-head` · references · method-call — 1 positions, 1 distinct
 
-- `Mojo/BaseUtil.pm:0:22` `Mojo::BaseUtil`  (+2 more positions answering identically)
-  - base: `n=67 top=[['Message::Request', 9], ['WebSocket', 9], ['UserAgent::CookieJar', 9], ['Cookie', 9]]`
-  - head: `n=70 top=[['Path', 9], ['Asset::Memory', 9], ['UserAgent::Transactor', 9], ['Template', 9]]`
-- `Dist/Zilla/Plugin/PkgDist.pm:0:36` `Dist::Zilla::Plugin::PkgDist`  (+1 more positions answering identically)
-  - base: `n=45 top=[['PodCoverageTests', 9], ['MetaNoIndex', 9], ['TestRelease', 9], ['RemovePrereqs', 9]]`
-  - head: `n=46 top=[['AutoPrereqs', 9], ['MetaYAML', 9], ['TestRelease', 9], ['GatherDir', 9]]`
-- `Email/MessageID.pm:2:24` `Email::MessageID`  (+1 more positions answering identically)
-  - base: `n=46 top=[['Abstract::MailMessage', 9], ['Sender::Simple', 9], ['Sender::Transport::SMTP', 9], ['MIME::Header::AddressList', 9]]`
-  - head: `n=47 top=[['Sender::Transport::DevNull', 9], ['Sender::Role::HasMessage', 9], ['MIME::ContentType', 9], ['MIME::Encodings', 9]]`
-- `URI/Escape.pm:0:19` `URI::Escape`  (+1 more positions answering identically)
-  - base: `n=67 top=[['ldap', 9], ['ssh', 9], ['file::Mac', 9], ['ftps', 9]]`
+- `Mojo/Server.pm:26:14` `req`
+  - base: `[]`
+  - head: `[["Mojo/Server.pm", [26, 14, 26, 17]], ["Mojo/Server.pm", [27, 7, 27, 10]], ["Mojo/Server/CGI.pm", [10, 17, 10, 20]], ["Mojo/Server/PSGI.pm", [7, 17, 7, 20]], ["Mojo/Transaction.pm", [10, 4, 10, 7]], …`
+
+### `only-head` · documentSymbol · file — 1 positions, 1 distinct
+
+- `Plack/HTTPParser.pm:None:None` `?`
+  - base: `[]`
+  - head: `[["Plack::HTTPParser", 3], ["Plack::HTTPParser::@EXPORT", 13]]`
+
+### `superset` · completion · package — 109 positions, 107 distinct
+
+- `URI/Escape.pm:0:19` `URI::Escape`  (+2 more positions answering identically)
+  - base: `n=67 top=[['_punycode', 9], ['tn3270', 9], ['file::Win32', 9], ['sips', 9]]`
   - head: `n=94 top=[['HAS_RESERVED_SQUARE_BRACKETS', 3], ['_obj_eq', 3], ['new', 3], ['new_abs', 3]]`
 - `Catalyst/ActionRole/Scheme.pm:0:36` `Catalyst::ActionRole::Scheme`
   - base: `n=1 top=[['Scheme', 9]]`
-  - head: `n=4 top=[['HTTPMethods', 9], ['ConsumesContent', 9], ['QueryMatching', 9], ['Scheme', 9]]`
-- …and 55 more distinct claims
+  - head: `n=4 top=[['QueryMatching', 9], ['ConsumesContent', 9], ['HTTPMethods', 9], ['Scheme', 9]]`
+- `Catalyst/Request/PartData.pm:0:35` `Catalyst::Request::PartData`
+  - base: `n=1 top=[['PartData', 9]]`
+  - head: `n=87 top=[['env', 3], ['action', 3], ['user', 3], ['snippets', 3]]`
+- …and 104 more distinct claims
 
 ### `superset` · completion · hash-key — 35 positions, 34 distinct
 
@@ -867,53 +655,61 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `DateTime/TimeZone/America/Argentina/Cordoba.pm:592:34` `spans`
   - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
   - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `DateTime/TimeZone/America/Argentina/Jujuy.pm:574:34` `spans`
-  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
-  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `DateTime/TimeZone/America/Argentina/Rio_Gallegos.pm:592:34` `spans`
-  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
-  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- …and 29 more distinct claims
+- …and 31 more distinct claims
 
-### `superset` · completion · module-path — 27 positions, 24 distinct
+### `superset` · completion · module-path — 30 positions, 28 distinct
 
 - `DateTime/TimeZone/America/Boa_Vista.pm:21:66` `Class::Singleton`  (+2 more positions answering identically)
-  - base: `n=2 top=[['Struct', 9], ['Tiny', 9]]`
-  - head: `n=35 top=[['MOP::MiniTrait', 9], ['Load', 9], ['MOP::Method::Generated', 9], ['MOP::Mixin::HasMethods', 9]]`
-- `Mojo/Server.pm:6:14` `Mojo::Util`  (+1 more positions answering identically)
-  - base: `n=1 top=[['Mojo::Util', 9]]`
-  - head: `n=2 top=[['Mojo::Util', 9], ['Mojo::Util::_Guard', 9]]`
+  - base: `n=2 top=[['Tiny', 9], ['Struct', 9]]`
+  - head: `n=35 top=[['Inspector::Functions', 9], ['Method::Modifiers', 9], ['Inspector', 9], ['MOP::Mixin::AttributeCore', 9]]`
 - `Config/MVP/Assembler.pm:65:35` `Config::MVP::Sequence`
   - base: `n=1 top=[['Assembler', 9]]`
-  - head: `n=12 top=[['Reader::Hash', 9], ['Sequence', 9], ['Reader::Finder', 9], ['Reader::Findable', 9]]`
+  - head: `n=12 top=[['Reader::Findable::ByExtension', 9], ['Error', 9], ['Assembler::WithBundles', 9], ['Reader::Hash', 9]]`
 - `Config/MVP/Reader/Hash.pm:4:28` `Config::MVP::Reader`
   - base: `n=1 top=[['Reader::Hash', 9]]`
-  - head: `n=12 top=[['Reader::Hash', 9], ['Sequence', 9], ['Reader::Finder', 9], ['Reader::Findable', 9]]`
-- `DateTime/TimeZone/America/Argentina/Cordoba.pm:576:28` `DateTime::TimeZone::INFINITY`
-  - base: `n=1 top=[['America::Argentina::Cordoba', 9]]`
-  - head: `n=200 top=[['INFINITY', 3], ['IS_DST', 3], ['LOCAL_END', 3], ['LOCAL_START', 3]]`
-- …and 19 more distinct claims
+  - head: `n=12 top=[['Reader::Findable::ByExtension', 9], ['Error', 9], ['Assembler::WithBundles', 9], ['Reader::Hash', 9]]`
+- …and 25 more distinct claims
 
-### `superset` · references · use-module — 17 positions, 17 distinct
+### `superset` · references · use-module — 21 positions, 21 distinct
 
 - `DateTime/TimeZone/America/Argentina/San_Luis.pm:13:4` `namespace::autoclean`
-  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [13, 4, 13, 24]], ["…`
+  - base: `[["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util.pm", [4, 4, 4, 24]], ["DateTime/TimeZo…`
   - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
 - `DateTime/TimeZone/America/Manaus.pm:19:4` `DateTime::TimeZone::OlsonDB`
-  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
+  - base: `[["DateTime/TimeZone/America/Boise.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Halifax.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Indiana/Knox.pm", [19, 4, 19, 31]], ["DateTime/TimeZone…`
   - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
 - `DateTime/TimeZone/America/Rio_Branco.pm:13:4` `namespace::autoclean`
-  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [13, 4, 13, 24]], ["…`
+  - base: `[["DateTime/TimeZone/America/Boise.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Halifax.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Indiana/Knox.pm", [13, 4, 13, 24]], ["DateTime/TimeZone…`
   - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
-- `DateTime/TimeZone/America/Sao_Paulo.pm:12:4` `warnings`
-  - base: `[["App/Cmd.pm", [4, 4, 4, 12]], ["App/Cmd/ArgProcessor.pm", [1, 4, 1, 12]], ["App/Cmd/Command.pm", [1, 4, 1, 12]], ["App/Cmd/Command/commands.pm", [1, 4, 1, 12]], ["App/Cmd/Command/help.pm", [1, 4, 1,…`
-  - head: `[["Apache/LogFormat/Compiler.pm", [3, 4, 3, 12]], ["App/Cmd.pm", [4, 4, 4, 12]], ["App/Cmd/ArgProcessor.pm", [1, 4, 1, 12]], ["App/Cmd/Command.pm", [1, 4, 1, 12]], ["App/Cmd/Command/commands.pm", [1, …`
-- `DateTime/TimeZone/Europe/Astrakhan.pm:19:4` `DateTime::TimeZone::OlsonDB`
-  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
-  - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
-- …and 12 more distinct claims
+- …and 18 more distinct claims
 
-### `superset` · completion · variable — 9 positions, 9 distinct
+### `superset` · completion · use-module — 11 positions, 8 distinct
+
+- `Email/Simple.pm:5:8` `Carp`  (+2 more positions answering identically)
+  - base: `n=2 top=[['Carp', 9], ['Carp::Heavy', 9]]`
+  - head: `n=3 top=[['Carp::Heavy', 9], ['Carp', 9], ['Carp::Clan', 9]]`
+- `Plack/Middleware/HTTPExceptions.pm:6:13` `Try::Tiny`  (+1 more positions answering identically)
+  - base: `n=1 top=[['Try::Tiny', 9]]`
+  - head: `n=2 top=[['Try::Tiny', 9], ['Try::Tiny::ScopeGuard', 9]]`
+- `Catalyst/Request/PartData.pm:4:10` `Encode`
+  - base: `n=24 top=[['Encode::CN::HZ', 9], ['Encode::MIME::Name', 9], ['Encode::JP::H2Z', 9], ['Encode::Unicode::UTF7', 9]]`
+  - head: `n=25 top=[['Encode', 9], ['Encode::Locale', 9], ['Encode::MIME::Header::ISO_2022_JP', 9], ['Encode::Encoder', 9]]`
+- …and 5 more distinct claims
+
+### `superset` · completion · call-site — 11 positions, 10 distinct
+
+- `Mojo/JSON/Pointer.pm:5:30` `_pointer`  (+1 more positions answering identically)
+  - base: `n=5 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+  - head: `n=12 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+- `Date/Language/Brazilian.pm:27:30` `_build_lookups`
+  - base: `n=1 top=[['Brazilian', 9]]`
+  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
+- `Date/Language/Finnish.pm:34:30` `_build_lookups`
+  - base: `n=1 top=[['Finnish', 9]]`
+  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
+- …and 7 more distinct claims
+
+### `superset` · completion · variable — 10 positions, 10 distinct
 
 - `DateTime/TimeZone/America/Argentina/Cordoba.pm:592:44` `spans`
   - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
@@ -924,99 +720,71 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
 - `DateTime/TimeZone/America/Rio_Branco.pm:322:44` `spans`
   - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
   - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `DateTime/TimeZone/America/Sao_Paulo.pm:862:44` `spans`
-  - base: `n=4 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
-  - head: `n=200 top=[['_max_year', 3], ['_new_instance', 3], ['has_dst_changes', 3], ['olson_version', 3]]`
-- `DateTime/TimeZone/Europe/Budapest.pm:1393:44` `spans`
-  - base: `n=7 top=[['olson_version', 3], ['has_dst_changes', 3], ['_max_year', 3], ['_new_instance', 3]]`
-  - head: `n=200 top=[['_last_observance', 3], ['_last_offset', 3], ['_max_year', 3], ['_new_instance', 3]]`
-- …and 4 more distinct claims
+- …and 7 more distinct claims
 
-### `superset` · completion · use-module — 8 positions, 7 distinct
+### `superset` · completion · method-call — 8 positions, 8 distinct
 
-- `Plack/Middleware/HTTPExceptions.pm:6:13` `Try::Tiny`  (+1 more positions answering identically)
-  - base: `n=1 top=[['Try::Tiny', 9]]`
-  - head: `n=2 top=[['Try::Tiny', 9], ['Try::Tiny::ScopeGuard', 9]]`
-- `Catalyst/Request/PartData.pm:4:10` `Encode`
-  - base: `n=24 top=[['Encode::JP', 9], ['Encode::Guess', 9], ['Encode::MIME::Name', 9], ['Encode::Alias', 9]]`
-  - head: `n=25 top=[['Encode', 9], ['Encode::Locale', 9], ['Encode::MIME::Header::ISO_2022_JP', 9], ['Encode::CN', 9]]`
-- `LWP/Debug/TraceHTTP.pm:18:14` `Data::Dump`
-  - base: `n=5 top=[['Data::Dump', 9], ['Data::Dump::Filtered', 9], ['Data::Dump::FilterContext', 9], ['Data::Dump::Trace', 9]]`
-  - head: `n=7 top=[['Data::Dump::Filtered', 9], ['Data::Dump::Trace::Call', 9], ['Data::Dump::FilterContext', 9], ['Data::Dump::Trace::Wrapper', 9]]`
-- `Mojo/IOLoop/Subprocess.pm:3:10` `Config`
-  - base: `n=18 top=[['Config::MVP::Assembler::WithBundles', 9], ['Config::MVP::Assembler', 9], ['Config::MVP', 9], ['Config::INI', 9]]`
-  - head: `n=19 top=[['Config::MVP::Reader::Hash', 9], ['Config::MVP', 9], ['Config::MVP::Sequence', 9], ['Config::MVP::Reader::Finder', 9]]`
-- `Type/Params/Parameter.pm:206:35` `Storable`
-  - base: `n=25 top=[['_croak', 3], ['new', 3], ['name', 3], ['has_name', 3]]`
-  - head: `n=200 top=[['_all_aliases', 3], ['_code_for_default', 3], ['_croak', 3], ['_dont_validate_slurpy', 3]]`
-- …and 2 more distinct claims
+- `Dist/Zilla/Role/ExecFiles.pm:18:21` `zilla`
+  - base: `n=2 top=[['dir', 2], ['find_files', 3]]`
+  - head: `n=13 top=[['dir', 2], ['find_files', 3], ['plugin_name', 2], ['zilla', 2]]`
+- `Mojo/DOM/CSS.pm:23:24` `tree`
+  - base: `n=26 top=[['DEBUG', 3], ['tree', 2], ['matches', 3], ['select', 3]]`
+  - head: `n=34 top=[['DEBUG', 3], ['tree', 2], ['matches', 3], ['select', 3]]`
+- `Mojo/JSON/Pointer.pm:13:24` `data`
+  - base: `n=5 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+  - head: `n=12 top=[['data', 2], ['contains', 3], ['get', 3], ['new', 3]]`
+- …and 5 more distinct claims
 
-### `superset` · completion · call-site — 8 positions, 8 distinct
-
-- `Date/Language/Brazilian.pm:27:30` `_build_lookups`
-  - base: `n=1 top=[['Brazilian', 9]]`
-  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
-- `Date/Language/Finnish.pm:34:30` `_build_lookups`
-  - base: `n=1 top=[['Finnish', 9]]`
-  - head: `n=98 top=[['_build_lookups', 3], ['new', 3], ['DESTROY', 3], ['AUTOLOAD', 3]]`
-- `PPI/Exception.pm:75:12` `caller`
-  - base: `n=4 top=[['new', 3], ['throw', 3], ['message', 3], ['callers', 3]]`
-  - head: `n=200 top=[['callers', 3], ['message', 3], ['new', 3], ['throw', 3]]`
-- `Plack/Handler/Apache2/Registry.pm:13:34` `load_app`
-  - base: `n=2 top=[['handler', 3], ['fixup_path', 3]]`
-  - head: `n=7 top=[['handler', 3], ['fixup_path', 3], ['new', 3], ['preload', 3]]`
-- `Type/Tiny/ConstrainedObject.pm:44:24` `Object`
-  - base: `n=6 top=[['HashRef', 9], ['Tied', 9], ['ArrayRef', 9], ['Tuple', 9]]`
-  - head: `n=45 top=[['_HAS_REFUTILXS', 3], ['_croak', 3], ['Stringable', 3], ['LazyLoad', 3]]`
-- …and 3 more distinct claims
-
-### `superset` · references · call-site — 5 positions, 5 distinct
+### `superset` · references · call-site — 7 positions, 7 distinct
 
 - `Config/MVP/Assembler.pm:134:22` `throw`
   - base: `[["Config/MVP/Assembler.pm", [134, 22, 134, 27]], ["Config/MVP/Assembler.pm", [164, 22, 164, 27]], ["Config/MVP/Assembler.pm", [204, 22, 204, 27]]]`
   - head: `[["Config/MVP/Assembler.pm", [134, 22, 134, 27]], ["Config/MVP/Assembler.pm", [164, 22, 164, 27]], ["Config/MVP/Assembler.pm", [204, 22, 204, 27]], ["Config/MVP/Reader/Finder.pm", [75, 22, 75, 27]], […`
-- `Path/Class/File.pm:187:16` `new`
-  - base: `[["Path/Class/File.pm", [13, 4, 13, 7]], ["Path/Class/File.pm", [187, 16, 187, 19]], ["Path/Class/File.pm", [195, 23, 195, 26]]]`
-  - head: `[["Catalyst.pm", [1296, 33, 1296, 36]], ["Catalyst.pm", [1298, 37, 1298, 40]], ["Catalyst.pm", [3417, 36, 3417, 39]], ["Catalyst.pm", [3583, 53, 3583, 56]], ["Path/Class.pm", [20, 30, 20, 33]], ["Path…`
-- `Plack/Handler/Apache2/Registry.pm:13:26` `load_app`
-  - base: `[["Plack/Handler/Apache2/Registry.pm", [13, 26, 13, 34]]]`
-  - head: `[["Plack/Handler/Apache2.pm", [23, 16, 23, 24]], ["Plack/Handler/Apache2.pm", [27, 4, 27, 12]], ["Plack/Handler/Apache2.pm", [125, 33, 125, 41]], ["Plack/Handler/Apache2/Registry.pm", [13, 26, 13, 34]…`
-- `URI/_ldap.pm:83:8` `uri_unescape`
-  - base: `[["URI/Escape.pm", [148, 28, 148, 40]], ["URI/Escape.pm", [215, 4, 215, 16]], ["URI/URL.pm", [18, 19, 18, 31]], ["URI/URL.pm", [121, 11, 121, 23]], ["URI/URL.pm", [146, 8, 146, 20]], ["URI/_emailauth.…`
-  - head: `[["Cookie/Baker.pm", [108, 28, 108, 40]], ["Cookie/Baker.pm", [113, 30, 113, 42]], ["HTTP/Message/PSGI.pm", [46, 42, 46, 54]], ["LWP/Protocol/http.pm", [97, 46, 97, 58]], ["LWP/Protocol/http.pm", [110…`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/Method/Accessor/Native/Array/sort_in_place.pm:6:12` `Util`
-  - base: `[["Data/OptList.pm", [6, 4, 6, 16]], ["Email/Stuffer.pm", [167, 4, 167, 16]], ["File/ShareDir.pm", [482, 4, 482, 16]], ["Log/Dispatchouli.pm", [12, 4, 12, 16]], ["Log/Dispatchouli/Proxy.pm", [9, 4, 9,…`
-  - head: `[["Config/MVP/Assembler/WithBundles.pm", [5, 4, 5, 16]], ["Data/OptList.pm", [6, 4, 6, 16]], ["Dist/Zilla/Role/Plugin.pm", [8, 4, 8, 16]], ["Email/Stuffer.pm", [167, 4, 167, 16]], ["File/ShareDir.pm",…`
+- `Date/Language/Sidama.pm:9:10` `Language`
+  - base: `[["Date/Language/Brazilian.pm", [10, 4, 10, 18]], ["Date/Language/Brazilian.pm", [15, 10, 15, 24]], ["Date/Language/Finnish.pm", [12, 10, 12, 24]], ["Date/Language/Finnish.pm", [16, 4, 16, 18]], ["Dat…`
+  - head: `[["Date/Format.pm", [21, 19, 21, 33]], ["Date/Format.pm", [21, 35, 21, 49]], ["Date/Language.pm", [1, 8, 1, 22]], ["Date/Language/Afar.pm", [9, 4, 9, 18]], ["Date/Language/Afar.pm", [10, 10, 10, 24]],…`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:23:20` `path`
+  - base: `[["Dist/Zilla/Role/MintingProfile/ShareDir.pm", [23, 20, 23, 24]]]`
+  - head: `[["Dist/Zilla.pm", [739, 18, 739, 22]], ["Dist/Zilla.pm", [741, 15, 741, 19]], ["Dist/Zilla.pm", [748, 2, 748, 6]], ["Dist/Zilla/App/Command/add.pm", [74, 13, 74, 17]], ["Dist/Zilla/App/Command/author…`
+- …and 4 more distinct claims
 
-### `superset` · references · module-path — 5 positions, 5 distinct
+### `superset` · references · module-path — 6 positions, 6 distinct
 
 - `DateTime/TimeZone/America/Argentina/Rio_Gallegos.pm:18:4` `DateTime::TimeZone`
   - base: `[["DateTime/TimeZone/America/Anchorage.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [18, 4, 18, 22]], ["…`
   - head: `[["DateTime/TimeZone.pm", [0, 8, 0, 26]], ["DateTime/TimeZone/Africa/Abidjan.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/Africa/Algiers.pm", [18, 4, 18, 22]], ["DateTime/TimeZone/Africa/Bissau.pm", [18…`
 - `DateTime/TimeZone/America/Rio_Branco.pm:19:4` `DateTime::TimeZone::OlsonDB`
-  - base: `[["DateTime/TimeZone/America/Anchorage.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Cordoba.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Argentina/Jujuy.pm", [19, 4, 19, 31]], ["…`
+  - base: `[["DateTime/TimeZone/America/Boise.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Halifax.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/America/Indiana/Knox.pm", [19, 4, 19, 31]], ["DateTime/TimeZone…`
   - head: `[["DateTime/TimeZone/Africa/Abidjan.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Algiers.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa/Bissau.pm", [19, 4, 19, 31]], ["DateTime/TimeZone/Africa…`
 - `DateTime/TimeZone/Pacific/Kosrae.pm:13:4` `namespace::autoclean`
-  - base: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+  - base: `[["DateTime/TimeZone/America/Boise.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Halifax.pm", [13, 4, 13, 24]], ["DateTime/TimeZone/America/Indiana/Knox.pm", [13, 4, 13, 24]], ["DateTime/TimeZone…`
   - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
-- `Software/License/GFDL_1_3.pm:4:12` `Software::License`
-  - base: `[["Software/License.pm", [2, 8, 2, 25]], ["Software/License/AGPL_3.pm", [4, 12, 4, 29]], ["Software/License/Apache_1_1.pm", [4, 12, 4, 29]], ["Software/License/Apache_2_0.pm", [4, 12, 4, 29]], ["Softw…`
-  - head: `[["Dist/Zilla.pm", [19, 4, 19, 21]], ["Software/License.pm", [2, 8, 2, 25]], ["Software/License/AGPL_3.pm", [4, 12, 4, 29]], ["Software/License/Apache_1_1.pm", [4, 12, 4, 29]], ["Software/License/Apac…`
-- `Text/Unidecode/xa4.pm:1:1` `Text::Unidecode::Char`
-  - base: `[["Text/Unidecode/x19.pm", [1, 18, 1, 22]], ["Text/Unidecode/x1e.pm", [1, 18, 1, 22]], ["Text/Unidecode/x24.pm", [1, 18, 1, 22]], ["Text/Unidecode/x28.pm", [1, 18, 1, 22]], ["Text/Unidecode/x30.pm", […`
-  - head: `[["Text/Unidecode/x00.pm", [1, 18, 1, 22]], ["Text/Unidecode/x01.pm", [1, 18, 1, 22]], ["Text/Unidecode/x02.pm", [1, 18, 1, 22]], ["Text/Unidecode/x03.pm", [1, 18, 1, 22]], ["Text/Unidecode/x04.pm", […`
+- …and 3 more distinct claims
 
-### `superset` · completion · method-call — 3 positions, 3 distinct
+### `superset` · references · sub-decl — 4 positions, 4 distinct
 
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm:46:54` `_expected_method_class`
-  - base: `n=2 top=[['_uninlined_body', 3], ['can_be_inlined', 3]]`
-  - head: `n=31 top=[['_uninlined_body', 3], ['can_be_inlined', 3], ['new', 3], ['_initialize_body', 3]]`
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Overload.pm:25:32` `_throw_exception`
-  - base: `n=19 top=[['new', 3], ['operator', 3], ['method_name', 3], ['has_method_name', 3]]`
-  - head: `n=31 top=[['new', 3], ['operator', 3], ['method_name', 3], ['has_method_name', 3]]`
-- `x86_64-linux-gnu-thread-multi/Moose/Meta/Class/Immutable/Trait.pm:37:42` `name`
-  - base: `n=4 top=[['add_role', 3], ['calculate_all_roles', 3], ['calculate_all_roles_with_inheritance', 3], ['does_role', 3]]`
-  - head: `n=18 top=[['add_role', 3], ['calculate_all_roles', 3], ['calculate_all_roles_with_inheritance', 3], ['does_role', 3]]`
+- `Dist/Zilla/MVP/Reader/Perl.pm:19:4` `read_into_assembler`
+  - base: `[["Dist/Zilla/MVP/Reader/Perl.pm", [19, 4, 19, 23]]]`
+  - head: `[["Config/MVP/Reader.pm", [75, 11, 75, 30]], ["Config/MVP/Reader.pm", [97, 4, 97, 23]], ["Config/MVP/Reader/Finder.pm", [121, 4, 121, 23]], ["Config/MVP/Reader/Hash.pm", [21, 4, 21, 23]], ["Config/MVP…`
+- `Mojo/BaseUtil.pm:14:4` `monkey_patch`
+  - base: `[["Mojo/BaseUtil.pm", [10, 35, 10, 47]], ["Mojo/BaseUtil.pm", [14, 4, 14, 16]]]`
+  - head: `[["Mojo/Base.pm", [41, 22, 41, 34]], ["Mojo/Base.pm", [90, 20, 90, 32]], ["Mojo/Base.pm", [110, 22, 110, 34]], ["Mojo/Base.pm", [133, 22, 133, 34]], ["Mojo/BaseUtil.pm", [10, 35, 10, 47]], ["Mojo/Base…`
+- `Mojo/WebSocket.pm:144:4` `server_handshake`
+  - base: `[["Mojo/WebSocket.pm", [21, 5, 21, 21]], ["Mojo/WebSocket.pm", [144, 4, 144, 20]]]`
+  - head: `[["Mojo/Server/Daemon.pm", [8, 23, 8, 39]], ["Mojo/Server/Daemon.pm", [98, 31, 98, 47]], ["Mojo/WebSocket.pm", [21, 5, 21, 21]], ["Mojo/WebSocket.pm", [144, 4, 144, 20]]]`
+- …and 1 more distinct claims
+
+### `superset` · references · method-call — 1 positions, 1 distinct
+
+- `PPI/Util.pm:36:23` `new`
+  - base: `[["PPI/Document.pm", [190, 4, 190, 7]], ["PPI/Document/File.pm", [49, 4, 49, 7]], ["PPI/Document/File.pm", [59, 27, 59, 30]], ["PPI/Lexer.pm", [196, 31, 196, 34]], ["PPI/Transform.pm", [180, 31, 180, …`
+  - head: `[["Dist/Zilla/Plugin/PkgDist.pm", [86, 34, 86, 37]], ["Dist/Zilla/Role/PPI.pm", [42, 32, 42, 35]], ["PPI/Document.pm", [190, 4, 190, 7]], ["PPI/Document/File.pm", [49, 4, 49, 7]], ["PPI/Document/File.…`
+
+### `superset` · references · package — 1 positions, 1 distinct
+
+- `YAML/PP/Representer.pm:2:8` `YAML::PP::Representer`
+  - base: `[["YAML/PP/Representer.pm", [2, 8, 2, 29]]]`
+  - head: `[["YAML/PP/Dumper.pm", [9, 4, 9, 25]], ["YAML/PP/Dumper.pm", [46, 23, 46, 44]], ["YAML/PP/Representer.pm", [2, 8, 2, 29]]]`
 
 ### `capped-head` · completion · package — 16 positions, 1 distinct
 
@@ -1024,122 +792,98 @@ Each row is one claim to adjudicate: *intended improvement*, *regression*, or *w
   - base: `n=234 top=[['trace', 3], ['_build_trace', 3], ['message', 3], ['_build_message', 3]]`
   - head: `n=200 top=[['BUILD', 3], ['_build_message', 3], ['_build_trace', 3], ['as_string', 3]]`
 
-### `capped-head` · completion · sub-decl — 5 positions, 5 distinct
+### `timeout-base` · completion · use-module — 3 positions, 3 distinct
 
-- `Email/Abstract/EmailSimple.pm:36:13` `as_string`
-  - base: `n=2546 top=[['target', 3], ['construct', 3], ['get_header', 3], ['get_body', 3]]`
-  - head: `n=200 top=[['as_string', 3], ['construct', 3], ['get_body', 3], ['get_header', 3]]`
-- `Email/Abstract/MIMEEntity.pm:8:16` `is_available`
-  - base: `n=2546 top=[['$is_avail', 6], ['is_available', 3], ['target', 3], ['construct', 3]]`
-  - head: `n=200 top=[['construct', 3], ['get_body', 3], ['is_available', 3], ['set_body', 3]]`
-- `Email/MessageID.pm:61:15` `create_host`
-  - base: `n=2547 top=[['$_SYS_HOSTNAME_LONG', 6], ['new', 3], ['create_host', 3], ['create_user', 3]]`
-  - head: `n=200 top=[['address', 3], ['as_string', 3], ['create_host', 3], ['create_user', 3]]`
-- `Email/Simple.pm:329:8` `crlf`
-  - base: `n=2555 top=[['$GROUCHY', 6], ['$CREATOR', 6], ['__crlf_re', 3], ['new', 3]]`
-  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
-- `HTTP/Message.pm:158:15` `add_content`
-  - base: `n=2580 top=[['$VERSION', 6], ['$MAXIMUM_BODY_SIZE', 6], ['$CRLF', 6], ['_utf8_downgrade', 3]]`
-  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
-
-### `capped-head` · completion · variable — 3 positions, 3 distinct
-
-- `Email/Abstract/MIMEEntity.pm:33:17` `obj`
-  - base: `n=2555 top=[['$class', 6], ['$obj', 6], ['$body', 6], ['$lines[]', 6]]`
-  - head: `n=200 top=[['construct', 3], ['get_body', 3], ['is_available', 3], ['set_body', 3]]`
-- `Email/Simple.pm:81:19` `mycrlf`
-  - base: `n=2560 top=[['$class', 6], ['$text', 6], ['$arg', 6], ['$text_ref', 6]]`
-  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
-- `HTTP/Message.pm:72:9` `hdr`
-  - base: `n=2587 top=[['$class', 6], ['$str', 6], ['$hdr[]', 6], ['$#hdr', 6]]`
-  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
-
-### `capped-head` · completion · use-module — 1 positions, 1 distinct
-
-- `Email/Sender/Failure/Permanent.pm:6:6` `Moo`
-  - base: `n=2540 top=[['Email::Sender::Failure::Permanent', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
-  - head: `n=200 top=[['Email::Sender::Failure::Permanent', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3], ['$ENCODING_CONSOLE_IN', 3]]`
-
-### `capped-head` · completion · hash-key — 1 positions, 1 distinct
-
-- `Email/Simple.pm:153:39` `Date`
-  - base: `n=2561 top=[['$class', 6], ['$args{}', 6], ['$headers', 6], ['$GROUCHY', 6]]`
-  - head: `n=200 top=[['__crlf_re', 3], ['__head', 3], ['_split_head_from_body', 3], ['as_string', 3]]`
-
-### `capped-head` · completion · call-site — 1 positions, 1 distinct
-
-- `HTTP/Message.pm:868:54` `rand`
-  - base: `n=2583 top=[['$size', 6], ['$b', 6], ['$VERSION', 6], ['$MAXIMUM_BODY_SIZE', 6]]`
-  - head: `n=200 top=[['AUTOLOAD', 3], ['DESTROY', 3], ['_boundary', 3], ['_content', 3]]`
-
-### `timeout-base` · completion · use-module — 1 positions, 1 distinct
-
-- `Date/Language/Sidama.pm:10:8` `base`
+- `DateTime/TimeZone/America/Boise.pm:17:20` `Class::Singleton`
   - base: `∅`
-  - head: `n=1 top=[['base', 9]]`
-
-### `timeout-base` · definition · use-module — 1 positions, 1 distinct
-
-- `Date/Language/Sidama.pm:10:4` `base`
+  - head: `n=1 top=[['Class::Singleton', 9]]`
+- `Email/MessageID.pm:63:63` `Sys::Hostname::Long`
   - base: `∅`
-  - head: `[["<ext>/perl/5.38.2/base.pm", [1, 8, 1, 12]], ["<ext>/x86_64-linux-gnu/perl-base/base.pm", [1, 8, 1, 12]]]`
-
-### `timeout-base` · references · call-site — 1 positions, 1 distinct
-
-- `Date/Language/Sidama.pm:9:10` `Language`
+  - head: `n=1 top=[['hostname', 3]]`
+- `Test/TypeTiny.pm:2:10` `strict`
   - base: `∅`
-  - head: `[["Date/Format.pm", [21, 19, 21, 33]], ["Date/Format.pm", [21, 35, 21, 49]], ["Date/Language.pm", [1, 8, 1, 22]], ["Date/Language/Afar.pm", [9, 4, 9, 18]], ["Date/Language/Afar.pm", [10, 10, 10, 24]],…`
+  - head: `n=200 top=[['EXTENDED_TESTING', 3], ['_mk_message', 3], ['match', 3], ['matchfor', 3]]`
 
-### `timeout-base` · completion · call-site — 1 positions, 1 distinct
+### `timeout-base` · definition · use-module — 3 positions, 3 distinct
 
-- `PPI/Util.pm:37:45` `_SCALAR0`
+- `DateTime/TimeZone/America/Boise.pm:17:4` `Class::Singleton`
   - base: `∅`
-  - head: `n=200 top=[['FALSE', 3], ['HAVE_UNICODE', 3], ['TRUE', 3], ['_Document', 3]]`
-
-### `timeout-base` · definition · call-site — 1 positions, 1 distinct
-
-- `PPI/Util.pm:37:37` `_SCALAR0`
+  - head: `[["Class/Singleton.pm", [21, 8, 21, 24]]]`
+- `Email/MessageID.pm:63:44` `Sys::Hostname::Long`
   - base: `∅`
-  - head: `[["x86_64-linux-gnu-thread-multi/Params/Util.pm", [85, 0, 85, 0]]]`
-
-### `timeout-base` · references · method-call — 1 positions, 1 distinct
-
-- `PPI/Util.pm:36:23` `new`
+  - head: `[]`
+- `Test/TypeTiny.pm:2:4` `strict`
   - base: `∅`
-  - head: `[["Dist/Zilla/Plugin/PkgDist.pm", [86, 34, 86, 37]], ["Dist/Zilla/Role/PPI.pm", [42, 32, 42, 35]], ["PPI/Document.pm", [190, 4, 190, 7]], ["PPI/Document/File.pm", [49, 4, 49, 7]], ["PPI/Document/File.…`
+  - head: `[["<ext>/perl/5.38.2/strict.pm", [0, 8, 0, 14]], ["<ext>/x86_64-linux-gnu/perl-base/strict.pm", [0, 8, 0, 14]]]`
+
+### `timeout-base` · references · use-module — 3 positions, 2 distinct
+
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm:3:4` `strict`  (+1 more positions answering identically)
+  - base: `∅`
+  - head: `[["Apache/LogFormat/Compiler.pm", [2, 4, 2, 10]], ["App/Cmd.pm", [37, 7, 37, 13]], ["App/Cmd/ArgProcessor.pm", [0, 4, 0, 10]], ["App/Cmd/Command.pm", [0, 4, 0, 10]], ["App/Cmd/Command/commands.pm", [0…`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:8:4` `namespace::autoclean`
+  - base: `∅`
+  - head: `[["DateTime/Locale.pm", [6, 4, 6, 24]], ["DateTime/Locale/Base.pm", [4, 4, 4, 24]], ["DateTime/Locale/Data.pm", [18, 4, 18, 24]], ["DateTime/Locale/FromData.pm", [4, 4, 4, 24]], ["DateTime/Locale/Util…`
+
+### `timeout-base` · completion · call-site — 3 positions, 3 distinct
+
+- `Mojo/Server.pm:19:19` `app`
+  - base: `∅`
+  - head: `n=24 top=[['app', 2], ['reverse_proxy', 2], ['trusted_proxies', 2], ['build_app', 3]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm:17:27` `isa`
+  - base: `∅`
+  - head: `n=2 top=[['_uninlined_body', 3], ['can_be_inlined', 3]]`
+- `x86_64-linux-gnu-thread-multi/oose.pm:6:15` `Util`
+  - base: `∅`
+  - head: `n=4 top=[['Moose::Util', 9], ['Moose::Util::TypeConstraints', 9], ['Moose::Util::TypeConstraints::Builtins', 9], ['Moose::Util::MetaRole', 9]]`
+
+### `timeout-base` · definition · call-site — 3 positions, 3 distinct
+
+- `Mojo/Server.pm:19:16` `app`
+  - base: `∅`
+  - head: `[["Mojo/Server.pm", [10, 4, 10, 7]]]`
+- `x86_64-linux-gnu-thread-multi/Class/MOP/Method/Inlined.pm:17:24` `isa`
+  - base: `∅`
+  - head: `[]`
+- `x86_64-linux-gnu-thread-multi/oose.pm:6:11` `Util`
+  - base: `∅`
+  - head: `[["x86_64-linux-gnu-thread-multi/Moose/Util.pm", [0, 8, 0, 19]]]`
+
+### `timeout-base` · references · package — 2 positions, 2 distinct
+
+- `DateTime/TimeZone/America/Boise.pm:9:8` `DateTime::TimeZone::America::Boise`
+  - base: `∅`
+  - head: `[["DateTime/TimeZone/America/Boise.pm", [9, 8, 9, 42]]]`
+- `Test/TypeTiny.pm:0:8` `Test::TypeTiny`
+  - base: `∅`
+  - head: `[["Test/TypeTiny.pm", [0, 8, 0, 22]]]`
 
 ### `timeout-base` · completion · sub-decl — 1 positions, 1 distinct
 
-- `YAML/PP/Representer.pm:46:25` `preserve_scalar_style`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:20:15` `profile_dir`
   - base: `∅`
-  - head: `n=200 top=[['_represent_node_nonref', 3], ['_represent_noderef', 3], ['clone', 3], ['new', 3]]`
+  - head: `n=200 top=[['profile_dir', 3], ['Dist::Zilla::Role::MintingProfile::ShareDir', 7], ['$CURLY_SYMBOL', 3], ['$DYNAMIC_FILE_UPLOAD', 3]]`
 
 ### `timeout-base` · definition · sub-decl — 1 positions, 1 distinct
 
-- `YAML/PP/Representer.pm:46:4` `preserve_scalar_style`
+- `Dist/Zilla/Role/MintingProfile/ShareDir.pm:20:4` `profile_dir`
   - base: `∅`
-  - head: `[["YAML/PP/Representer.pm", [46, 4, 46, 25]]]`
+  - head: `[["Dist/Zilla/Role/MintingProfile/ShareDir.pm", [20, 4, 20, 15]]]`
 
-### `timeout-base` · references · package — 1 positions, 1 distinct
+### `timeout-base` · references · sub-decl — 1 positions, 1 distinct
 
-- `YAML/PP/Representer.pm:2:8` `YAML::PP::Representer`
+- `Email/MessageID.pm:61:4` `create_host`
   - base: `∅`
-  - head: `[["YAML/PP/Dumper.pm", [9, 4, 9, 25]], ["YAML/PP/Dumper.pm", [46, 23, 46, 44]], ["YAML/PP/Representer.pm", [2, 8, 2, 29]]]`
+  - head: `[["Email/MessageID.pm", [45, 28, 45, 39]], ["Email/MessageID.pm", [61, 4, 61, 15]]]`
 
-### `timeout-base` · completion · method-call — 1 positions, 1 distinct
+### `timeout-base` · references · hash-key — 1 positions, 1 distinct
 
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:23:36` `name`
+- `Mojo/Server.pm:12:4` `trusted_proxies`
   - base: `∅`
-  - head: `n=6 top=[['add_attribute', 3], ['has_attribute', 3], ['get_attribute', 3], ['remove_attribute', 3]]`
+  - head: `[["Mojo/Server.pm", [11, 68, 11, 83]], ["Mojo/Server.pm", [12, 4, 12, 19]], ["Mojo/Server.pm", [26, 46, 26, 61]], ["Mojo/Server/Hypnotoad.pm", [24, 12, 24, 27]], ["Mojolicious/Command/daemon.pm", [26,…`
 
-### `timeout-base` · definition · method-call — 1 positions, 1 distinct
+### `timeout-base` · references · call-site — 1 positions, 1 distinct
 
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:23:32` `name`
+- `Path/Class/File.pm:187:16` `new`
   - base: `∅`
-  - head: `[]`
-
-### `timeout-base` · references · use-module — 1 positions, 1 distinct
-
-- `x86_64-linux-gnu-thread-multi/Class/MOP/Mixin/HasAttributes.pm:6:4` `Scalar::Util`
-  - base: `∅`
-  - head: `[["B/Hooks/EndOfScope/PP/HintHash.pm", [12, 4, 12, 16]], ["Capture/Tiny.pm", [11, 4, 11, 16]], ["Catalyst.pm", [53, 4, 53, 16]], ["Catalyst/Action.pm", [22, 4, 22, 16]], ["Catalyst/Component.pm", [10,…`
+  - head: `[["Catalyst.pm", [1296, 33, 1296, 36]], ["Catalyst.pm", [1298, 37, 1298, 40]], ["Catalyst.pm", [3417, 36, 3417, 39]], ["Catalyst.pm", [3583, 53, 3583, 56]], ["Path/Class.pm", [20, 30, 20, 33]], ["Path…`

--- a/bench/sweep/run.sh
+++ b/bench/sweep/run.sh
@@ -11,6 +11,14 @@ set -euo pipefail
 
 BASE_BIN=${1:?base binary}; HEAD_BIN=${2:?head binary}
 ROOT=${3:?corpus root};     OUT=${4:?output dir}; shift 4
+# Captured HERE, at top level. Inside a function `$@` is that function's own
+# arguments, so reaching for the caller's extras from within `run_side` gets
+# the wrong list — and `"$@:3"` is not slice syntax at all (that is `${@:3}`),
+# so it expanded to the function's two args plus a literal `:3` and both
+# sides died on `unrecognized arguments`. The wrapper was completely
+# non-functional and the Python selftest could not see it, which is why
+# `selftest-shell.sh` now invokes this script for real.
+EXTRA=("$@")
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 mkdir -p "$OUT"
 
@@ -30,10 +38,13 @@ EXTRA=("$@")
 
 run_side() {  # side, binary
   local side=$1 bin=$2
+  # `${EXTRA+...}` rather than a bare `"${EXTRA[@]}"`: under `set -u` an empty
+  # array is an unbound-variable error on bash before 4.4, and macOS still
+  # ships 3.2 as /bin/bash. Untested here (this box is 5.2), free to keep.
   python3 "$HERE/sweep.py" run --bin "$bin" --root "$ROOT" \
     --positions "$OUT/positions.jsonl" --out "$OUT/answers-$side.jsonl" --side "$side" \
     --cache-dir "$OUT/cache-$side" --timeout "$SWEEP_TIMEOUT" \
-    --ready-timeout "$SWEEP_READY_TIMEOUT" "${EXTRA[@]}" 2>&1 | sed "s/^/[$side] /"
+    --ready-timeout "$SWEEP_READY_TIMEOUT" ${EXTRA+"${EXTRA[@]}"} 2>&1 | sed "s/^/[$side] /"
 }
 
 if [ "${SWEEP_SERIAL:-0}" = 1 ]; then

--- a/bench/sweep/selftest-shell.sh
+++ b/bench/sweep/selftest-shell.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# End-to-end test of `run.sh`, because the Python selftest cannot see the
+# shell wrapper — and that is exactly where the wrapper broke.
+#
+# `run_side()` passed the caller's extra arguments as `"$@:3"`. That is not
+# slice syntax (`${@:3}` is), and inside a function `$@` is the function's own
+# arguments anyway, so it expanded to two args plus a literal `:3` and BOTH
+# sides died on `unrecognized arguments`. The wrapper did not run at all. The
+# Python selftest passed throughout, which is the point: a green unit suite
+# said nothing about whether the entry point worked.
+#
+# So this runs the real script, on a two-file corpus, and asserts a report
+# came out the far end. Usage:
+#     bench/sweep/selftest-shell.sh [path-to-perl-lsp]
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BIN=${1:-$HERE/../../target/release/perl-lsp}
+[ -x "$BIN" ] || { echo "no binary at $BIN (cargo build --release)"; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/corpus/lib"
+
+# The corpus needs a real cross-file edge: the readiness gate demands a
+# definition that lands in a DIFFERENT file, so a single-file corpus would
+# hang until the budget expired and prove nothing.
+cat > "$TMP/corpus/lib/Widget.pm" <<'EOF'
+package Widget;
+sub new { my $c = shift; return bless {}, $c }
+sub spin { return 1 }
+1;
+EOF
+cat > "$TMP/corpus/lib/User.pm" <<'EOF'
+package User;
+use Widget;
+sub go { my $w = Widget->new(); return $w->spin(); }
+1;
+EOF
+
+# Extra args go through the same path that was broken, so passing one here is
+# the actual regression test rather than a smoke test of the happy path.
+SWEEP_MAX_FILES=2 SWEEP_PER_FILE=4 SWEEP_SERIAL=1 SWEEP_READY_TIMEOUT=90 \
+  "$HERE/run.sh" "$BIN" "$BIN" "$TMP/corpus" "$TMP/out" --timeout 20
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -s "$TMP/out/positions.jsonl" ]   || fail "no positions emitted"
+[ -s "$TMP/out/answers-base.jsonl" ]|| fail "base side produced no answers"
+[ -s "$TMP/out/answers-head.jsonl" ]|| fail "head side produced no answers"
+[ -s "$TMP/out/report.md" ]         || fail "no report produced"
+grep -q "Differential sweep report" "$TMP/out/report.md" || fail "report has no header"
+grep -q "answers compared"          "$TMP/out/report.md" || fail "report compared nothing"
+
+# Same binary on both sides: anything but agreement means the harness is
+# inventing divergences, which is its worst failure mode and its quietest.
+n=$(grep -oE '^\| `[a-z-]+` \| [0-9]+' "$TMP/out/report.md" | wc -l || true)
+[ "$n" -eq 0 ] || { sed -n '/Divergences by shape/,/^$/p' "$TMP/out/report.md"
+                    fail "same binary against itself reported $n divergent shapes"; }
+
+echo "sweep shell selftest: run.sh works end to end, and agrees with itself"

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -191,6 +191,37 @@ for _f in (_n1, _n2):
     os.unlink(_f)
 
 
+# A short side is a side that STOPPED, not a side that found less. Every
+# ratio over it is a ratio over the positions it got through — the cheap ones.
+_short = _tmp_answers([_row(1, _D)])
+_L = open(_short).read().split("\n")
+_m = _json.loads(_L[0]); _m["_meta"]["expected_positions"] = 10
+_L[0] = _json.dumps(_m); open(_short, "w").write("\n".join(_L))
+_meta_s, _rows_s = S._load(_short)
+check("a truncated side is detected against its own declared count",
+      S._completeness(_meta_s, _rows_s)[:2], (1, 10))
+
+# ...and a side that answered everything but never wrote its completion
+# marker died somewhere after the main loop, which is equally not-finished.
+_nomark = _tmp_answers([_row(1, _D)])
+_L = open(_nomark).read().split("\n")
+_m = _json.loads(_L[0]); _m["_meta"]["expected_positions"] = 1
+_L[0] = _json.dumps(_m); open(_nomark, "w").write("\n".join(_L))
+_meta_n, _rows_n = S._load(_nomark)
+check("a run with no completion marker is not treated as complete",
+      S._completeness(_meta_n, _rows_n)[2], False)
+
+_full = _tmp_answers([_row(1, _D), {"_event": "complete", "positions_answered": 1}])
+_L = open(_full).read().split("\n")
+_m = _json.loads(_L[0]); _m["_meta"]["expected_positions"] = 1
+_L[0] = _json.dumps(_m); open(_full, "w").write("\n".join(_L))
+_meta_f, _rows_f = S._load(_full)
+check("a complete run reports complete",
+      S._completeness(_meta_f, _rows_f), (1, 1, True))
+for _f in (_short, _nomark, _full):
+    os.unlink(_f)
+
+
 # --- position selection -----------------------------------------------------
 
 check("selection is deterministic across processes — hash() is salted, "

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -179,8 +179,14 @@ _n1 = _tmp_answers([_row(1, _D), _row(9, _D)])
 _n2 = _tmp_answers([_row(1, []), _row(9, [])])
 _counts, _cov = S._shape_counts(_n1, _n2, {"definition"},
                                 {("a.pm", 1, 0, "definition")})
+# Shape-level keys are plain strings; per-verb keys are (shape, verb) tuples.
+# Summing indiscriminately double-counts, which is why this asserts each.
+_shape_only = {k: v for k, v in _counts.items() if isinstance(k, str)}
 check("the floor counts only answers the A/B actually compared",
-      (sum(_counts.values()), _cov), (1, 1))
+      (sum(_shape_only.values()), _cov), (1, 1))
+check("the floor is also sliced per verb, the only baseline a single-verb "
+      "block can be read against",
+      _counts.get(("only-base", "definition")), 1)
 for _f in (_n1, _n2):
     os.unlink(_f)
 

--- a/bench/sweep/selftest.py
+++ b/bench/sweep/selftest.py
@@ -138,7 +138,7 @@ check("an untruncated smaller list is still a subset",
 
 # The recheck pass must SUPERSEDE the cold answer, or the sweep measures
 # startup rather than the branch. Written as an appended row, applied on load.
-import io, json as _json, tempfile as _tf
+import json as _json, tempfile as _tf
 _p = _tf.NamedTemporaryFile("w", suffix=".jsonl", delete=False)
 _p.write(_json.dumps({"_meta": {"side": "t"}}) + "\n")
 _p.write(_json.dumps({"file": "a.pm", "line": 1, "char": 2, "verb": "definition",
@@ -153,6 +153,36 @@ check("a warm recheck supersedes the cold empty answer",
       (_row["norm"], _row.get("filled_when_warm")),
       ([["lib/X.pm", [0, 0, 0, 1]]], True))
 os.unlink(_p.name)
+
+
+# The noise floor is a per-answer RATE, so it is only subtractable from a
+# count over the same answers. On Koha the base wedged and produced 1,184
+# comparable answers where the two noise runs produced ~21,790; a floor from
+# the larger population quoted beside the smaller count is not a correction,
+# it is a different measurement. `_shape_counts` must intersect.
+def _tmp_answers(rows):
+    f = _tf.NamedTemporaryFile("w", suffix=".jsonl", delete=False)
+    f.write(_json.dumps({"_meta": {"side": "t"}}) + "\n")
+    for r in rows:
+        f.write(_json.dumps(r) + "\n")
+    f.close()
+    return f.name
+
+def _row(line, norm, **kw):
+    return dict({"file": "a.pm", "line": line, "char": 0, "verb": "definition",
+                 "norm": norm, "ms": 1}, **kw)
+
+_D = [["lib/X.pm", [0, 0, 0, 1]]]
+# Two noise runs that disagree at line 1 AND at line 9. Only line 1 is in the
+# A/B's comparable set, so only line 1 may count toward the floor.
+_n1 = _tmp_answers([_row(1, _D), _row(9, _D)])
+_n2 = _tmp_answers([_row(1, []), _row(9, [])])
+_counts, _cov = S._shape_counts(_n1, _n2, {"definition"},
+                                {("a.pm", 1, 0, "definition")})
+check("the floor counts only answers the A/B actually compared",
+      (sum(_counts.values()), _cov), (1, 1))
+for _f in (_n1, _n2):
+    os.unlink(_f)
 
 
 # --- position selection -----------------------------------------------------

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -193,6 +193,14 @@ def cmd_run(args):
     if ready_ms is not None:
         print(f"[{args.side}] cross-file ready after {round(ready_ms)}ms", flush=True)
 
+    # Written to `.partial` and renamed only on clean completion. A reader
+    # cannot tell a finished answer file from one still being appended to,
+    # and the failure is silent: three sessions in one evening published
+    # numbers taken from a file that was not yet what it would be — a floor
+    # from a run that had not started, and a coverage ratio read while the
+    # base side was still writing. The rename is the only signal that costs
+    # nothing to check and cannot be misread.
+    out_partial = args.out + ".partial"
     opened, done = {first: ready}, 0
     # Lists, not ints: the loop rebinds `lsp` on restart and these have to
     # survive that without a nonlocal dance in a nested scope.
@@ -205,7 +213,7 @@ def cmd_run(args):
     epoch, epoch_warm = [0], [True]
     deferred = []
     t0 = time.monotonic()
-    with open(args.out, "w") as fh:
+    with open(out_partial, "w") as fh:
         fh.write(json.dumps({"_meta": {
             # Identity of the QUESTIONS and of when they were asked. The diff
             # cross-checks these across all four inputs, because nothing else
@@ -223,6 +231,13 @@ def cmd_run(args):
             "cross_file_ready": ready_ms is not None, "verbs": served,
             "unserved": sorted(set(VERBS) - set(served)),
             "verb_rate": VERB_RATE, "positions": len(pos),
+            # What a COMPLETE run of this side would contain. A side that
+            # aborted looks exactly like a side that legitimately answered
+            # less, and that is precisely the distinction the sweep exists to
+            # draw — so the expectation is written down before the work
+            # starts, and the diff checks the delivery against it.
+            "expected_positions": len(pos),
+            "expected_files": len({p["file"] for p in pos}),
             "version": _version(args.bin),
         }}) + "\n")
         by_file = {}
@@ -331,7 +346,8 @@ def cmd_run(args):
                                     "reason": "restart budget exhausted",
                                     "swept": done, "of": len(pos)}) + "\n")
                                 print(f"[{args.side}] ABORTED after "
-                                      f"{restarts[0]} restarts", flush=True)
+                                      f"{restarts[0]} restarts — leaving "
+                                      f"{out_partial} unrenamed", flush=True)
                                 lsp.shutdown()
                                 return
                             try:
@@ -395,9 +411,12 @@ def cmd_run(args):
         fh.write(json.dumps({"_event": "recheck",
                              "empty_first_ask": len(deferred),
                              "filled_when_warm": filled}) + "\n")
+        fh.write(json.dumps({"_event": "complete",
+                             "positions_answered": done}) + "\n")
         print(f"[{args.side}] recheck: {filled} of {len(deferred)} empty answers "
               f"resolved once warm", flush=True)
     lsp.shutdown()
+    os.replace(out_partial, args.out)
     print(f"[{args.side}] done: {done} positions in "
           f"{time.monotonic()-t0:.0f}s -> {args.out}")
 
@@ -467,6 +486,18 @@ def _open(lsp, root, rel):
 
 # ---- diff ----
 
+def _completeness(meta, rows):
+    """Did this side deliver what its own header said it would?
+
+    Returns (answered, expected, complete_marker_present). A short side is
+    not a side that found less — it is a side that stopped, and conflating
+    the two is the exact error this whole harness exists to prevent.
+    """
+    positions = {(r["file"], r.get("line"), r.get("char"))
+                 for r in rows.values() if r.get("line") is not None}
+    return len(positions), meta.get("expected_positions"), meta.get("_complete")
+
+
 def _load(path):
     meta, rows, events = {}, {}, []
     for line in open(path):
@@ -488,6 +519,7 @@ def _load(path):
             continue
         rows[key] = r
     meta["events"] = events
+    meta["_complete"] = any(e.get("_event") == "complete" for e in events)
     return meta, rows
 
 
@@ -668,6 +700,30 @@ def cmd_diff(args):
     # branch and bury what does. The shortfall is reported as COVERAGE
     # instead, which is the honest framing: this is what we compared, and
     # this is what we could not.
+    # Completeness before anything else. A short side is a side that
+    # STOPPED, and every ratio computed over it is a ratio over the positions
+    # it got through — which are the cheap ones. This is checked first and
+    # loudly because the alternative is a plausible report built on a
+    # truncated file, which is how three sessions published wrong numbers in
+    # one evening.
+    short = []
+    for label, m, rws in (("base", meta_a, base), ("head", meta_b, head)):
+        got, want, done_marker = _completeness(m, rws)
+        if want and got < want:
+            short.append(f"{label} answered {got} of the {want} positions its "
+                         f"own header declared ({got/want:.1%})")
+        elif want and not done_marker:
+            short.append(f"{label} reached its position count but never wrote "
+                         f"a completion marker — it may have died in the "
+                         f"recheck pass")
+    if short and not args.allow_short:
+        for msg in short:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        print("Refusing to diff a truncated run. Re-run the short side, or "
+              "pass --allow-short to compare anyway (the report will say so).",
+              file=sys.stderr)
+        sys.exit(3)
+
     all_keys = {k for k in (set(base) | set(head)) if k[3] in common}
     comparable = {k for k in all_keys if k in base and k in head}
     only_base_keys = sum(1 for k in all_keys if k not in head)
@@ -755,6 +811,13 @@ def cmd_diff(args):
             W(f"- **{side} {ev['_event']}**: " + ", ".join(
                 f"{k}={v}" for k, v in sorted(ev.items()) if k != "_event"))
     W("")
+    if short:
+        W("> **TRUNCATED RUN — every number below is over the positions the "
+          "short side got through, which are the ones it reached before it "
+          "stopped, not a sample of the corpus.**\n")
+        for msg in short:
+            W(f"> - {msg}")
+        W("")
     W(f"**{total} (position, verb) answers compared — {same} identical "
       f"({same/max(total,1):.2%}), {diverged} divergent.**\n")
     if only_base_keys or only_head_keys:
@@ -950,6 +1013,9 @@ def main():
     p.add_argument("--examples", type=int, default=8)
     p.add_argument("--noise-base", help="answers from a repeat run of ONE binary")
     p.add_argument("--noise-head", help="answers from a second run of that SAME binary")
+    p.add_argument("--allow-short", action="store_true",
+                   help="diff even when a side delivered fewer positions than "
+                        "its header declared; the report is marked TRUNCATED")
     p.add_argument("--force-noise", action="store_true",
                    help="use the noise pair even if it fails the provenance check")
     p.set_defaults(fn=cmd_diff)

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -709,10 +709,16 @@ def cmd_diff(args):
     short = []
     for label, m, rws in (("base", meta_a, base), ("head", meta_b, head)):
         got, want, done_marker = _completeness(m, rws)
-        if want and got < want:
+        if want is None:
+            # An unverifiable file is not a verified one. Silently accepting
+            # it would re-open the exact hole these checks close — every
+            # wrong number this evening came from a file that looked fine.
+            short.append(f"{label} predates completeness stamping, so it "
+                         f"cannot be shown to be a complete run")
+        elif got < want:
             short.append(f"{label} answered {got} of the {want} positions its "
                          f"own header declared ({got/want:.1%})")
-        elif want and not done_marker:
+        elif not done_marker:
             short.append(f"{label} reached its position count but never wrote "
                          f"a completion marker — it may have died in the "
                          f"recheck pass")

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -599,6 +599,46 @@ SHAPE_ORDER = ["only-base", "subset", "timeout-head", "error-head", "disagree",
                "missing-head", "missing-base"]
 
 
+def _floor_over_pairs(paths, common, only_keys):
+    """The floor from EVERY pair of same-binary runs, not one pair.
+
+    A two-run floor is a single draw from a distribution, and for some shapes
+    that distribution is wide: measured over four head runs on the substrate,
+    `disagree` came out 14, 15, 17, 19, 25, 25 across the six pairs — nearly
+    2x between the luckiest and unluckiest pair, on identical inputs. Quoting
+    whichever pair happened to run is how a shape gets called signal because
+    its floor was measured on a good day.
+
+    The reported floor is the MAX across pairs, because a shape earns
+    "signal" only by clearing the worst self-disagreement observed, and the
+    range comes back too so a reader can see how stable the estimate is.
+    `reranked` is tight here (158-168); `disagree` is not.
+    """
+    import itertools
+    loaded = [(p, _load(p)[1]) for p in paths]
+    per_pair = []
+    covered = 0
+    for (pa, a), (pb, b) in itertools.combinations(loaded, 2):
+        keys = set(a) & set(b) & only_keys
+        covered = max(covered, len(keys))
+        c = {}
+        for k in keys:
+            if k[3] not in common:
+                continue
+            sh = classify(k[3], a[k], b[k])
+            if sh != "same":
+                c[sh] = c.get(sh, 0) + 1
+                c[(sh, k[3])] = c.get((sh, k[3]), 0) + 1
+        per_pair.append(c)
+    if not per_pair:
+        return {}, {}, 0, 0
+    shapes = {k for c in per_pair for k in c}
+    floor = {k: max(c.get(k, 0) for c in per_pair) for k in shapes}
+    spread = {k: (min(c.get(k, 0) for c in per_pair),
+                  max(c.get(k, 0) for c in per_pair)) for k in shapes}
+    return floor, spread, covered, len(per_pair)
+
+
 def _shape_counts(base_path, head_path, common, only_keys):
     """The noise floor, measured over EXACTLY the answers the A/B compared.
 
@@ -641,7 +681,7 @@ def _shape_counts(base_path, head_path, common, only_keys):
     return out, len(keys)
 
 
-def _check_provenance(meta_a, meta_b, args):
+def _check_provenance(meta_a, meta_b, noise_paths):
     """Do all four inputs come from ONE sweep, asking ONE set of questions?
 
     Nothing downstream can tell that they do not. Four well-formed answer
@@ -656,10 +696,9 @@ def _check_provenance(meta_a, meta_b, args):
     -file case by definition.
     """
     metas = {}
-    for label, path in (("noise-base", args.noise_base),
-                        ("noise-head", args.noise_head)):
+    for path in noise_paths:
         m, _ = _load(path)
-        metas[label] = m
+        metas[os.path.basename(path)] = m
     want = meta_b.get("positions_sha") or meta_a.get("positions_sha")
     if want:
         for label, m in metas.items():
@@ -776,13 +815,17 @@ def cmd_diff(args):
     # completion ordering is not stable run to run. This is not a correction
     # applied to the counts; it is the resolution limit printed beside them.
     noise, noise_n, noise_reject = {}, 0, None
+    spread, npairs = {}, 0
+    noise_paths = list(args.noise or [])
     if args.noise_base and args.noise_head:
-        noise_reject = _check_provenance(meta_a, meta_b, args)
+        noise_paths = [args.noise_base, args.noise_head] + noise_paths
+    if len(noise_paths) >= 2:
+        noise_reject = _check_provenance(meta_a, meta_b, noise_paths)
         if noise_reject:
             print(f"WARNING: {noise_reject}", file=sys.stderr)
         if not (noise_reject and not args.force_noise):
-            noise, noise_n = _shape_counts(args.noise_base, args.noise_head,
-                                           common, keys)
+            noise, spread, noise_n, npairs = _floor_over_pairs(
+                noise_paths, common, keys)
 
     total = len(keys)
     diverged = sum(v for (s, _), v in counts.items() if s != "same")
@@ -864,11 +907,27 @@ def cmd_diff(args):
           f"> **Noise floor is SUSPECT — {noise_reject}.** Shown anyway "
           f"because `--force-noise` was passed.\n")
     if noise or noise_n:
-        W("`noise` is the same shape's count when the SAME binary is run "
-          "twice, measured over EXACTLY the answers compared here — a rate "
-          "taken over a different population is not subtractable from this "
-          "one. A block at or below its floor carries no information: read "
-          "`signal`, not `n`.\n")
+        W(f"`noise` is the WORST self-disagreement across all {npairs} pair"
+          f"{'s' if npairs != 1 else ''} of same-binary runs, measured over "
+          f"EXACTLY the answers compared here. A shape earns `signal` only by "
+          f"clearing the worst floor observed, not the luckiest.\n")
+        if npairs > 1:
+            # Keys are a mix of shape strings and (shape, verb) tuples, so
+            # sort on the shape name rather than the key itself.
+            wide = [(k, lo, hi) for k, (lo, hi) in spread.items()
+                    if isinstance(k, str) and hi and (hi - lo) > 0.25 * hi]
+            wide.sort(key=lambda t: t[0])
+            if wide:
+                W("> The floor is not one number. Across those pairs: "
+                  + "; ".join(f"`{k}` ranged {lo}–{hi}" for k, lo, hi in wide)
+                  + ". A single pair would have reported any one of those, so "
+                    "a block sitting between the low and high figures cannot "
+                    "be called signal from a two-run floor.\n")
+        elif npairs == 1:
+            W("> **Only one pair of noise runs was supplied, so the floor is a "
+              "single draw.** Measured on this corpus, `disagree` ranged 14–25 "
+              "across six pairs of identical runs — pass three or four runs to "
+              "`--noise` if a thin block's verdict depends on the floor.\n")
         cover = noise_n / max(total, 1)
         if cover < 0.98:
             W(f"> **The floor covers {noise_n} of {total} compared answers "
@@ -1019,6 +1078,11 @@ def main():
     p.add_argument("--examples", type=int, default=8)
     p.add_argument("--noise-base", help="answers from a repeat run of ONE binary")
     p.add_argument("--noise-head", help="answers from a second run of that SAME binary")
+    p.add_argument("--noise", nargs="+", metavar="ANSWERS",
+                   help="two or more runs of ONE binary. Every pair is "
+                        "measured and the floor is the worst of them — a "
+                        "single pair is one draw from a distribution that is "
+                        "wide for some shapes.")
     p.add_argument("--allow-short", action="store_true",
                    help="diff even when a side delivered fewer positions than "
                         "its header declared; the report is marked TRUNCATED")

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -25,7 +25,7 @@ Two traps this handles, both of which silently corrupt a comparison:
     look like it lost answers -- the single most misleading thing a
     differential sweep can report.
 """
-import argparse, json, os, pathlib, subprocess, sys, time
+import argparse, hashlib, json, os, pathlib, subprocess, sys, time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -86,7 +86,16 @@ def cmd_positions(args):
           f"per_file={args.per_file})")
 
 
+def _sha_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
 def cmd_run(args):
+    _t0_wall = time.time()
     root = os.path.abspath(args.root)
     root_uri = pathlib.Path(root).as_uri()
     pos = [json.loads(l) for l in open(args.positions)]
@@ -198,6 +207,17 @@ def cmd_run(args):
     t0 = time.monotonic()
     with open(args.out, "w") as fh:
         fh.write(json.dumps({"_meta": {
+            # Identity of the QUESTIONS and of when they were asked. The diff
+            # cross-checks these across all four inputs, because nothing else
+            # can: four well-formed answer files from two different sweeps
+            # produce a report that is entirely plausible and entirely wrong.
+            # That happened — a report was generated the moment the head side
+            # finished, while the two noise runs the script had yet to start
+            # were still on disk from the previous invocation, and the floor
+            # it published came from a different sweep.
+            "positions_sha": _sha_file(args.positions),
+            "positions_path": os.path.abspath(args.positions),
+            "started_at": _t0_wall,
             "side": args.side, "bin": os.path.abspath(args.bin), "root": root,
             "root_uri": root_uri, "ready_ms": ready_ms and round(ready_ms),
             "cross_file_ready": ready_ms is not None, "verbs": served,
@@ -578,8 +598,57 @@ def _shape_counts(base_path, head_path, common, only_keys):
             continue
         sh = classify(k[3], a[k], b[k])
         if sh != "same":
+            # Keyed by (shape, verb) as well as shape. An aggregate floor is
+            # the wrong baseline for a single-verb block and the error is not
+            # conservative in either direction: measured here, `disagree` is
+            # 5 aggregate and ALL 5 of it is completion, so a `definition`
+            # sub-block read against the aggregate is handed noise it does
+            # not have, while on another corpus the reverse hides real signal.
             out[sh] = out.get(sh, 0) + 1
+            out[(sh, k[3])] = out.get((sh, k[3]), 0) + 1
     return out, len(keys)
+
+
+def _check_provenance(meta_a, meta_b, args):
+    """Do all four inputs come from ONE sweep, asking ONE set of questions?
+
+    Nothing downstream can tell that they do not. Four well-formed answer
+    files produce a well-formed report whether or not they belong together,
+    and the failure is silent and plausible — a floor from a previous run,
+    quoted beside fresh counts, reads exactly like a floor from this one.
+    It happened here, and it published wrong numbers.
+
+    Two checks. The positions hash must match, because a floor over different
+    QUESTIONS is not a floor at all. And the noise runs must not predate the
+    A/B: a noise pair older than the run it is quoted against is the stale
+    -file case by definition.
+    """
+    metas = {}
+    for label, path in (("noise-base", args.noise_base),
+                        ("noise-head", args.noise_head)):
+        m, _ = _load(path)
+        metas[label] = m
+    want = meta_b.get("positions_sha") or meta_a.get("positions_sha")
+    if want:
+        for label, m in metas.items():
+            got = m.get("positions_sha")
+            if got and got != want:
+                return (f"{label} answered a DIFFERENT position set "
+                        f"({got} vs {want}) — its floor is not a floor for "
+                        f"this comparison")
+            if not got:
+                return (f"{label} predates position-set stamping, so it "
+                        f"cannot be shown to answer the same questions")
+    ab_start = max(x for x in (meta_a.get("started_at"), meta_b.get("started_at"))
+                   if x) if (meta_a.get("started_at") or meta_b.get("started_at")) else None
+    if ab_start:
+        for label, m in metas.items():
+            st = m.get("started_at")
+            if st and st < ab_start:
+                return (f"{label} STARTED BEFORE the A/B run it is quoted "
+                        f"against — this is the stale-file case; re-run the "
+                        f"noise pair or pass --force-noise")
+    return None
 
 
 def cmd_diff(args):
@@ -644,10 +713,14 @@ def cmd_diff(args):
     # way to tell a 68-row `reranked` block from nothing at all, because
     # completion ordering is not stable run to run. This is not a correction
     # applied to the counts; it is the resolution limit printed beside them.
-    noise, noise_n = {}, 0
+    noise, noise_n, noise_reject = {}, 0, None
     if args.noise_base and args.noise_head:
-        noise, noise_n = _shape_counts(args.noise_base, args.noise_head,
-                                       common, keys)
+        noise_reject = _check_provenance(meta_a, meta_b, args)
+        if noise_reject:
+            print(f"WARNING: {noise_reject}", file=sys.stderr)
+        if not (noise_reject and not args.force_noise):
+            noise, noise_n = _shape_counts(args.noise_base, args.noise_head,
+                                           common, keys)
 
     total = len(keys)
     diverged = sum(v for (s, _), v in counts.items() if s != "same")
@@ -715,6 +788,12 @@ def cmd_diff(args):
     for (s, v), n in counts.items():
         if s != "same":
             by_shape[s] = by_shape.get(s, 0) + n
+    if noise_reject:
+        W(f"> **NOISE FLOOR REJECTED — {noise_reject}.** No floor is shown "
+          f"below. Counts are raw, and `reranked` in particular cannot be "
+          f"read without one.\n" if not args.force_noise else
+          f"> **Noise floor is SUSPECT — {noise_reject}.** Shown anyway "
+          f"because `--force-noise` was passed.\n")
     if noise or noise_n:
         W("`noise` is the same shape's count when the SAME binary is run "
           "twice, measured over EXACTLY the answers compared here — a rate "
@@ -756,13 +835,23 @@ def cmd_diff(args):
       "data file can contribute sixty positions that all disagree the same "
       "way; that is one thing to adjudicate, not sixty, and reading `n` as "
       "the workload is how a sweep gets abandoned as noise.\n")
-    W("| shape | verb | token kind | n | distinct |")
-    W("|---|---|---|---|---|")
+    if noise:
+        W("The `verb noise` column is the floor for that shape ON THAT VERB, "
+          "which is the only baseline a single-verb block can be read "
+          "against. It is summed over the verb's kinds, so a block covering "
+          "one kind sits well under it.\n")
+    W("| shape | verb | token kind | n | distinct |"
+      + (" verb noise |" if noise else ""))
+    W("|---|---|---|---|---|" + ("---|" if noise else ""))
     for (shape, verb, kind), items in sorted(
             groups.items(), key=lambda kv: (SHAPE_ORDER.index(kv[0][0])
                                             if kv[0][0] in SHAPE_ORDER else 99,
                                             -len(kv[1]))):
-        W(f"| `{shape}` | {verb} | {kind} | {len(items)} | {_distinct(verb, items)} |")
+        row = (f"| `{shape}` | {verb} | {kind} | {len(items)} | "
+               f"{_distinct(verb, items)} |")
+        if noise:
+            row += f" {noise.get((shape, verb), 0)} |"
+        W(row)
     W("")
 
     W("## Examples\n")
@@ -861,6 +950,8 @@ def main():
     p.add_argument("--examples", type=int, default=8)
     p.add_argument("--noise-base", help="answers from a repeat run of ONE binary")
     p.add_argument("--noise-head", help="answers from a second run of that SAME binary")
+    p.add_argument("--force-noise", action="store_true",
+                   help="use the noise pair even if it fails the provenance check")
     p.set_defaults(fn=cmd_diff)
 
     args = ap.parse_args()

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -188,6 +188,12 @@ def cmd_run(args):
     # Lists, not ints: the loop rebinds `lsp` on restart and these have to
     # survive that without a nonlocal dance in a nested scope.
     wedge, restarts = [0], [0]
+    # A re-warmed server is not the same server. Rows carry the SERVER
+    # GENERATION they were answered by, and whether that generation ever
+    # confirmed cross-file readiness — on Koha 3 of 8 restarts never did, and
+    # a row from an unconfirmed generation is an answer from a server that
+    # was, as far as anyone can show, still cold.
+    epoch, epoch_warm = [0], [True]
     deferred = []
     t0 = time.monotonic()
     with open(args.out, "w") as fh:
@@ -213,7 +219,8 @@ def cmd_run(args):
                                   {"textDocument": {"uri": uri}}, timeout=args.timeout)
             fh.write(json.dumps({
                 "file": rel, "kind": "file", "verb": "documentSymbol",
-                "ms": round(ms, 1),
+                "ms": round(ms, 1), "epoch": epoch[0],
+                **({"warm_unconfirmed": True} if not epoch_warm[0] else {}),
                 "norm": N.normalize("documentSymbol", (msg or {}).get("result"), root_uri),
                 "err": _err(msg),
             }, sort_keys=True, default=str) + "\n")
@@ -232,7 +239,10 @@ def cmd_run(args):
                     msg, ms = lsp.request(method, params, timeout=args.timeout)
                     rec = {"file": rel, "line": p["line"], "char": ch,
                            "kind": p["kind"], "name": p["name"], "verb": verb,
-                           "ms": round(ms, 1), "err": _err(msg)}
+                           "ms": round(ms, 1), "err": _err(msg),
+                           "epoch": epoch[0]}
+                    if not epoch_warm[0]:
+                        rec["warm_unconfirmed"] = True
                     if msg is None:
                         rec["timeout"] = True
                         rec["norm"] = None
@@ -323,8 +333,10 @@ def cmd_run(args):
                             # the initial gate exists to close, and easier to
                             # miss here because the run is already underway.
                             _, _, warm_ms = await_cross_file(lsp, args.rewarm_timeout)
+                            epoch[0] += 1
+                            epoch_warm[0] = warm_ms is not None
                             fh.write(json.dumps({"_event": "restart-rewarm",
-                                "restart": restarts[0],
+                                "restart": restarts[0], "epoch": epoch[0],
                                 "cross_file_ready_ms": warm_ms and round(warm_ms),
                                 "confirmed": warm_ms is not None}) + "\n")
                             if warm_ms is None:
@@ -358,7 +370,8 @@ def cmd_run(args):
             fh.write(json.dumps({"_recheck": True, "file": rel, "line": ln,
                                  "char": ch, "verb": verb, "kind": kind,
                                  "name": name, "ms": round(ms, 1),
-                                 "norm": norm}, sort_keys=True, default=str) + "\n")
+                                 "epoch": epoch[0], "norm": norm},
+                                sort_keys=True, default=str) + "\n")
         fh.write(json.dumps({"_event": "recheck",
                              "empty_first_ask": len(deferred),
                              "filled_when_warm": filled}) + "\n")
@@ -534,19 +547,39 @@ SHAPE_ORDER = ["only-base", "subset", "timeout-head", "error-head", "disagree",
                "missing-head", "missing-base"]
 
 
-def _shape_counts(base_path, head_path, common):
-    """Shape histogram for one pair of answer files — used for the A/B run and,
-    with the SAME binary on both sides, for the noise floor."""
+def _shape_counts(base_path, head_path, common, only_keys):
+    """The noise floor, measured over EXACTLY the answers the A/B compared.
+
+    `only_keys` is not an optimisation, it is the whole correctness of the
+    number. The floor is a per-answer rate, so it is only subtractable from a
+    count taken over the same answers. Measured on Koha: the base wedged
+    repeatedly and produced 1,184 comparable answers where the two noise runs
+    (which never wedge, being the head binary) produced ~21,790 — quoting a
+    floor from 21,790 beside a count from 1,184 compares populations that
+    differ by a factor of eighteen and share an unknown fraction of their
+    members.
+
+    It is also biased, not merely scaled: the answers the base reached before
+    wedging are the CHEAP ones, and cheap positions are exactly where two
+    runs agree. A whole-corpus floor is therefore an over-estimate of the
+    floor on the surviving sample in some shapes and an under-estimate in
+    others, with no way to tell which from the number itself.
+
+    Returns the histogram plus how many of `only_keys` the noise runs could
+    actually answer — a floor measured over a fraction of the comparison is
+    still not comparable, and the caller has to be able to say so.
+    """
     _, a = _load(base_path)
     _, b = _load(head_path)
+    keys = (set(a) & set(b) & only_keys)
     out = {}
-    for k in set(a) & set(b):
+    for k in keys:
         if k[3] not in common:
             continue
         sh = classify(k[3], a[k], b[k])
         if sh != "same":
             out[sh] = out.get(sh, 0) + 1
-    return out
+    return out, len(keys)
 
 
 def cmd_diff(args):
@@ -567,9 +600,25 @@ def cmd_diff(args):
     # instead, which is the honest framing: this is what we compared, and
     # this is what we could not.
     all_keys = {k for k in (set(base) | set(head)) if k[3] in common}
-    keys = {k for k in all_keys if k in base and k in head}
+    comparable = {k for k in all_keys if k in base and k in head}
     only_base_keys = sum(1 for k in all_keys if k not in head)
     only_head_keys = sum(1 for k in all_keys if k not in base)
+
+    # An answer from a server generation that never re-confirmed cross-file
+    # readiness is an answer from a server that was, as far as anything here
+    # can show, still cold. It is held out rather than counted: an unconfirmed
+    # empty is indistinguishable from a lost resolution, which is the one
+    # confusion this whole harness exists to prevent.
+    unconfirmed = {k for k in comparable
+                   if base[k].get("warm_unconfirmed")
+                   or head[k].get("warm_unconfirmed")}
+    keys = comparable - unconfirmed
+    # Rows answered AFTER a restart by a generation that did re-warm are
+    # counted, but reported: they came from a different process with a
+    # rebuilt index, and a reader deciding how much to trust a thin block
+    # should know how much of it is post-restart.
+    post_restart = sum(1 for k in keys
+                       if base[k].get("epoch", 0) or head[k].get("epoch", 0))
 
     groups, counts, uninformative = {}, {}, 0
     for k in sorted(keys, key=lambda k: (k[0], k[3], k[1] is None, k[1] or 0, k[2] or 0)):
@@ -595,9 +644,10 @@ def cmd_diff(args):
     # way to tell a 68-row `reranked` block from nothing at all, because
     # completion ordering is not stable run to run. This is not a correction
     # applied to the counts; it is the resolution limit printed beside them.
-    noise = {}
+    noise, noise_n = {}, 0
     if args.noise_base and args.noise_head:
-        noise = _shape_counts(args.noise_base, args.noise_head, common)
+        noise, noise_n = _shape_counts(args.noise_base, args.noise_head,
+                                       common, keys)
 
     total = len(keys)
     diverged = sum(v for (s, _), v in counts.items() if s != "same")
@@ -635,11 +685,27 @@ def cmd_diff(args):
     W(f"**{total} (position, verb) answers compared — {same} identical "
       f"({same/max(total,1):.2%}), {diverged} divergent.**\n")
     if only_base_keys or only_head_keys:
+        reach = total / max(len(all_keys), 1)
         W(f"Coverage shortfall: {only_base_keys} answers exist only in the base "
           f"run and {only_head_keys} only in the head run — a side that aborted "
           f"or skipped never produced them. They are EXCLUDED from every count "
           f"above, because a position one side never reached is a gap in the "
           f"sweep, not a disagreement about an answer.\n")
+        if reach < 0.5:
+            W(f"> **Only {reach:.1%} of positions were answered by both sides.** "
+              f"The comparable set is not a random sample of the corpus — it is "
+              f"the positions the weaker side got through before it stopped, "
+              f"which are the cheap ones. Treat what follows as a statement "
+              f"about coverage, not a divergence list.\n")
+    if unconfirmed:
+        W(f"Held out: {len(unconfirmed)} answers came from a server generation "
+          f"that never re-confirmed cross-file readiness after a restart. They "
+          f"are excluded from every count — an unconfirmed empty cannot be "
+          f"told apart from a lost resolution.\n")
+    if post_restart:
+        W(f"Of the {total} compared, {post_restart} were answered after at "
+          f"least one side restarted (by a generation that did re-warm). A "
+          f"rebuilt index is not the same index.\n")
     W(f"Of the identical ones, {uninformative} were empty on both sides: positions "
       f"nobody would ask about, kept in the denominator but called out so the "
       f"agreement rate is not read as coverage.\n")
@@ -649,10 +715,20 @@ def cmd_diff(args):
     for (s, v), n in counts.items():
         if s != "same":
             by_shape[s] = by_shape.get(s, 0) + n
-    if noise:
+    if noise or noise_n:
         W("`noise` is the same shape's count when the SAME binary is run "
-          "twice over these positions. A block at or below its noise floor "
-          "carries no information — read the `signal` column, not `n`.\n")
+          "twice, measured over EXACTLY the answers compared here — a rate "
+          "taken over a different population is not subtractable from this "
+          "one. A block at or below its floor carries no information: read "
+          "`signal`, not `n`.\n")
+        cover = noise_n / max(total, 1)
+        if cover < 0.98:
+            W(f"> **The floor covers {noise_n} of {total} compared answers "
+              f"({cover:.1%}).** The rest could not be measured: the noise "
+              f"runs did not answer at those positions. Shapes below are "
+              f"scaled by that fraction only if the unmeasured answers behave "
+              f"like the measured ones, which is exactly what a run that "
+              f"stalled part-way does not guarantee.\n")
         W("| shape | n | noise | signal | meaning |")
         W("|---|---|---|---|---|")
         for s in SHAPE_ORDER:

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -395,3 +395,21 @@ The real fix is to encode every deliberate ordering into `sort_text` so
 sorting becomes order-preserving, at which point both paths can sort and
 completion becomes reproducible — and therefore gold-testable, which today it
 is not for any position in that 173.
+
+**Two blockers found while attempting it, both concrete:**
+
+1. `rank_candidates_by_expected_type` nudges only non-matching **variables**
+   from `PRIORITY_LOCAL` to `PRIORITY_LOCAL + 1`. Same-tier candidates of
+   other kinds keep `PRIORITY_LOCAL`, so once sorted a non-matching local
+   falls *below* them and the locals stop being contiguous. Assembly order
+   hid this by keeping them together. Demoting every non-match at the local
+   tier is the one-line correction.
+
+2. Unexplained, and the reason the attempt was reverted rather than pushed
+   through: with the sort hoisted, the tiers predict `$total, $label, Foo,
+   apply` for `arg-rank-fixture/main.pl:8:6` — locals at 0 and 1,
+   same-file subs and packages at `PRIORITY_FILE_WIDE` (10) — and the CLI
+   prints exactly that **reversed**. Either a later stage reorders or the
+   printer does; until that is understood, a sorted list cannot be checked
+   against a fixture, because it is not clear what the fixture is asserting
+   about. Start here, not at the sort.

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -374,7 +374,7 @@ longer ships in hash-iteration order. Over four cold runs of 1,458 positions
 
 Two residuals, both understood:
 
-**15 — the pool is still filling.** All at the cap, all carrying
+**14 of the 15 — the pool is still filling.** All at the cap, all carrying
 `isIncomplete`, and they decay across sweep order (21/12/0/0 by quartile
 before the hoist) — a query racing an incomplete index legitimately answers
 differently before and after resolution, which is what `isIncomplete` says.
@@ -383,6 +383,26 @@ first-quartile positions are measuring a warming index rather than the
 server, so early positions carry systematically more noise than late ones;
 and `isIncomplete` gives the class a mechanical signature, so it can be
 separated from a real disagreement rather than adjudicated by hand.
+
+**1 of the 15 — a receiver-resolution race that does NOT announce itself.**
+`Mojo/UserAgent/CookieJar.pm:145:12` (`$tmp->spew(...)`, receiver
+`Mojo::File`) answered **14, 14, 35, 14** items across four runs, under the
+cap, with `isIncomplete: false` every time. The 21 extra items in the odd run
+are `Mojo::File`'s methods — `spew`, `_path`, `basename`, `child`, `chmod` —
+so three runs answered before the receiver's class resolved and one answered
+after.
+
+This is a different cause from the capped 14 and a worse-behaved one. Those
+are truncated and say so; this returns a list that claims to be COMPLETE
+while missing the receiver's whole method set. `cap_completion_items`' own
+doc comment names the consequence: a client caches a complete response and
+never asks again. It was invisible before the hoist, buried in 173 rows of
+ordering noise.
+
+Not fixed here. The honest options are to answer `isIncomplete: true` while a
+member-access receiver is still unresolved, or to make the member path wait
+on resolution; both are member-completion design decisions rather than a
+capping one.
 
 **2 — ties that agree on every sort key.** `sort_by` is stable, so two
 candidates matching on `sort_text`, label AND kind keep the order the

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -359,57 +359,37 @@ Pinned by `fixtures/type-at.json::ti-classname-string` (xfail). Found by
 fell back to offering the ENCLOSING PACKAGE's own subs, which are not the
 receiver's methods at all.
 
-## Completion is not reproducible under the cap, and the order is load-bearing
+## Completion's residual nondeterminism (17 of 4,302 answers)
 
-Four cold runs of the same binary over 1,458 positions (`bench/sweep`)
-disagree on **206 completion answers and nothing else** — definition, hover,
-references and documentSymbol are stable across all four. The 206 split
-cleanly by list size, and the split is the diagnosis:
+`cap_completion_items` now sorts whether or not it cuts, so the list no
+longer ships in hash-iteration order. Over four cold runs of 1,458 positions
+(`bench/sweep`) the unstable answers went **206 -> 17**:
 
-| | count | list size | cause |
-|---|---|---|---|
-| same candidate SET, different order | 173 | all **under** the cap | the list is never sorted |
-| candidate set actually moves | 33 | all **exactly at** the cap (200) | the pool is still filling |
+| | before | after |
+|---|---|---|
+| same set, different order | 173 | **2** |
+| candidate set moves | 33 | **15** |
+| `reranked` floor across 6 pairs | 158-168 | **0-1** |
+| `disagree` floor across 6 pairs | 14-25 | **5-12** |
 
-`cap_completion_items` returns early below `MAX_COMPLETION_ITEMS`, so an
-under-cap list goes out in whatever order the hash-backed tiers iterated. The
-33 are a different animal: all carry `isIncomplete`, and they occur **21, 12,
-0, 0** across quartiles of sweep order — confined to the first half of a run
-and absent from the second. That is the index still filling, which is what
-`isIncomplete` exists to say.
+Two residuals, both understood:
 
-**Sorting unconditionally is not the fix, and it was tried.** It removes the
-whole ordering component (the `reranked` floor falls from 158–168 to 0–1
-across six pairs) and fails
-`completion/completion-arg-position-type-match-ranks-first`, which is right
-to fail: `rank_candidates_by_expected_type` reorders candidates and nudges
-priorities, and dispatch items are explicitly prepended. Some of that intent
-lives in list POSITION rather than in `sort_text`, so a sort by `sort_text`
-discards it.
+**15 — the pool is still filling.** All at the cap, all carrying
+`isIncomplete`, and they decay across sweep order (21/12/0/0 by quartile
+before the hoist) — a query racing an incomplete index legitimately answers
+differently before and after resolution, which is what `isIncomplete` says.
+Not a defect. Two things follow for anyone reading per-position results:
+first-quartile positions are measuring a warming index rather than the
+server, so early positions carry systematically more noise than late ones;
+and `isIncomplete` gives the class a mechanical signature, so it can be
+separated from a real disagreement rather than adjudicated by hand.
 
-Note the inconsistency that implies: the over-cap path already sorts by
-`sort_text`, so it already discards that same intent. Under the cap it is
-preserved. The two paths disagree about whether position carries meaning.
+**2 — ties that agree on every sort key.** `sort_by` is stable, so two
+candidates matching on `sort_text`, label AND kind keep the order the
+producing map iterated in. Negligible in practice; if this number ever grows,
+this is where to look.
 
-The real fix is to encode every deliberate ordering into `sort_text` so
-sorting becomes order-preserving, at which point both paths can sort and
-completion becomes reproducible — and therefore gold-testable, which today it
-is not for any position in that 173.
-
-**Two blockers found while attempting it, both concrete:**
-
-1. `rank_candidates_by_expected_type` nudges only non-matching **variables**
-   from `PRIORITY_LOCAL` to `PRIORITY_LOCAL + 1`. Same-tier candidates of
-   other kinds keep `PRIORITY_LOCAL`, so once sorted a non-matching local
-   falls *below* them and the locals stop being contiguous. Assembly order
-   hid this by keeping them together. Demoting every non-match at the local
-   tier is the one-line correction.
-
-2. Unexplained, and the reason the attempt was reverted rather than pushed
-   through: with the sort hoisted, the tiers predict `$total, $label, Foo,
-   apply` for `arg-rank-fixture/main.pl:8:6` — locals at 0 and 1,
-   same-file subs and packages at `PRIORITY_FILE_WIDE` (10) — and the CLI
-   prints exactly that **reversed**. Either a later stage reorders or the
-   printer does; until that is understood, a sorted list cannot be checked
-   against a fixture, because it is not clear what the fixture is asserting
-   about. Start here, not at the sort.
+Worth recording that the hoist cut the SET-moving class too (33 -> 15), which
+the diagnosis did not predict: roughly half of what looked like pool
+variation was the cut boundary itself falling differently, because a
+non-total order made "the top 200" ambiguous even for an identical pool.

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -358,3 +358,40 @@ Pinned by `fixtures/type-at.json::ti-classname-string` (xfail). Found by
 `(anon)` fix, and adjudicating it showed 0.6.1 fails the same way — it just
 fell back to offering the ENCLOSING PACKAGE's own subs, which are not the
 receiver's methods at all.
+
+## Completion is not reproducible under the cap, and the order is load-bearing
+
+Four cold runs of the same binary over 1,458 positions (`bench/sweep`)
+disagree on **206 completion answers and nothing else** — definition, hover,
+references and documentSymbol are stable across all four. The 206 split
+cleanly by list size, and the split is the diagnosis:
+
+| | count | list size | cause |
+|---|---|---|---|
+| same candidate SET, different order | 173 | all **under** the cap | the list is never sorted |
+| candidate set actually moves | 33 | all **exactly at** the cap (200) | the pool is still filling |
+
+`cap_completion_items` returns early below `MAX_COMPLETION_ITEMS`, so an
+under-cap list goes out in whatever order the hash-backed tiers iterated. The
+33 are a different animal: all carry `isIncomplete`, and they occur **21, 12,
+0, 0** across quartiles of sweep order — confined to the first half of a run
+and absent from the second. That is the index still filling, which is what
+`isIncomplete` exists to say.
+
+**Sorting unconditionally is not the fix, and it was tried.** It removes the
+whole ordering component (the `reranked` floor falls from 158–168 to 0–1
+across six pairs) and fails
+`completion/completion-arg-position-type-match-ranks-first`, which is right
+to fail: `rank_candidates_by_expected_type` reorders candidates and nudges
+priorities, and dispatch items are explicitly prepended. Some of that intent
+lives in list POSITION rather than in `sort_text`, so a sort by `sort_text`
+discards it.
+
+Note the inconsistency that implies: the over-cap path already sorts by
+`sort_text`, so it already discards that same intent. Under the cap it is
+preserved. The two paths disagree about whether position carries meaning.
+
+The real fix is to encode every deliberate ordering into `sort_text` so
+sorting becomes order-preserving, at which point both paths can sort and
+completion becomes reproducible — and therefore gold-testable, which today it
+is not for any position in that 173.

--- a/src/lsp/symbols/completion.rs
+++ b/src/lsp/symbols/completion.rs
@@ -39,9 +39,21 @@ fn rank_candidates_by_expected_type(
     };
     let mut tagged: Vec<(bool, CompletionCandidate)> =
         candidates.drain(..).map(|c| (is_match(&c), c)).collect();
+    // Demote every non-match by one from ITS OWN tier, rather than only
+    // variables sitting exactly on `PRIORITY_LOCAL`. The old guard never
+    // fired on the path this function actually serves: an in-scope `my` in
+    // `complete_general` carries `PRIORITY_FILE_WIDE`, so `$total` and
+    // `$label` both shipped as `010…` and the type-match ranking existed
+    // ONLY as the position this reorder gave them — invisible while the
+    // under-cap list went out unsorted, and lost the moment it is sorted
+    // (`010$label` sorts before `010$total`).
+    //
+    // One step is enough and cannot cross a tier: the priority constants are
+    // at least two apart, so a demoted candidate stays between its own tier
+    // and the next.
     for (m, c) in tagged.iter_mut() {
-        if !*m && matches!(c.kind, FaSymKind::Variable) && c.sort_priority == PRIORITY_LOCAL {
-            c.sort_priority = PRIORITY_LOCAL + 1;
+        if !*m {
+            c.sort_priority = c.sort_priority.saturating_add(1);
         }
     }
     tagged.sort_by_key(|(m, _)| !*m); // stable: matches (key false) lead
@@ -82,7 +94,19 @@ pub const MAX_COMPLETION_ITEMS: usize = 200;
 /// the workspace firehose by construction. Under the cap nothing changes:
 /// the full list returns as a complete (client-cacheable) response.
 pub(crate) fn cap_completion_items(items: &mut Vec<CompletionItem>, typed_prefix: &str) -> bool {
+    // Sorted whether or not anything is cut. The tiers assemble from
+    // hash-backed stores, so an unsorted list ships in iteration order and
+    // differs between two runs of the same binary on the same file — 173 of
+    // 1,458 positions over four cold runs (`bench/sweep`), every one of them
+    // under the cap. It also means the priority tiers and the type-match
+    // ranking were computed and then DISCARDED below 200 items, which is
+    // where most lists live.
+    //
+    // This does not claim users saw scrambled lists: a conforming client
+    // re-sorts by `sort_text`. It makes our own output reproducible, and it
+    // is what puts the ranking work into effect at all.
     if items.len() <= MAX_COMPLETION_ITEMS {
+        sort_completion_items(items);
         return false;
     }
     if !typed_prefix.is_empty() {
@@ -94,14 +118,24 @@ pub(crate) fn cap_completion_items(items: &mut Vec<CompletionItem>, typed_prefix
         });
     }
     if items.len() > MAX_COMPLETION_ITEMS {
-        items.sort_by(|a, b| {
-            let ka = a.sort_text.as_deref().unwrap_or(&a.label);
-            let kb = b.sort_text.as_deref().unwrap_or(&b.label);
-            ka.cmp(kb).then_with(|| a.label.cmp(&b.label))
-        });
+        sort_completion_items(items);
         items.truncate(MAX_COMPLETION_ITEMS);
     }
     true
+}
+
+/// The order the client sorts on (`sort_text`, label fallback), with label
+/// then kind as tie-breaks so the comparator is TOTAL. `sort_by` is stable,
+/// so two candidates agreeing on every key would otherwise keep the order
+/// the producing map iterated in — the nondeterminism this exists to remove.
+fn sort_completion_items(items: &mut [CompletionItem]) {
+    items.sort_by(|a, b| {
+        let ka = a.sort_text.as_deref().unwrap_or(&a.label);
+        let kb = b.sort_text.as_deref().unwrap_or(&b.label);
+        ka.cmp(kb)
+            .then_with(|| a.label.cmp(&b.label))
+            .then_with(|| format!("{:?}", a.kind).cmp(&format!("{:?}", b.kind)))
+    });
 }
 
 pub(crate) fn candidate_to_completion_item(c: CompletionCandidate) -> CompletionItem {


### PR DESCRIPTION
Based on `cfa33175`.

**The headline is not the ranking bug. It is that completion becomes A/B-able for the first time — and that the noise it removes was concealing a real defect.** We spent an evening unable to trust completion comparisons because the same binary, run twice on the same file, returned different answers at 206 of 4,302 positions. That is now 17.

| | before | after |
|---|---|---|
| unstable answers (of 4,302) | 206 | **17** |
| same set, different order | 173 | **2** |
| candidate set moves | 33 | **15** |
| `reranked` floor across 6 pairs | 158–168 | **0–1** |
| `disagree` floor across 6 pairs | 14–25 | **5–12** |

A shape whose floor is 0–1 can be read at face value. At 158–168 it could not be read at all.

**And the noise was not inert.** One of the residual rows turned out to be a member-completion correctness bug — `Mojo/UserAgent/CookieJar.pm:145:12` answering 14/14/35/14 items with `isIncomplete: false` every time, i.e. claiming completeness while missing the receiver's entire method set. It had been sitting inside those 173 rows of ordering noise the whole time, and no amount of reading the aggregate would have surfaced it. Follow-up measurement puts the class at **8 of 156 member-access positions (5.1%) during warm-up, and 0% once the index settles**. Details below; the fix is deliberately NOT in this PR.

## What was wrong

`cap_completion_items` returned before sorting whenever the list fit under `MAX_COMPLETION_ITEMS`. Two consequences:

**The output could not be pinned.** The tiers assemble from hash-backed stores, so an unsorted list ships in iteration order.

**The ranking apparatus was unreached.** Priority tiers and `rank_candidates_by_expected_type` were computed and then discarded below 200 items — which is where most lists live.

### Honest scope

This does **not** claim users saw scrambled lists. A conforming client re-sorts by `sort_text`, as the function's own doc comment says. The claim is narrower and provable: our output was not reproducible, and **a nondeterministic answer cannot carry a gold fixture at all.** Every one of those 173 positions was structurally un-pinnable.

## The hoist alone was not enough, and the gold row is why

Sorting broke `completion/completion-arg-position-type-match-ranks-first`. **That row failed correctly** — it caught a real inversion, not a stale expectation. Nothing here was fixed by adjusting it, and it should not be read that way in the history.

The cause took two reverts to corner. `rank_candidates_by_expected_type` demoted non-matches only when `sort_priority == PRIORITY_LOCAL`, but the path it serves puts in-scope `my` variables on `PRIORITY_FILE_WIDE`. The guard never fired. Over the server path:

```
010$total   010$label   010apply   020Foo   030abs …
```

`$total` and `$label` shipped with the *same* sort key, so the type-match ranking existed only as the position `rank_candidates_by_expected_type` gave them — preserved by accident while the list went out unsorted, and destroyed the moment it was ordered (`010$label` sorts before `010$total`).

I diagnosed this wrongly twice, and the second time I predicted the sorted order from the priority constants without checking the real values. The CLI strips `sortText`; dumping it over the server path settled it in one command.

**Fix:** demote non-matches one step from *their own* tier rather than from a named constant. Cannot cross a boundary — the constants are at least two apart. Now `010$total`, `011$label`, `011apply`, `021Foo`, `031abs`: the same visible order as before, expressed in `sort_text` instead of list position, so it survives sorting.

## The pattern this is the second instance of

`[D]`'s bug was `priority = min(scope_size, 255)` where `span_size` saturates every multi-line scope to 255 — ranking machinery computed against a value constant in practice. This one is the same shape: **code testing against a specific tier constant the live path does not produce.** Both were invisible because the surrounding order happened to be right for another reason — theirs because the list was uncapped, mine because assembly order kept locals contiguous.

Demoting from the value's own tier rather than a named constant is rule #10 on a numeric ladder: ask the value where it sits instead of asserting where it must be. And since both survived on accidentally-correct output, the way to hunt a third is to look for tier-constant equality tests, not for wrong answers.

## One thing the diagnosis did not predict

The **set-moving** class fell 33 → 15. Sorting should not change *which* candidates exist. It does, because a non-total order made "the top 200" ambiguous even for an identical pool — so roughly half of what had been characterised as "pool still filling" was the cut boundary landing differently. The 33 was never one phenomenon.

Of the residual 15: 14 are the warmup population (at cap, `isIncomplete`, decaying across sweep order). The fifteenth is the correctness bug described above. The residual 2 order-only are ties agreeing on `sort_text`, label **and** kind, where a stable sort falls back to iteration order. All recorded in `KNOWN-GAPS.md`; none fixed here, so this PR stays an instrument fix.

## Also in this branch

The differential sweep harness (`bench/sweep/`) that produced every number above, from #133 — position selection, normalisation, the N-run worst-case floor estimator, provenance and completeness guards, and both selftests.

## Verification

| | result |
|---|---|
| `cargo test --features cpp` | **1,576 passed / 0 failed** |
| `cargo test` | **1,513 passed / 0 failed** |
| gold | **498 PASS / 16 xfail / 0 FAIL / 0 XPASS / 0 CRASH / 0 skip / 0 lang-skip** |
| `bench/sweep/selftest.py` | pass |
| `bench/sweep/selftest-shell.sh` | pass |

True exit codes; `skip` and `lang-skip` both grepped. **e2e did not run — `nvim` is not installed in this sandbox**, so `types.lua` / `dbic_parametric.lua` post-`ab95d48` are unverified from here and need a box with `nvim`.