### PR TITLE
goto-def disagreed with references and implementations on a template method

### DIFF
--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -410,19 +410,33 @@ while the answer can still change. What that gate is, is the whole problem:
 | receiver has no resolved type | **32.7%** | all | a third of member completions permanently non-cacheable — trades a correctness bug for a latency one |
 | resolver queue non-empty | 0% | **none** | `@INC` resolution is on demand; the query answers without ever enqueuing, so the queue is empty exactly when it matters |
 | any of this file's imports not cached | 1.9% | **none** | the import IS cached; that is not what is missing |
+| receiver bound to an imported call with unknown return | 0% | **none** | the precise version of the CookieJar shape, and it still misses — because that shape is the minority |
 
-The third measurement is the useful one, because it says where the real
-signal lives. `Mojo/UserAgent/CookieJar.pm` does `use Mojo::File qw(path)`
-and then `my $tmp = path(...)`, so the receiver's type comes from the
-IMPORTED SUB'S RETURN TYPE. `Mojo::File` is cached at cold-query time —
-what has not happened yet is `enrich_imported_types_with_keys` propagating
-`path()`'s return into this document's bag.
+**The causal model behind all four gates was wrong, and that is the finding.**
+They were built by generalising from CookieJar — receiver untyped, therefore
+short list. Counting what actually changes says otherwise. Across three
+independent cold sessions, 19 member answers differed between the cold ask
+and a warm re-ask:
 
-So the condition is not "is the index warm" but **"has this document been
-enriched against its providers yet"**, which is per-document state
-(`FileStore::enrich_open`, the `enriched_snapshot` overlay) rather than
-anything the index queue or the module cache exposes. A fourth gate should
-start there; the first three are recorded so nobody re-measures them.
+| | count |
+|---|---|
+| claimed `isIncomplete: false` | **19 of 19** |
+| went from ZERO items to a real list | **12 (63%)** |
+| went from a short list to a longer one (the CookieJar shape) | 7 (37%) |
+
+So the dominant class is not a mistyped receiver at all — it is the slot
+answering **nothing** and later answering properly, which no receiver-typing
+gate can see. CookieJar was the example to hand and it is the minority case.
+
+What survives: the defect is real and universal in this population — every
+answer that changes claims to be complete while it is not. What does not
+survive is the diagnosis, so the fix should be designed against the 0-to-N
+class first. An obvious candidate is "an empty list never claims
+completeness" (an empty result has nothing to filter client-side, so the flag
+only asks for a re-query the client would make on the next keystroke anyway),
+but it was NOT confirmed here: setting it in `complete_general` did not change
+the observed flag, so the empty answers are leaving by some other path and
+that needs tracing before anyone builds on it.
 
 **2 — ties that agree on every sort key.** `sort_by` is stable, so two
 candidates matching on `sort_text`, label AND kind keep the order the

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -399,10 +399,30 @@ doc comment names the consequence: a client caches a complete response and
 never asks again. It was invisible before the hoist, buried in 173 rows of
 ordering noise.
 
-Not fixed here. The honest options are to answer `isIncomplete: true` while a
-member-access receiver is still unresolved, or to make the member path wait
-on resolution; both are member-completion design decisions rather than a
-capping one.
+Not fixed, and three candidate gates were measured and rejected. The rate is
+**8 of 156 member positions (5.1%) during warm-up, 0% once the index
+settles** — three passes in one session, cold / after / after-that, with the
+second and third byte-identical. So flagging is free IF the gate only fires
+while the answer can still change. What that gate is, is the whole problem:
+
+| gate | warm cost | catches the 6-8 | verdict |
+|---|---|---|---|
+| receiver has no resolved type | **32.7%** | all | a third of member completions permanently non-cacheable — trades a correctness bug for a latency one |
+| resolver queue non-empty | 0% | **none** | `@INC` resolution is on demand; the query answers without ever enqueuing, so the queue is empty exactly when it matters |
+| any of this file's imports not cached | 1.9% | **none** | the import IS cached; that is not what is missing |
+
+The third measurement is the useful one, because it says where the real
+signal lives. `Mojo/UserAgent/CookieJar.pm` does `use Mojo::File qw(path)`
+and then `my $tmp = path(...)`, so the receiver's type comes from the
+IMPORTED SUB'S RETURN TYPE. `Mojo::File` is cached at cold-query time —
+what has not happened yet is `enrich_imported_types_with_keys` propagating
+`path()`'s return into this document's bag.
+
+So the condition is not "is the index warm" but **"has this document been
+enriched against its providers yet"**, which is per-document state
+(`FileStore::enrich_open`, the `enriched_snapshot` overlay) rather than
+anything the index queue or the module cache exposes. A fourth gate should
+start there; the first three are recorded so nobody re-measures them.
 
 **2 — ties that agree on every sort key.** `sort_by` is stable, so two
 candidates matching on `sort_text`, label AND kind keep the order the

