### PR TITLE
references missed a sibling role that --implementations found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,11 @@ verified.
 A suite that fails only on its **first** assertion (`no hover result`, then
 every later probe passes) is a startup-readiness race, not a logic bug — the
 first request is the only one that can arrive before the server is ready.
-`lua/test/lsp.lua::wait_for_analysis` is the gate; it polls `documentSymbol`
-rather than sleeping, because a fixed sleep is a guess about a gap that varies.
-If a suite still races, extend that gate to cover the verb it needs — do not
-add a sleep, and do not gate on the verb under assertion or the poll masks the
-regression the suite exists to catch.
+`lua/test/lsp.lua::open_and_attach` is the gate: it polls `documentSymbol`
+until the server answers with content, because a fixed sleep encodes the
+box speed that wrote it. If a suite still races, extend that poll to cover the
+verb it needs — do not add a sleep, and do not gate on the verb under
+assertion or the poll masks the regression the suite exists to catch.
 
 ## Architecture
 

--- a/docs/adr/sibling-forks.md
+++ b/docs/adr/sibling-forks.md
@@ -48,6 +48,23 @@ fallback would have been sound-looking and wrong. Measure overlap on a
 real corpus before choosing the shape: the in-regime synthetic corpus
 showed 100% overlap and would have made deletion look safe.
 
+> A worked one, because the fork was invisible until the two walks were
+> read side by side: `implementations_of` gathered descendants PLUS the
+> co-ancestors those descendants reach going back up their own MRO,
+> while `method_override_family` gathered descendants only. Nothing
+> declared them siblings — they were written for different verbs. But a
+> role that CALLS `$self->m` and the sibling role that DEFINES it are
+> joined only through their shared composer, down one edge and back up
+> another, so the narrower gather returned nothing and `collect`'s
+> membership test turned that into an empty `references` answer from a
+> cursor where `--implementations` answered fine.
+>
+> Collapsed to `dispatch_participants`: one gather, `implementations_of`
+> subtracts its own contract line, `method_override_family` unions the
+> root. The residual claim is that the two verbs differ only by those
+> post-filters — which is the shape the leg-2 weakening in class 1 makes
+> explicit from the other side.
+
 **3. Language-lane forks — fold the decision into a seam.** A Perl arm
 and a pack arm making one decision. The cure is the value-carries-its-
 rule pattern already in service: `Slot`, `VisibilityAxis`,
@@ -55,6 +72,19 @@ rule pattern already in service: `Slot`, `VisibilityAxis`,
 genuinely differs per language and the *decision* is already seamed
 (presenters over a shared resolution; `cursor_context` vs
 `cursor_sentinel` under the `Slot` vocabulary).
+
+> And a consequence worth recording where the next person will find it,
+> because the measurement points the other way. The sibling-role gold
+> fixture carries **no `requires`**: once the gather is shared, the
+> projection alone answers, so the shape that motivated a `demands` lane
+> — a Surface field, an `EXTRACT_VERSION` bump, per-package consumer
+> churn — needs no recorded obligation at all. The 107-shape figure in
+> `skipping-cross-file-work.md` is the population a `demands` lane
+> *could* convert; it is not an argument that one is needed for the
+> template-method case, which is closed. What remains is the
+> abstract-base shape, pinned as an xfail row in
+> `fixtures/call-hierarchy.json`, which will XPASS the day someone
+> closes it.
 
 **4. Eager/lazy twins — a ledger, not a backlog.** An eager writer and
 a lazy reader of one rule is a deliberate purchase of speed with a

--- a/gold-corpus/fixtures/call-hierarchy.json
+++ b/gold-corpus/fixtures/call-hierarchy.json
@@ -70,6 +70,40 @@
       },
       "status": "gold",
       "note": "a package declaration is not a callable; prepare answers nothing rather than inventing an item."
