### PR TITLE
The fold's order-independence becomes a gate, and the conclusion layer gets specified rather than argued for

### DIFF
--- a/docs/prompt-conclusion-layer.md
+++ b/docs/prompt-conclusion-layer.md
@@ -503,14 +503,32 @@ well-formed. Nothing catches that except someone remembering to bump a
 version, and a plausible-but-wrong answer maintained by discipline is the
 failure shape this codebase keeps paying for.
 
-**Prerequisite, measured: the fold is deterministic.** A fingerprint is
-worthless if the baked answer can differ from the live answer on identical
-code. `--dump-package` over the substrate, five packages, three warm runs
-each plus a cold run against a fresh cache dir: byte-identical every time,
-cold matching warm, across ~330 KB of dumped conclusions including Catalyst
-(145 KB) and Type::Tiny (109 KB), which are the heaviest cross-file candidate
-iterations available. Nothing in the fold depends on map iteration order —
-unlike completion's ranking, which did.
+**Prerequisite: no iteration-order dependence observed where measured.** A
+fingerprint is worthless if the baked answer can differ from the live answer
+on identical code. `--dump-package` over the substrate, five packages, three
+warm runs each plus a cold run against a fresh cache dir: byte-identical
+every time, cold matching warm, across ~330 KB of dumped conclusions
+including Catalyst (145 KB) and Type::Tiny (109 KB), the heaviest cross-file
+candidate iterations available. (`DBIx::Class::ResultSet` returned zero
+bytes — absent from the substrate, so not a data point rather than a pass.)
+
+Stated that way deliberately. Five packages of one substrate is a sample, not
+a proof, and the stronger sentence — "the fold is deterministic" — is the one
+a later reader stops checking behind.
+
+**And it is now load-bearing, so it is a gate rather than a paragraph.**
+Today nothing depends on the fold being stable; after this layer it is a
+correctness precondition of the cache, because an order-dependent fold
+produces a stale answer that MATCHES ITS OWN FINGERPRINT — a perfect
+mechanism protecting a broken premise.
+`witnesses_tests::the_fold_does_not_depend_on_map_iteration_order` fails a
+build instead. It leans on `RandomState` seeding per instance, so two
+independently built analyses of one source carry differently ordered maps;
+that makes it probabilistic per source and reliable across the set, and it
+carries a vacuity guard that fails loudly if seeding ever stops varying
+rather than passing while checking nothing. Both assertions are
+mutation-verified: making the fold order-dependent, and making seeding
+invariant, each fail it by name.
 
 **The fingerprint.** Conclusions get their own version, derived rather than
 maintained: a `build.rs` hashes the derivation sources into a compile-time

--- a/docs/prompt-conclusion-layer.md
+++ b/docs/prompt-conclusion-layer.md
@@ -1,132 +1,513 @@
-# Forward design: a dependent conclusion layer for the witness bag
+# Specification: the conclusion layer
 
-**Status: designed, closes, NOT recommended for build yet.** Staged, with
-stage 1 cheap and semantics-free and stage 2 gated on a re-measurement.
+**Status: specified, closes, staged; stage 2 gated on a post-stage-1
+re-measurement (verdict at the end).**
 
-The bag is the DERIVATION. It is 41.5% of a stored `FileAnalysis` by
-compressed bytes and 52.9% of the bincode payload. The question was whether
-we can persist CONCLUSIONS and load the bag only on demand.
+A **conclusion** is the registry chase partially evaluated over what one file's
+bag knows, with the three query binders (`ReducerQuery.point` / `.receiver` /
+`.arity_hint`, `reducers.rs:12-38`) and the cross-file world left free. Free
+binders residualize as syntax; the cross-file world residualizes only as a
+`Link`. A per-file `ConclusionMap` persists next to the blob and serves the
+cross-file consult path without decoding the bag; the bag remains the
+derivation of record and the fallback.
 
-## Measurements this rests on
+```rust
+/// Portable, cross-file-enterable key. Strings only — see "Keys" below.
+pub enum ConclusionKey {
+    MethodOnClass { class: String, name: String },
+    SubByName(String),
+    SlotType { class: String, key: String },
+    TypeName(String),
+}
 
-All from `--check` over the 2,265-module substrate; counters are in-tree
-behind `PERL_LSP_GHOST_STATS`, probes are `#[ignore]`d in
-`index/module_cache/blob.rs`.
+/// One key's partially-evaluated answer.
+pub enum Conclusion {
+    Value(InferredType),
+    ReturnOf(ReturnExpr),
+    Timeline(Vec<TimelineSegment>),          // λ point — bake-internal, never persisted
+    Link { target: ConclusionKey, arity: Option<u32>, receiver: ReceiverRule },
+    Project { base: Box<Conclusion>, step: ProjectionStep },
+    OpenNone,
+}
 
-Cross-file consult shapes: `MethodOnClass` 106,533 (**96.0%**), `slot_type`
-4,367, `bridged` 42, `imported_sub_return` 5.
+pub struct TimelineSegment { pub span: Span, pub value: InferredType }
 
-A FLAT conclusion layer (one resolved return per sub) does not close it:
-85,952 `MethodOnClass` queries (77.3%) answer without entering an
-`Expr(span)`; 25,201 (22.7%) do. That layer is 534,938 bincode / 276,551
-zstd — 0.9% / 4.1% of the bag.
+pub enum ReceiverRule {
+    /// Pass the evaluating query's receiver through unchanged (inheritance hop).
+    Thread,
+    /// `fresh_dispatch_receiver(incoming, class)` (registry.rs:92-107): keep
+    /// the incoming receiver iff its class IS `class` or a subclass of it;
+    /// otherwise substitute `ClassName(class)`.
+    Dispatch(String),
+}
 
