### PR TITLE
The witness bag gets its own blob column: 28.6% off average decode cost on the backward walk

### DIFF
--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -103,10 +103,115 @@ pub(super) fn closure_stamp(
     acc as i64
 }
 
-/// Serialize FileAnalysis via bincode then compress with zstd.
-pub fn encode_analysis(fa: &FileAnalysis) -> Option<Vec<u8>> {
-    let bin = bincode::serialize(fa).ok()?;
-    zstd::encode_all(bin.as_slice(), ZSTD_LEVEL).ok()
+/// A stored analysis, split into the lane every reader needs and the lane
+/// most readers throw away.
+///
+/// The two halves travel together so a writer cannot persist one without the
+/// other: a row whose `analysis` is post-split but whose `bag` never landed
+/// would answer every type query with an empty bag — absence read as an
+/// answer, which is the failure this whole storage layer is arranged to
+/// prevent.
+pub struct EncodedAnalysis {
+    /// The analysis with its witness bag taken out.
+    pub analysis: Vec<u8>,
+    /// The witness bag alone. NEVER empty for a row this code writes — the
+    /// `bag IS NULL` test is how a reader tells a pre-split row (bag inline
+    /// in `analysis`) from a post-split one, so an empty encoding here would
+    /// silently make a new row look old. `zstd` always emits a frame header,
+    /// and `encoded_bag_is_never_empty` pins it.
+    pub bag: Vec<u8>,
+}
+
+impl EncodedAnalysis {
+    /// Total stored size, for the writers' byte accounting.
+    pub fn len(&self) -> usize {
+        self.analysis.len() + self.bag.len()
+    }
+
+    /// Re-decode both halves into the analysis they came from.
+    ///
+    /// For the bulk writers' failure recovery: a chunk that failed to commit
+    /// leaves its resident copies stripped with no committed blob to
+    /// rehydrate from, so the in-hand encoding is the only remaining source
+    /// and it must come back WHOLE — a bag-less recovery would pin a copy
+    /// that answers every type query with silence.
+    pub fn decode_whole(&self) -> Option<FileAnalysis> {
+        decode_analysis_parts(&self.analysis, Some(&self.bag), true)
+    }
+}
+
+/// Serialize FileAnalysis via bincode then compress with zstd, splitting the
+/// witness bag into its own blob.
+///
+/// The split is why: a refs/symbols reader decodes `analysis` alone, and the
+/// bag is 52.9% of the uncompressed bytes bincode would otherwise walk. On
+/// the backward-walk workloads that own this path (references, rename,
+/// documentHighlight, callHierarchy incoming, heatmap fan-in) 94.9% of
+/// decodes want no bag at all.
+pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
+    // Split off the bag by value: `bincode` has no field-skipping hook, so
+    // the alternative is serializing a clone of the whole analysis. The bag
+    // goes back before this returns, so `fa` is observably unchanged.
+    let mut owned;
+    let (bagless, bag) = {
+        owned = fa.clone();
+        let bag = std::mem::take(&mut owned.witnesses);
+        (&owned, bag)
+    };
+    let bin = bincode::serialize(bagless).ok()?;
+    let analysis = zstd::encode_all(bin.as_slice(), ZSTD_LEVEL).ok()?;
+    let bag_bin = bincode::serialize(&bag).ok()?;
+    let bag = zstd::encode_all(bag_bin.as_slice(), ZSTD_LEVEL).ok()?;
+    debug_assert!(!bag.is_empty(), "an empty bag blob would read as a pre-split row");
+    Some(EncodedAnalysis { analysis, bag })
+}
+
+/// Decompress + deserialize an analysis blob, installing `bag` when the
+/// caller wants the witness lane.
+///
+/// Row format is NOT inferred here. Pre-split rows carry their bag inside
+/// `analysis` and would be indistinguishable from a post-split row whose bag
+/// column went missing — both arrive as a `None` bag over an analysis with no
+/// witnesses, one benign and one an invariant break. `EXTRACT_VERSION` is
+/// bumped for the split and every reader filters on it, so a row reaching
+/// this function is always post-split and the ambiguity does not exist.
+///
+/// A `None` bag therefore means exactly one of two things:
+///
+///   * `want_bag` false — the caller never fetched the column. Mark the
+///     analysis bag-EVICTED so a later type query rehydrates rather than
+///     reading an empty bag as "no type facts".
+///   * `want_bag` true — the column was NULL on a row that must have one.
+///     Same marker, because degrading honestly is what the rest of this
+///     layer does with a broken invariant, plus a counter so it is visible
+///     instead of silent.
+pub fn decode_analysis_parts(
+    blob: &[u8],
+    bag: Option<&[u8]>,
+    want_bag: bool,
+) -> Option<FileAnalysis> {
+    let mut fa = decode_analysis(blob)?;
+    match bag {
+        Some(b) => {
+            let bin = crate::util::ghost_stats::timed("decode.2_zstd_bag", || zstd::decode_all(b))
+                .ok()?;
+            fa.witnesses = crate::util::ghost_stats::timed("decode.3_bincode_bag", || {
+                bincode::deserialize(&bin)
+            })
+            .ok()?;
+        }
+        None => {
+            if want_bag {
+                crate::util::ghost_stats::count("decode.bag_column_missing");
+                log::warn!(
+                    "post-split row had no bag column; serving bag-evicted \
+                     (types for this file are incomplete until it is rewritten)"
+                );
+            }
+            fa.evict_witness_bag();
+        }
+    }
+    Some(fa)
 }
 
 /// Decompress + deserialize an analysis blob.