+    },
+    {
+      "id": "ch-incoming-sibling-role-template-method",
+      "difficulty": "tricky",
+      "semantic_area": "roles",
+      "root": "gold-corpus/tmplmethod-fixture",
+      "file": "lib/My/Provider.pm",
+      "line": 3,
+      "col": 4,
+      "expect": {
+        "all": [
+          "{\"col\":\"5\",\"file\":\"Caller.pm\",\"kind\":\"Sub\",\"line\":\"7\",\"name\":\"run\",\"sites\":[{\"col\":\"19\",\"line\":\"9\"}]}"
+        ],
+        "none": []
+      },
+      "status": "gold",
+      "note": "The caller is a SIBLING role, not an ancestor: My::Caller calls $self->fetch_raw, My::Provider defines it, and only My::App composes both. An INHERITS_INV sweep from Provider never reaches Caller \u2014 the path is down to the composer and back up. `dispatch_participants` is the one gather both --implementations and the override family read, so references/call-hierarchy see the sibling that --implementations already saw. Note there is no `requires` here: the projection alone answers, so this shape needs no recorded obligation."
+    },
+    {
+      "id": "ch-incoming-abstract-base-template-method",
+      "difficulty": "tricky",
+      "semantic_area": "inheritance",
+      "root": "gold-corpus/tmplmethod-fixture",
+      "file": "lib/My/Concrete.pm",
+      "line": 3,
+      "col": 4,
+      "expect": {
+        "all": [
+          "{\"col\":\"5\",\"file\":\"AbstractBase.pm\",\"kind\":\"Sub\",\"line\":\"7\",\"name\":\"run\",\"sites\":[{\"col\":\"19\",\"line\":\"9\"}]}"
+        ],
+        "none": []
+      },
+      "status": "xfail",
+      "note": "What is missing here is the FACT, not the projection. My::AbstractBase calls $self->fetch_raw and My::Concrete defines it, but nothing records that the base has an obligation, so no edge connects them in either direction \u2014 unlike the sibling-role row above, where the composer supplies the path and the projection alone suffices. A `demands` lane (names a package's own bodies call on a conventional invocant and the file does not define) is what would convert this. Measured population: 107 of 2,516 distinct (class, method) shapes on the substrate \u2014 78 where a descendant defines the method, 29 where only a sibling can see it. Promote this row when that lands."
     }
   ]
 }

--- a/gold-corpus/tmplmethod-fixture/lib/My/AbstractBase.pm
+++ b/gold-corpus/tmplmethod-fixture/lib/My/AbstractBase.pm
@@ -1,0 +1,12 @@
+package My::AbstractBase;
+
+# Shape B: the demand lives in a base and the definition in a DESCENDANT.
+# Nothing records that the base has an obligation, so no edge connects the
+# two at all — unlike the sibling-role shape, where the composer supplies
+# the path. This is the population a `demands` lane would convert.
+sub run {
+    my $self = shift;
+    return $self->fetch_raw;
+}
+
+1;

--- a/gold-corpus/tmplmethod-fixture/lib/My/App.pm
+++ b/gold-corpus/tmplmethod-fixture/lib/My/App.pm
@@ -1,0 +1,7 @@
+package My::App;
+use Moo;
+
+with 'My::Caller';
+with 'My::Provider';
+
+1;

--- a/gold-corpus/tmplmethod-fixture/lib/My/Caller.pm
+++ b/gold-corpus/tmplmethod-fixture/lib/My/Caller.pm
@@ -1,0 +1,12 @@
+package My::Caller;
+use Moo::Role;
+
+# The template half: generic machinery that dispatches to a step it does
+# not provide and does not declare `requires` for. The provider is a
+# SIBLING role, not an ancestor — reachable only through the composer.
+sub run {
+    my $self = shift;
+    return $self->fetch_raw;
+}
+
+1;

--- a/gold-corpus/tmplmethod-fixture/lib/My/Concrete.pm
+++ b/gold-corpus/tmplmethod-fixture/lib/My/Concrete.pm
@@ -1,0 +1,8 @@
+package My::Concrete;
+use parent -norequire, 'My::AbstractBase';
+
+sub fetch_raw {
+    return 7;
+}
+
+1;

--- a/gold-corpus/tmplmethod-fixture/lib/My/Provider.pm
+++ b/gold-corpus/tmplmethod-fixture/lib/My/Provider.pm
@@ -1,0 +1,8 @@
+package My::Provider;
+use Moo::Role;
+
+sub fetch_raw {
+    return 42;
+}
+
+1;