-What the chase reads at `Expr` attachments: `Edge` 446,478, `InferredType`
-180,515, `Projected` 44,901, `ReturnExpr` 25,402, **zero `Observation`**.
+/// Per-file, persisted with the blob, invalidated with it (same stamp),
+/// versioned by CONCLUSION_VERSION in the EXTRACT_VERSION gate family
+/// (`schema.rs:13`).
+pub struct ConclusionMap(HashMap<ConclusionKey, Conclusion>);
+```
 
-What it reads at EVERY attachment: `Edge` 2,166,944 (47.5%), **`Observation`
-1,298,645 (28.5%)**, `InferredType` 554,032, `Fact` 163,457, `CallReturn`
-137,682, `Projected` 134,578, `ReturnExpr` 62,344, `QualifiedCallReturn`
-10,484.
+**Evaluation contract.** A conclusion query is `(key, receiver:
+Option<InferredType>, arity: Option<u32>, args: Vec<InferredType>)` — there is
+deliberately no `point` (see `Timeline`). The evaluator mirrors
+`query_rec_body`'s consult ladder (`registry.rs:462-769`): per visible def
+candidate, look the key up in that file's map; on a form, evaluate it; then
+the inheritance walk over `PackageFacts::parents` (pinned fields, not the
+bag); then bridges. Cycle guard and depth cap mirror `VisitedKey`
+(`registry.rs:25`: attachment + receiver identity + arity, here `(file, key,
+receiver, arity)`). Three outcomes per lookup:
 
-## Why it closes
+- **a form** — evaluate per the sections below; no bag decode.
+- **`OpenNone`** — this key is unbakeable here; decode the blob, rebuild
+  `BagContext`, run the real registry chase (`registry.rs:273`). Full cost,
+  paid for this key only.
+- **absent** — the bag deterministically answers `None` for this key; serve
+  `None` with no decode and let the ladder move on (parents, next candidate) —
+  exactly what a local-reducer miss does today (`registry.rs:417-427` falls
+  through to the fallbacks).
 
-A conclusion is `query()` partially evaluated over what the file knows,
-leaving free only what it cannot: the query POINT, the RECEIVER, the ARITY,
-and the state of the cross-file world. The first three are bounded and
-residualize as syntax — a dependent conclusion. The fourth is unbounded and
-residualizes only as a LINK. That is the bag's own "edges, not values" rule
-lifted one layer up.
+The absent-means-None split is the sharpest knife in the design: it is sound
+only if the bake enumerates **every key the bag could answer** — derivable
+from the bag's attachment index (`mod.rs:44-48`, keyed by attachment), the
+`SymbolTable` names, and the file's declared bridges. A key-production site
+the enumeration misses turns "the bag would answer" into a silent `None`.
 
-The observations are the crux, and they close for a measured reason. They
-live at `Variable` attachments, where `FrameworkAwareTypeFold` gates them
-temporally (`reducers.rs:166-181`, `:832`) — so a variable's conclusion is
-`λ point. InferredType`, a step function with a breakpoint per witness span.
+## Keys: `ConclusionKey` vs internal ids
 
-**Timelines cannot cross a file boundary, and the code enforces it.** Every
-cross-file entry builds a FRESH query with `point: None` against a context
-rebuilt from the provider's own `scopes`/`packages` (all five sites in
-`witnesses/query.rs`), entering at a point-free `Symbol(sid)`. The asker's
-point is never threaded across the boundary. The single `point: Some(..)`
-construction (`registry.rs:1034`) is the scope-chain walk INSIDE one bag, and
-the `point: q.point` threading is likewise intra-walk.
+The four variants are exactly the four measured cross-file consult shapes:
+`MethodOnClass` 106,533 (96.0%, counter `registry.rs:532`), `SlotType` 4,367
+(`registry.rs:681`), bridged 42 (`registry.rs:619`), `imported_sub_return` 5
+(`query.rs:143`). Every variant is strings-only: mintable by an asker holding
+nothing but names, stable across any edit of the provider.
 
-So an intra-file edge does reference a timeline — that is where the 1.3M
-observation reads are — but no INBOUND edge from another file can name one.
-The portable key set is point-free by design and the reset makes it point-free
-by enforcement, independently. The apparent counterexample is not one:
-enrichment's MCB bridge pushes `Variable → Edge(MethodOnClass)`, a
-consumer-local variable pointing OUTWARD at a foreign symbol. Nothing outside
-ever names that variable.
+The internal ids — `SymbolId`, `ScopeId`, `RefIdx`, `Span` — are per-`FileAnalysis`
+and shift on unrelated edits. They never appear in a key. The code already
+enforces the boundary: every cross-file entry today lands on a strings-only
+attachment (`MethodOnClass` at `registry.rs:462-549`, `SlotType` at
+`registry.rs:640-694`, `TypeName` at `registry.rs:730-758`) or resolves a
+**name** to a local `Symbol(sid)` on the provider's side (`query.rs:91-106` —
+`SubByName` is that lookup given a key spelling). The one exception is the
+bridged hop, which enters at `Symbol(sym.id)` because "per-FA SymbolIds can't
+be portably edge-encoded" (`registry.rs:444-447`); the bake closes it from the
+other side — the bridging file knows its own bridges, so it writes those
+entries under `MethodOnClass{bridged_class, name}`.
 
-That is a stronger property than the composition argument below, and it is the
-one that matters for thrash: the only consumer of an UNAPPLIED timeline is
-`inferred_type_via_bag(var, point)` — hover / inlay / completion on a file the
-user has open, where the bag is resident anyway. Leaving timelines to the full
-bag decode therefore costs nothing, because the on-demand decode never fires
-for timeline reasons on a closed provider.
+Internal ids MAY appear *inside* a persisted `Conclusion`'s `InferredType`
+(e.g. `CodeRef { return_edge: Some(Expr(span)) }`, `types.rs` of
+`file_analysis`, lines 26-49): unlike the Surface, the map is co-persisted and
+co-invalidated with the blob whose bag those ids index, so they are
+stamp-consistent — but *interpreting* one later requires the bag (see the
+`Value` break below).
 
-**And the binder is always applied at bake.** Every hop that enters a
-`Variable` fixes the point AT the hop, from bake-time constants —
-`registry.rs:799-801` uses `Expr(span).start` for edges chased from
-expressions and `scope_point(scope)` otherwise. So composition through a
-variable selects ONE segment, and no cross-file key ever needs an unapplied
-timeline. **Timelines exist in the algebra and never on disk.** That is what
-keeps the layer at conclusion size: persisting them instead would be
-~9-18 MB, 16-32% of the bag, most of the way back to keeping it.
+The in-RAM precedent already exists: the resolution session's `CandidateKey`
+(`session.rs:48-58`) memoizes cross-file consult answers keyed `(path,
+attachment, receiver, arity, point, framework)` for one walk. The map is the
+persisted, point-free, epoch-independent projection of that key.
 
-The forms: `Value`, `ReturnOf(ReturnExpr)` (reusing `eval_return_expr`
-verbatim — `ReturnExpr` is ALREADY a dependent conclusion),
-`Timeline` (bake-internal), `Link{target, arity, receiver}` (subsuming
-`Edge`, `CallReturn`, `QualifiedCallReturn`), `Project{base, step}`, and
-`OpenNone`. Estimated ~1.5-2.5 MB bincode, 3-5x the flat map, ~20x under the
-bag — reasoned, not measured; verify before committing a schema.
+---
 
-## The residue, which is real
+## `Value(InferredType)`
 
-1. **Rename transport and `--dump-package`** consume the bag as a data
-   structure, not through the registry. No conclusion form serves them. The
-   honest claim is "the TYPE CHASE never decodes the bag", never "nothing
-   does".
-2. **`Custom` payloads / non-default reducers** are unbakeable by
-   construction. The plugin fingerprint's hard-clear must cover the
-   conclusion column, and that is a discipline rather than a shape.
-3. **Enrichment-overlay retries still decode and enrich the whole provider
-   bag**, because enrichment is bag surgery. The layer makes the raw-tier hop
-   cheap and cannot touch the enriched-tier hop.
+**Type.** The `InferredType` enum of `model/file_analysis/types.rs:17` —
+`ClassName`, `HashWithKeys`, `Parametric(..)`, `Sequence`, etc. — stored
+verbatim, constant in all three binders.
 
-## Traps
+**Real Perl.**
 
-- `MethodSurface::ret` is a PRE-ENRICHMENT local conclusion
-  (`surface.rs:62-66`): two providers with different enriched returns project
-  byte-identical Surfaces. So only post-fold, post-finalize conclusions
-  persist; invalidation rides the blob axis, never the Surface axis; enriched
-  answers are never written back.
-- The chase survives — hops get cheaper, not fewer. An answer still moves
-  when a provider resolves, so the persisted map must never hold a
-  materialized cross-file value.
-- Any reducer change now changes SEMANTICS without changing shape, so it must
-  bump `EXTRACT_VERSION` (or a sibling `CONCLUSION_VERSION` in the same gate
-  family).
-- Never bake through a degradation: a `QUERY_REC_DEPTH_CAP` truncation or a
-  `degraded` analysis must persist `Link`/`OpenNone`, not the short answer.
+```perl
+package My::Client;
+sub _build_ua {
+    my $self = shift;
+    return LWP::UserAgent->new( timeout => 10 );
+}
+```
+
+Witnesses: the walk types the constructor call `ClassName("LWP::UserAgent")`
+(the `Foo->new(...) → ClassName(Foo)` convention, `build/builder/chain.rs:17`)
+on the call's `Expr(span)`; the return arm pushes `SymbolReturnArm(sid) →
+Edge(Expr(call_span))` and `Symbol(sid) → Edge(SymbolReturnArm(sid))`
+(`types.rs:54-60`); writeback publishes `MethodOnClass{"My::Client",
+"_build_ua"} → Edge(Symbol(sid))` (tag `local_return`, fold step 6). Reducers:
+the registry materializes the edge chain (`registry.rs:784-864`),
+`SymbolReturnArmFold` (`reducers.rs:426-462`) folds the one arm via
+`join_return_arms` (`file_analysis/types.rs:938`).
+
+Baked, under both `MethodOnClass{"My::Client","_build_ua"}` and
+`SubByName("_build_ua")`:
+
+```
+Value(ClassName("LWP::UserAgent"))
+```
+
+**Evaluation.** Hash lookup; return the type unchanged. `receiver`, `arity`,
+`point` are all ignored — the bake has proven the answer constant in them.
+For the snippet: `ClassName("LWP::UserAgent")`, zero hops, zero decode.
+
+**Where it breaks.** Anything non-constant. Receiver-dependence (a fluent
+accessor baked as `Value` would hand the *declaring* class to a subclass call)
+must be `ReturnOf`; arity-dependence likewise; cross-file dependence must be
+`Link` — a materialized cross-file value would freeze the world, and the
+constraint is hops cheaper, never fewer. Second break: an embedded
+non-portable attachment. `Value(CodeRef { return_edge: Some(Expr(span)) })`
+serves the *type* fine, but a consumer that later invokes the coderef must
+chase `Expr(span)` — not a `ConclusionKey` — so that drill falls back to the
+full blob decode. The map hands out answers, not the ability to keep deriving.
+
+## `ReturnOf(ReturnExpr)`
+
+**Type.** The existing `ReturnExpr` (`types.rs:270-311`): `Concrete` /
+`Receiver` / `ReceiverOr` / `Operator(RowOf | ParamOf | InstanceOf)` /
+`UnionOnArgs { branches: Vec<(ArgGuard, ReturnExpr)> }` / `Arg(u32)`.
+`ReturnExpr` is ALREADY a dependent conclusion — `(receiver, arity, args) →
+InferredType` — and the form stores the payload verbatim; evaluation reuses
+`eval_return_expr` (`reducers.rs:867-941`) unchanged.
+
+**Real Perl.**
+
+```perl
+package Mojo::UserAgent;
+use Mojo::Base -base;
+has ioloop => sub { Mojo::IOLoop->new };
+```
+
+Witnesses: `visit_has_call` synthesizes the `ioloop` Method symbol and the
+Mojo::Base accessor synthesis pushes onto `Symbol(sid)` and
+`MethodOnClass{"Mojo::UserAgent","ioloop"}`:
+
+```
+ReturnExpr(UnionOnArgs { branches: [
+    (Empty,      Concrete(ClassName("Mojo::IOLoop"))),   // getter
+    (AtLeast(1), Receiver),                               // fluent writer
+]})
+```
+
+Reducer: `ReturnExprReducer` (`reducers.rs:797-859`), registered second so
+declarative shapes dominate writeback (`registry.rs:222-255`).
+
+Baked: `ReturnOf(<that same UnionOnArgs>)` — literally the witness payload,
+moved out of the bag.
+
+**Evaluation.** Run `eval_return_expr` against the query. For
+`$ua->ioloop` where `$ua : ClassName("My::UA")` (a subclass — the receiver
+survives the dispatch hop via the subclass pass-through,
+`registry.rs:97-106`): arity `Some(0)` → guard `Empty` fires →
+`ClassName("Mojo::IOLoop")`. For `$ua->ioloop($loop)`: arity `Some(1)` →
+`AtLeast(1)` → `Receiver` → `ClassName("My::UA")`. Hint-less introspection:
+no `Any` branch → the `Empty` fallback (`reducers.rs:913-938`) →
+`ClassName("Mojo::IOLoop")`.
+
+**Where it breaks.** `ReturnExpr` is a *substitution* language, sealed over
+`(receiver, args)` — no variant names another attachment or key (deliberate:
+`types.rs:255-268`). A default sub that *chases* — `has ua => sub {
+shift->build_ua }` — is not a substitution; its answer routes through edges
+and must residualize as `Link`. And a `UnionOnArgs` whose branches were
+frozen at fold time carries only what the build-time fold resolved: an arm
+that chains through an import resolves only under enrichment, which never
+persists — the persisted map misses it exactly as the persisted bag does
+(the R4 residue, unchanged).
+
+## `Timeline` (λ point)
+
+**Type.** `Vec<TimelineSegment>` — span-scoped verdicts, latest-emitted-wins
+within containment, evaluated by picking the fold's verdict at a point. Keyed
+by `Variable { name, scope: ScopeId }` — an **internal** id, so a Timeline has
+no `ConclusionKey`: it exists in the bake's working set and never on disk.
+
+**Real Perl.**
+
+```perl
+my $obj = { name => 'origin' };   # (1)
+$obj->{x} = 0;                    # (2)
+bless $obj, 'Point';              # (3)
+$obj->draw;                       # (4)
+```
+
+Witnesses on `Variable{"$obj", scope}`: (1) the TC mirror pushes
+`InferredType(HashWithKeys{[("name",_)], open:false})`; (2) the
+mutation-extension pass (`query.rs:269-387`) pushes the extended
+`HashWithKeys{[name,x],..}` at a zero-width span at the write; (3)
+`Observation(ClassAssertion("Point"))` + `Observation(BlessTarget(Hash))`.
+Reducer: `FrameworkAwareTypeFold` — Observations are temporal: witnesses past
+the query point are skipped (`reducers.rs:169-173`; the `ReturnExpr` sibling
+gate is `reducers.rs:832-838`), spans narrow (narrowest containing span,
+`reducers.rs:124-141`), and class identity dominates rep
+(`reducers.rs:250-266`). So the variable's conclusion is a step function:
+
+```
+Timeline([
+    { span: (1)..,        value: HashWithKeys{[name]} },
+    { span: (2)..(2),     value: HashWithKeys{[name,x]} },
+    { span: (3)..,        value: ClassName("Point") },
+])
+```
+
+The bake stores the *fold's verdict per breakpoint*, not the witnesses — it
+runs the fold at each witness start. Segments carry spans, not bare start
+points, because narrowing is 2-D: a flow-narrowed guard region
+(`docs/adr/flow-narrowing.md`) contributes a verdict that *ends*, which a
+breakpoint-only step function cannot express.
+
+**Evaluation.** Given a point: among segments whose span contains it (or, for
+zero-width write segments, whose start ≤ it), the latest-starting wins. At
+(4): `ClassName("Point")`. Between (2) and (3): `HashWithKeys{[name,x]}`.
+
+**Where it breaks — and why never persisting it is free.** The key is
+internal, so no cross-file asker can name a Timeline, and the code enforces
+point-freedom at every boundary independently: all five `ReducerQuery`
+constructions in `witnesses/query.rs` are `point: None` (lines 39, 68, 109,
+199, 309 — each cross-file recursion rebuilds context from the provider's own
+`scopes`/`packages`, `query.rs:99-106`); the sole `point: Some(..)` in the
+module is `registry.rs:1042`, the intra-bag scope-chain walk. And the binder
+is always **applied at the hop**: an edge entering a `Variable` fixes the
+point from bake-time constants — `Expr(span).start` when chased from an
+expression, `scope_point(scope)` otherwise (`registry.rs:807-809`) — so
+composition through a variable selects ONE segment and the Timeline collapses
+into the composing conclusion at bake. The only consumer of an *unapplied*
+timeline is `inferred_type_via_bag(var, point)` (`queries.rs:281`) — hover /
+inlay / completion on an open document, where the bag is resident anyway.
+Persisting timelines would cost ~9-18 MB (16-32% of the bag) to serve a path
+that never decodes.
+
+## `Link { target, arity, receiver }`
+
+**Type.** As defined at the top: a portable `ConclusionKey` target, an
+optional arity that overrides the evaluating query's hint, and a
+`ReceiverRule`. It subsumes three payloads and one hop kind:
+
+| today | as Link |
+|---|---|
+| `Edge(MethodOnClass{c,m})` from a non-`MethodOnClass` attachment (fresh dispatch, `registry.rs:816-836`) | `target: MethodOnClass{c,m}`, `arity: None`, `receiver: Dispatch(c)` |
+| `Edge(MethodOnClass{parent,m})` from a `MethodOnClass` (inheritance hop, `registry.rs:822-826`) | `receiver: Thread` |
+| `CallReturn { target, arity }` (`types.rs:182`, chased at `registry.rs:865-894`) | `arity: Some(n)`, `receiver: Dispatch(target.class)` |
+| `QualifiedCallReturn { method_lookup, receiver_class, arity }` (`types.rs:198-202`, chased at `registry.rs:971-995`) | `target: method_lookup` key, `arity: Some(n)`, `receiver: Dispatch(receiver_class)` |
+
+**Real Perl.**
+
+```perl
+package My::Schema::ResultSet::Users;
+use base 'DBIx::Class::ResultSet';
+sub active {
+    my $self = shift;
+    return $self->search({ active => 1 });
+}
+```
+
+Witnesses: `$self` gets `Observation(FirstParamInMethod{..})`; PostFold fills
+the call's invocant class; `emit_method_call_return_edges`
+(`build/builder/fold.rs:990-1013`) pushes `Expression(ridx) → CallReturn{
+MethodOnClass{"My::Schema::ResultSet::Users","search"}, arity: 1 }`; the
+return chain is `Symbol(sid) → Edge(SymbolReturnArm(sid)) → Edge(Expr(call
+span)) → Edge(Expression(ridx))`; writeback publishes
+`MethodOnClass{Users,"active"} → Edge(Symbol(sid))`. The bake (module-index-
+free) collapses every internal-id hop in that chain and stops at the first
+step that needs the world:
+
+```
+MethodOnClass{"My::Schema::ResultSet::Users","active"} ↦
+Link { target:   MethodOnClass{"My::Schema::ResultSet::Users","search"},
+       arity:    Some(1),
+       receiver: Dispatch("My::Schema::ResultSet::Users") }
+```
+
+**Evaluation.** For `my $rows = $users_rs->active;` (receiver
+`ClassName("...Users")`, arity 0): (1) the asker's consult finds the `Link`;
+(2) rebind — arity := `Some(1)`, receiver: the `Dispatch` rule sees the
+incoming receiver's class equals the target class → passes it through
+(`registry.rs:97-106`); (3) re-enter the ladder at the target key: the Users
+file's own map is absent for `search` → serve local `None`, walk
+`PackageFacts::parents` → `DBIx::Class::ResultSet`, whose (plugin-declared)
+entry is `ReturnOf(Operator/Receiver …)` → substitutes the threaded receiver.
+The hop count is identical to today's chase — the answer still moves when a
+provider resolves — but each hop is a map lookup instead of a bag decode plus
+registry recursion. The removable cost is that recursion: `consult.attempt`
+2,262 ms over 109,360 calls vs `consult.bag_present` (rehydrate) 621 ms —
+78% compute, identical cold vs warm (2,251.7 vs 2,262.2 ms).
+
+**Where it breaks.** (a) The target must be a *static* portable key. A
+receiver-dependent target — `$self->$method(@_)` past constant folding,
+`ref($x)->new` — has no key to write; the sub's entry is `OpenNone` (today
+those sites also pin no edge and count into `dynamic_dispatch_sites`,
+`file_analysis/mod.rs:258`). (b) Cycles/depth: the evaluator's visited set
+answers `None` on re-entry, mirroring `registry.rs:395-397`; its depth cap
+mirrors `QUERY_REC_DEPTH_CAP` (`registry.rs:191-194`). (c) The enriched-tier
+hop: when a provider's raw answer dead-ends because the provider's own
+imports need enriching, today's fallback-on-miss decodes and enriches the
+whole provider bag (`registry.rs:528-543`; symmetric arms at 610-625,
+671-691; `query.rs:121-151`). Enrichment is bag surgery; no conclusion form
+serves it. The `Link` makes the raw-tier hop near-free and leaves the
+enriched-tier hop exactly as expensive as it is.
+
+## `Project { base, step }`
+
+**Type.** `base: Box<Conclusion>` (recursive — the base is itself any form),
+`step: ProjectionStep` (`types.rs:250-253`: `HashKey(String)` |
+`ArrayIndex(i32)`). Subsumes the `Projected` payload (`types.rs:230-233`) and
+its chase arm (`registry.rs:895-970`).
+
+**Real Perl.**
+
+```perl
+package My::Worker;
+sub _dbh {
+    my $self = shift;
+    return $self->config->{dbh};
+}
+```
+
+Witnesses: the drill emits `Expr(drill_span) → Projected{ base:
+Expression(r_config), step: HashKey("dbh") }`; `Expression(r_config)` carries
+`CallReturn{ MethodOnClass{"My::Worker","config"}, 0 }`; the usual return
+chain hangs off `Symbol(sid)`. Baked:
+
+```
+MethodOnClass{"My::Worker","_dbh"} ↦
+Project { base: Link { target: MethodOnClass{"My::Worker","config"},
+                       arity: Some(0), receiver: Dispatch("My::Worker") },
+          step: HashKey("dbh") }
+```
+
+**Evaluation** (mirrors `registry.rs:895-970`): evaluate `base`; then narrow.
+If `config`'s entry is `Value(HashWithKeys{[("dbh", Some(ClassName("DBI::db"))), …]})`,
+`key_value_type("dbh")` answers `ClassName("DBI::db")` directly. If the base
+evaluates to a *class-typed* value instead (`ClassName("My::Config")`), the
+structural drill can't answer and the evaluator mints a follow-on
+`SlotType{"My::Config","dbh"}` lookup — a fresh key into My::Config's map and
+up its ancestry, exactly the `SlotType` fallback ladder today
+(`registry.rs:929-957` hands off to `registry.rs:640-721`). `ArrayIndex(i)` →
+`element_at(i)`.
+
+**Where it breaks.** A base with no structure axis: bare `HashRef` (rep-only
+evidence) has no per-key types → honest `None`. A dynamic key `->{$k}` never
+emits `Projected` in the first place (constant-folded `$k` does — provenance
+rule 9), so there is nothing to bake and the entry is absent-or-`OpenNone`
+depending on what else the sub returns. `ArrayIndex` on a non-`Sequence` →
+`None` via `element_at`.
+
+## `OpenNone`
+
+**Type.** A unit variant. It means: *this key's local derivation is
+unbakeable — the bag may still answer; decode it.* Deliberately payload-free:
+the *why* lives in ghost-stats counters, not the map.
+
+**Real Perl.** Any path whose fold consumes what the algebra cannot express:
+
+```perl
+package My::App;
+use My::DSL;                     # .rhai plugin pushing Custom payloads
+resource user => ( ... );        # plugin-synthesized entity
+```
+
+If the plugin's emissions put a `Custom { family, json }` payload
+(`types.rs:221`) — or a `Fact` of a family no default fold consumes — on the
+subgraph reachable from `MethodOnClass{"My::App","user"}`, the bake cannot
+reproduce whatever a plugin-registered reducer would do with it. Likewise a
+bake whose own chase hits `QUERY_REC_DEPTH_CAP` (`registry.rs:360-379`): the
+resulting `None` is a truncation, not a verdict, and baking it — or baking
+any answer derived through it — would freeze a degradation. Both cases write:
+
+```
+MethodOnClass{"My::App","user"} ↦ OpenNone
+```
+
+**Evaluation.** Decode the blob (`blob.rs:115-120`), rebuild `BagContext`
+from the rehydrated analysis, run `ReducerRegistry::query`
+(`registry.rs:273`) — today's path, paid per-key. Sibling keys in the same
+file still answer from the map.
+
+**Where it breaks.** `OpenNone` is honest but blunt: it cannot say *how much*
+of the derivation was open, so one `Custom` witness on a hot class's method
+subgraph makes every consult of that key pay full price. And the
+`OpenNone`-vs-absent boundary is where the bake's soundness lives: mislabel a
+should-be-`OpenNone` key as absent and the evaluator serves `None` where the
+bag would have answered — silently. The conservative rule: any doubt at bake
+time (unrecognized payload family, cap hit, any non-default reducer in play)
+writes `OpenNone`, never absence, never a value.
+
+---
+
+## Closure table
+
+Payload kinds (`types.rs:160-247`) against the chase's measured reads
+(2,262 ms / 109,360 cross-file consults; per-payload counts from the hop
+counters at `registry.rs:316-330`):
+
+| payload | reads (all attachments) | subsumed by |
+|---|---|---|
+| `Edge` | 2,166,944 (47.5%) | `Link` when the target is portable; **collapsed at bake** when internal (`Expr`/`Expression`/`Symbol`/`Variable` chains fold into the owning key's form) |
+| `Observation` | 1,298,645 (28.5%) | `Timeline`, via the fold — bake-internal; binder applied at every hop (`registry.rs:807-809`), so nothing persists. Zero `Observation` reads occur at `Expr` attachments — the fact that makes the expression subgraph collapsible |
+| `InferredType` | 554,032 | `Value` |
+| `Fact` | 163,457 | folded at bake (`undef_arm` → `join_return_arms`; `mutation` → shape extension) — no residual form; unrecognized family → `OpenNone` |
+| `CallReturn` | 137,682 | `Link { arity: Some }` |
+| `Projected` | 134,578 | `Project` |
+| `ReturnExpr` | 62,344 | `ReturnOf` (payload verbatim, `eval_return_expr` reused) |
+| `QualifiedCallReturn` | 10,484 | `Link { receiver: Dispatch(receiver_class), arity: Some }` |
+| `Derivation` | — | not a type payload; rename transport walks it in the bag — **unserved residue** |
+| `Custom` | — | `OpenNone` |
+| `DomainCompare` | — | off the flow chase (`Field` axis, human surfaces only) — not served |
+
+## The bake
+
+Runs post-fold, post-finalize, in the persist path beside blob encode
+(`blob.rs:107-110`), on non-degraded analyses only — degraded analyses are
+never persisted at all (`file_analysis/mod.rs:269-277`), so the map inherits
+that gate. The bake's registry runs with `module_index: None`: no cross-file
+value can be materialized, and every fallback that would consult the index
+(`registry.rs:457-769`) residualizes as `Link` instead. Key enumeration:
+the bag's attachment index + symbol names + declared bridges. Degradation
+rules: cap hit or unrecognized payload → `OpenNone`, never the truncated or
+guessed answer.
+
+## Constraints (binding on any implementation)
+
+1. **`MethodSurface::ret` is not this layer** (`surface.rs:62-66`): it is a
+   pre-enrichment LOCAL conclusion, and two providers with different enriched
+   returns project byte-identical Surfaces. Only post-fold conclusions
+   persist, and invalidation rides the blob axis (per-file stamp,
+   `blob.rs:43-55`) — never Surface equality. Enriched answers are never
+   written back.
+2. **Hops cheaper, never fewer.** `Link` preserves every hop; the map never
+   holds a materialized cross-file value. An answer still moves when a
+   provider resolves.
+3. **Reducer changes now change semantics without changing shape.** Any edit
+   to a reducer, to `eval_return_expr`, or to registration order
+   (`registry.rs:218-257`) must bump `EXTRACT_VERSION` (`schema.rs:13`) or a
+   sibling `CONCLUSION_VERSION` in the same gate family (as `REF_ROWS_VERSION`
+   `schema.rs:19` and `STUB_VERSION` `stubs.rs:22` already are).
+4. **Never bake through a degradation** — `QUERY_REC_DEPTH_CAP`, a `degraded`
+   analysis, a truncated chase: `OpenNone` or nothing.
+5. **Unserved residue, permanent:** rename transport and `--dump-package`
+   consume the bag as a data structure, not through the registry — the honest
+   claim is "the type chase never decodes the bag", never "nothing does".
+   `Custom` payloads and non-default reducers are unbakeable by construction
+   (the plugin-fingerprint hard-clear must cover the map). The
+   enriched-overlay retry still decodes and enriches whole provider bags.
+
+## Corrections to the prior draft (code wins)
+
+- The sole `point: Some(..)` construction is **`registry.rs:1042`** (was cited
+  as :1034).
+- The binder-application-at-hop site is **`registry.rs:807-809`** (was
+  :799-801).
+- The temporal gates: the Observation skip is **`reducers.rs:169-173`**
+  inside `FrameworkAwareTypeFold::reduce` (cited as :166-181 — that range now
+  also spans unrelated lines), and the `ReturnExpr` sibling is
+  **`reducers.rs:832-838`**. The five `point: None` sites in
+  `witnesses/query.rs` are lines 39, 68, 109, 199, 309. All verified
+  2026-08-22.
 
 ## Verdict
 
-**Stage 1 — worth building.** Store the bag in its own blob column. One
-schema bump, zero new semantics, and it captures the rows-axis share
-(69.3% of decodes discard the bag; 27.0% of decode time) while making
-`--dump-package`/rename's full decode an explicit second read.
+**Stage 1 — a separate bag blob column — is worth building now.** One schema
+bump, zero new semantics: the bag (56,932,990 bincode / 6,697,721 zstd —
+41.5% of stored bytes, 52.9% of bincode payload) moves to its own column,
+decoded on demand; `--dump-package` and rename's full read become an explicit
+second fetch. It captures the decode-side share by itself and creates the
+measurement seam stage 2 needs.
 
-**Stage 2 — the conclusion layer — only on evidence.** The ceiling is small:
-decode is ~13% of the tail, so eliminating bag decode entirely is worth ~7%,
-and stage 1 already reaches most of what stage 2 would.
-
-One argument for stage 2 needs correcting before anyone leans on it. The
-design cites the provider chase at 61.6% of an enrichment build — that figure
-is superseded. `docs/adr/enrichment-build-cost.md` records the resident-copy
-export gate taking the chase 1,541 -> 240 ms; recomputed, the chase is now
-**~20% of a build, not 61.6%**. The direction of the argument survives (a
-conclusion map makes raw-tier consults near-free, and that share is still
-rehydration-dominated) but its magnitude is three times smaller than stated.
-Re-measure the chase post-stage-1 and let that number decide.
+**Stage 2 — this layer — only on post-stage-1 evidence.** The map lands
+between the flat one-return-per-sub table (534,938 / 276,551 — which does not
+close: 22.7% of `MethodOnClass` queries enter an `Expr`) and the bag;
+estimate low-single-digit MB, verify before committing a schema. The target
+is the compute half — `consult.attempt`'s 2,262 ms is 78% of the removable
+cost and identical cold vs warm — so re-measure that counter once stage 1 and
+the session memo have taken their share, and let the number decide.

--- a/docs/prompt-conclusion-layer.md
+++ b/docs/prompt-conclusion-layer.md
@@ -1,0 +1,109 @@
+# Forward design: a dependent conclusion layer for the witness bag
+
+**Status: designed, closes, NOT recommended for build yet.** Staged, with
+stage 1 cheap and semantics-free and stage 2 gated on a re-measurement.
+
+The bag is the DERIVATION. It is 41.5% of a stored `FileAnalysis` by
+compressed bytes and 52.9% of the bincode payload. The question was whether
+we can persist CONCLUSIONS and load the bag only on demand.
+
+## Measurements this rests on
+
+All from `--check` over the 2,265-module substrate; counters are in-tree
+behind `PERL_LSP_GHOST_STATS`, probes are `#[ignore]`d in
+`index/module_cache/blob.rs`.
+
+Cross-file consult shapes: `MethodOnClass` 106,533 (**96.0%**), `slot_type`
+4,367, `bridged` 42, `imported_sub_return` 5.
+
+A FLAT conclusion layer (one resolved return per sub) does not close it:
+85,952 `MethodOnClass` queries (77.3%) answer without entering an
+`Expr(span)`; 25,201 (22.7%) do. That layer is 534,938 bincode / 276,551
+zstd — 0.9% / 4.1% of the bag.
+
+What the chase reads at `Expr` attachments: `Edge` 446,478, `InferredType`
+180,515, `Projected` 44,901, `ReturnExpr` 25,402, **zero `Observation`**.
+
+What it reads at EVERY attachment: `Edge` 2,166,944 (47.5%), **`Observation`
+1,298,645 (28.5%)**, `InferredType` 554,032, `Fact` 163,457, `CallReturn`
+137,682, `Projected` 134,578, `ReturnExpr` 62,344, `QualifiedCallReturn`
+10,484.
+
+## Why it closes
+
+A conclusion is `query()` partially evaluated over what the file knows,
+leaving free only what it cannot: the query POINT, the RECEIVER, the ARITY,
+and the state of the cross-file world. The first three are bounded and
+residualize as syntax — a dependent conclusion. The fourth is unbounded and
+residualizes only as a LINK. That is the bag's own "edges, not values" rule
+lifted one layer up.
+
+The observations are the crux, and they close for a measured reason. They
+live at `Variable` attachments, where `FrameworkAwareTypeFold` gates them
+temporally (`reducers.rs:166-181`, `:832`) — so a variable's conclusion is
+`λ point. InferredType`, a step function with a breakpoint per witness span.
+
+**And the binder is always applied at bake.** Every hop that enters a
+`Variable` fixes the point AT the hop, from bake-time constants —
+`registry.rs:799-801` uses `Expr(span).start` for edges chased from
+expressions and `scope_point(scope)` otherwise. So composition through a
+variable selects ONE segment, and no cross-file key ever needs an unapplied
+timeline. **Timelines exist in the algebra and never on disk.** That is what
+keeps the layer at conclusion size: persisting them instead would be
+~9-18 MB, 16-32% of the bag, most of the way back to keeping it.
+
+The forms: `Value`, `ReturnOf(ReturnExpr)` (reusing `eval_return_expr`
+verbatim — `ReturnExpr` is ALREADY a dependent conclusion),
+`Timeline` (bake-internal), `Link{target, arity, receiver}` (subsuming
+`Edge`, `CallReturn`, `QualifiedCallReturn`), `Project{base, step}`, and
+`OpenNone`. Estimated ~1.5-2.5 MB bincode, 3-5x the flat map, ~20x under the
+bag — reasoned, not measured; verify before committing a schema.
+
+## The residue, which is real
+
+1. **Rename transport and `--dump-package`** consume the bag as a data
+   structure, not through the registry. No conclusion form serves them. The
+   honest claim is "the TYPE CHASE never decodes the bag", never "nothing
+   does".
+2. **`Custom` payloads / non-default reducers** are unbakeable by
+   construction. The plugin fingerprint's hard-clear must cover the
+   conclusion column, and that is a discipline rather than a shape.
+3. **Enrichment-overlay retries still decode and enrich the whole provider
+   bag**, because enrichment is bag surgery. The layer makes the raw-tier hop
+   cheap and cannot touch the enriched-tier hop.
+
+## Traps
+
+- `MethodSurface::ret` is a PRE-ENRICHMENT local conclusion
+  (`surface.rs:62-66`): two providers with different enriched returns project
+  byte-identical Surfaces. So only post-fold, post-finalize conclusions
+  persist; invalidation rides the blob axis, never the Surface axis; enriched
+  answers are never written back.
+- The chase survives — hops get cheaper, not fewer. An answer still moves
+  when a provider resolves, so the persisted map must never hold a
+  materialized cross-file value.
+- Any reducer change now changes SEMANTICS without changing shape, so it must
+  bump `EXTRACT_VERSION` (or a sibling `CONCLUSION_VERSION` in the same gate
+  family).
+- Never bake through a degradation: a `QUERY_REC_DEPTH_CAP` truncation or a
+  `degraded` analysis must persist `Link`/`OpenNone`, not the short answer.
+
+## Verdict
+
+**Stage 1 — worth building.** Store the bag in its own blob column. One
+schema bump, zero new semantics, and it captures the rows-axis share
+(69.3% of decodes discard the bag; 27.0% of decode time) while making
+`--dump-package`/rename's full decode an explicit second read.
+
+**Stage 2 — the conclusion layer — only on evidence.** The ceiling is small:
+decode is ~13% of the tail, so eliminating bag decode entirely is worth ~7%,
+and stage 1 already reaches most of what stage 2 would.
+
+One argument for stage 2 needs correcting before anyone leans on it. The
+design cites the provider chase at 61.6% of an enrichment build — that figure
+is superseded. `docs/adr/enrichment-build-cost.md` records the resident-copy
+export gate taking the chase 1,541 -> 240 ms; recomputed, the chase is now
+**~20% of a build, not 61.6%**. The direction of the argument survives (a
+conclusion map makes raw-tier consults near-free, and that share is still
+rehydration-dominated) but its magnitude is three times smaller than stated.
+Re-measure the chase post-stage-1 and let that number decide.

