### PR TITLE
Pin the typeglob fallback's semantics, and record that collapsing its overlap buys nothing

### DIFF
--- a/docs/adr/sibling-forks.md
+++ b/docs/adr/sibling-forks.md
@@ -48,6 +48,69 @@ fallback would have been sound-looking and wrong. Measure overlap on a
 real corpus before choosing the shape: the in-regime synthetic corpus
 showed 100% overlap and would have made deletion look safe.
 
+**And the mroc/mdmp narrowing was then built, measured, and rejected.**
+The shape above is right; the reason to pay for it was not. The
+narrowing is implementable and answer-preserving — the ancestor walk
+records, per candidate whose symbols it already holds, the answer to
+the FALLBACK's question (not its own: the walk sees through re-exports
+and admits class-content, so donating `has_member` loses answers), and
+the fallback honours it. It removed the fetches it targeted and nothing
+else:
+
+| counter | before | after |
+|---|---|---|
+| `mdmp.candidate_fetched`, substrate | 39,491 | 882 |
+| `mdmp.candidate_fetched`, in-regime | 1,689,378 | 0 |
+| `mdmp.found` | 80 | 80 |
+| `mroc.*`, `mdmp.call`/`modules_scanned`/`not_found` | — | identical |
+
+It bought no wall time in any regime measured — substrate cold
+(20.79 → 20.59 s median), the in-regime duplicated-package corpus
+(76.00 → 74.20 s), and substrate with the sweep memo disabled
+(21.06 → 21.02 s), all inside run-to-run spread on three interleaved
+cold repeats each.
+
+The third arm is the one that explains the other two. Disabling the
+sweep memo was meant to make these fetches expensive; instead, removing
+36,712 rehydrations left `rehydrate.loader` TOTAL flat (3,531 → 3,579
+ms, up by noise) while its AVERAGE rose (10.2 → 11.5 µs). That
+signature is self-consistent and it is the finding: pull the cheapest
+entries out of a denominator and the mean rises while the total does
+not move. **The fetches the narrowing removes are the cheapest
+rehydrations in the system.**
+
+So the overlap number was **true about count and false about cost** —
+and a 98.6% overlap invites exactly that inference, which is why this
+is written down. A rehydrate COUNT is a poor proxy for rehydrate COST.
+
+The structural argument does not rescue it either. The sibling-fork
+rule exists to stop two implementations of one question from diverging
+in their ANSWERS; the path-level data says the fallback's set is a
+strict superset (the 563 paths it alone answers), so this is two
+questions with overlapping work, not two answers to one question.
+Duplicated work with no measured cost does not earn new machinery.
+"Nested ones narrow" stands as taxonomy; it does not oblige paying for
+the narrowing here.
+
+What landed instead is the pair of fixtures that pin the fallback's
+semantics (`typeglob_fallback_still_answers_from_a_candidate_the_
+ancestor_walk_rejected`, `typeglob_fallback_keeps_its_provider_
+ordering_across_the_overlap`) — previously unpinned, and the thing any
+future attempt must not break. The rejected implementation is PR #151,
+commit `0f41907e`.
+
+**Bound-first is not enough on its own — ablate the bound.** The first
+fixture written for this narrowing, committed before the change per the
+bound-first discipline, PASSED under both wrong designs: an installer
+sorting before the class short-circuited the fallback's `find()` before
+the memo was ever consulted, so it asserted a true thing about a path
+the change does not touch. It was caught by ablating it, not by reading
+it. **An un-ablated fixture is an assertion, not a net.** The cheap
+check is to break the change deliberately, in each way it could
+plausibly be got wrong, and confirm the fixture fails each time — the
+pair above was verified that way (donate `has_member` → the first
+fails; answer out of the walk loop → the second fails).
+
 > A worked one, because the fork was invisible until the two walks were
 > read side by side: `implementations_of` gathered descendants PLUS the
 > co-ancestors those descendants reach going back up their own MRO,

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2157,6 +2157,118 @@ fn typeglob_install_is_found_through_the_class_keyed_provider_index() {
     );
 }
 
