### PR TITLE
Retargeting a PR fires `edited`, which triggered nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,20 @@ on:
   # another feature branch is covered (the reason the default `[main]`
   # filter was dropped). Runs on PRs; doesn't *require* a green check —
   # that's branch protection, separate from this file.
+  #
+  # `edited` is added to the DEFAULT set (opened, synchronize, reopened)
+  # because retargeting a PR's base fires `edited` and nothing else. That is
+  # not an edge case for a stacked PR: squash-merging the bottom of a stack
+  # orphans the rest, and the restack that follows ends in a retarget — so
+  # without this the workflow is blind precisely where stacks live, and the
+  # PR sits with zero checks rather than pending ones. Observed on #145.
+  #
+  # `edited` also fires on title/body edits, which cannot change what the code
+  # does, so each job carries the guard `action != 'edited' || changes.base` —
+  # run on a retarget, skip on a description tweak. On push and synchronize
+  # `action` is not 'edited', so the first clause already passes.
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 # Cancel superseded runs when a PR branch is re-pushed.
 concurrency:
@@ -20,6 +33,7 @@ env:
 jobs:
   rust-tests:
     name: Rust tests
+    if: github.event.action != 'edited' || github.event.changes.base   # see `on:`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -36,6 +50,7 @@ jobs:
 
   e2e-tests:
     name: E2E tests (headless nvim)
+    if: github.event.action != 'edited' || github.event.changes.base   # see `on:`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -58,6 +73,7 @@ jobs:
 
   gold-corpus:
     name: Gold corpus
+    if: github.event.action != 'edited' || github.event.changes.base   # see `on:`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
**One file, 16 lines.** No code, no tests touched.

## The observation

After its restack, #145 sat with **zero check runs** on its head — not queued, not cancelled, no workflow run for that SHA at all.

`pull_request` defaults to `types: [opened, synchronize, reopened]`. Retargeting a PR's base fires **`edited`**, which is not in that set, so nothing re-triggered the workflow.

That is not an exotic corner for this repo. Squash-merging the bottom of a stack orphans the rest, the restack that follows ends in a retarget, and stacked PRs are where integration happens here — so the workflow was blind precisely where stacks live.

The failure mode is the bad kind. A PR with no checks doesn't announce itself; it reads as "the stack is green" if you're looking at the PR *above* it, which contains the same commits and did get a run. It also can't be distinguished from "pending" without checking the count — `total_count: 0` is not "still running", it's "nothing is coming."

## The fix

Add `edited` to the types. Since `edited` also fires on title and body edits — which cannot change what the code does — each job carries a guard:

```yaml
if: github.event.action != 'edited' || github.event.changes.base
```

Run on a retarget, skip on a description tweak. On `push` and `synchronize`, `action` is not `'edited'`, so the first clause already passes and nothing changes for the normal path. Rationale lives once at the `on:` block; the three jobs carry the one-line guard and a pointer, rather than three copies of the paragraph.

## What this does not explain

Stated plainly because the diagnosis is only half of one: this explains why the **retarget** didn't trigger CI. It does **not** explain why the force-push immediately before it failed to fire `synchronize`, which is the documented default and which fired on every other push in the same arc. That anomaly is still open — I'd rather ship the part that's established and say so than let a clean-sounding story cover both.

## Verification

YAML parses; jobs and triggers enumerate as expected. The real test is the next stacked restack — which this repo will produce shortly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy44TSZ96KhDFCy36dZcUj)_