--- a/src/index/resolve/refs.rs
+++ b/src/index/resolve/refs.rs
@@ -775,45 +775,14 @@ pub fn implementations_of(
     // The composer fan-out is a graph walk: INHERITS_INV from the
     // contract's class — the first strangler-fig consumer ported onto
     // the one walker (docs/prompt-graph-walking.md).
-    let mut descendants: Vec<String> = Vec::new();
     let probe = crate::model::graph::GraphView::new(origin, Some(idx));
-    probe.walk(
-        crate::model::graph::Node::Class(class.clone()),
-        crate::model::graph::EdgeKindMask::INHERITS_INV,
-        &mut |n| {
-            if let crate::model::graph::Node::Class(c) = n {
-                descendants.push(c.clone());
-            }
-            crate::model::graph::WalkControl::Continue
-        },
-    );
-
-    // Mixin/sibling overrides. A concrete class assembles its dispatch table
-    // from MULTIPLE parents (Perl multi-parent composition: `load_components`,
-    // Moo/Moose `with` roles, `use base` with several bases). An override of
-    // the target's method can therefore live on a SIBLING PARENT of a shared
-    // descendant — a class that is an ancestor of some concrete descendant of
-    // the target yet is NOT itself a descendant of the target, so the
-    // INHERITS_INV sweep above never reaches it (DBIC's `Ordered` sits
-    // alongside `Row` in `Track`'s MRO, not beneath it). Surface these by
-    // walking UP each descendant's full MRO and collecting every co-ancestor:
-    // a class that shares a concrete descendant with the target participates
-    // in that descendant's dispatch for the method.
-    let mut implementers: std::collections::BTreeSet<String> =
-        descendants.iter().cloned().collect();
-    for d in &descendants {
-        probe.walk(
-            crate::model::graph::Node::Class(d.clone()),
-            crate::model::graph::EdgeKindMask::INHERITS
-                | crate::model::graph::EdgeKindMask::APP_SURFACE,
-            &mut |n| {
-                if let crate::model::graph::Node::Class(c) = n {
-                    implementers.insert(c.clone());
-                }
-                crate::model::graph::WalkControl::Continue
-            },
-        );
-    }
+    // Descendants PLUS their co-ancestors: an override can live on a SIBLING
+    // PARENT of a shared descendant (DBIC's `Ordered` sits alongside `Row` in
+    // `Track`'s MRO, not beneath it), which an INHERITS_INV sweep alone never
+    // reaches. `dispatch_participants` is that gather, shared with
+    // `method_override_family` — while each had its own walk, this verb found
+    // the sibling and `references` did not, from the same cursor.
+    let mut implementers = origin.dispatch_participants(class, Some(idx));
     // The target and its own ancestry are the CONTRACT side, not an
     // implementation: goto-def lands on the target itself, and a superclass
     // method sits BEHIND the target in every descendant's MRO (shadowed by the

--- a/src/model/file_analysis/ancestry.rs
+++ b/src/model/file_analysis/ancestry.rs
@@ -322,8 +322,65 @@ impl FileAnalysis {
             }
             std::ops::ControlFlow::Continue(())
         });
-        // Root + all transitive descendants (`walk` excludes the origin).
-        self.descendant_family(root, module_index)
+        // Root + every class participating in its dispatch. Descendants
+        // alone would miss a sibling that composes into a shared consumer,
+        // which is where a role's caller lives — and `collect`'s membership
+        // test is what turns that miss into an empty references answer.
+        let mut family = self.descendant_family(root.clone(), module_index);
+        for p in self.dispatch_participants(&root, module_index) {
+            if !family.iter().any(|f| f == &p) {
+                family.push(p);
+            }
+        }
+        family
+    }
+
+    /// Every class that participates in `class`'s dispatch for a method:
+    /// the transitive `INHERITS_INV` descendants, PLUS the co-ancestors
+    /// those descendants reach walking back UP their own MRO.
+    ///
+    /// The co-ancestor half is what a descendants-only walk cannot see. A
+    /// concrete class assembles its dispatch table from SEVERAL parents
+    /// (Moo/Moose `with`, `load_components`, multi-base `use base`), so a
+    /// role that only CALLS `$self->m` sits alongside the role that defines
+    /// it — sibling parents of one composer, neither below the other. The
+    /// path between them is down to the shared composer and back up, which
+    /// is why `INHERITS_INV` alone returns nothing and the caller sees an
+    /// empty answer rather than a wrong one.
+    ///
+    /// One gather, two readers: `implementations_of` (which then subtracts
+    /// its own contract line) and `method_override_family`. They disagreed
+    /// while each had its own walk — `--implementations` found the sibling
+    /// and `references` did not, from the same cursor.
+    pub fn dispatch_participants(
+        &self,
+        class: &str,
+        module_index: Option<&dyn CrossFileLookup>,
+    ) -> std::collections::BTreeSet<String> {
+        use crate::model::graph::{EdgeKindMask, GraphView, Node, WalkControl};
+        let probe = GraphView::new(self, module_index);
+        let mut descendants: Vec<String> = Vec::new();
+        probe.walk(Node::Class(class.to_string()), EdgeKindMask::INHERITS_INV, &mut |n| {
+            if let Node::Class(c) = n {
+                descendants.push(c.clone());
+            }
+            WalkControl::Continue
+        });
+        let mut out: std::collections::BTreeSet<String> =
+            descendants.iter().cloned().collect();
+        for d in &descendants {
+            probe.walk(
+                Node::Class(d.clone()),
+                EdgeKindMask::INHERITS | EdgeKindMask::APP_SURFACE,
+                &mut |n| {
+                    if let Node::Class(c) = n {
+                        out.insert(c.clone());
+                    }
+                    WalkControl::Continue
+                },
+            );
+        }
+        out
     }
 
     /// A root class plus every transitive descendant that inherits from it,


