### PR TITLE
fix(resolve): goto-def failed where references succeeded on an inherited hash key

### DIFF
--- a/docs/adr/resolution-candidate-set.md
+++ b/docs/adr/resolution-candidate-set.md
@@ -60,6 +60,10 @@ here." The CandidateSet owns, computed once at the set level:
   group members with per-member rename rules, and the descendants walk
   (`implementations_of` over `GraphView`); each projection declares which
   edges it follows,
+- **declaration** — a projection group carries `decl_spans` (the `has` /
+  column token, the `field` decl) beside its spellings, each tagged with
+  the file it was minted from; goto-def projects it rather than re-deriving
+  where an inherited attr was declared,
 - **per-site policy** — `RefLocation.rewritable`, `MemberRename` texts:
   policy rides the candidates, handlers never re-derive it.
 
@@ -71,7 +75,7 @@ Every feature is a **projection** of the same CandidateSet:
 | rename | `rename_edits(new)` — references + rewritability policy; an edit outside the references image is unrepresentable |
 | prepareRename | `renameable()` — mirrors `rename_edits`' arms |
 | implementations | `implementations()` — the family/descendants walk |
-| goto-def | `definitions()` — forward-best projection |
+| goto-def | `definitions()` — forward-best projection, backstopped by the identity's declaration axis: when every forward lane misses and the cursor resolved to a group, the group's `decl_spans` answer, so goto-def cannot come up empty where `references()` names a declaration |
 | completion gathering | `complete(prefix, import_slot)` — prefix-enumeration of the visible identifier universe (Perl: in-scope + explicit imports on OPEN, export surfaces + auto-import firehose on DEPENDENCY; pack: the origin's include-closure universe); `complete_modules(prefix)` — the loadable-module half (DEPENDENCY). `import_slot` is the slot's import affordance: `false` = the slot offers no import-sourced names (an import candidate without a place for its edit completes to broken code); candidates carry `ImportFact`, the adapter composes the edit |
 | hover | the set resolves for BOTH languages; each keeps its presenter. Pack: `hover_candidate()` — the top-ranked `definitions()` candidate, presented. Perl: the model hover primitives render local identity, and the cross-file call lanes present `function_binding()` — the same import-classification / FQ-package lanes `definitions()` jumps through — so hover and goto-def cannot disagree at a position |
 | documentHighlight | `highlights()` — the origin-file-narrowed image of `references()` (same identity, same matcher via `refs_to_in_file`, walk never leaves the cursor's document), carrying `RefLocation.access` for highlight kinds |

--- a/src/index/resolve/definitions.rs
+++ b/src/index/resolve/definitions.rs
@@ -1050,6 +1050,31 @@ impl<'a> CandidateSet<'a> {
             }
         }
 
+        // Identity backstop: the cursor's resolution is a projection GROUP,
+        // so its declaration axis IS the answer. The forward lanes above
+        // resolve through the owner the REF carries, which for an inherited
+        // attr is the subclass (`$self->{size}` in `Gadget` where `Widget`
+        // declares `has size`) — they miss, and `references()` would still
+        // name the base's decl, because identity already climbed the
+        // ancestry to mint the group. Reading the group here is what keeps
+        // the two projections from disagreeing; no second ancestry walk.
+        if let Some(ResolvedTarget::Group { decl_spans, .. }) = self.resolution() {
+            let out: Vec<RefLocation> = decl_spans
+                .iter()
+                .filter(|(path, _)| path.as_ref().is_none_or(|p| Url::from_file_path(p).is_ok()))
+                .map(|(path, span)| RefLocation {
+                    key: path.clone().map_or_else(|| self.origin_key.clone(), FileKey::Path),
+                    span: *span,
+                    access: AccessKind::Declaration,
+                    rewritable: true,
+                    label: None,
+                })
+                .collect();
+            if !out.is_empty() {
+                return out;
+            }
+        }
+
         // Last resort (pack): a token no query captures — a namespace middle
         // segment (`StatusCode` in `absl::StatusCode::kNotFound` is a
         // namespace_identifier, ref-less) — resolves by word to a named

--- a/src/index/resolve/identity.rs
+++ b/src/index/resolve/identity.rs
@@ -193,6 +193,9 @@ pub fn resolve_symbol_scoped(
             return Some(ResolvedTarget::Group {
                 local_spans: spans,
                 pinned_spans: Vec::new(),
+                // The `our` decl is in the origin file, where goto-def's
+                // local path already lands — no group-level decl to add.
+                decl_spans: Vec::new(),
                 members: Vec::new(),
             });
         }

--- a/src/index/resolve/mod.rs
+++ b/src/index/resolve/mod.rs
@@ -98,8 +98,9 @@ pub struct CandidateSet<'a> {
     source: Option<&'a str>,
     scope: OverrideScope,
     /// Identity, minted once via `resolve_symbol_scoped` — lazily, so a
-    /// projection that never consults it (goto-def's forward path) doesn't
-    /// pay the override-family walk. `None` = nothing cross-file-resolvable
+    /// projection answering off its own forward path (goto-def, until every
+    /// lane misses) doesn't pay the override-family walk. `None` = nothing
+    /// cross-file-resolvable
     /// at the cursor; local projections still answer from `origin`.
     resolution: std::sync::OnceLock<Option<ResolvedTarget>>,
     /// Visibility for a `Target` resolution, memoized — computed by

--- a/src/index/resolve/projections.rs
+++ b/src/index/resolve/projections.rs
@@ -107,7 +107,7 @@ impl<'a> CandidateSet<'a> {
                 let mask = self.target_visibility(t);
                 refs_to(self.files, self.module_index, t, mask)
             }
-            Some(ResolvedTarget::Group { local_spans, pinned_spans, members }) => group_refs(
+            Some(ResolvedTarget::Group { local_spans, pinned_spans, members, .. }) => group_refs(
                 self.files,
                 self.module_index,
                 &self.origin_key,
@@ -199,7 +199,7 @@ impl<'a> CandidateSet<'a> {
                 .map(|loc| (loc, true))
                 .collect()
             }
-            Some(ResolvedTarget::Group { local_spans, pinned_spans, members }) => {
+            Some(ResolvedTarget::Group { local_spans, pinned_spans, members, .. }) => {
                 let origin_path = key_for_sort(&self.origin_key);
                 let mut out: Vec<(RefLocation, bool)> = local_spans
                     .iter()
@@ -335,7 +335,7 @@ impl<'a> CandidateSet<'a> {
                     .map(|loc| (loc, new_name.to_string()))
                     .collect()
             }
-            Some(ResolvedTarget::Group { local_spans, pinned_spans, members }) => {
+            Some(ResolvedTarget::Group { local_spans, pinned_spans, members, .. }) => {
                 // Group spellings are bare name tokens; a sigil on the typed
                 // name applies only to variable-shaped members' own rules.
                 let bare_new = self.bare_new_name(new_name);

--- a/src/index/resolve/refs.rs
+++ b/src/index/resolve/refs.rs
@@ -101,6 +101,7 @@ pub(super) fn group_from_projections(
         None => ResolvedTarget::Group {
             local_spans: p.variable_spans,
             pinned_spans: Vec::new(),
+            decl_spans: p.decl_spans.into_iter().map(|s| (None, s)).collect(),
             members,
         },
         Some(path) => ResolvedTarget::Group {
@@ -109,6 +110,11 @@ pub(super) fn group_from_projections(
                 .variable_spans
                 .into_iter()
                 .map(|s| (path.clone(), s))
+                .collect(),
+            decl_spans: p
+                .decl_spans
+                .into_iter()
+                .map(|s| (Some(path.clone()), s))
                 .collect(),
             members,
         },

--- a/src/index/resolve/target.rs
+++ b/src/index/resolve/target.rs
@@ -240,6 +240,12 @@ pub enum ResolvedTarget {
         /// cursor sat in a consumer; the source decl lives with the
         /// class).
         pinned_spans: Vec<(PathBuf, Span)>,
+        /// Where the group is DECLARED — a subset of the spellings above,
+        /// each carrying its file (`None` = the origin, matching
+        /// `local_spans`). The declaration axis of the identity, so
+        /// goto-def projects the same group references walks instead of
+        /// re-deriving where an inherited attr was declared.
+        decl_spans: Vec<(Option<PathBuf>, Span)>,
         members: Vec<GroupMember>,
     },
     /// Inherently file-local: lexical variables, and hash keys with no

--- a/src/index/resolve/tests/candidate_set_tests.rs
+++ b/src/index/resolve/tests/candidate_set_tests.rs
@@ -380,3 +380,55 @@ fn collect_from_analysis_still_finds_sub_refs_after_scope_hardening() {
         "expected call-site read, got {results:?}"
     );
 }
+
+/// goto-def and references are two projections of ONE CandidateSet, so they
+/// cannot disagree about whether a declaration exists. An INHERITED Moo slot
+/// poke is the shape that split them: `$self->{size}` in `Gadget` carries a
+/// `Class(Gadget)` owner, so goto-def's owner-keyed hash-key lookup asked the
+/// SUBCLASS for a key only the base declares and found nothing, while
+/// references reached `Widget`'s `has size` through the group the identity
+/// already climbs to. Both must land on the base's decl token.
+#[test]
+fn goto_def_agrees_with_references_on_inherited_slot() {
+    use crate::index::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    let store = FileStore::new();
+    let widget = PathBuf::from("/tmp/cs_inh_widget.pm");
+    let gadget = PathBuf::from("/tmp/cs_inh_gadget.pm");
+    let widget_src = "package Widget;\nuse Moo;\nhas size => (is => 'ro');\nhas color => (is => 'ro');\n1;\n";
+    let gadget_src = "package Gadget;\nuse Moo;\nextends 'Widget';\nsub area { my $self = shift; return $self->{size}; }\n1;\n";
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(widget.clone(), Arc::new(parse(widget_src)));
+    idx.register_workspace_module(gadget.clone(), Arc::new(parse(gadget_src)));
+    store.insert_workspace(widget.clone(), parse(widget_src));
+    store.insert_workspace(gadget.clone(), parse(gadget_src));
+
+    let gadget_fa = store.workspace_raw().get(&gadget).unwrap().value().clone();
+    let col = gadget_src.lines().nth(3).unwrap().find("{size}").unwrap() + 1;
+    let cs = resolve(
+        &store,
+        &gadget_fa,
+        FileKey::Path(gadget.clone()),
+        tree_sitter::Point { row: 3, column: col },
+        Some(&idx),
+        OverrideScope::default(),
+    );
+
+    let decl_col = widget_src.lines().nth(2).unwrap().find("size").unwrap();
+    let refs = cs.references();
+    assert!(
+        refs.iter().any(|r| matches!(&r.key, FileKey::Path(p) if p == &widget)
+            && r.span.start.row == 2
+            && r.span.start.column == decl_col),
+        "references reaches the base decl: {refs:?}",
+    );
+
+    let defs = cs.definitions();
+    assert!(
+        defs.iter().any(|d| matches!(&d.key, FileKey::Path(p) if p == &widget)
+            && d.span.start.row == 2
+            && d.span.start.column == decl_col),
+        "goto-def must land on the same base decl references already names: {defs:?}",
+    );
+}

--- a/src/index/resolve/tests/groups_tests.rs
+++ b/src/index/resolve/tests/groups_tests.rs
@@ -120,7 +120,7 @@ my $val = $p->x;
     // Cursor on `$x` in the field decl (row 2, col 11 = bare name).
     let resolved = resolve_symbol(&origin_fa, tree_sitter::Point { row: 2, column: 11 }, None)
         .expect("field decl resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group, got {:?}", resolved);
     };
     assert!(pinned_spans.is_empty(), "local mint has no pinned spans");
@@ -183,7 +183,7 @@ class Point {
     // From the ctor key `x` (row 1, col 19).
     let resolved = resolve_symbol(&consumer, tree_sitter::Point { row: 1, column: 19 }, Some(&idx))
         .expect("consumer key resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group from consumer key, got {:?}", resolved);
     };
     assert!(local_spans.is_empty(), "remote mint: no origin spans");
@@ -232,7 +232,7 @@ fn test_group_rename_rederives_mapped_members_cross_file() {
     // Cursor on the attr decl token `size` (row 2, col 4).
     let resolved = resolve_symbol(&class_fa, tree_sitter::Point { row: 2, column: 4 }, None)
         .expect("attr decl resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group, got {:?}", resolved);
     };
     let edits = group_rename_edits(
@@ -279,7 +279,7 @@ fn moo_explicit_string_accessor_renames_its_defining_string() {
     // Cursor on the `has size` attr token (row 2, col 4).
     let resolved = resolve_symbol(&fa, tree_sitter::Point { row: 2, column: 4 }, None)
         .expect("attr decl resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group, got {:?}", resolved);
     };
     let edits = group_rename_edits(
@@ -450,7 +450,7 @@ fn package_var_main_global_does_not_cross_scripts() {
     store.insert_workspace(b.clone(), parse("our $config = 2;\nprint $config;\n"));
 
     let a_fa = store.workspace_raw().get(&a).unwrap().value().clone();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&a_fa, tree_sitter::Point { row: 0, column: 5 }, None).unwrap()
     else {
         panic!("main global should be a file-local Group")
@@ -601,7 +601,7 @@ fn dbic_column_rename_reaches_single_arg_call_keys() {
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -633,7 +633,7 @@ fn dbic_column_rename_multiarg_search_excludes_attrs_hash() {
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -669,7 +669,7 @@ fn dbic_column_rename_reaches_fluent_resultset_chain() {
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -712,7 +712,7 @@ sub go {\n\
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -756,7 +756,7 @@ fn moo_attr_group_includes_cross_file_constructor_key() {
     store.insert_workspace(app.clone(), parse(app_src));
     let lib_fa = store.workspace_raw().get(&lib).unwrap().value().clone();
     let col = lib_src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&lib_fa, tree_sitter::Point { row: 2, column: col }, Some(&idx)).expect("attr resolves")
     else {
         panic!("expected a Moo attr Group")
@@ -811,7 +811,7 @@ fn inherited_attr_rename_reaches_subclass_constructor_key() {
     store.insert_workspace(app.clone(), parse(app_src));
     let animal_fa = store.workspace_raw().get(&animal).unwrap().value().clone();
     let col = animal_src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&animal_fa, tree_sitter::Point { row: 2, column: col }, Some(&idx)).expect("attr resolves")
     else {
         panic!("expected a Moo attr Group")
@@ -848,7 +848,7 @@ fn corinna_field_subclass_does_not_bleed_to_ancestor() {
     let col = deriv_src.lines().nth(1).unwrap().find("size").unwrap();
     let resolved = resolve_symbol(&deriv_fa, tree_sitter::Point { row: 1, column: col }, Some(&idx))
         .expect("field resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected a field Group, got {resolved:?}")
     };
     let edits = group_rename_edits(
@@ -884,7 +884,7 @@ fn overridden_attr_renames_whole_family_symmetrically() {
         let fa = store.workspace_raw().get(path).unwrap().value().clone();
         let col = src.lines().nth(row).unwrap().find("name").unwrap();
         let r = resolve_symbol(&fa, tree_sitter::Point { row, column: col }, Some(&idx)).unwrap();
-        let ResolvedTarget::Group { local_spans, pinned_spans, members } = r else {
+        let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = r else {
             panic!("expected Group, got {r:?}")
         };
         let mut got: Vec<String> = group_rename_edits(
@@ -925,7 +925,7 @@ fn dbic_multi_key_hashref_links_all_columns() {
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     // Rename the MIDDLE column `beta` — it must reach the search arg key (row 3).
     let col = src.lines().nth(2).unwrap().find("beta").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -1020,7 +1020,7 @@ fn dbic_custom_sub_shadowing_verb_is_not_column_keyed() {
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -1048,7 +1048,7 @@ fn dbic_scalar_cond_does_not_column_key_attrs_hash() {
     store.insert_workspace(path.clone(), parse(src));
     let fa = store.workspace_raw().get(&path).unwrap().value().clone();
     let col = src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&fa, tree_sitter::Point { row: 2, column: col }, None).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -1082,7 +1082,7 @@ fn dbic_column_rename_reaches_cross_file_consumer_arg_key() {
     store.insert_workspace(app.clone(), parse(app_src));
     let lib_fa = store.workspace_raw().get(&lib).unwrap().value().clone();
     let col = lib_src.lines().nth(2).unwrap().find("name").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&lib_fa, tree_sitter::Point { row: 2, column: col }, Some(&idx)).expect("column resolves")
     else {
         panic!("expected a column attr Group")
@@ -1134,7 +1134,7 @@ fn dbic_column_rename_owner_gated_excludes_framework_and_siblings() {
 
     let widget_fa = store.workspace_raw().get(&widget).unwrap().value().clone();
     let col = widget_src.lines().nth(2).unwrap().find("id").unwrap();
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } =
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } =
         resolve_symbol(&widget_fa, tree_sitter::Point { row: 2, column: col }, Some(&idx))
             .expect("column resolves to a group")
     else {
@@ -1329,7 +1329,7 @@ fn test_internal_slot_pokes_join_group_cross_file() {
     let class_fa = store.workspace_raw().get(&class_path).unwrap().value().clone();
     let resolved = resolve_symbol(&class_fa, tree_sitter::Point { row: 2, column: 4 }, None)
         .expect("attr decl resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group, got {:?}", resolved);
     };
     assert!(
@@ -1378,7 +1378,7 @@ fn rename_from_bless_key_reaches_self_slot_accesses() {
     let key_col = src.lines().nth(1).unwrap().find("history").unwrap();
     let resolved = resolve_symbol(&fa, tree_sitter::Point { row: 1, column: key_col }, None)
         .expect("bless key resolves");
-    let ResolvedTarget::Group { local_spans, pinned_spans, members } = resolved else {
+    let ResolvedTarget::Group { local_spans, pinned_spans, members, .. } = resolved else {
         panic!("expected Group, got {:?}", resolved);
     };
     assert!(

--- a/src/model/file_analysis/cursor_queries.rs
+++ b/src/model/file_analysis/cursor_queries.rs
@@ -1012,8 +1012,22 @@ impl FileAnalysis {
                     .collect()
             })
             .unwrap_or_default();
+        // A `has`/column group's decl token IS its only spelling here; a
+        // field-backed group's decl is the field symbol's own token (the
+        // rest of `variable_spans` are body uses), sigil-skipped like them.
+        let mut decl_spans: Vec<Span> = g
+            .field_sym
+            .map(|fs| {
+                let sel = self.symbol(fs).selection_span;
+                vec![Span {
+                    start: Point::new(sel.start.row, sel.start.column + 1),
+                    end: sel.end,
+                }]
+            })
+            .unwrap_or_default();
         if let Some(decl) = g.decl_span {
             variable_spans.push(decl);
+            decl_spans.push(decl);
         }
         let mapped = self
             .attr_projections
@@ -1054,6 +1068,7 @@ impl FileAnalysis {
             has_class_key,
             field_backed: g.field_sym.is_some(),
             variable_spans,
+            decl_spans,
             mapped,
         }
     }

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -617,6 +617,10 @@ pub struct FieldProjections {
     pub field_backed: bool,
     /// Origin-file variable spellings (decl + body uses), bare-adjusted.
     pub variable_spans: Vec<Span>,
+    /// The DECLARATION subset of `variable_spans` — the `has`/column token,
+    /// or the `field $x` decl. Goto-def is the projection that wants just
+    /// this; references/rename take every spelling.
+    pub decl_spans: Vec<Span>,
     /// Plugin-declared, name-mapped members (`predicate => has_size`).
     /// `affix` = `(prefix, suffix)` when the method name embeds the attr —
     /// rename re-derives the name; `None` = references-only member.


### PR DESCRIPTION
## The failing case

```perl
# Widget.pm
package Widget;
use Moo;
has size  => (is => 'ro');
has color => (is => 'ro');
1;

# Gadget.pm
package Gadget;
use Moo;
extends 'Widget';
sub area { my $self = shift; return $self->{size}; }
1;
```

Cursor on `size` inside `$self->{size}` in Gadget.pm:

| verb | before | after |
|---|---|---|
| `--definition` | `No definition found` | `Widget.pm:3:5` |
| `--references` | `Gadget.pm:6:20`, `Widget.pm:3:5` | unchanged |

Two projections of one `CandidateSet` disagreeing about whether a declaration
exists — the thing `docs/adr/resolution-candidate-set.md` says cannot happen.

## Mechanism

Only one of them consulted the identity.

References / rename / highlights resolve a hash-key cursor through
`resolve_symbol_scoped` → `attr_group_via_ancestors`
(`src/index/resolve/identity.rs`), which climbs the inheritance chain to the
class that actually **declares** the attr and mints the attr's projection
group from `Widget`.

`definitions()` never asked for the resolution at all on this path. Its
hash-key lane took the owner the *ref* carries — `Class(Gadget)` — and looked
the key up on the subclass. Gadget declares nothing, so the lane came up
empty and every remaining lane fell through. `definitions.rs` contained no
mention of `Group` or `attr_group`.

## Why this shares rather than duplicates

The naive repair — walk the ancestors inside `definitions.rs` to find the
declaring class — writes the bug a second time: two ancestry walks that can
drift, a rule-5 violation.

Instead the identity gains a **declaration axis**, and goto-def projects it:

- `FieldProjections` gains `decl_spans` — the `has`/column token, or the
  `field $x` decl — computed in `projections_of`, right where the spelling
  set it is a subset of is already computed.
- `ResolvedTarget::Group` carries `decl_spans: Vec<(Option<PathBuf>, Span)>`,
  each span tagged with the file the group was minted from (`None` = origin),
  mirroring the existing `local_spans` / `pinned_spans` split.
- `definitions()` gains **one arm** that reads that axis.

The ancestry walk stays in `attr_group_via_ancestors`, the single place it
already lived. goto-def now reads the same group references walks, so the two
cannot disagree about whether a declaration exists. Per the ADR's own rule, a
new cross-cutting axis went into CandidateSet construction, not into a
handler.

The arm is placed as a **backstop** — after every forward lane. Those lanes
resolve *through* the invocant/owner and are more precise where they answer
(the accessor-call lane, the ctor-key lane, the cross-file method lane all
still answer exactly as before); the group's declaration fills only the hole
where references already names a declaration and goto-def had nothing. That
is what keeps "make the failing case pass" from turning into "change
currently-passing behavior".

Spot-checked by CLI beyond the test: `has` decl, same-class slot poke,
inherited accessor call, inherited ctor key, and consumer-side inherited slot
all land correctly.

## Regression test

`goto_def_agrees_with_references_on_inherited_slot`
(`src/index/resolve/tests/candidate_set_tests.rs`) builds the two-file
Widget/Gadget workspace, resolves once, and asserts **both** projections land
on the base's decl token.

Verified failing on the unfixed tree — `references` passed, `definitions`
returned `[]`:

```
goto-def must land on the same base decl references already names: []
```

## Gates

| gate | result |
|---|---|
| `cargo test` | 1500 passed, 0 failed, 3 ignored (+ 14 in the integration bins) |
| `cargo test --features cpp` | 1560 passed, 0 failed, 3 ignored |
| `gold-corpus/run.pl` | **PASS 498, xfail 16, FAIL 0, XPASS 0, CRASH 0, skip 0, lang-skip 0** (release built `--features cpp` so no cpp row is skipped) |
| `./e2e/run.sh` | 113 passed, 0 failed across 10 suites |

No gold row XPASSed — this gap was not recorded in `KNOWN-GAPS.md`, so
nothing to promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkNR6uJfyNCCndwqmEnuGN