### PR TITLE
perf: retract a module's edges by record, not by scanning every bucket

### DIFF
--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2014,3 +2014,82 @@ fn unregistering_a_workspace_file_retracts_its_loader_shapes() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// The reverse record must retract EXACTLY what the whole-map sweep did.
+///
+/// `purge_module` no longer scans every bucket; it walks the keys the module
+/// was fed under. That is a pure performance change whose failure mode is a
+/// stale edge surviving a purge — silent, and only visible later as a
+/// phantom module in a lookup. So this compares the two implementations
+/// directly on the same state rather than asserting a hand-written expected
+/// shape, and it does it on the case that motivated the change: SEVERAL
+/// FILES feeding under ONE module name, which is what an installed @INC tree
+/// is full of and what `rebuild_name_registration` replays after each purge.
+#[test]
+fn the_record_driven_purge_matches_the_whole_map_sweep() {
+    use crate::index::module_index::ModuleEdgeIndexes;
+
+    // Overlapping symbol names across modules is what makes shared buckets;
+    // two files under `Dup::Mod` is the duplicate-name shape.
+    let srcs: Vec<(&str, &str)> = vec![
+        ("Dup::Mod", "package Dup::Mod; use parent 'Base::One'; sub new {} sub run {}"),
+        ("Dup::Mod", "package Dup::Mod; use parent 'Base::Two'; sub new {} sub helper {}"),
+        ("Other::Mod", "package Other::Mod; use parent 'Base::One'; sub new {} sub run {}"),
+        ("Third::Mod", "package Third::Mod; sub new {} sub only_here {}"),
+    ];
+
+    let build = || {
+        let edges = ModuleEdgeIndexes::new();
+        for (i, (name, src)) in srcs.iter().enumerate() {
+            let fa = build_fa(src);
+            edges.feed(name, &PathBuf::from(format!("/fake/f{i}.pm")), &fa);
+        }
+        edges.publish_spec("Primary::T", "Dup::Mod");
+        edges.publish_child("Base::One", "Dup::Mod");
+        edges
+    };
+
+    // Every module in play, including one never fed.
+    for target in ["Dup::Mod", "Other::Mod", "Third::Mod", "Never::Fed"] {
+        let by_record = build();
+        let by_sweep = build();
+        assert_eq!(
+            by_record.snapshot(),
+            by_sweep.snapshot(),
+            "the two indexes did not start identical for {target}"
+        );
+        by_record.purge_module(target);
+        by_sweep.purge_module_by_sweep(target);
+        assert_eq!(
+            by_record.snapshot(),
+            by_sweep.snapshot(),
+            "record-driven purge of {target} diverged from the whole-map sweep"
+        );
+    }
+}
+
+/// A purge must retract a sibling's contribution too, not just the last
+/// feed's. Both files under `Dup::Mod` publish `new`; if the record replaced
+/// instead of unioning, the first file's keys would go unrecorded and its
+/// edge would outlive the purge.
+#[test]
+fn a_purge_retracts_every_sibling_feed_under_one_name() {
+    use crate::index::module_index::ModuleEdgeIndexes;
+    let edges = ModuleEdgeIndexes::new();
+    for (i, src) in [
+        "package Dup::Mod; sub only_in_first {}",
+        "package Dup::Mod; sub only_in_second {}",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let fa = build_fa(src);
+        edges.feed("Dup::Mod", &PathBuf::from(format!("/fake/s{i}.pm")), &fa);
+    }
+    edges.purge_module("Dup::Mod");
+    assert!(
+        edges.snapshot().is_empty(),
+        "a sibling feed's edges survived the purge: {:?}",
+        edges.snapshot()
+    );
+}