### PR DESCRIPTION
Split out of #137 so it can be reviewed — and reverted — on its own. Stacked on #145; the diff below is the one commit.

**9 files.** `cargo test --features cpp` 1583/0 · gold **499 PASS · 17 xfail · 0 FAIL · 0 XPASS · skip 0 · lang-skip 0** · e2e 113 pass ×2.

## The bug

A role that calls `$self->fetch_raw` and a sibling role that defines it are connected only through their shared composer — down an `INHERITS_INV` edge and back up an `INHERITS` one. From one cursor:

```
$ perl-lsp --implementations <root> --at lib/My/Role.pm:4:11     # finds the sibling
$ perl-lsp --references     <root> --at lib/My/Composer.pm:5:5   # did not
```

`implementations_of` already walked descendants **plus the co-ancestors those descendants reach going back up their own MRO**. `method_override_family` walked descendants only, and `collect`'s membership test turns that narrower set into an empty answer. Call hierarchy incoming: empty. Rename: an incomplete edit set that silently breaks a caller. `--heatmap`: every template-method implementation nominated for deletion at fan_in 0.

## The fix

One gather, two readers — not a second walk for `references`.

`FileAnalysis::dispatch_participants` is the walk. `implementations_of` reads it and subtracts its own contract line; `method_override_family` unions it with the root. Same move as `0ea23d8a` in the neighbouring projection: the walk stays in one place and the projections read it, rather than being re-encoded per verb.

## Fixtures, committed as a permanent net

`gold-corpus/tmplmethod-fixture`, two rows in `fixtures/call-hierarchy.json`:

| row | shape | status |
|---|---|---|
| `ch-incoming-sibling-role-template-method` | `My::Caller` calls, `My::Provider` defines, `My::App` composes both | **gold** |
| `ch-incoming-abstract-base-template-method` | `My::AbstractBase` calls, `My::Concrete` defines | **xfail** |

Fixture A contains **no `requires`**. The projection alone answers it, so this shape needs no recorded obligation — which is what took a `demands` lane (a Surface field plus an `EXTRACT_VERSION` bump) off the table for the motivating case.

B is the honest boundary. Its note says what is missing is the **fact, not the projection**: nothing records that a base has an obligation, so no edge connects it to the descendant in either direction. It carries the measured population — 107 of 2,516 distinct `(class, method)` shapes on the substrate, 78 descendant-defines and 29 sibling-visible — so whoever prices a `demands` lane later argues against a number.

**Negative control:** with the family change reverted, row A **FAILS** and row B stays xfail. Verified, then restored.

## How it was found — by hand, not by the net

Asked directly, so: **[D]'s consistency net was not involved.** I found it while costing an unrelated design (the `demands` lane), reading `implementations_of` and `method_override_family` next to each other and noticing one gathered co-ancestors and the other didn't. Then I built the fixtures and ran the verb.

Worth knowing for the net's reach: the invariant [D] drafted (`for every atom S in inverse(M): implementations(S) contains M`) would **not** have caught this, and in fact fails today on a non-bug — `implementations(SubRole's re-requires)` is `{Deep::fetch}` while `references(Composer::fetch)` contains SubRole's atom. `implementations` answers dispatch reachability; `references` answers rename correctness, and the rename set is legitimately wider. Detail and a suggested weakening in [#120 5359467595](https://github.com/tree-sitter-perl/perl-lsp/issues/120#issuecomment-5359467595).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy44TSZ96KhDFCy36dZcUj)_