--- a/src/index/resolve/definitions.rs
+++ b/src/index/resolve/definitions.rs
@@ -1075,6 +1075,31 @@ impl<'a> CandidateSet<'a> {
             }
         }
 
+        // The same identity backstop for a CALLABLE target. A method
+        // resolves to `Target`, never `Group`, so it never reached the arm
+        // above — and the cross-file lane that would have answered it is
+        // `resolve_method_in_ancestors`, which climbs UPWARD only. A
+        // template method (`$self->step_one()` in a base, declared only in
+        // the subclass) lives below, so every forward lane misses while
+        // `references()` names the child's decl through the override family
+        // identity already computed.
+        //
+        // This projects that same family rather than walking it again: the
+        // declaration axis of `references()` IS the answer, and the whole
+        // defect is two projections each growing their own mechanism. It is
+        // a LAST RESORT — every forward lane has already missed — so the
+        // walk it costs is one nobody paid on the answered path.
+        if matches!(self.resolution(), Some(ResolvedTarget::Target(_))) {
+            let decls: Vec<RefLocation> = self
+                .references()
+                .into_iter()
+                .filter(|r| r.access == AccessKind::Declaration)
+                .collect();
+            if !decls.is_empty() {
+                return decls;
+            }
+        }
+
         // Last resort (pack): a token no query captures — a namespace middle
         // segment (`StatusCode` in `absl::StatusCode::kNotFound` is a
         // namespace_identifier, ref-less) — resolves by word to a named

--- a/src/index/resolve/tests/candidate_set_tests.rs
+++ b/src/index/resolve/tests/candidate_set_tests.rs
@@ -432,3 +432,57 @@ fn goto_def_agrees_with_references_on_inherited_slot() {
         "goto-def must land on the same base decl references already names: {defs:?}",
     );
 }
+
+/// The same projection disagreement on the TEMPLATE-METHOD shape, which is
+/// plain inheritance with no roles and no plugins: a base calls
+/// `$self->step_one()` and only the subclass declares it. references reaches
+/// the child's decl through the override family identity already computed,
+/// and goto-def's forward lane is `resolve_method_in_ancestors` — UPWARD
+/// only, so it climbs past a method that lives BELOW and answers nothing.
+///
+/// The `Group` identity backstop does not cover it: a method resolves to
+/// `ResolvedTarget::Target`, never `Group`, so it never reaches that arm.
+#[test]
+fn goto_def_agrees_with_references_on_template_method() {
+    use crate::index::module_index::ModuleIndex;
+    use std::sync::Arc;
+
+    let store = FileStore::new();
+    let base = PathBuf::from("/tmp/cs_tmpl_base.pm");
+    let child = PathBuf::from("/tmp/cs_tmpl_child.pm");
+    let base_src = "package Base;\nsub run {\n    my $self = shift;\n    return $self->step_one() + 1;\n}\n1;\n";
+    let child_src = "package Child;\nuse parent 'Base';\nsub step_one { return 41 }\n1;\n";
+    let idx = ModuleIndex::new_for_test();
+    idx.register_workspace_module(base.clone(), Arc::new(parse(base_src)));
+    idx.register_workspace_module(child.clone(), Arc::new(parse(child_src)));
+    store.insert_workspace(base.clone(), parse(base_src));
+    store.insert_workspace(child.clone(), parse(child_src));
+
+    let base_fa = store.workspace_raw().get(&base).unwrap().value().clone();
+    let col = base_src.lines().nth(3).unwrap().find("step_one").unwrap();
+    let cs = resolve(
+        &store,
+        &base_fa,
+        FileKey::Path(base.clone()),
+        tree_sitter::Point { row: 3, column: col },
+        Some(&idx),
+        OverrideScope::default(),
+    );
+
+    let decl_col = child_src.lines().nth(2).unwrap().find("step_one").unwrap();
+    let refs = cs.references();
+    assert!(
+        refs.iter().any(|r| matches!(&r.key, FileKey::Path(p) if p == &child)
+            && r.span.start.row == 2
+            && r.span.start.column == decl_col),
+        "references reaches the child decl: {refs:?}",
+    );
+
+    let defs = cs.definitions();
+    assert!(
+        defs.iter().any(|d| matches!(&d.key, FileKey::Path(p) if p == &child)
+            && d.span.start.row == 2
+            && d.span.start.column == decl_col),
+        "goto-def must land on the same child decl references already names: {defs:?}",
+    );
+}