--- a/docs/prompt-conclusion-layer.md
+++ b/docs/prompt-conclusion-layer.md
@@ -43,6 +43,29 @@ live at `Variable` attachments, where `FrameworkAwareTypeFold` gates them
 temporally (`reducers.rs:166-181`, `:832`) — so a variable's conclusion is
 `λ point. InferredType`, a step function with a breakpoint per witness span.
 
+**Timelines cannot cross a file boundary, and the code enforces it.** Every
+cross-file entry builds a FRESH query with `point: None` against a context
+rebuilt from the provider's own `scopes`/`packages` (all five sites in
+`witnesses/query.rs`), entering at a point-free `Symbol(sid)`. The asker's
+point is never threaded across the boundary. The single `point: Some(..)`
+construction (`registry.rs:1034`) is the scope-chain walk INSIDE one bag, and
+the `point: q.point` threading is likewise intra-walk.
+
+So an intra-file edge does reference a timeline — that is where the 1.3M
+observation reads are — but no INBOUND edge from another file can name one.
+The portable key set is point-free by design and the reset makes it point-free
+by enforcement, independently. The apparent counterexample is not one:
+enrichment's MCB bridge pushes `Variable → Edge(MethodOnClass)`, a
+consumer-local variable pointing OUTWARD at a foreign symbol. Nothing outside
+ever names that variable.
+
+That is a stronger property than the composition argument below, and it is the
+one that matters for thrash: the only consumer of an UNAPPLIED timeline is
+`inferred_type_via_bag(var, point)` — hover / inlay / completion on a file the
+user has open, where the bag is resident anyway. Leaving timelines to the full
+bag decode therefore costs nothing, because the on-demand decode never fires
+for timeline reasons on a closed provider.
+
 **And the binder is always applied at bake.** Every hop that enters a
 `Variable` fixes the point AT the hop, from bake-time constants —
 `registry.rs:799-801` uses `Expr(span).start` for edges chased from