--- a/src/index/module_index/parts.rs
+++ b/src/index/module_index/parts.rs
@@ -122,15 +122,51 @@ pub struct ModuleEdgeIndexes {
     /// (re-feeds are exactly when it's needed); `remove_path_record` drops
     /// it when the file itself goes.
     name_records: DashMap<std::path::PathBuf, Vec<String>>,
-    /// Every module name `feed` has published edges under. `purge_module`
-    /// removes one module from every bucket of every map — an O(all
-    /// buckets) sweep — and a bulk index calls it once per registered
-    /// package name, which is the second quadratic term in workspace
-    /// registration. A name that was never fed has nothing to remove, and
-    /// during a cold bulk index that is every name: the sweep only earns
-    /// its cost on RE-registration (a watcher edit, a reopened package's
-    /// second file), which is not the hot path.
-    fed_modules: DashMap<String, ()>,
+    /// Every module name `feed` has published edges under, and — the point
+    /// — WHICH bucket keys it was published under in each map, so
+    /// `purge_module` touches only its own edges.
+    ///
+    /// The guard alone is not enough. Its old comment claimed a cold bulk
+    /// index never re-feeds a name; that is false on any corpus with
+    /// duplicate package names, and being false silently is what hid this.
+    /// An installed `@INC` tree is full of them — bundled `inc/Module/Install`
+    /// alone appears in hundreds of distributions — and each duplicate pays a
+    /// sweep over EVERY bucket of all four maps. Applications with unique
+    /// module names skip every sweep, which is why the term is invisible on
+    /// Koha and only bites on a CPAN-shaped tree.
+    fed_modules: DashMap<String, FedKeys>,
+}
+
+/// The bucket keys one module was fed under, per map — the reverse record
+/// that makes retraction O(own edges) instead of O(all buckets).
+///
+/// `ModuleBucket` reused rather than a fresh set type: it is exactly a
+/// deduplicated string collection that scans while small and promotes to a
+/// hash when it is not, and one name's key list has the same shape as one
+/// bucket's member list. A second implementation of that threshold would be
+/// a thing to keep in sync for no gain.
+#[derive(Default, Clone)]
+struct FedKeys {
+    names: ModuleBucket,
+    bridges: ModuleBucket,
+    children: ModuleBucket,
+    specs: ModuleBucket,
+}
+
+impl FedKeys {
+    /// Union `other`'s keys into this record.
+    fn merge(&mut self, other: &FedKeys) {
+        for (dst, src) in [
+            (&mut self.names, &other.names),
+            (&mut self.bridges, &other.bridges),
+            (&mut self.children, &other.children),
+            (&mut self.specs, &other.specs),
+        ] {
+            for k in src.as_slice() {
+                dst.insert(k);
+            }
+        }
+    }
 }
 
 impl ModuleEdgeIndexes {
@@ -167,22 +203,33 @@ impl ModuleEdgeIndexes {
             self.name_records.insert(path.to_path_buf(), names.clone());
             names
         };
-        self.fed_modules.insert(module_name.to_string(), ());
-        let push_unique = |map: &DashMap<String, ModuleBucket>, key: String| {
-            map.entry(key).or_default().insert(module_name);
-        };
+        // Built locally and merged once: holding a `fed_modules` entry across
+        // the edge-map writes would nest two DashMap locks on the bulk path
+        // for no reason.
+        let mut fed = FedKeys::default();
+        let push_unique =
+            |map: &DashMap<String, ModuleBucket>, key: String, seen: &mut ModuleBucket| {
+                seen.insert(&key);
+                map.entry(key).or_default().insert(module_name);
+            };
         for name in names {
-            push_unique(&self.names, name);
+            push_unique(&self.names, name, &mut fed.names);
         }
         for class in Self::bridge_classes(analysis) {
-            push_unique(&self.bridges, class);
+            push_unique(&self.bridges, class, &mut fed.bridges);
         }
         for parent in Self::parent_classes(analysis) {
-            push_unique(&self.children, parent);
+            push_unique(&self.children, parent, &mut fed.children);
         }
         for primary in Self::spec_primaries(analysis) {
-            push_unique(&self.specs, primary);
+            push_unique(&self.specs, primary, &mut fed.specs);
         }
+        // UNION, not replace: several files can feed under one package name
+        // (Perl reopens packages anywhere), and `rebuild_name_registration`
+        // feeds every candidate after one purge. Replacing would leave the
+        // earlier siblings' keys unrecorded and their edges unpurgeable.
+        let mut rec = self.fed_modules.entry(module_name.to_string()).or_default();
+        rec.merge(&fed);
     }
 
     /// Publish ONE specialization edge (primary → spec). The pack path