### PR DESCRIPTION
Based on `db40c27`.

## One CandidateSet, three projections, two of them agreeing

Plain inheritance. No roles, no plugins:

```perl
# Base.pm
sub run { my $self = shift; return $self->step_one() + 1 }
# Child.pm
use parent 'Base';  sub step_one { return 41 }
```

Cursor on the **call site** in `Base.pm`:

| projection | answer |
|---|---|
| `--references` | `Base.pm:4` (the call) **and** `Child.pm:2` (the decl) |
| `--implementations` | `Child.pm:2` |
| `--definition` | **"No definition found"** |

The brief described this as two projections disagreeing. It is stronger than that: **two agree and one dissents**, from a single `CandidateSet` at a single cursor — which `docs/adr/resolution-candidate-set.md` promises cannot happen, and which #141 closed for hash keys.

## Why #141 did not already cover it

The identity backstop #141 added fires only for `ResolvedTarget::Group`. A method resolves to `ResolvedTarget::Target`, so it never reaches that arm. The lane that should have answered is `resolve_method_in_ancestors` — **upward only**. A template method is declared *below* the calling class, so every forward lane climbs straight past it.

## The fix projects the family instead of walking it again

```rust
if matches!(self.resolution(), Some(ResolvedTarget::Target(_))) {
    let decls = self.references().into_iter()
        .filter(|r| r.access == AccessKind::Declaration).collect();
    if !decls.is_empty() { return decls; }
}
```

No ancestry walk, no descendant walk, no second mechanism. Identity already computed the override family (`method_classes`), and `references()` already names the declarations it reaches — so the declaration axis of `references()` *is* the answer. Adding a descendant walk to `definitions.rs` would have written the original defect a second time; two projections each growing their own mechanism is the entire bug.

**Last-resort placement.** Reached only after every forward lane has missed, so the walk costs nothing on any path that already answers.

**It cannot invent an answer.** `references()` is target-scoped, so its declarations are declarations of *this* target's family. Verified with a negative control: `$self->nonexistent_thing()` still reports "No definition found".

**Multi-location answers are accepted** where a class family has several providers — strictly the set `goto-implementation` already returns from the same cursor, and N > 0 beats nothing.

## The test was watched failing first

`goto_def_agrees_with_references_on_template_method`, alongside #141's `..._on_inherited_slot`. On the unfixed build the *references* assertion passed and the *goto-def* assertion failed — the disagreement stated directly as a test, rather than a test written after the fact against a fix that already worked.

## Also in this branch (docs only, no behavior change)

Four measured-and-rejected gates for the member-completion `isIncomplete` bug, recorded in `gold-corpus/KNOWN-GAPS.md` so the next attempt starts from data rather than repeating them. The short version: the defect is real and universal in its population — across three independent cold sessions, 19 member answers changed cold→warm and **all 19 claimed `isIncomplete: false`** — but the diagnosis behind all four gates was wrong. **12 of the 19 (63%) went from ZERO items to a real list**, not from short to long, so no receiver-typing gate can see the dominant class.

## Verification

| | result |
|---|---|
| `cargo test --features cpp` | **1,582 passed / 0 failed** |
| `cargo test` | **1,519 passed / 0 failed** |
| gold (`--features cpp`) | **498 PASS / 16 xfail / 0 FAIL / 0 XPASS / 0 CRASH / 0 skip / 0 lang-skip** |
| e2e | **113 passed / 0 failed** across 10 suites |
| `bench/sweep` selftests | pass (unit + shell) |

True exit codes; `skip` and `lang-skip` both grepped; e2e run locally on `NVIM v0.11.0`, the version CI pins.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv)_