--- a/docs/prompt-conclusion-layer.md
+++ b/docs/prompt-conclusion-layer.md
@@ -495,6 +495,53 @@ guessed answer.
   `witnesses/query.rs` are lines 39, 68, 109, 199, 309. All verified
   2026-08-22.
 
+## Invalidation must be structural, not remembered
+
+A baked conclusion introduces a staleness class the bag does not have: a
+reducer edit changes what the right answer IS while the stored bytes stay
+well-formed. Nothing catches that except someone remembering to bump a
+version, and a plausible-but-wrong answer maintained by discipline is the
+failure shape this codebase keeps paying for.
+
+**Prerequisite, measured: the fold is deterministic.** A fingerprint is
+worthless if the baked answer can differ from the live answer on identical
+code. `--dump-package` over the substrate, five packages, three warm runs
+each plus a cold run against a fresh cache dir: byte-identical every time,
+cold matching warm, across ~330 KB of dumped conclusions including Catalyst
+(145 KB) and Type::Tiny (109 KB), which are the heaviest cross-file candidate
+iterations available. Nothing in the fold depends on map iteration order —
+unlike completion's ranking, which did.
+
+**The fingerprint.** Conclusions get their own version, derived rather than
+maintained: a `build.rs` hashes the derivation sources into a compile-time
+constant, and the cache checks it exactly as it already checks the plugin
+fingerprint over `.rhai` files. There is no `build.rs` today; this is what it
+would be for.
+
+Do not try to enumerate "the files that can change a fold's outcome". The
+core is `model/witnesses/**`, but the fold calls into `InferredType`'s
+methods, `conventions.rs`, and the framework tables, and that boundary is
+fuzzy — a fuzzy boundary is the same discipline problem one level down. Hash
+the whole source tree. Over-invalidation is the safe direction, and it is
+nearly free here for a reason worth stating: **the conclusion version is
+independent of `EXTRACT_VERSION`.** A source change drops the conclusion
+column and KEEPS the blobs, so the next run re-bakes by decoding blobs it
+already has — one decode per file, once, which is precisely the cost stage 1
+reduces. The two stages compose.
+
+## Absence must not mean an answer
+
+The three-way lookup — a form, `OpenNone`, or absent — makes "absent" a
+definite `None`, which is sound only while key enumeration is complete. That
+is another correctness precondition maintained by discipline.
+
+Make absent mean DECODE THE BAG. A definite negative is then only ever an
+explicitly stored one, and an unenumerated key costs a decode instead of
+returning a wrong answer. When the enumeration is right this costs nothing;
+when it is wrong the layer is slow instead of incorrect, which is the trade
+to take. It also removes the burden entirely from anyone adding a key shape
+later.
+
 ## Verdict
 
 **Stage 1 — a separate bag blob column — is worth building now.** One schema

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -423,3 +423,129 @@ pub fn save_to_db(
     }
     ok
 }