@@ -190,15 +237,62 @@ impl ModuleEdgeIndexes {
     /// member fed or `purge_module`'s guard will skip a module that does
     /// have edges.
     pub fn publish_spec(&self, primary: &str, spec: &str) {
-        self.fed_modules.insert(spec.to_string(), ());
+        self.fed_modules
+            .entry(spec.to_string())
+            .or_default()
+            .specs
+            .insert(primary);
         self.specs.entry(primary.to_string()).or_default().insert(spec);
     }
 
     /// Publish ONE inverse-inheritance edge (parent → child). Same
     /// marking contract as `publish_spec`.
     pub fn publish_child(&self, parent: &str, child: &str) {
-        self.fed_modules.insert(child.to_string(), ());
+        self.fed_modules
+            .entry(child.to_string())
+            .or_default()
+            .children
+            .insert(parent);
         self.children.entry(parent.to_string()).or_default().insert(child);
+    }
+
+    /// Test-only REFERENCE implementation: the whole-map sweep the reverse
+    /// record replaced. Kept so the record-driven purge can be checked
+    /// against it directly rather than against hand-written expectations —
+    /// the failure mode is a stale edge that survives, which no
+    /// spot-assertion reliably catches.
+    #[cfg(test)]
+    pub fn purge_module_by_sweep(&self, module_name: &str) {
+        if self.fed_modules.remove(module_name).is_none() {
+            return;
+        }
+        for map in [&self.names, &self.bridges, &self.children, &self.specs] {
+            map.retain(|_key, bucket| {
+                bucket.remove(module_name);
+                !bucket.is_empty()
+            });
+        }
+    }
+
+    /// Test-only: the whole edge state, canonically ordered, for comparing
+    /// two purge implementations.
+    #[cfg(test)]
+    pub fn snapshot(&self) -> Vec<(&'static str, String, Vec<String>)> {
+        let mut out = Vec::new();
+        for (label, map) in [
+            ("names", &self.names),
+            ("bridges", &self.bridges),
+            ("children", &self.children),
+            ("specs", &self.specs),
+        ] {
+            for e in map.iter() {
+                let mut members = e.value().as_slice().to_vec();
+                members.sort();
+                out.push((label, e.key().clone(), members));
+            }
+        }
+        out.sort();
+        out
     }
 
     /// Test-only bucket readers: the maps are `pub(super)`, and these
@@ -228,17 +322,33 @@ impl ModuleEdgeIndexes {
     /// KEEPS `name_records` — they are per-PATH, and a same-name sibling
     /// file's replay source must survive this file's re-registration.
     pub fn purge_module(&self, module_name: &str) {
-        // Never fed ⇒ no bucket can hold it. The sweep below is O(every
-        // bucket of every map); a cold bulk index would otherwise pay it
-        // once per registered name for nothing.
-        if self.fed_modules.remove(module_name).is_none() {
+        // Never fed ⇒ no bucket can hold it.
+        let Some((_, fed)) = self.fed_modules.remove(module_name) else {
+            crate::util::ghost_stats::count("edges.purge_skipped_never_fed");
             return;
-        }
-        for map in [&self.names, &self.bridges, &self.children, &self.specs] {
-            map.retain(|_key, bucket| {
-                bucket.remove(module_name);
-                !bucket.is_empty()
-            });
+        };
+        crate::util::ghost_stats::count("edges.purge_by_record");
+        for (map, keys) in [
+            (&self.names, &fed.names),
+            (&self.bridges, &fed.bridges),
+            (&self.children, &fed.children),
+            (&self.specs, &fed.specs),
+        ] {
+            for key in keys.as_slice() {
+                let now_empty = match map.get_mut(key) {
+                    Some(mut bucket) => {
+                        bucket.remove(module_name);
+                        bucket.is_empty()
+                    }
+                    None => false,
+                };
+                if now_empty {
+                    // Keep "emptied" indistinguishable from "never fed", so no
+                    // reader needs an empty-bucket arm — the shape the whole-map
+                    // `retain` produced by dropping the entry.
+                    map.remove_if(key, |_, b| b.is_empty());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Shape (b): a per-module reverse record of the bucket keys it was fed under, making `purge_module` O(own edges) instead of O(all buckets). Same shape as `shapes_by_contributor` (`cacbc88c`), which fixed the sibling bug on `purge_loader_shapes`.

The record reuses `ModuleBucket` rather than growing a second dedup-with-threshold set to keep in sync — one name's key list has exactly the shape of one bucket's member list.

## The subtle part: union, not replace

Several files can feed under one package name — Perl reopens packages, and an installed tree bundles the same distribution repeatedly — and `rebuild_name_registration` feeds **every** candidate after a single purge. A record that replaced would leave the earlier siblings' keys unrecorded and their edges unpurgeable: a stale edge outliving its file, silent, visible only later as a phantom module.

## The comment is part of the fix

`fed_modules`' comment asserted that a cold bulk index never re-feeds a name. That is false on any corpus with duplicate package names, and its being false *silently* is what kept this term hidden. Corrected with the code, not after it — applications with unique module names skip every sweep, which is why this is invisible on an application checkout and only bites on a CPAN-shaped `@INC` tree.

## Equivalence, not spot-assertions

The old whole-map sweep is kept as a test-only reference (`purge_module_by_sweep`) and the new purge is compared against it on the same state, for every module including a never-fed one, on the duplicate-name shape that motivated the change. The failure mode is a stale edge that *survives* — which no hand-written expectation reliably catches, but a diff against the implementation being replaced does.

**Base-verified:** dropping the `children` key from the record makes it fail naming the exact surviving edge — `("children", "Base::Two", ["Dup::Mod"])`.

## Measured

Constructed duplicate-name corpus — 8,000 files, 4,000 bundled copies of one package name, ~240k distinct buckets — alternating runs:

| | run 1 | run 2 |
|---|---:|---:|
| before | 218.1 s | 221.2 s |
| after | **193.3 s** | **200.5 s** |

−10.4% mean, arms non-overlapping.

That reproduces the **regime, not the scale**: it sits at the small end where the term is ~10%, consistent with the 8.2%-of-phase attribution at 8.8k files. I cannot reproduce the 124k figure here and am not claiming it.

Two intermediate corpora were discarded as invalid before this one: the first reproduced the sweep *count* (849) but not the sweep *cost*, because it had few distinct bucket keys — the cost term tracks total buckets, so a corpus with duplicate names but a small name space shows nothing. Worth recording, since "has duplicate names" is not by itself the regime.

**The gold substrate cannot show this at all**: 23 record-driven purges against 2,106 skipped. Its names are effectively unique — the same reason applications look fast.

`edges.purge_by_record` / `edges.purge_skipped_never_fed` are left in so a corpus-scale run confirms the count directly rather than by inference.

## Gates

`cargo test` 1,498/0 · `cargo test --features cpp` **1,558 passed / 0 failed / 3 ignored** · `--languages` = `perl, cpp (beta)` · cache cleared then gold **498 PASS, 16 xfail, 0 FAIL, 0 XPASS, 0 CRASH, 0 skip, 0 lang-skip**.

**e2e: not green, and not because of this change** — `types.lua` / `dbic_parametric.lua` flapped. I ran the rate harness to settle it rather than assume; detail on #120. Summary: the merged base fails at the same rate as this branch, and the binary that measured 0/30 on both specs this morning now measures 19/20 and 9/20 **unchanged**. It is the box, not the diff — but it also means those two specs are load-dependent on current main, which is worth knowing given e2e is now a required gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_