### PR TITLE
An empty completion answered null, which is the most cacheable answer we can give

### DIFF
--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -384,59 +384,29 @@ server, so early positions carry systematically more noise than late ones;
 and `isIncomplete` gives the class a mechanical signature, so it can be
 separated from a real disagreement rather than adjudicated by hand.
 
-**1 of the 15 — a receiver-resolution race that does NOT announce itself.**
-`Mojo/UserAgent/CookieJar.pm:145:12` (`$tmp->spew(...)`, receiver
-`Mojo::File`) answered **14, 14, 35, 14** items across four runs, under the
-cap, with `isIncomplete: false` every time. The 21 extra items in the odd run
-are `Mojo::File`'s methods — `spew`, `_path`, `basename`, `child`, `chmod` —
-so three runs answered before the receiver's class resolved and one answered
-after.
+**1 of the 15 — a receiver-resolution race. FIXED at the response layer.**
+`Mojo/UserAgent/CookieJar.pm:145:12` answered 14/14/35/14 across four runs
+with `isIncomplete: false` every time. Four gates were built against that
+shape — untyped receiver (32.7% warm cost), resolver queue, imports cached,
+receiver bound to an imported call — and none of them worked, because
+counting showed the shape was the MINORITY. Across three cold sessions, 19
+member answers changed cold-to-warm, all 19 claimed complete, and **12 (63%)
+went from ZERO items to a real list** rather than from short to long.
 
-This is a different cause from the capped 14 and a worse-behaved one. Those
-are truncated and say so; this returns a list that claims to be COMPLETE
-while missing the receiver's whole method set. `cap_completion_items`' own
-doc comment names the consequence: a client caches a complete response and
-never asks again. It was invisible before the hoist, buried in 173 rows of
-ordering noise.
+The zero case had a different cause and a different home:
+`Backend::completion` returned `Ok(None)` for an empty Perl list. A null
+response carries no `isIncomplete` field at all, so it is the MOST cacheable
+answer the server can give — the client is told there is nothing here and
+never asks again. The pack path one branch above already preserved an
+incomplete-empty response; the Perl path dropped it unconditionally. Empty
+now answers `isIncomplete: true`, taking cold-empty member asks carrying a
+signal from 0 of 39 to 35 of 39 (the remaining 4 are the `get_open`
+short-circuit, a different and legitimate null).
 
-Not fixed, and three candidate gates were measured and rejected. The rate is
-**8 of 156 member positions (5.1%) during warm-up, 0% once the index
-settles** — three passes in one session, cold / after / after-that, with the
-second and third byte-identical. So flagging is free IF the gate only fires
-while the answer can still change. What that gate is, is the whole problem:
-
-| gate | warm cost | catches the 6-8 | verdict |
-|---|---|---|---|
-| receiver has no resolved type | **32.7%** | all | a third of member completions permanently non-cacheable — trades a correctness bug for a latency one |
-| resolver queue non-empty | 0% | **none** | `@INC` resolution is on demand; the query answers without ever enqueuing, so the queue is empty exactly when it matters |
-| any of this file's imports not cached | 1.9% | **none** | the import IS cached; that is not what is missing |
-| receiver bound to an imported call with unknown return | 0% | **none** | the precise version of the CookieJar shape, and it still misses — because that shape is the minority |
-
-**The causal model behind all four gates was wrong, and that is the finding.**
-They were built by generalising from CookieJar — receiver untyped, therefore
-short list. Counting what actually changes says otherwise. Across three
-independent cold sessions, 19 member answers differed between the cold ask
-and a warm re-ask:
-
-| | count |
-|---|---|
-| claimed `isIncomplete: false` | **19 of 19** |
-| went from ZERO items to a real list | **12 (63%)** |
-| went from a short list to a longer one (the CookieJar shape) | 7 (37%) |
-
-So the dominant class is not a mistyped receiver at all — it is the slot
-answering **nothing** and later answering properly, which no receiver-typing
-gate can see. CookieJar was the example to hand and it is the minority case.
-
-What survives: the defect is real and universal in this population — every
-answer that changes claims to be complete while it is not. What does not
-survive is the diagnosis, so the fix should be designed against the 0-to-N
-class first. An obvious candidate is "an empty list never claims
-completeness" (an empty result has nothing to filter client-side, so the flag
-only asks for a re-query the client would make on the next keystroke anyway),
-but it was NOT confirmed here: setting it in `complete_general` did not change
-the observed flag, so the empty answers are leaving by some other path and
-that needs tracing before anyone builds on it.
+The short-to-long residual is NOT fixed: a receiver that types late still
+returns a shorter list claiming completeness, and no cheap gate found so far
+separates "not yet" from "not ever". The four measured attempts are recorded
+above so the next one starts from data.
 
 **2 — ties that agree on every sort key.** `sort_by` is stable, so two
 candidates matching on `sort_text`, label AND kind keep the order the

--- a/src/lsp/backend/server.rs
+++ b/src/lsp/backend/server.rs
@@ -1258,14 +1258,30 @@ impl LanguageServer for Backend {
                 )
             })
             .await?;