+/// The ancestor walk and the typeglob fallback ask DIFFERENT questions
+/// over overlapping candidate sets, and this is the difference. The walk
+/// sees through a re-export and admits class-content variables; the
+/// fallback does neither. So a file the walk REJECTED can still be the
+/// fallback's answer.
+///
+/// Pinned because the two enumerations overlap almost entirely (98.6% of
+/// the fallback's fetches on the substrate, 100% in a duplicated-package
+/// corpus, are files the walk just decoded), which makes "have the walk
+/// answer for both" a standing temptation. It is only sound while the two
+/// verdicts stay separate. The rejected file is the ONLY match here, so a
+/// version that reused the walk's own verdict answers `None` rather than
+/// passing by luck on an earlier provider.
+///
+/// `docs/adr/sibling-forks.md` has the measurement that says collapsing
+/// the overlap buys nothing.
+#[test]
+fn typeglob_fallback_still_answers_from_a_candidate_the_ancestor_walk_rejected() {
+    use crate::model::file_analysis::{CrossFileLookup, MethodResolution, SymKind};
+    let idx = ModuleIndex::new_for_test();
+
+    let reg = |name: &str, fa: crate::model::file_analysis::FileAnalysis| {
+        let path = PathBuf::from(format!("/fake/overlap/{}.pm", name.replace("::", "_")));
+        let _ = idx.register_workspace_resident(path, Arc::new(fa));
+    };
+
+    // `Widget` declares `paint` itself, but only as a RE-EXPORT — the
+    // ancestor walk sees through it (`is_reexport`) and finds no member.
+    let mut widget = build_fa("package Widget;\nsub paint { 1 }\n1;\n");
+    for sym in widget.symbols_mut() {
+        if sym.name == "paint" && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+            sym.attributes.push("reexport".to_string());
+        }
+    }
+    reg("Widget", widget);
+    // A second provider of `Widget`, sorting FIRST, that installs a
+    // different method — so the fallback's scan must run past it and reach
+    // the file the walk already decoded.
+    reg(
+        "Aaa::Painter",
+        build_fa("package Aaa::Painter;\n*{ 'Widget::draw' } = sub { 2 };\n1;\n"),
+    );
+
+    assert_eq!(
+        idx.modules_providing_package("Widget"),
+        vec!["Aaa::Painter".to_string(), "Widget".to_string()],
+        "fixture must give the class two providers, the non-answer sorting first"
+    );
+    assert_eq!(
+        idx.visible_def_candidates("Widget").len(),
+        1,
+        "fixture must put `Widget`'s own file in the walk's path — the overlap"
+    );
+
+    assert_eq!(
+        idx.module_declaring_method_in_package("paint", "Widget")
+            .as_deref(),
+        Some("Widget"),
+        "the fallback does not see through the re-export the walk sees through"
+    );
+    let caller = build_fa("package Caller;\nsub go { return Widget->paint(); }\n1;\n");
+    match caller.resolve_method_in_ancestors("Widget", "paint", Some(&idx)) {
+        Some(MethodResolution::CrossFile { class, def_module }) => {
+            assert_eq!(class, "Widget");
+            assert_eq!(def_module.as_deref(), Some("Widget"));
+        }
+        other => panic!("the walk-rejected candidate must still answer, got {other:?}"),
+    }
+}
+
+/// The companion to the verdict rule: WHICH module wins when several
+/// provide the class. The fallback scans providers in SORTED order, so an
+/// installer sorting before `cls` answers even though the walk decoded
+/// `cls`'s own file first. Anything that answered straight out of the walk
+/// loop would return `cls` here instead.
+#[test]
+fn typeglob_fallback_keeps_its_provider_ordering_across_the_overlap() {
+    use crate::model::file_analysis::{CrossFileLookup, MethodResolution, SymKind};
+    let idx = ModuleIndex::new_for_test();
+
+    let reg = |name: &str, fa: crate::model::file_analysis::FileAnalysis| {
+        let path = PathBuf::from(format!("/fake/order/{}.pm", name.replace("::", "_")));
+        let _ = idx.register_workspace_resident(path, Arc::new(fa));
+    };
+
+    let mut widget = build_fa("package Widget;\nsub paint { 1 }\n1;\n");
+    for sym in widget.symbols_mut() {
+        if sym.name == "paint" && matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+            sym.attributes.push("reexport".to_string());
+        }
+    }
+    reg("Widget", widget);
+    // Sorts first AND matches — so both providers are answers and only the
+    // order decides.
+    reg(
+        "Aaa::Painter",
+        build_fa("package Aaa::Painter;\n*{ 'Widget::paint' } = sub { 2 };\n1;\n"),
+    );
+
+    let caller = build_fa("package Caller;\nsub go { return Widget->paint(); }\n1;\n");
+    match caller.resolve_method_in_ancestors("Widget", "paint", Some(&idx)) {
+        Some(MethodResolution::CrossFile { def_module, .. }) => {
+            assert_eq!(
+                def_module.as_deref(),
+                Some("Aaa::Painter"),
+                "the sorted provider scan decides, not the walk's fetch order"
+            );
+        }
+        other => panic!("expected the fallback's provider-ordered home, got {other:?}"),
+    }
+}
+
 /// The provider edge is symbol-derived, so a symbol-EVICTED resident copy
 /// must replay it from the per-path record like the name edges do. Without
 /// the replay the installer silently stops providing its target package

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -391,6 +391,11 @@ impl ModuleIndex {
                 // existence scan — no bag/refs read.
                 self.def_candidates(mod_name).iter().any(|c| {
                     crate::util::ghost_stats::count("mdmp.candidate_fetched");
+                    crate::util::ghost_stats::count(if crate::util::ghost_stats::mroc_saw(&c.path) {
+                        "mdmp.candidate_seen_by_mroc"
+                    } else {
+                        "mdmp.candidate_new"
+                    });
                     self.symbols_present(c).has_sub_in_package(name, class)
                 })
             });

