### PR TITLE
A warm scan hands out bag-evicted copies that don't say so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ always a hard fail. The suite runs **twice — cold, then warm against the cache
 the cold pass wrote** — under a private throwaway `XDG_CACHE_HOME`, so a row
 that passes cold and fails warm surfaces as `warm-FAIL` instead of being
 invisible (CI always starts cold). Known warm gaps are declared per row as
-`"warm": "xfail"`; `--no-warm` skips the second pass. Never "fix" a flaky gold
+`"warm": "xfail"`; `--no-warm` skips the second pass. **A warm scan hands out
+bag-EVICTED analyses** — decode them through `decode_analysis_parts(.., None,
+false)`, never raw `decode_analysis`, or the copy claims a bag it does not have
+and every bag-reading projection silently records nothing. Never "fix" a flaky gold
 run by clearing the real cache — that deletes the evidence a warm gap exists,
 and a PARTIAL clear is worse than none. Run it alongside `cargo test` + `./e2e/run.sh` before
 calling a change verified; `gold-corpus/run.pl --emit <cap> <file> <row>

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -426,53 +426,24 @@ non-total order made "the top 200" ambiguous even for an identical pool.
 
 ## Warm gaps (`"warm": "xfail"`)
 
+**None currently open.**
+
 A warm gap is not a missing feature — it is a feature that works once. The
 assertion holds on a cold cache and stops holding when the same analysis is
 rehydrated from a cache blob, so the capability is present the first time a user
 opens a project and silently absent from their second session onward. Nothing
 errors; the answer just gets quieter. CI never sees this class, because CI
-checks out fresh and starts cold every time.
+checks out fresh and starts cold every time — which is why the harness runs a
+second, warm pass and reports `warm-FAIL` as its own status.
 
-### `loader-config-conf-shape-closed` — the closed hash shape does not survive rehydration
-- **Capability:** diagnostics · **Root:** `gold-corpus/longdist-fixture`
-- **Expect:** `key 'alpa' is not in $conf's literal shape (keys: alpha, beta)`
-- **Actual (warm only):** that diagnostic is absent entirely — the file reports
-  just the unrelated `helper-not-loaded` hint. Not a weakened answer, a missing one.
-- **Reproduced four times independently**, on four setups, all landing here.
-- **Deterministic, not a race:** first run after a cold cache passes, every
-  subsequent run against that cache fails. Four consecutive runs give
-  PASS/FAIL/FAIL/FAIL. That rules out a startup-readiness explanation, which
-  is where the shape otherwise points — and would be the wrong tree anyway,
-  since the warm path is the *faster* one.
-- **There is no path sensitivity, and no symlink involvement.** Both were
-  briefly believed. The apparent path-dependent case was a bare
-  `perl-lsp --clear-cache` — which with no root argument wipes the whole
-  `~/.cache/perl-lsp` tree, across checkouts — run between the two
-  measurements, so both of those runs were cold and passed for the ordinary
-  reason. Recorded because it cost real time twice in one evening and the
-  retraction is more useful than the hypothesis: a measurement taken around
-  an unlogged cache-clearing step measures the clear, not the code.
-- **Lead, not a conclusion:** the diagnostic that shows up instead is
-  `'orphan_h' is provided by My::Plugin::Orphan, which no workspace entrypoint
-  loads`, and entrypoint discovery is a **shallow** scan — root plus `bin/` and
-  `script/` (`scan_entrypoint_scripts`). The chain this row pins begins at "the
-  PluginLoad fact from a PACKAGELESS lite entrypoint", and this fixture's
-  loading entrypoints are `app.pl` and the extensionless `jobs` script. Worth
-  ruling out before anything deeper in the rehydration path: if the entrypoint
-  is found cold and missed warm, the shape has nothing to close over and you
-  get exactly this substitution. Not yet verified — check it before believing it.
-- **Fast repro** — 21 rows over 6 roots instead of the full 500:
-  ```sh
-  gold-corpus/run.pl diagnostics
-  ```
-  ~55s measured for both passes (the cold pass alone is ~10s; the rest is the
-  second pass plus per-root startup). The warm lane runs both passes in that one
-  invocation and reports the verdict directly, so no manual cold/warm sequencing
-  — and no cache clearing — is needed.
-- **Fix sketch:** unknown pending the above. The two candidate shapes are (a) the
-  entrypoint/PluginLoad fact is not re-registered on a warm start, or (b) it is
-  registered but the registration-time shape projection is not re-derived from
-  the blob. They are distinguishable by whether the `helper-not-loaded` hint for
-  `orphan_h` is itself correct on the warm run: under (a) the set of
-  entrypoint-loaded plugins changes, so that hint's own claim should move too;
-  under (b) it should be unchanged and only the shape should be lost.
+Declare a known one on the row as `"warm": "xfail"`; it reports as `warm-xfail`
+and flips to `warm-XPASS` when fixed, exactly like `xfail` → `XPASS`.
+
+The first one found and closed was `loader-config-conf-shape-closed`, and its
+shape is worth knowing because nothing about it was specific to that row: the
+warm scan handed out analyses whose witness bag had been left behind but which
+did not say so, so a projection that reads the bag recorded nothing and the
+diagnostic downstream of it went quiet. Any consumer of a warm-scanned analysis
+that reads type facts was exposed to the same thing. Fixed by routing the warm
+decodes through the API that marks a bagless copy evicted, and rehydrating for
+the files whose projections actually need the bag.