-        if items.is_empty() {
-            Ok(None)
-        } else {
-            // Incomplete when the payload cap fired (re-query narrows
-            // server-side as the prefix grows) or any item is a loading
-            // placeholder (re-request after the module resolves).
-            let is_incomplete =
-                capped || items.iter().any(|i| i.insert_text.as_deref() == Some(""));
+        // Incomplete when the payload cap fired (re-query narrows
+        // server-side as the prefix grows), when any item is a loading
+        // placeholder (re-request after the module resolves), or when the
+        // list is EMPTY.
+        //
+        // The empty arm is the load-bearing one. This used to return
+        // `Ok(None)` — a null result, which carries no `isIncomplete` field
+        // at all and is therefore the most cacheable answer we can give: the
+        // client is told there is nothing here and never asks again.
+        // Measured over three cold sessions of 156 member positions, 2.8% of
+        // member asks answer EMPTY and then answer properly once warm, so a
+        // cached null leaves that slot dead for the rest of the session with
+        // nothing to tell the user it is wrong. The pack path above already
+        // preserves an incomplete-empty response (`items.is_empty() &&
+        // !is_incomplete`); this one dropped it unconditionally.
+        //
+        // The cost lands only where an empty answer is genuinely permanent
+        // (5.8% of member asks), and it is close to notional: an empty list
+        // has nothing to filter client-side, so `isIncomplete` only asks for
+        // a re-query the client already makes when the prefix changes.
+        let is_incomplete = capped
+            || items.is_empty()
+            || items.iter().any(|i| i.insert_text.as_deref() == Some(""));
+        {
             if is_incomplete {
                 // Trigger resolution for the module being loaded
                 for i in &items {


### PR DESCRIPTION
Based on `715da9c2`. One commit, one file.

## The defect

```rust
// Backend::completion, the Perl path
if items.is_empty() { Ok(None) }
```

A null completion response has **no `isIncomplete` field** — there is nowhere in the shape to put one. So a null is the most cacheable answer a language server can give: the client is told "there is nothing here" with no mechanism to ever ask again. Every `isIncomplete` this codebase computes downstream was correct and then thrown away by the response shape.

That matters because empty is often *temporary*. Measured over three cold sessions of 156 member positions, **2.8% of member asks answer empty and then answer properly once warm** — and a cached null leaves that slot dead for the rest of the session, with nothing to tell the user the menu is wrong.

Empty now answers `isIncomplete: true`. Cold-empty member asks carrying any signal go from **0 of 39 to 35 of 39**; the remaining four are the `get_open` short-circuit, a different and legitimate null, deliberately untouched.

**The cost is bounded and close to notional.** It lands only where an empty answer is permanent (5.8% of member asks), and an empty list has nothing to filter client-side — so `isIncomplete` only asks for a re-query the client already makes when the prefix changes.

## The pack path one branch above was already correct

```rust
if items.is_empty() && !is_incomplete { return Ok(None); }   // pack
if items.is_empty()                   { Ok(None) }            // perl
```

Two sibling paths disagreeing about whether an empty answer may be provisional, with one of them already right.

**That is the fourth instance of this shape I have seen this round** — goto-def vs references on a template method (#142), and this one, are the two I verified directly; the coordinator reports the same shape in the demander-vs-implementation edge and in methods-walk vs keys-inject. In every case one sibling already had the correct behavior. It is starting to look less like coincidence and more like the dominant defect shape here: not wrong logic, but two paths that answer the same question and were never made to agree.

## How it was found, because the route matters

Four gates were built against the wrong diagnosis and measured and rejected: untyped receiver (**32.7%** warm cost — worse than the bug), resolver queue non-empty (0% cost, catches nothing), file imports not cached (1.9%, nothing), receiver bound to an imported call with unknown return (0%, nothing — and that one is the *precise* shape the diagnosis was built from).

Counting what actually changes is what broke it: across three cold sessions, 19 member answers changed cold→warm, **all 19 claimed `isIncomplete: false`**, and **12 (63%) went from zero items to a real list** rather than short to long. No receiver-typing gate can see that population.

The thing that actually located the bug was a loose end left in my own report — *"I set the flag in `complete_general` and it didn't move; I don't know why"*. Chasing that rather than designing a fifth gate is what found the short-circuit.

**On the predicted narrowing:** the coordinator guessed this would be far narrower than gate 1 and predicted the magnitude correctly — 5.8% vs 32.7%, 5.6× — but for the wrong reason. The proposed mechanism was "member lane empty AND receiver unresolved"; the actual defect is at the response layer and has nothing to do with receivers. The record should show that guess as half-lucky rather than as insight.

## Not fixed, stated plainly

**Short-to-long is still broken.** A receiver that types late still returns a *shorter* list claiming completeness — the original CookieJar shape, 14/14/35/14 with `isIncomplete: false` throughout. None of the four gates separates "not yet" from "not ever", and the cheap proxies are measured and dead. The four measurements are recorded in `gold-corpus/KNOWN-GAPS.md` so the next attempt starts from data instead of repeating them.

## Verification

| | result |
|---|---|
| `cargo test --features cpp` | **1,582 passed / 0 failed** |
| `cargo test` | **1,519 passed / 0 failed** |
| gold (`--features cpp`) | **498 PASS / 16 xfail / 0 FAIL / 0 XPASS / 0 CRASH / 0 skip / 0 lang-skip** |
| e2e | **113 passed / 0 failed** across 10 suites |

e2e carries more weight than usual here: this changes what goes on the wire for an empty completion — `null` → `CompletionList { is_incomplete: true, items: [] }` — and a real client round-trip is the only gate that exercises that. Run locally on `NVIM v0.11.0`, the version CI pins. True exit codes; `skip` and `lang-skip` both grepped.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv)_