+
+#[cfg(test)]
+mod bag_share_probe {
+    //! What share of a stored FileAnalysis is the witness bag?
+    //!
+    //! `rows_for_diag` decodes the whole blob and then strips the bag, so a
+    //! rows-axis reader pays zstd + bincode for a lane it discards. That is
+    //! only worth acting on if the bag is a large share of the BYTES, and
+    //! only in the population whose decodes actually cost — so this reports
+    //! the DISTRIBUTION by blob size, never a corpus mean. A mean would
+    //! average a few giant analyses into thousands of tiny ones and say the
+    //! opposite of what the giants do.
+    //!
+    //! `cargo test --release bag_share -- --ignored --nocapture`
+    use crate::model::file_analysis::FileAnalysis;
+
+    #[test]
+    #[ignore]
+    fn probe_bag_share_of_stored_bytes() {
+        let root = std::path::Path::new("gold-corpus/local/lib/perl5");
+        if !root.is_dir() {
+            eprintln!("substrate absent — skipping");
+            return;
+        }
+        let mut files: Vec<std::path::PathBuf> = Vec::new();
+        collect_pm(root, &mut files, 0);
+        files.sort();
+        // The single-point grammar accessor — `layering_tests` forbids
+        // naming the grammar outside the builder, and it is right to.
+        let mut parser = crate::build::builder::create_parser();
+
+        // (zstd bytes whole, zstd bytes bagless, bincode whole, bincode bagless)
+        let mut rows: Vec<(usize, usize, usize, usize)> = Vec::new();
+        for path in files.iter() {
+            let Ok(src) = std::fs::read_to_string(path) else { continue };
+            if src.len() > 1_000_000 {
+                continue;
+            }
+            let Some(tree) = parser.parse(&src, None) else { continue };
+            let fa = crate::build::builder::build(&tree, src.as_bytes());
+            let mut bagless = fa.clone();
+            bagless.witnesses = Default::default();
+            let (Some(w), Some(b)) = (
+                super::encode_analysis(&fa),
+                super::encode_analysis(&bagless),
+            ) else {
+                continue;
+            };
+            let bw = bincode::serialize(&fa).map(|v| v.len()).unwrap_or(0);
+            let bb = bincode::serialize(&bagless).map(|v| v.len()).unwrap_or(0);
+            rows.push((w.len(), b.len(), bw, bb));
+        }
+        assert!(!rows.is_empty(), "no analyses built");
+
+        // Bucketed by STORED size, because the decode cost that matters
+        // tracks blob size and the two populations behave differently.
+        let buckets: [(&str, usize, usize); 5] = [
+            ("   <4 KB", 0, 4 * 1024),
+            (" 4-16 KB", 4 * 1024, 16 * 1024),
+            ("16-64 KB", 16 * 1024, 64 * 1024),
+            ("64-256KB", 64 * 1024, 256 * 1024),
+            ("  >256KB", 256 * 1024, usize::MAX),
+        ];
+        println!("\n{} analyses, sizes are the STORED (zstd) blob\n", rows.len());
+        println!("{:<9} {:>6} {:>12} {:>10} {:>10}", "bucket", "n", "zstd bytes", "bag% zstd", "bag% bin");
+        let mut tot_w = 0usize;
+        let mut tot_b = 0usize;
+        for (label, lo, hi) in buckets {
+            let sel: Vec<_> = rows.iter().filter(|r| r.0 >= lo && r.0 < hi).collect();
+            if sel.is_empty() {
+                continue;
+            }
+            let zw: usize = sel.iter().map(|r| r.0).sum();
+            let zb: usize = sel.iter().map(|r| r.1).sum();
+            let bw: usize = sel.iter().map(|r| r.2).sum();
+            let bb: usize = sel.iter().map(|r| r.3).sum();
+            tot_w += zw;
+            tot_b += zb;
+            println!(
+                "{:<9} {:>6} {:>12} {:>9.1}% {:>9.1}%",
+                label, sel.len(), zw,
+                100.0 * (zw - zb) as f64 / zw as f64,
+                100.0 * (bw - bb) as f64 / bw as f64,
+            );
+        }
+        let tot_bw: usize = rows.iter().map(|r| r.2).sum();
+        let tot_bb: usize = rows.iter().map(|r| r.3).sum();
+        println!(
+            "\nwhole corpus: {} zstd bytes, bag is {:.1}% of them",
+            tot_w, 100.0 * (tot_w - tot_b) as f64 / tot_w as f64
+        );
+        // The stage that costs most is bincode deserialize, and it works on
+        // the UNCOMPRESSED bytes — so this, not the zstd share, is the bag's
+        // share of the expensive half.
+        println!(
+            "              {} bincode bytes, bag is {:.1}% of them",
+            tot_bw, 100.0 * (tot_bw - tot_bb) as f64 / tot_bw as f64
+        );
+        // Where the BYTES live, which is where the decode seconds live.
+        let mut by_size: Vec<_> = rows.clone();
+        by_size.sort_by_key(|r| std::cmp::Reverse(r.0));
+        let top: usize = (rows.len() / 100).max(1);
+        let top_w: usize = by_size[..top].iter().map(|r| r.0).sum();
+        let top_b: usize = by_size[..top].iter().map(|r| r.1).sum();
+        println!(
+            "largest 1% ({} files): {:.1}% of all stored bytes, bag is {:.1}% of them",
+            top, 100.0 * top_w as f64 / tot_w as f64,
+            100.0 * (top_w - top_b) as f64 / top_w as f64
+        );
+    }
+
+    fn collect_pm(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>, depth: u32) {
+        if depth > 12 {
+            return;
+        }
+        let Ok(rd) = std::fs::read_dir(dir) else { return };
+        for e in rd.filter_map(|e| e.ok()) {
+            let p = e.path();
+            if p.is_dir() {
+                collect_pm(&p, out, depth + 1);
+            } else if p.extension().map(|x| x == "pm").unwrap_or(false) {
+                out.push(p);
+            }
+        }
+    }
+}

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -534,7 +534,82 @@ mod bag_share_probe {
         );
     }
 