--- a/gold-corpus/fixtures/longdist-diagnostics.json
+++ b/gold-corpus/fixtures/longdist-diagnostics.json
@@ -33,9 +33,7 @@
         "none": []
       },
       "status": "gold",
-      "note": "The $conf typo hint proves the whole loader-config chain: the PluginLoad fact from a PACKAGELESS lite entrypoint, the registration-time shape projection, the enrichment join, and the resulting CLOSED HashWithKeys{alpha, beta} feeding the unknown-hash-key diagnostic.",
-      "warm": "xfail",
-      "warm_note": "Passes cold, fails warm: the closed HashWithKeys{alpha, beta} is derived when the PluginLoad fact is registered and is not rebuilt from the cache blob, so on a warm start the shape comes back open and the unknown-key diagnostic has nothing to fire on. Present at 9db9ba19, predates the warm lane that reports it."
+      "note": "The $conf typo hint proves the whole loader-config chain: the PluginLoad fact from a PACKAGELESS lite entrypoint, the registration-time shape projection, the enrichment join, and the resulting CLOSED HashWithKeys{alpha, beta} feeding the unknown-hash-key diagnostic."
     }
   ]
 }

--- a/src/index/module_cache/warm.rs
+++ b/src/index/module_cache/warm.rs
@@ -75,7 +75,14 @@ pub fn warm_cache_streaming(
         let Some(blob) = analysis_blob.filter(|b| !b.is_empty()) else {
             continue;
         };
-        let Some(fa) = decode_analysis(&blob) else {
+        // `decode_analysis_parts(.., None, false)` and not the raw
+        // `decode_analysis`: the scan deliberately does not fetch the bag
+        // column, and only the former marks the result bag-EVICTED. Without
+        // the marker a bagless copy is indistinguishable from one that
+        // genuinely has no type facts, so every downstream reader takes the
+        // empty bag at face value instead of rehydrating — silently, with no
+        // error and no empty-vs-evicted question it could even ask.
+        let Some(fa) = decode_analysis_parts(&blob, None, false) else {
             log::warn!("Failed to decode cached analysis for '{}', skipping", module_name);
             continue;
         };
@@ -348,7 +355,7 @@ pub fn warm_cache(
 
         match analysis_blob {
             Some(blob) if !blob.is_empty() => {
-                match decode_analysis(&blob) {
+                match decode_analysis_parts(&blob, None, false) {
                     Some(mut fa) => {
                         // A pack file's analysis bakes its headers (splices,
                         // witnesses, closure): the row is valid only while the

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -186,7 +186,25 @@ pub fn index_workspace_with_index(
                     ));
                 }
                 if let Some(idx) = module_index {
-                    idx.record_workspace_projections(&path, &fa);
+                    // The loader-shape half of these projections reads the
+                    // witness bag (`expr_type_at_span` over the config
+                    // literal's `Expr` witnesses), and the warm scan hands
+                    // out bag-evicted copies. Reading one anyway does not
+                    // fail — it records NO shape, so the closed
+                    // `HashWithKeys` a `plugin 'X', {...}` load contributes
+                    // simply never exists on a warm start and every
+                    // diagnostic downstream of it goes quiet. Rehydrate for
+                    // the files that actually carry loads: entrypoints and
+                    // little else, so this is a handful of point fetches,
+                    // not a re-decode of the workspace.
+                    if !fa.plugin.loads.is_empty() && fa.bag_is_evicted() {
+                        match module_cache::load_one(conn, &path.to_string_lossy()) {
+                            Some(whole) => idx.record_workspace_projections(&path, &whole),
+                            None => idx.record_workspace_projections(&path, &fa),
+                        }
+                    } else {
+                        idx.record_workspace_projections(&path, &fa);
+                    }
                 }
                 // Registration-owned strip: the name/edge feeds read the
                 // WHOLE analysis, then the requested axes evict, then the


### PR DESCRIPTION
**Stacked on #153** (the warm lane) — that PR's diff is the first commit; this one is the second. **5 files.** `cargo test --features cpp` **1602/0** · gold **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · skip 0 · lang-skip 0 · warm-FAIL 0 · warm-xfail 0** · e2e **113/0**.

This is the fix for the bug #153's warm lane was built to report. **No warm gaps remain open.**

## Root cause

Both warm scans decode with the raw `decode_analysis`. The witness bag lives in its own column and the scan deliberately doesn't fetch it — that split is the point, 94.9% of decodes don't want it. But only `decode_analysis_parts` **marks** that state, which is the entire reason it exists. Its own doc comment says so:

> `want_bag` false — the caller never fetched the column. Mark the analysis bag-EVICTED so a later type query rehydrates rather than reading an empty bag as "no type facts".

The raw call skips the marker, and `bag_evicted` is `#[serde(skip)]`, so a copy comes back off disk **claiming a bag it doesn't have**. Nothing downstream can tell empty from stripped — there is no question it could even ask.

`record_workspace_projections` is the consumer that pays. Its doc already states the requirement — *"loader-config shapes, which read the witness bag via `expr_type_at_span`"* — and the cold walk honours it by running on the whole analysis before stripping. The warm lane hands it a copy that lies, so `expr_type_at_span` finds nothing, no shape is recorded, the closed `HashWithKeys{alpha, beta}` never exists, and the diagnostic keyed off it has nothing to fire on.

## The probe that settled it

```
COLD  contributor=app.pl name=Confy bag_live=true witnesses=74
      -> Some(HashWithKeys { keys: [alpha, beta], open: false })
WARM  contributor=app.pl name=Confy bag_live=true witnesses=0  -> None
```

`bag_live=true` on a copy with zero witnesses is the bug in one line. Every warm-decoded blob showed it, not just the entrypoints — `loads` survived, witnesses didn't.

## It also killed the standing hypothesis

Entrypoint discovery was the suspect. The discriminator was whether the `helper-not-loaded` hint for `orphan_h` changes warm — under a discovery failure the set of entrypoint-loaded plugins moves, so that hint's own claim should move too.

It doesn't. The hint is byte-identical cold and warm, and `widget_count` stays correctly silent, which means the `PluginLoad` facts **are** registered warm and entrypoint discovery is fine. Only the bag-reading half fails. Worth stating because it was a plausible lead that a plausible-sounding investigation could have confirmed instead of tested.

## Fix

**Both warm decodes route through `decode_analysis_parts(.., None, false)`** so a bagless copy is honest. That closes the *class*, not just this row — any warm-scanned consumer of type facts was exposed to the same silence, and this row is simply the one that had a gold assertion pointed at it.

**Then rehydrate where the projection actually needs the bag:** `plugin.loads` non-empty is entrypoints and little else, so it's a handful of point fetches through the existing `load_one`, not a re-decode of the workspace.

## Verified by the instrument, which is the nice part

The row was declared `"warm": "xfail"` in #153. With this fix the suite reported **`warm-XPASS 1`** — the declaration telling me to drop it. Dropped; the gold row now holds cold *and* warm, and `warm-xfail` is 0.

## Cost

Nothing measurable. Cold wall 76.5s vs 75.8s, warm 62.6s vs 62.3s, peak RSS **467 MB vs 497 MB**. Marking copies evicted could in principle have added rehydrate traffic on warm start; it didn't show up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy44TSZ96KhDFCy36dZcUj)_