@@ -159,12 +264,21 @@ fn decode_bucket(tag: &str, v: u64) {
 /// No mtime/closure validation: the caller (`PackBagCache`) invalidates its
 /// entry on file change, and the row's shape is EXTRACT_VERSION-pinned.
 pub fn load_one(conn: &Connection, path: &str) -> Option<FileAnalysis> {
-    load_one_diag(conn, path).ok()
+    load_one_diag(conn, path, true).ok()
 }
 
 /// `load_one` that discriminates the failure (see `RehydrateMiss`) instead
 /// of collapsing to `None`, so the rehydration tripwire can name the cause.
-pub fn load_one_diag(conn: &Connection, path: &str) -> Result<FileAnalysis, RehydrateMiss> {
+///
+/// `want_bag` false selects a narrower row: the `bag` column is not named in
+/// the SELECT, so SQLite never reads its overflow pages and the decode never
+/// walks its bytes. That is the whole point of the split — on backward-walk
+/// traffic 94.9% of decodes take this path.
+pub fn load_one_diag(
+    conn: &Connection,
+    path: &str,
+    want_bag: bool,
+) -> Result<FileAnalysis, RehydrateMiss> {
     // A dual-homed project-lib file has TWO rows for one path (name-keyed
     // import + path-keyed workspace). Prefer a row whose stamp matches the
     // disk (one tier's persist may have failed or lagged, leaving a stale
@@ -172,22 +286,33 @@ pub fn load_one_diag(conn: &Connection, path: &str) -> Result<FileAnalysis, Rehy
     // deliberately skip stamp validation — the registered generation may
     // legitimately predate an unsaved edit, and the caller invalidates the
     // LRU on file change.
+    //
+    // The `extract_version` filter is what lets `decode_analysis_parts` skip
+    // format inference: a pre-split row carries its bag inside `analysis` and
+    // would decode as a post-split row whose bag column vanished. Filtering
+    // makes such a row invisible here rather than plausible.
     let mut stmt = conn
-        .prepare(
-            "SELECT analysis, mtime_secs, file_size FROM modules WHERE path = ?1 \
-             ORDER BY CASE source WHEN 'workspace' THEN 0 ELSE 1 END",
-        )
+        .prepare(if want_bag {
+            "SELECT analysis, mtime_secs, file_size, bag FROM modules \
+             WHERE path = ?1 AND extract_version = ?2 \
+             ORDER BY CASE source WHEN 'workspace' THEN 0 ELSE 1 END"
+        } else {
+            "SELECT analysis, mtime_secs, file_size, NULL FROM modules \
+             WHERE path = ?1 AND extract_version = ?2 \
+             ORDER BY CASE source WHEN 'workspace' THEN 0 ELSE 1 END"
+        })
         .map_err(|_| RehydrateMiss::NoRow)?;
     // Stage 1 of the rehydrate: the SQL roundtrip that fetches the bytes.
     // Timed separately from the decode because batching the fetch is only
     // worth doing if THIS is the dominant term.
-    let rows: Vec<(Option<Vec<u8>>, i64, i64)> =
+    let rows: Vec<(Option<Vec<u8>>, i64, i64, Option<Vec<u8>>)> =
         crate::util::ghost_stats::timed("decode.1_sql_fetch", || {
-            stmt.query_map(params![path], |row| {
+            stmt.query_map(params![path, EXTRACT_VERSION], |row| {
                 Ok((
                     row.get::<_, Option<Vec<u8>>>(0)?,
                     row.get::<_, i64>(1)?,
                     row.get::<_, i64>(2)?,
+                    row.get::<_, Option<Vec<u8>>>(3)?,
                 ))
             })
             .map(|rows| rows.flatten().collect::<Vec<_>>())
@@ -196,19 +321,22 @@ pub fn load_one_diag(conn: &Connection, path: &str) -> Result<FileAnalysis, Rehy
     if rows.is_empty() {
         return Err(RehydrateMiss::NoRow);
     }
-    let pick = |require_stamp: bool| -> Option<&Vec<u8>> {
-        rows.iter().find_map(|(blob, m, sz)| {
+    // The bag rides with the blob it was split from: picking them separately
+    // could pair a workspace row's analysis with an import row's bag.
+    let pick = |require_stamp: bool| -> Option<(&Vec<u8>, Option<&Vec<u8>>)> {
+        rows.iter().find_map(|(blob, m, sz, bag)| {
             let blob = blob.as_ref().filter(|b| !b.is_empty())?;
             if require_stamp && file_stamp(std::path::Path::new(path)) != Some((*m, *sz)) {
                 return None;
             }
-            Some(blob)
+            Some((blob, bag.as_ref().filter(|b| !b.is_empty())))
         })
     };
-    let blob = pick(rows.len() > 1)
+    let (blob, bag) = pick(rows.len() > 1)
         .or_else(|| pick(false))
         .ok_or(RehydrateMiss::EmptyBlob)?;
-    decode_analysis(blob).ok_or(RehydrateMiss::DecodeFailed)
+    decode_analysis_parts(blob, bag.map(|b| b.as_slice()), want_bag)
+        .ok_or(RehydrateMiss::DecodeFailed)
 }
 
 /// The bag-cache rehydration loader body, shared by every per-lang loader
@@ -222,10 +350,11 @@ pub fn open_and_load_diag(
     cache_key: Option<&str>,
     lang: &str,
     paths: &[String],
+    want_bag: bool,
 ) -> Result<FileAnalysis, RehydrateMiss> {
     let dir = cache_dir_for_workspace(cache_key)
         .ok_or_else(|| RehydrateMiss::OpenerFailed("no cache dir for workspace".into()))?;
-    load_with_wal_fallback(&db_path_for(&dir, lang), paths)
+    load_with_wal_fallback(&db_path_for(&dir, lang), paths, want_bag)
 }
 
 #[cfg(test)]
@@ -233,6 +362,7 @@ pub fn open_and_load_diag(
     _cache_key: Option<&str>,
     _lang: &str,
     _paths: &[String],
+    _want_bag: bool,
 ) -> Result<FileAnalysis, RehydrateMiss> {
     Err(RehydrateMiss::NoRow)
 }
@@ -254,6 +384,7 @@ pub fn open_and_load_diag(
 pub fn load_with_wal_fallback(
     db_path: &std::path::Path,
     paths: &[String],
+    want_bag: bool,
 ) -> Result<FileAnalysis, RehydrateMiss> {
     // `open_reader_retrying` waits out the transient CANTOPEN window; the
     // rw_open closure below then handles the (rarer) opened-but-row-invisible
@@ -262,6 +393,7 @@ pub fn load_with_wal_fallback(
         open_reader_retrying(db_path),
         || open_rw_shared_at(db_path),
         paths,
+        want_bag,
     )
 }
 
@@ -274,12 +406,13 @@ pub(super) fn rehydrate_from_opens(
     ro: Result<Connection, String>,
     rw_open: impl FnOnce() -> Option<Connection>,
     paths: &[String],
+    want_bag: bool,
 ) -> Result<FileAnalysis, RehydrateMiss> {
     let ro_err = ro.as_ref().err().cloned();
     let mut last = RehydrateMiss::NoRow;
     if let Ok(conn) = &ro {
         for p in paths {
-            match load_one_diag(conn, p) {
+            match load_one_diag(conn, p, want_bag) {
                 Ok(fa) => return Ok(fa),
                 Err(RehydrateMiss::NoRow) => {}
                 Err(other) => last = other,
@@ -292,7 +425,7 @@ pub(super) fn rehydrate_from_opens(
     if ro_err.is_some() || matches!(last, RehydrateMiss::NoRow) {
         if let Some(rw) = rw_open() {
             for p in paths {
-                if let Ok(fa) = load_one_diag(&rw, p) {
+                if let Ok(fa) = load_one_diag(&rw, p, want_bag) {
                     let _ = rw.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
                     return Ok(fa);
                 }
@@ -317,22 +450,23 @@ pub fn save_blob_to_db_stamped(
     module_name: &str,
     path: &std::path::Path,
     include_closure: &crate::model::file_analysis::path_intern::ClosureList,
-    blob: &[u8],
+    blob: &EncodedAnalysis,
     source: &str,
     stamp: (i64, i64),
 ) {
     let (mtime, size) = stamp;
     let deps = closure_stamp(include_closure, &mut std::collections::HashMap::new());
     let r = conn.execute(
-        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, source, analysis, extract_version, deps_stamp)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, source, analysis, bag, extract_version, deps_stamp)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         params![
             module_name,
             path.to_string_lossy(),
             mtime,
             size,
             source,
-            Some(blob),
+            Some(&blob.analysis),
+            Some(&blob.bag),
             EXTRACT_VERSION,
             deps
         ],
@@ -403,9 +537,19 @@ pub fn save_to_db(
     };
 
     let r = conn.execute(
-        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, source, analysis, extract_version, deps_stamp)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        params![module_name, path_str, mtime, size, source, analysis_blob, EXTRACT_VERSION, deps_stamp],
+        "INSERT OR REPLACE INTO modules (module_name, path, mtime_secs, file_size, source, analysis, bag, extract_version, deps_stamp)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            module_name,
+            path_str,
+            mtime,
+            size,
+            source,
+            analysis_blob.as_ref().map(|b| &b.analysis),
+            analysis_blob.as_ref().map(|b| &b.bag),
+            EXTRACT_VERSION,
+            deps_stamp
+        ],
     );
     let ok = match r {
         // A row whose blob failed to ENCODE landed as NULL — not a

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1054,6 +1054,7 @@ fn readonly_open_failure_recovers_through_read_write() {
         Err("simulated SQLITE_CANTOPEN".to_string()),
         || open_rw_shared_at(&db),
         std::slice::from_ref(&pm_str),
+        true,
     )
     .expect("RW fallback must recover the row a failed read-only open couldn't reach");
     assert!(!recovered.bag_is_evicted());
@@ -1066,6 +1067,7 @@ fn readonly_open_failure_recovers_through_read_write() {
         Err("simulated SQLITE_CANTOPEN".to_string()),
         || None,
         std::slice::from_ref(&pm_str),
+        true,
     )
     .unwrap_err();
     assert!(matches!(miss, RehydrateMiss::OpenerFailed(_)), "got {miss}");
@@ -1087,10 +1089,10 @@ fn rehydrate_absent_row_is_honest_miss() {
         init_schema(&w).unwrap();
     }
     // Row truly absent (present DB, no matching row) → NoRow, via both opens.
-    let miss = load_with_wal_fallback(&db, &["/no/such.pm".to_string()]).unwrap_err();
+    let miss = load_with_wal_fallback(&db, &["/no/such.pm".to_string()], true).unwrap_err();
     assert!(matches!(miss, RehydrateMiss::NoRow), "got {miss}");
     // No DB file at all → OpenerFailed (neither read-only nor read-write open).
-    let none = load_with_wal_fallback(&dir.join("nope.db"), &["/x.pm".to_string()]).unwrap_err();
+    let none = load_with_wal_fallback(&dir.join("nope.db"), &["/x.pm".to_string()], true).unwrap_err();
     assert!(matches!(none, RehydrateMiss::OpenerFailed(_)), "got {none}");
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -1106,9 +1108,9 @@ fn load_one_diag_discriminates_failures() {
     let cached = parse_source_to_cached(&std::fs::read_to_string(&pm).unwrap(), &pm);
     let pm_str = pm.to_string_lossy().into_owned();
     save_to_db(&conn, &pm_str, &Some(cached), "workspace");
-    assert!(load_one_diag(&conn, &pm_str).is_ok());
+    assert!(load_one_diag(&conn, &pm_str, true).is_ok());
     assert!(matches!(
-        load_one_diag(&conn, "/absent.pm").unwrap_err(),
+        load_one_diag(&conn, "/absent.pm", true).unwrap_err(),
         RehydrateMiss::NoRow
     ));
     conn.execute(
@@ -1118,7 +1120,7 @@ fn load_one_diag_discriminates_failures() {
     )
     .unwrap();
     assert!(matches!(
-        load_one_diag(&conn, "/empty.pm").unwrap_err(),
+        load_one_diag(&conn, "/empty.pm", true).unwrap_err(),
         RehydrateMiss::EmptyBlob
     ));
     conn.execute(
@@ -1128,7 +1130,7 @@ fn load_one_diag_discriminates_failures() {
     )
     .unwrap();
     assert!(matches!(
-        load_one_diag(&conn, "/garbage.pm").unwrap_err(),
+        load_one_diag(&conn, "/garbage.pm", true).unwrap_err(),
         RehydrateMiss::DecodeFailed
     ));
     let _ = std::fs::remove_file(&pm);
@@ -1454,13 +1456,14 @@ fn a_deleted_files_rows_are_collectable() {
     ).unwrap();
     // Stamp the row to the file as it is on disk, so the scan would admit it.
     let (mtime, size) = file_stamp(&p).expect("stamp");
+    let enc = encode_analysis(&cached.analysis).expect("encode");
     conn.execute(
         "INSERT OR REPLACE INTO modules
-           (module_name, path, mtime_secs, file_size, source, analysis, extract_version, deps_stamp)
-         VALUES (?1, ?1, ?2, ?3, 'workspace', ?4, ?5, 0)",
+           (module_name, path, mtime_secs, file_size, source, analysis, bag, extract_version, deps_stamp)
+         VALUES (?1, ?1, ?2, ?3, 'workspace', ?4, ?5, ?6, 0)",
         params![
             path_str, mtime, size,
-            encode_analysis(&cached.analysis).expect("encode"),
+            enc.analysis, enc.bag,
             EXTRACT_VERSION
         ],
     ).unwrap();
@@ -1485,4 +1488,112 @@ fn a_deleted_files_rows_are_collectable() {
     invalidate_generation_tier(&conn, &path_str, "workspace");
     assert!(gc_strings(&conn) > 0, "the dead file's names stayed pinned");
     assert!(ref_candidate_files(&conn, &["only_here".to_string()]).is_empty());
+}
+
+/// The `bag IS NULL` discriminator is only sound if a row this code writes
+/// never has an empty bag blob — an empty one would read as a pre-split row.
+///
+/// Nothing in the writer enforces that directly; it holds because `zstd`
+/// always emits a frame header, which is a property of a dependency rather
+/// than of this codebase. So it is pinned here: the case that would break it
+/// is an analysis whose witness bag is genuinely empty, which is exactly the
+/// input a reader could not otherwise tell apart from an old row.
+#[test]
+fn encoded_bag_is_never_empty() {
+    let src = "1;\n";
+    let mut parser = crate::build::builder::create_parser();
+    let tree = parser.parse(src, None).expect("parse");
+    let mut fa = crate::build::builder::build(&tree, src.as_bytes());
+    fa.witnesses = Default::default();
+    assert!(
+        fa.witnesses.is_empty(),
+        "this test is vacuous unless the bag really is empty"
+    );
+    let enc = encode_analysis(&fa).expect("encode");
+    assert!(
+        !enc.bag.is_empty(),
+        "an empty bag blob is indistinguishable from a pre-split row's NULL, \
+         so every such row would silently decode as though its bag lived \
+         inside the analysis blob"
+    );
+}
+
+/// A rows-only read must not report "this file has no type facts".
+///
+/// The split makes that failure newly reachable: the bag genuinely is not in
+/// the bytes any more, so an analysis that forgot to mark itself evicted
+/// would answer type queries with a confident, empty, wrong answer instead of
+/// rehydrating. The marker is the only thing standing between the two.
+#[test]
+fn rows_only_read_is_marked_evicted_not_empty() {
+    let conn = test_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("stage1_axis.pm");
+    std::fs::write(&pm, "package A;\nsub f { return 'x' }\n1;\n").unwrap();
+    let cached = parse_source_to_cached(&std::fs::read_to_string(&pm).unwrap(), &pm);
+    assert!(
+        !cached.analysis.witnesses.is_empty(),
+        "fixture must carry witnesses or neither assertion below means anything"
+    );
+    let n = cached.analysis.witnesses.len();
+    let pm_str = pm.to_string_lossy().into_owned();
+    save_to_db(&conn, &pm_str, &Some(cached), "workspace");
+
+    let rows = load_one_diag(&conn, &pm_str, false).expect("rows-only read");
+    assert!(
+        rows.bag_is_evicted(),
+        "a rows-only read left the bag absent WITHOUT the evicted marker — a \
+         type query would read the empty bag as 'no facts' and never rehydrate"
+    );
+
+    let whole = load_one_diag(&conn, &pm_str, true).expect("bag read");
+    assert!(!whole.bag_is_evicted());
+    assert_eq!(
+        whole.witnesses.len(),
+        n,
+        "the split must round-trip the bag exactly, not approximately"
+    );
+    let _ = std::fs::remove_file(&pm);
+}
+
+/// A pre-split row must never be served as a post-split one.
+///
+/// Such a row carries its bag inside `analysis` and a NULL `bag` column,
+/// which is byte-for-byte what a post-split row with a lost bag looks like.
+/// `decode_analysis_parts` deliberately does not try to tell them apart; the
+/// `extract_version` filter is what makes the ambiguous row unreachable, and
+/// this is the test that fails if that filter is ever dropped.
+#[test]
+fn pre_split_rows_are_filtered_not_guessed() {
+    let conn = test_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("stage1_presplit.pm");
+    std::fs::write(&pm, "package B;\nsub g { return 1 }\n1;\n").unwrap();
+    let cached = parse_source_to_cached(&std::fs::read_to_string(&pm).unwrap(), &pm);
+    let pm_str = pm.to_string_lossy().into_owned();
+
+    // A row in the OLD shape: whole analysis (bag inline) in `analysis`,
+    // NULL `bag`, and the extract_version that shipped before the split.
+    let whole_blob = {
+        let bin = bincode::serialize(&*cached.analysis).expect("bincode");
+        zstd::encode_all(bin.as_slice(), 3).expect("zstd")
+    };
+    conn.execute(
+        "INSERT OR REPLACE INTO modules
+           (module_name, path, mtime_secs, file_size, source, analysis, bag, extract_version, deps_stamp)
+         VALUES (?1, ?1, 0, 0, 'workspace', ?2, NULL, ?3, 0)",
+        params![pm_str, whole_blob, EXTRACT_VERSION - 1],
+    )
+    .unwrap();
+
+    assert!(
+        matches!(
+            load_one_diag(&conn, &pm_str, true).unwrap_err(),
+            RehydrateMiss::NoRow
+        ),
+        "a pre-split row was served as post-split; its inline bag would be \
+         mistaken for a missing bag column (or vice versa) and one of those \
+         two readings is silently wrong"
+    );
+    let _ = std::fs::remove_file(&pm);
 }

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -10,7 +10,7 @@ const SCHEMA_VERSION: &str = "10";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 183;
+pub const EXTRACT_VERSION: i64 = 184;
 
 /// Bumped when the ROW format of the relational ref index changes shape.
 /// Unlike `EXTRACT_VERSION` (which governs the blobs), a mismatch only wipes
@@ -31,6 +31,7 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
             file_size        INTEGER NOT NULL,
             source           TEXT NOT NULL DEFAULT 'import',
             analysis         BLOB,
+            bag              BLOB,
             extract_version  INTEGER NOT NULL DEFAULT 0,
             deps_stamp       INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (module_name, path)
@@ -159,6 +160,12 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     let _ = conn.execute_batch(
         "ALTER TABLE modules ADD COLUMN deps_stamp INTEGER NOT NULL DEFAULT 0;",
     );
+    // Same in-place treatment for the split-out witness bag. Pre-existing
+    // rows keep their bag inside `analysis` and get a NULL here; they are
+    // never READ as post-split rows, because the split bumped
+    // `EXTRACT_VERSION` and every reader filters on it. So they age out by
+    // re-resolution rather than needing a migration or a format probe.
+    let _ = conn.execute_batch("ALTER TABLE modules ADD COLUMN bag BLOB;");
     // Stub generation gate — stamped here so every fresh DB is writable by
     // the persist writers (their per-chunk `stub_version_current` check
     // would otherwise fail-closed until the first warm scan stamped it).
@@ -185,6 +192,7 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
                     file_size        INTEGER NOT NULL,
                     source           TEXT NOT NULL DEFAULT 'import',
                     analysis         BLOB,
+                    bag              BLOB,
                     extract_version  INTEGER NOT NULL DEFAULT 0,
                     deps_stamp       INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (module_name, path)

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -38,7 +38,7 @@ fn bag_present_rehydrates_evicted_at_both_caps() {
     for cap in [8 * 1024 * 1024usize, 0] {
         // Loader hands back the FULL analysis (as SQLite would after decode).
         let full_for_loader = full.analysis.clone();
-        let cache = Arc::new(PackBagCache::new(cap, move |_p| {
+        let cache = Arc::new(PackBagCache::new(cap, move |_p, _want_bag: bool| {
             Ok((*full_for_loader).clone())
         }));
         let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -73,7 +73,7 @@ fn symbols_present_answers_resident_when_only_bag_evicted() {
     let path = full.path.clone();
 
     // Loader that PANICS: proof the bag-only-evicted path never rehydrates.
-    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, |_p: &std::path::Path| {
+    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, |_p: &std::path::Path, _want_bag: bool| {
         panic!("symbols_present must not rehydrate a symbols-resident copy")
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -103,7 +103,7 @@ fn symbols_present_rehydrates_evicted_symbols_never_absence_by_eviction() {
     let src = "package Widget;\nsub make { my $c = shift; return bless {}, $c; }\n1;\n";
     let full = parse_source_to_cached(src, "Widget");
     let full_for_loader = full.analysis.clone();
-    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, move |_p: &std::path::Path| {
+    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, move |_p: &std::path::Path, _want_bag: bool| {
         Ok((*full_for_loader).clone())
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -128,7 +128,7 @@ fn refs_present_answers_resident_when_only_bag_evicted() {
     use crate::model::file_analysis::CrossFileLookup;
     let src = "package Widget;\nsub make { my $c = shift; return bless {}, $c; }\nWidget::make('Widget');\n1;\n";
     let full = parse_source_to_cached(src, "Widget");
-    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, |_p: &std::path::Path| {
+    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, |_p: &std::path::Path, _want_bag: bool| {
         panic!("refs_present must not rehydrate a rows-resident copy")
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -153,7 +153,7 @@ fn refs_present_rehydrates_evicted_refs_never_absence_by_eviction() {
     let src = "package Widget;\nsub make { my $c = shift; return bless {}, $c; }\nWidget::make('Widget');\n1;\n";
     let full = parse_source_to_cached(src, "Widget");
     let full_for_loader = full.analysis.clone();
-    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, move |_p: &std::path::Path| {
+    let cache = Arc::new(PackBagCache::new(8 * 1024 * 1024, move |_p: &std::path::Path, _want_bag: bool| {
         Ok((*full_for_loader).clone())
     }));
     let idx = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -627,7 +627,7 @@ fn register_symbols_stripping_feeds_before_evict() {
 
     // whole_present rehydrates symbols through the LRU.
     let full_for_loader = full.analysis.clone();
-    let cache = std::sync::Arc::new(PackBagCache::new(1024 * 1024, move |_p| {
+    let cache = std::sync::Arc::new(PackBagCache::new(1024 * 1024, move |_p, _want_bag: bool| {
         Ok((*full_for_loader).clone())
     }));
     let idx2 = ModuleIndex::new_for_cli().with_bag_cache(cache);
@@ -1167,7 +1167,7 @@ fn foreign_path_rehydrates_through_the_owning_sibling() {
     let served = Arc::clone(&whole_arc);
     hub.set_bag_cache(Arc::new(crate::index::pack_bag_cache::PackBagCache::new(
         128 * 1024 * 1024,
-        move |p: &std::path::Path| {
+        move |p: &std::path::Path, _want_bag: bool| {
             if p == std::path::Path::new("/fake/hub/Ghost.pm") {
                 Ok((*served).clone())
             } else {

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -67,7 +67,7 @@ impl ModuleIndex {
         // evicted once persisted; queries that need the whole analysis
         // rehydrate through this, same as the pack sub-indexes. Fixed
         // 128 MiB cap (Perl analyses are 10-100x smaller than cpp ones).
-        let loader = move |path: &std::path::Path| {
+        let loader = move |path: &std::path::Path, want_bag: bool| {
             // Raw walk path first (preserves the pre-diag behavior), canonical
             // as a fallback spelling; the discriminated helper survives the
             // readonly-open CANTOPEN/WAL race behind both.
@@ -82,7 +82,12 @@ impl ModuleIndex {
                     spellings.push(c);
                 }
             }
-            crate::index::module_cache::open_and_load_diag(key.as_deref(), "perl", &spellings)
+            crate::index::module_cache::open_and_load_diag(
+                key.as_deref(),
+                "perl",
+                &spellings,
+                want_bag,
+            )
         };
         // Measurement-only override for ghost-stats cap experiments
         // (`PERL_LSP_BAG_CACHE_MB`); unset ⇒ the stock 128 MiB.

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -88,7 +88,7 @@ pub fn index_pack_languages(
         // decodes the one requested file's full bag.
         let bag_cache = {
             let cache_key_owned = cache_key.map(|s| s.to_string());
-            let loader = move |path: &std::path::Path| {
+            let loader = move |path: &std::path::Path, want_bag: bool| {
                 // The blob is persisted under the CANONICAL path (both feed
                 // paths write `canon`), while the resident copy may be
                 // registered under the walk's raw path — canonicalize so the
@@ -101,7 +101,12 @@ pub fn index_pack_languages(
                 if raw != spellings[0] {
                     spellings.push(raw);
                 }
-                module_cache::open_and_load_diag(cache_key_owned.as_deref(), lang, &spellings)
+                module_cache::open_and_load_diag(
+                    cache_key_owned.as_deref(),
+                    lang,
+                    &spellings,
+                    want_bag,
+                )
             };
             Arc::new(crate::index::pack_bag_cache::PackBagCache::new_labeled(
                 bag_cache_bytes,
@@ -289,7 +294,7 @@ pub fn index_pack_languages(
             // copies). `None` → the worker already registered a whole copy
             // (NO_EVICT/degraded); the writer only persists.
             parts: Option<crate::index::module_index::PackRegistrationParts>,
-            blob: Vec<u8>,
+            blob: crate::index::module_cache::EncodedAnalysis,
             // Warm stub (deferred/stripped entries only) — persisted in the
             // same chunk txn as the blob so the next warm start registers
             // from it without decoding `blob`.
@@ -360,7 +365,7 @@ pub fn index_pack_languages(
                     },
                     |e: FreshEntry| {
                         pack_index_writer.invalidate_bag_cache(&e.path);
-                        if let Some(fa) = module_cache::decode_analysis(&e.blob) {
+                        if let Some(fa) = e.blob.decode_whole() {
                             let bytes = fa.heap_estimate().total();
                             if fallback_bytes.saturating_add(bytes) <= FALLBACK_WHOLE_BYTE_CAP {
                                 fallback_bytes += bytes;

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -266,7 +266,7 @@ pub fn index_workspace_with_index(
         /// Register + mirror in the writer after COMMIT. `false` = the
         /// worker already registered a WHOLE copy (NO_EVICT); persist only.
         deferred: bool,
-        blob: Vec<u8>,
+        blob: crate::index::module_cache::EncodedAnalysis,
         seeds: Vec<crate::model::file_analysis::RefRowSeed>,
         sym_seeds: Vec<crate::model::file_analysis::SymRowSeed>,
         closure: crate::model::file_analysis::path_intern::ClosureList,
@@ -332,7 +332,7 @@ pub fn index_workspace_with_index(
                     if let Some(idx) = module_index {
                         idx.invalidate_bag_cache(&e.path);
                     }
-                    if let Some(fa) = module_cache::decode_analysis(&e.blob) {
+                    if let Some(fa) = e.blob.decode_whole() {
                         let bytes = fa.heap_estimate().total();
                         if fallback_bytes.saturating_add(bytes) > FALLBACK_WHOLE_BYTE_CAP {
                             // Over budget: DROP (the chunk didn't commit, so a

--- a/src/index/pack_bag_cache.rs
+++ b/src/index/pack_bag_cache.rs
@@ -29,7 +29,7 @@ use dashmap::DashMap;
 use crate::model::file_analysis::FileAnalysis;
 use crate::index::module_cache::RehydrateMiss;
 
-type Loader = Box<dyn Fn(&Path) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync>;
+type Loader = Box<dyn Fn(&Path, bool) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync>;
 
 pub struct PackBagCache {
     /// Rehydrated, bag-present analyses keyed by canonical path, each paired
@@ -73,7 +73,7 @@ impl PackBagCache {
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn new(
         cap_bytes: usize,
-        loader: impl Fn(&Path) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync + 'static,
+        loader: impl Fn(&Path, bool) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync + 'static,
     ) -> Self {
         Self::new_labeled(cap_bytes, "pack-bag", loader)
     }
@@ -83,7 +83,7 @@ impl PackBagCache {
     pub fn new_labeled(
         cap_bytes: usize,
         label: &str,
-        loader: impl Fn(&Path) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync + 'static,
+        loader: impl Fn(&Path, bool) -> Result<FileAnalysis, RehydrateMiss> + Send + Sync + 'static,
     ) -> Self {
         PackBagCache {
             entries: DashMap::new(),
@@ -178,8 +178,19 @@ impl PackBagCache {
             "decode.rows_only"
         });
         let gen_before = self.generation.get(path).map(|g| *g).unwrap_or(0);
+        // The axis goes DOWN to the loader rather than being applied to what
+        // it returns. Decoding the bag and then dropping it was 52.9% of the
+        // bincode bytes on a path where 94.9% of decodes never wanted it.
         let mut loaded = crate::util::ghost_stats::timed(
-            "bagcache.decode", || (self.loader)(path))?;
+            "bagcache.decode", || (self.loader)(path, want_bag))?;
+        // The strip STAYS, even though the loader was asked for the narrow
+        // axis. It is not where the saving lives — that is in the bytes SQL
+        // never fetched and bincode never walked — and dropping it would make
+        // "a rows-lane entry retains without the bag" depend on every loader
+        // remembering to honour the flag. A loader that returns a superset is
+        // within its contract; the cache still owes callers the marker, since
+        // `get_or_load`'s stripped-resident check reads it to decide whether a
+        // later bag request may be served from this entry.
         if !want_bag {
             loaded.evict_witness_bag();
         }
@@ -307,7 +318,7 @@ mod tests {
     fn cap_zero_never_retains() {
         let calls = Arc::new(AtomicUsize::new(0));
         let c = calls.clone();
-        let cache = PackBagCache::new(0, move |_p| {
+        let cache = PackBagCache::new(0, move |_p, _want_bag: bool| {
             c.fetch_add(1, Ordering::Relaxed);
             Ok(empty_fa())
         });
@@ -323,7 +334,7 @@ mod tests {
     fn hit_avoids_reload() {
         let calls = Arc::new(AtomicUsize::new(0));
         let c = calls.clone();
-        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p| {
+        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p, _want_bag: bool| {
             c.fetch_add(1, Ordering::Relaxed);
             Ok(empty_fa())
         });
@@ -339,7 +350,7 @@ mod tests {
         // only one so inserting a second evicts the first.
         let one = empty_fa().heap_estimate().total();
         assert!(one > 0);
-        let cache = PackBagCache::new(one, move |_p| Ok(empty_fa()));
+        let cache = PackBagCache::new(one, move |_p, _want_bag: bool| Ok(empty_fa()));
         let a = PathBuf::from("/x/a.h");
         let b = PathBuf::from("/x/b.h");
         cache.bag_for(&a);
@@ -358,7 +369,7 @@ mod tests {
         let c2 = cache.clone();
         let p = PathBuf::from("/x/racy.h");
         let p2 = p.clone();
-        let built = PackBagCache::new(128 * 1024 * 1024, move |_p| {
+        let built = PackBagCache::new(128 * 1024 * 1024, move |_p, _want_bag: bool| {
             if let Some(c) = c2.get() {
                 c.invalidate(&p2);
             }
@@ -381,7 +392,7 @@ mod tests {
     #[test]
     fn charge_total_tracks_the_map_and_cannot_ratchet() {
         let one = empty_fa().heap_estimate().total();
-        let cache = PackBagCache::new(one * 8, move |_p| Ok(empty_fa()));
+        let cache = PackBagCache::new(one * 8, move |_p, _want_bag: bool| Ok(empty_fa()));
         let paths: Vec<PathBuf> =
             (0..24).map(|i| PathBuf::from(format!("/x/{i}.h"))).collect();
         for p in &paths {
@@ -412,7 +423,7 @@ mod tests {
     /// the total past cap for good.
     #[test]
     fn concurrent_decodes_of_one_path_charge_once() {
-        let cache = Arc::new(PackBagCache::new(128 * 1024 * 1024, move |_p| {
+        let cache = Arc::new(PackBagCache::new(128 * 1024 * 1024, move |_p, _want_bag: bool| {
             // Wide enough for the misses to overlap on the insert.
             std::thread::sleep(std::time::Duration::from_millis(20));
             Ok(empty_fa())
@@ -447,7 +458,7 @@ mod tests {
     fn rows_lane_strips_and_bag_request_upgrades() {
         let calls = Arc::new(AtomicUsize::new(0));
         let c = calls.clone();
-        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p| {
+        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p, _want_bag: bool| {
             c.fetch_add(1, Ordering::Relaxed);
             Ok(empty_fa())
         });
@@ -480,7 +491,7 @@ mod tests {
         let one = empty_fa().heap_estimate().total();
         assert!(one > 1);
         // Cap below a single entry: the first insert is permanently over.
-        let cache = PackBagCache::new(one - 1, move |_p| Ok(empty_fa()));
+        let cache = PackBagCache::new(one - 1, move |_p, _want_bag: bool| Ok(empty_fa()));
         let a = PathBuf::from("/x/a.h");
         cache.bag_for(&a);
         assert!(
@@ -504,7 +515,7 @@ mod tests {
     #[test]
     fn a_drifted_counter_is_reported() {
         let one = empty_fa().heap_estimate().total();
-        let cache = PackBagCache::new(one * 8, move |_p| Ok(empty_fa()));
+        let cache = PackBagCache::new(one * 8, move |_p, _want_bag: bool| Ok(empty_fa()));
         let paths: Vec<PathBuf> =
             (0..4).map(|i| PathBuf::from(format!("/x/{i}.h"))).collect();
         for p in &paths {
@@ -523,7 +534,7 @@ mod tests {
 
     #[test]
     fn invalidate_drops_entry() {
-        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p| Ok(empty_fa()));
+        let cache = PackBagCache::new(128 * 1024 * 1024, move |_p, _want_bag: bool| Ok(empty_fa()));
         let p = PathBuf::from("/x/a.h");
         cache.bag_for(&p);
         assert!(cache.entries.contains_key(&p));


### PR DESCRIPTION
A rows-axis rehydrate decoded the whole analysis and threw the bag away on the next line — `pack_bag_cache.rs` literally called `evict_witness_bag()` on bytes it had just paid zstd and bincode to produce. The bag is 52.9% of the uncompressed bytes bincode walks, and on backward-walk traffic 94.9% of decodes never wanted it.

The axis now goes **down** to the loader instead of being applied to what it returns: `want_bag: false` names a narrower SELECT, so SQLite never reads the bag column's overflow pages and bincode never walks its bytes.

## Results, on both workloads

Sizing this on one workload is what produced the wrong answer last time, so both are here and neither should be quoted without the other.

Per-decode averages, because the heatmap runs are partial (stopped at 518,592 and 756,742 decodes; shares flat across readings) and only rates compare across partial runs. Both binaries post-#148, both cold caches.

**`--heatmap`** — the backward walk: `references`, `rename`, `documentHighlight`, callHierarchy incoming, fan-in.

| | before | after | |
|---|---|---|---|
| `bagcache.decode` | 603.1 µs | **430.4 µs** | **−28.6%** |
| bincode | 218.8 µs | 89.7 µs | −59.0% |
| zstd | 91.7 µs | 66.5 µs | −27.5% |
| rows-only share | 94.9% | 95.8% | |

**`--check`** — diagnostics sweep. `bagcache.decode` 2,065.5 → 1,986.8 ms total, 9.2% rows-only. Unchanged, as expected: `--check` barely touches the backward walk, which is why it showed ~40 ms of recoverable time before the split and shows the same after. It is the outlier, not the baseline.

### The bincode saving beat its own model, which needed explaining rather than pocketing

Predicted `0.958 × 0.529 = 50.7%`; measured 59.0%. The 52.9% is the **corpus-wide** bag share, but the decode population is 90% sub-10KB blobs, where the bag is 67.1%. Population-weighted the share is 64.8%, predicting 62.1% against 59.0% measured — and the model now slightly *over*-predicts, which is the right direction since some bincode cost is per-call overhead rather than per-byte.

No anomaly, then: a model applied to the wrong population. Same denominator error as the noise floor and the call-site counter, caught this time by auditing a number that flattered the change.

## Three things that could fail silently

Each one produces a plausible answer rather than an error, so each is pinned by a test, and all three are **mutation-verified to fail by name**.

**A rows-only read leaves the bag genuinely absent from the bytes.** An analysis that forgot to mark itself evicted would answer type queries with a confident empty result instead of rehydrating. The strip therefore stays in `PackBagCache` even though the loader was asked for the narrow axis — the saving is in the bytes never fetched, not in the marker, and making the invariant depend on every loader honouring a flag is how it gets lost. (This is what caught it: `rows_lane_strips_and_bag_request_upgrades` failed when I first made the cache trust the loader.)

**A pre-split row is byte-identical to a broken post-split one.** It carries its bag inside `analysis` with a NULL `bag` column — exactly what a post-split row whose bag went missing looks like. One benign, one an invariant break. `decode_analysis_parts` deliberately does not guess between them: `EXTRACT_VERSION` is bumped and readers filter on it, so the ambiguous row is *unreachable* rather than *plausible*.

**The `bag IS NULL` discriminator rests on a dependency's behaviour.** It is sound only because zstd always emits a frame header, which is a property of zstd rather than of this codebase. Pinned by a test rather than assumed.

| mutation | assertion that fires |
|---|---|
| drop the evicted marker on a rows-only read | `a rows-only read left the bag absent WITHOUT the evicted marker` |
| drop the `extract_version` filter | `a pre-split row was served as post-split` |
| let an empty bag encode to zero bytes | `an empty bag blob is indistinguishable from a pre-split row's NULL` |

## Migration

None needed. Pre-existing rows keep their bag inside `analysis`, get a NULL `bag`, and are never read as post-split rows because of the version filter — they age out by re-resolution. The column is added in place via the same `ALTER TABLE` pattern `deps_stamp` uses, so no table drop.

## Verification

- `cargo test --features cpp` — 1595 passed, 0 failed
- `cargo test` — 1531 passed, 0 failed
- `gold-corpus/run.pl` (release, `--features cpp`) — PASS 502, xfail 16, FAIL 0, XPASS 0, CRASH 0, **lang-skip 0**. Worth noting the harness sets `PERL_LSP_STRICT_RESIDENCY=1`, so any rehydration miss introduced by the split would have panicked rather than passed.
- `./e2e/run.sh` (nvim 0.11.0) — 113 passed, 0 failed across 10 suites

---
_Generated by [Claude Code](https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv)_