-    fn collect_pm(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>, depth: u32) {
+
+    /// How big is the CONCLUSION layer next to the derivation it would
+    /// replace?
+    ///
+    /// The conclusion measured here is the POST-FOLD one — the resolved
+    /// return per sub, taken through the same registry path a query uses —
+    /// not `MethodSurface::ret`, which is projected with no module index and
+    /// is therefore the pre-enrichment answer. Two providers with different
+    /// enriched returns project byte-identical surfaces, so persisting that
+    /// one would store a value the query does not agree with.
+    ///
+    /// This is a floor on the layer's size, not the whole design: it does not
+    /// carry the `ReturnExpr` SHAPES (`Receiver`, `ReceiverPolymorphic`),
+    /// where the conclusion is "returns its invocant" rather than a value —
+    /// a handful of bytes each, but they must be represented, so the real
+    /// layer is somewhat larger than this.
+    #[test]
+    #[ignore]
+    fn probe_conclusion_layer_size() {
+        use crate::model::file_analysis::SymKind;
+        let root = std::path::Path::new("gold-corpus/local/lib/perl5");
+        if !root.is_dir() {
+            eprintln!("substrate absent — skipping");
+            return;
+        }
+        let mut files: Vec<std::path::PathBuf> = Vec::new();
+        super::bag_share_probe::collect_pm(root, &mut files, 0);
+        files.sort();
+        let mut parser = crate::build::builder::create_parser();
+        let (mut bag_z, mut concl_z, mut bag_b, mut concl_b) = (0usize, 0usize, 0usize, 0usize);
+        let (mut subs, mut typed) = (0usize, 0usize);
+        for path in files.iter() {
+            let Ok(src) = std::fs::read_to_string(path) else { continue };
+            if src.len() > 1_000_000 {
+                continue;
+            }
+            let Some(tree) = parser.parse(&src, None) else { continue };
+            let fa = crate::build::builder::build(&tree, src.as_bytes());
+            let concl: Vec<(String, Option<crate::model::file_analysis::InferredType>)> = fa
+                .symbols()
+                .iter()
+                .filter(|s| matches!(s.kind, SymKind::Sub | SymKind::Method))
+                .map(|s| {
+                    let t = fa.sub_return_type_at_arity(&s.name, None);
+                    (s.name.clone(), t)
+                })
+                .collect();
+            subs += concl.len();
+            typed += concl.iter().filter(|(_, t)| t.is_some()).count();
+            let (Ok(cb), Ok(bb)) = (
+                bincode::serialize(&concl),
+                bincode::serialize(&fa.witnesses),
+            ) else {
+                continue;
+            };
+            let (Some(cz), Some(bz)) = (
+                zstd::encode_all(cb.as_slice(), super::ZSTD_LEVEL).ok(),
+                zstd::encode_all(bb.as_slice(), super::ZSTD_LEVEL).ok(),
+            ) else {
+                continue;
+            };
+            concl_b += cb.len();
+            bag_b += bb.len();
+            concl_z += cz.len();
+            bag_z += bz.len();
+        }
+        println!("\nsubs: {subs}, of which the fold gives a return type: {typed} ({:.1}%)",
+                 100.0 * typed as f64 / subs.max(1) as f64);
+        println!("bag        : {bag_b:>10} bincode  {bag_z:>9} zstd");
+        println!("conclusions: {concl_b:>10} bincode  {concl_z:>9} zstd");
+        println!("conclusions are {:.1}% of the bag by bincode, {:.1}% by zstd",
+                 100.0 * concl_b as f64 / bag_b.max(1) as f64,
+                 100.0 * concl_z as f64 / bag_z.max(1) as f64);
+    }
+
+    pub(super) fn collect_pm(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>, depth: u32) {
         if depth > 12 {
             return;
         }

--- a/src/index/pack_bag_cache.rs
+++ b/src/index/pack_bag_cache.rs
@@ -166,6 +166,17 @@ impl PackBagCache {
         if let Some(g) = &self.ghost {
             g.on_miss(&path.to_string_lossy());
         }
+        // The axis of an actual DECODE. Deliberately here and NOT at
+        // `rehydrate_axes_or_resident`, which is where the `want_bag`
+        // parameter lives and where it is tempting to count: at a 99.2% hit
+        // rate that denominator is 1.66M lookups against 14.8k decodes, and
+        // it answers 84% rows-axis where the decodes say 69%. Only a decode
+        // can waste anything, so only decodes are counted.
+        crate::util::ghost_stats::count(if want_bag {
+            "decode.want_bag"
+        } else {
+            "decode.rows_only"
+        });
         let gen_before = self.generation.get(path).map(|g| *g).unwrap_or(0);
         let mut loaded = crate::util::ghost_stats::timed(
             "bagcache.decode", || (self.loader)(path))?;

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -194,6 +194,12 @@ const QUERY_REC_DEPTH_CAP: u32 = 512;
 const QUERY_REC_DEPTH_CAP: u32 = 256;
 
 thread_local! {
+    /// Set when an edge chase reads an `Expr(span)` attachment — the marker
+    /// for "this answer needed the raw derivation, not just a conclusion".
+    static TOUCHED_EXPR: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+thread_local! {
     static QUERY_REC_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
     /// One-shot so we don't flood stderr while a deep walk unwinds.
     static QUERY_REC_DEPTH_WARNED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -266,9 +272,27 @@ impl ReducerRegistry {
     /// mutual-inheritance loops that span files.
     pub fn query(&self, bag: &WitnessBag, q: &ReducerQuery) -> ReducedValue {
         let mut state = QueryState::new();
+        // Is the CONCLUSION LAYER CLOSED for the shape that dominates
+        // cross-file traffic? A `MethodOnClass` answer that never reads an
+        // `Expr(span)` witness could be served from stored conclusions; one
+        // that does needs the raw derivation, so the bag has to come along.
+        // Measured at the top-level query only — inner hops are the thing
+        // being counted, not separate questions.
+        let top_moc = matches!(q.attachment, WitnessAttachment::MethodOnClass { .. });
+        if top_moc {
+            TOUCHED_EXPR.with(|c| c.set(false));
+        }
         // Sole boundary where an owned `ReducedValue` is required; the
         // internal recursion threads `Arc` to avoid deep clones per hop.
-        (*self.query_rec(bag, q, &mut state)).clone()
+        let out = (*self.query_rec(bag, q, &mut state)).clone();
+        if top_moc {
+            crate::util::ghost_stats::count(if TOUCHED_EXPR.with(|c| c.get()) {
+                "moc.touched_expr"
+            } else {
+                "moc.conclusions_only"
+            });
+        }
+        out
     }
 
     /// Returns an `Arc` so the memo, the cycle-guard early-outs, and the
@@ -281,6 +305,12 @@ impl ReducerRegistry {
         q: &ReducerQuery,
         state: &mut QueryState,
     ) -> std::sync::Arc<ReducedValue> {
+        // The chase has landed on a raw-derivation attachment. Whatever the
+        // top-level question was, its answer now depends on the bag's
+        // observations rather than on any conclusion we could have stored.
+        if matches!(q.attachment, WitnessAttachment::Expr(_)) {
+            TOUCHED_EXPR.with(|c| c.set(true));
+        }
         let depth = QUERY_REC_DEPTH.with(|c| {
             let d = c.get();
             c.set(d + 1);

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -308,8 +308,49 @@ impl ReducerRegistry {
         // The chase has landed on a raw-derivation attachment. Whatever the
         // top-level question was, its answer now depends on the bag's
         // observations rather than on any conclusion we could have stored.
+        // Closure test proper: what does the chase read at EVERY attachment
+        // it enters, not just the `Expr` ones. An `Edge` is only expressible
+        // as a conclusion if what it points at is too, transitively — so an
+        // `Observation` anywhere in the walk is what would make the layer
+        // genuinely open.
+        for w in bag.for_attachment(&q.attachment) {
+            crate::util::ghost_stats::count(match &w.payload {
+                WitnessPayload::Observation(_) => "hop.OBSERVATION",
+                WitnessPayload::InferredType(_) => "hop.inferred_type",
+                WitnessPayload::Edge(_) => "hop.edge",
+                WitnessPayload::CallReturn { .. } => "hop.call_return",
+                WitnessPayload::QualifiedCallReturn { .. } => "hop.qualified_call",
+                WitnessPayload::ReturnExpr(_) => "hop.return_expr",
+                WitnessPayload::Fact { .. } => "hop.fact",
+                WitnessPayload::Derivation => "hop.derivation",
+                WitnessPayload::Custom { .. } => "hop.custom",
+                WitnessPayload::Projected { .. } => "hop.projected",
+                _ => "hop.other",
+            });
+        }
         if matches!(q.attachment, WitnessAttachment::Expr(_)) {
             TOUCHED_EXPR.with(|c| c.set(true));
+            // WHY the chase needs the raw derivation here. If these land in a
+            // few recurring payload shapes, each is a candidate for a
+            // PARAMETERISED conclusion (`ReturnExpr::Receiver` already is
+            // one — "returns its invocant", a function of the query rather
+            // than a value). If they are spread across everything, the
+            // derivation is genuinely open and no conclusion layer closes it.
+            for w in bag.for_attachment(&q.attachment) {
+                crate::util::ghost_stats::count(match &w.payload {
+                    WitnessPayload::InferredType(_) => "expr_hop.inferred_type",
+                    WitnessPayload::Observation(_) => "expr_hop.observation",
+                    WitnessPayload::Edge(_) => "expr_hop.edge",
+                    WitnessPayload::CallReturn { .. } => "expr_hop.call_return",
+                    WitnessPayload::QualifiedCallReturn { .. } => "expr_hop.qualified_call",
+                    WitnessPayload::ReturnExpr(_) => "expr_hop.return_expr",
+                    WitnessPayload::Fact { .. } => "expr_hop.fact",
+                    WitnessPayload::Derivation => "expr_hop.derivation",
+                    WitnessPayload::Custom { .. } => "expr_hop.custom",
+                    WitnessPayload::Projected { .. } => "expr_hop.projected",
+                    _ => "expr_hop.other",
+                });
+            }
         }
         let depth = QUERY_REC_DEPTH.with(|c| {
             let d = c.get();

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -507,7 +507,19 @@ impl ReducerRegistry {
                             break;
                         }
                         crate::util::ghost_stats::count("moc.provider_fetched");
-                        let full = idx.bag_present(cached);
+                        // The three costs of one cross-file consult, split
+                        // because a conclusion layer would remove the first
+                        // two and CANNOT remove the third (enrichment is bag
+                        // surgery). Sizing stage 2 means knowing which is
+                        // which, not the total.
+                        //
+                        // These NEST over the `decode.*` stage split rather
+                        // than restating it: a miss here descends through
+                        // `bagcache.decode` into `decode.2_zstd`/`3_bincode`.
+                        // Summing a `consult.*` against a `decode.*` term
+                        // double-counts the same microseconds.
+                        let full = crate::util::ghost_stats::timed(
+                            "consult.bag_present", || idx.bag_present(cached));
                         if std::ptr::eq(bag, &full.witnesses) {
                             // Self: the reducers above already tried this bag.
                             // Not an answer about the candidate, so nothing to
@@ -515,7 +527,8 @@ impl ReducerRegistry {
                             continue;
                         }
                         let v = {
-                            let v = attempt(&full, state);
+                            let v = crate::util::ghost_stats::timed(
+                                "consult.attempt", || attempt(&full, state));
                             crate::util::ghost_stats::count(if v == ReducedValue::None {
                                 "moc.provider_no_answer"
                             } else {
@@ -529,7 +542,8 @@ impl ReducerRegistry {
                             // invisible to the raw bag, present in the
                             // enriched overlay.
                             crate::util::ghost_stats::count("consult.moc_primary");
-                            let enriched = idx.enriched_present(cached);
+                            let enriched = crate::util::ghost_stats::timed(
+                                "consult.enriched", || idx.enriched_present(cached));
                             if !std::sync::Arc::ptr_eq(&enriched, &full)
                                 && !std::ptr::eq(bag, &enriched.witnesses)
                             {

--- a/src/model/witnesses/witnesses_tests.rs
+++ b/src/model/witnesses/witnesses_tests.rs
@@ -1056,3 +1056,106 @@ fn isa_chain(n: usize) -> String {
     src.push_str(&format!("package C{}; sub target {{ return \"hi\" }}\n", n - 1));
     src
 }
+
+/// The fold must not depend on map iteration order — a gate, not a note.
+///
+/// Today nothing relies on this. Once conclusions are baked into the cache
+/// (`docs/prompt-conclusion-layer.md`) it becomes a correctness precondition:
+/// a fold that varies by iteration order produces a stale answer that
+/// MATCHES ITS OWN FINGERPRINT, which is a perfect mechanism protecting a
+/// broken premise. So it fails a build here instead.
+///
+/// The lever is that `RandomState` seeds per instance, so two independently
+/// built analyses of the same source carry maps with different iteration
+/// orders. That makes this probabilistic per source and reliable across the
+/// set — which is why the vacuity guard below matters more than it looks:
+/// if seeding ever stops varying, this test would pass by construction while
+/// checking nothing, and it says so instead.
+///
+/// Scope honestly: this observes no order dependence on the fold paths
+/// exercised below. It is not a proof over all Perl.
+#[test]
+fn the_fold_does_not_depend_on_map_iteration_order() {
+    use std::collections::HashMap;
+
+    // Vacuity guard. Two same-content maps must disagree about iteration
+    // order, or the comparison below proves nothing.
+    let order_of = || {
+        let m: HashMap<u32, u32> = (0..64u32).map(|i| (i, i)).collect();
+        m.keys().copied().collect::<Vec<_>>()
+    };
+    let mut seeds_vary = false;
+    for _ in 0..8 {
+        if order_of() != order_of() {
+            seeds_vary = true;
+            break;
+        }
+    }
+    assert!(
+        seeds_vary,
+        "two independently built HashMaps iterated identically 8 times — \
+         map seeding no longer varies per instance, so this test cannot \
+         detect order dependence and must be rewritten rather than trusted"
+    );
+
+    // One source per fold path that could plausibly read a map: framework
+    // accessor synthesis, branch-arm agreement, arity discrimination,
+    // inheritance, and a structural projection.
+    let sources: &[(&str, &str)] = &[
+        ("moo accessors", "package W;\nuse Moo;\nhas name => (is => 'ro', isa => sub {});\n\
+                           has size => (is => 'rw');\nsub go { my $s = shift; return $s->name }\n1;\n"),
+        ("branch arms", "package B;\nsub pick { my $c = shift;\n  if ($c) { return 'x' } else { return 'y' }\n}\n\
+                         sub num { return 1 + 1 }\n1;\n"),
+        ("arity union", "package A;\nsub acc { my $s = shift; if (@_) { return $s } return $s->{v} }\n\
+                         sub go { my $s = shift; return $s->acc(1) }\n1;\n"),
+        ("inheritance", "package P;\nsub make { my $c = shift; return bless {}, $c }\n\
+                         package C;\nour @ISA = ('P');\nsub run { my $s = shift; return $s->make }\n1;\n"),
+        ("projection", "package H;\nsub cfg { return { host => 'h', port => 1 } }\n\
+                        sub go { my $s = shift; my $c = $s->cfg; return $c->{host} }\n1;\n"),
+    ];
+
+    // Every sub's resolved return, sorted by name so the COMPARISON is over
+    // values rather than over output ordering — output ordering is not the
+    // property under test.
+    let conclusions = |src: &str| -> Vec<(String, String)> {
+        let mut parser = crate::build::builder::create_parser();
+        let tree = parser.parse(src, None).expect("parse");
+        let fa = crate::build::builder::build(&tree, src.as_bytes());
+        let mut out: Vec<(String, String)> = fa
+            .symbols()
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.kind,
+                    crate::model::file_analysis::SymKind::Sub
+                        | crate::model::file_analysis::SymKind::Method
+                )
+            })
+            .map(|s| {
+                let t = fa.sub_return_type_at_arity(&s.name, None);
+                (s.name.clone(), format!("{t:?}"))
+            })
+            .collect();
+        out.sort();
+        out
+    };
+
+    for (label, src) in sources {
+        let first = conclusions(src);
+        assert!(
+            !first.is_empty(),
+            "{label}: no subs resolved, so this source exercises nothing"
+        );
+        // Several rounds: each build re-seeds, so a dependence that only
+        // shows on some orderings still surfaces.
+        for round in 0..6 {
+            let again = conclusions(src);
+            assert_eq!(
+                first, again,
+                "{label}: the fold gave a different answer on round {round} \
+                 with identical input — an iteration-order dependence, which \
+                 makes a baked conclusion unsound"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Nine commits: seven of measurement and design for a **conclusion layer** in the cache, and one that turns a property that layer would depend on into a build gate.

**The gate is the headline.** Read `35fcb1d` first — it is the only commit here that changes what a build does.

## What the gate guards is not a wrong fold — it is a right one, stale

`witnesses_tests::the_fold_does_not_depend_on_map_iteration_order`.

Today nothing depends on the fold being stable across runs. Once conclusions are baked into the cache it becomes a correctness precondition, and the failure has a shape that is easy to lose: an order-dependent fold produces a stale answer **that matches its own fingerprint**. The invalidation mechanism keeps working perfectly, forever, while protecting a broken premise. Nothing downstream catches that, because everything downstream is checking the mechanism and the mechanism is fine. That is why it is a gate and not a paragraph in the design doc.

The lever is that `RandomState` seeds per instance, so two independently built analyses of one source carry maps that iterate differently. Five sources — Moo accessor synthesis, branch-arm agreement, arity discrimination, inheritance, structural projection — six rounds each, compared on name-sorted `sub_return_type_at_arity` so the comparison is over values and not over output ordering.

## The vacuity guard is the part not to skim

The test's validity rests on that seeding varying per instance. Nobody controls that: it is an environmental property of the standard library, and it could stop being true without anyone noticing. If it did, this test would pass by construction while checking nothing — which is the same disease as the bug it guards, one level up in the instrument.

So it asserts its own premise. Two same-content `HashMap`s must disagree about iteration order within 8 tries, and if they don't it fails saying the test "must be rewritten rather than trusted" rather than quietly going green.

Both assertions are mutation-verified to fire by name:

| mutation | assertion that fires |
|---|---|
| fold made order-dependent (collect into a `HashMap` rather than sorting) | `moo accessors: the fold gave a different answer on round 0 with identical input` |
| seeding made invariant | `two independently built HashMaps iterated identically 8 times — map seeding no longer varies per instance` |

## The claim is deliberately weaker than what I could have written

The doc says "no iteration-order dependence observed where measured", not "the fold is deterministic", with the reason stated inline: five packages of one substrate is a sample, not a proof, and the stronger sentence is the one a later reader stops checking behind.

It also records that `DBIx::Class::ResultSet` dumped **zero bytes** — it is absent from the substrate, so it was never a pass. A zero sitting in a results table reads as a pass to every later reader, which is why it is now labelled not-a-data-point.

## Instrumentation: what I kept after #148, and why

Rebased onto `97089f5`. #148 and this branch both added instruments to the cross-file consult path, so rather than resolve mechanically I checked what each one answers.

**Kept all three `consult.*` timers, and added a nesting warning.** They are not duplicates of #148's `decode.*` split — they **nest over** it. A `consult.bag_present` miss descends through `bagcache.decode` into `decode.2_zstd`/`3_bincode`. The magnitudes confirm it rather than the reading: on one `--check`, `consult.bag_present` is 369.5 ms against `bagcache.decode`'s 2,065.5 ms, because the consult path is a slice of all decode traffic, not the whole of it. The hazard is real but it is summation, not double-counting, so the comment at the site now says explicitly that adding a `consult.*` to a `decode.*` term double-counts the same microseconds.

**`consult.attempt` is the one that earns its place outright** — 1,822 ms against 369.5 ms of fetch. Nothing in #148's set isolates the chase from the fetch, and that ratio is the whole 78%-is-compute finding.

**`consult.enriched` (97.8 ms) stays as the third term of a partition.** #148 has `enriched_snapshot.hit`/`build`/`decline` counters, but those are counts, not time. A two-of-three split invites a reader to assume the remainder is zero.

**#148's `moc.provider_*` counters are kept alongside, not replaced.** They landed on the same two lines as my timers, but a count and a duration are different quantities: how many provider fetches answered vs how long fetching took. Both survive the resolution.

**One correction to the merge brief I was given:** `rehydrate.by.bag_present` / `rehydrate.by.refs_present` were described as possibly duplicating `consult.bag_present`. They are not in the merged tree — `git grep rehydrate.by` on `97089f5` is empty — so there was nothing to deduplicate against. Flagging it because a phantom overlap is as easy to act on as a real one.

## The other eight commits

Measurement and design only — no behaviour change, all instrumentation inert unless `PERL_LSP_GHOST_STATS` is set, both probes `#[ignore]`d.

- `bcc6f43`-equivalent — a rows-axis decode throws away 27% of the work it just did. **This number has since been collected by #148 — see the note below.**
- the conclusion layer is not closed; the chase reads 1.3M raw observations and they are all temporal.
- the dependent-conclusion algebra closes, and is still not worth building; a timeline cannot cross a file boundary.
- **the win is compute, not decode.** The consult split is `consult.attempt` against `consult.bag_present` + `consult.enriched`: 78% compute, and cache-independent. This inverted the brief I started from.
- the spec, and why its invalidation can be structural (a `build.rs` hashes the derivation sources, so the conclusion version is derived rather than maintained, and absence means decode rather than an answer).

### The 27% is now ~3.5%, and #148 is why

The rows-axis measurement in this branch argued for a separate bag blob column. Re-baselined on the post-#148 tip, same `--check` over the same 3,336-file substrate:

| | pre-#148 | post-#148 |
|---|---|---|
| `decode.rows_only` | 11,983 | **364** |
| `decode.want_bag` | 4,516 | 3,660 |
| rows-only share of decodes | 72.6% | **9.0%** |
| `bagcache.decode` | 7,955 ms | 2,066 ms |
| `rehydrate.loader` | 12,141 ms | 2,753 ms |

The column only ever saved work on rows-only decodes — a `want_bag` decode needs the bag regardless. At 9.0% of a 2,066 ms total, the recovered time is on the order of **40 ms**, against a schema migration. That is not worth building.

The byte shares themselves did not move and reproduce exactly (41.5% of stored bytes, 52.9% of the uncompressed bytes bincode walks). The earlier 27% was not a measurement error — it was a correct product whose population term then shrank 97% underneath it. Keying the typeglob-install lookup by class collected that win, which is a better outcome than the column would have been.

## Verification

Full bar on the rebased tip (`97089f5`):

- `cargo test --features cpp` — 1592 passed, 0 failed
- `cargo test` — 1528 passed, 0 failed
- `gold-corpus/run.pl` (release, `--features cpp`) — PASS 502, xfail 16, FAIL 0, XPASS 0, CRASH 0, **lang-skip 0**
- `./e2e/run.sh` (nvim 0.11.0) — 113 passed, 0 failed across 10 suites

## One note on shape

This is one PR rather than the gate split out onto its own branch, which would have read better. My standing instructions restrict me to a single designated branch, and that is not something I will work around on a peer's say-so. The gate is `35fcb1d` and stands alone in the diff; the only reason it cannot be its own base is that its doc hunk edits a file the earlier commits create.