--- a/src/model/file_analysis/ancestry.rs
+++ b/src/model/file_analysis/ancestry.rs
@@ -513,6 +513,7 @@ impl FileAnalysis {
             // same-named class must not hijack the walk — while Perl gets
             // the whole relation. The goto-def consumer re-picks the
             // defining candidate with the same test.
+            crate::util::ghost_stats::mroc_begin();
             for cached in idx.visible_def_candidates(cls) {
                 // Class-scoped, not file-scoped: a pack file holds MANY
                 // classes, so "some sub of this name exists in cls's file"
@@ -527,6 +528,7 @@ impl FileAnalysis {
                 // only while the copy still HAS symbols, and the workspace tier
                 // strips them, so at scale this is a decode per candidate.
                 crate::util::ghost_stats::count("mroc.candidate_fetched");
+                crate::util::ghost_stats::mroc_note(&cached.path);
                 let whole = crate::util::ghost_stats::in_ancestor_walk(|| {
                     idx.symbols_present(&cached)
                 });

--- a/src/util/ghost_stats.rs
+++ b/src/util/ghost_stats.rs
@@ -940,3 +940,31 @@ pub fn in_ancestor_walk<R>(f: impl FnOnce() -> R) -> R {
 pub fn inside_ancestor_walk() -> bool {
     ANCESTOR_WALK.with(|c| c.get()) > 0
 }
+
+thread_local! {
+    /// Paths the ancestor walk's candidate loop fetched for the CURRENT
+    /// (class, method) resolution. Lives here for the same layering reason as
+    /// `ANCESTOR_WALK`: the loop is Model, the second enumeration is Index.
+    ///
+    /// It exists to test one claim empirically — that the typeglob fallback
+    /// re-fetches the very files the loop just rejected. Two totals being
+    /// exactly equal is suggestive; per-path overlap is decisive.
+    static MROC_PATHS: std::cell::RefCell<Vec<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+pub fn mroc_begin() {
+    if enabled() {
+        MROC_PATHS.with(|c| c.borrow_mut().clear());
+    }
+}
+
+pub fn mroc_note(path: &std::path::Path) {
+    if enabled() {
+        MROC_PATHS.with(|c| c.borrow_mut().push(path.to_path_buf()));
+    }
+}
+
+pub fn mroc_saw(path: &std::path::Path) -> bool {
+    enabled() && MROC_PATHS.with(|c| c.borrow().iter().any(|p| p == path))
+}


### PR DESCRIPTION
Two commits, restacked on `7aaafbe0`. The narrowing this branch started as has been **built, measured, and dropped**; what lands is the pair of fixtures that pin the behaviour it would have changed, and the measured negative result written down so nobody rebuilds it.

## The overlap, and why it looks worth collapsing

`method_resolution_on_class` enumerates every file registered under the class. When none matches, the typeglob fallback enumerates every file registered under every module *providing* the class — which includes the class itself whenever it declares a sub of its own. Per-path instrumentation (commit 1), because two equal totals are suggestive and per-path identity is decisive:

| | substrate (`gold-corpus/local`) | in-regime (duplicated-package corpus) |
|---|---|---|
| fallback fetches already seen by the walk | 38,609 / 39,491 — **98.6%** | 1,689,378 / 1,689,378 — **100%** |
| genuinely new | 882 | 0 |
| answers found | 80, **all from the 882** | 0 |

The answers live entirely outside the overlap, so the fallback narrows; it can never be deleted.

## Why the narrowing is not in this PR

It was implemented and it works — the walk records, per candidate whose symbols it already holds, the answer to *the fallback's* question (not its own: the walk sees through re-exports and admits class-content, so donating `has_member` loses answers), and the fallback honours it. `mdmp.candidate_fetched` 39,491 → 882 on the substrate and 1,689,378 → **0** in-regime, `mdmp.found` unchanged at 80, six other counters identical as controls.

It buys no wall time anywhere I could measure — three interleaved cold repeats per arm, medians: substrate 20.79 → 20.59 s, in-regime 76.00 → 74.20 s, substrate with `PERL_LSP_NO_SWEEP_MEMO=1` 21.06 → 21.02 s. All inside spread.

The third arm explains the other two. It was built to make these fetches *expensive*; instead, removing 36,712 rehydrations left `rehydrate.loader` **total** flat (3,531 → 3,579 ms, up by noise) while its **average rose** (10.2 → 11.5 µs). Self-consistent, and it is the finding: pull the cheapest entries out of a denominator and the mean rises while the total does not move. **The fetches the narrowing removes are the cheapest rehydrations in the system.**

So the overlap number was **true about count and false about cost**. A 98.6% overlap invites exactly that inference — which is why it is now in `docs/adr/sibling-forks.md` rather than only in a closed PR. A rehydrate *count* is a poor proxy for rehydrate *cost*.

The structural argument does not rescue it either: the sibling-fork rule exists to stop two implementations of one question from diverging in their *answers*, and the path-level data says the fallback's set is a strict superset (the 563 paths it alone answers). Two questions with overlapping work, not two answers to one question. Duplicated work with no measured cost does not earn new machinery.

## What lands

**Commit 1** — the per-path instrumentation. Kept, because it is what produced the numbers above and what anyone re-deriving the finding would otherwise rewrite. Inert without `PERL_LSP_GHOST_STATS`.

**Commit 2** — two fixtures plus the ADR section. The fallback's semantics were entirely unpinned: nothing asserted that it does *not* see through a re-export the walk sees through, nor which provider wins when several match. Both now hold, and both are what any future attempt at this must not break.

Each fixture is verified load-bearing by ablation:

| ablation | rejected-candidate fixture | provider-ordering fixture |
|---|---|---|
| donate the walk's own verdict | **FAILED** | ok |
| answer straight out of the walk loop | ok | **FAILED** |
| as shipped | ok | ok |

That check is part of the deliverable because of how the first version went. The fixture I wrote *before* the change, per the bound-first discipline, **passed under both wrong designs** — an installer sorting before the class short-circuited the fallback's `find()` before the memo was ever consulted, so it asserted a true thing about a path the change does not touch. Caught by ablating it, not by reading it. **An un-ablated fixture is an assertion, not a net**, and bound-first without ablation is false comfort; both are now written next to the doctrine in the ADR.

## Gates

Re-run at `7aaafbe0` after the restack, not at the stale base:

- `cargo test` — **1,526 passed, 0 failed, 6 ignored**
- `cargo test --features cpp` — **1,587 passed, 0 failed, 6 ignored**
- `./e2e/run.sh` — **113 passed, 0 failed** (nvim v0.11.0, the version CI pins)
- gold, after `--clear-cache`, built `--features cpp` — **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · 0 CRASH · lang-skip 0** (503/17 rather than 502/16 is the row that arrived with the new tip)

The rejected implementation was commit `0f41907e`, reachable through this PR's force-push timeline entry and cited from the ADR.