### PR TITLE
Build the gates with --features cpp — 61 tests and 255 gold rows were never checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # `--features cpp` everywhere the gate builds: a plain build serves Perl
+      # only, so the pack half of the repo goes unchecked while the run stays
+      # green — 61 unit tests never compiled, and gold reports its 255 pack rows
+      # as lang-SKIPS rather than failures, which is the mode that hides a
+      # regression behind a passing check.
       - name: Build
-        run: cargo build
+        run: cargo build --features cpp
 
       - name: Test
-        run: cargo test
+        run: cargo test --features cpp
 
   e2e-tests:
     name: E2E tests (headless nvim)
@@ -59,8 +64,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # Changes no test TODAY — `run.sh` drives a fixed, Perl-only suite list, so
+      # the pack suites (`e2e/run-cpp.sh`, its own lane) are unaffected by the
+      # flag. It is here so the four build lines do not diverge and invite the
+      # question of why this one is different.
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --features cpp
 
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
@@ -123,7 +132,7 @@ jobs:
           cpm install -L local --resolver snapshot
 
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --features cpp   # see rust-tests' Build step
 
       - name: Run gold-corpus harness
         run: perl gold-corpus/run.pl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,10 @@ jobs:
           cpm install -g Carton::Snapshot   # --resolver snapshot needs this to read cpanfile.snapshot
           cpm install -L local --resolver snapshot
 
+      # The release gate has the same half-gate as CI's: a plain build
+      # lang-skips the pack corpus and reports it green. Ship on the whole one.
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --features cpp
 
       - name: Run gold-corpus harness
         run: perl gold-corpus/run.pl

--- a/gold-corpus/KNOWN-GAPS.md
+++ b/gold-corpus/KNOWN-GAPS.md
@@ -447,3 +447,25 @@ diagnostic downstream of it went quiet. Any consumer of a warm-scanned analysis
 that reads type facts was exposed to the same thing. Fixed by routing the warm
 decodes through the API that marks a bagless copy evicted, and rehydrating for
 the files whose projections actually need the bag.
+
+## The gates test a configuration the releases do not ship
+
+CI and the release gate build `--features cpp`, so the whole corpus runs and
+`lang-skip` is 0. The **shipped artifacts do not**: `release.yml`'s
+per-target build stays plain, deliberately, because whether the pack
+languages ship enabled is a product decision — they are beta, and
+`--languages` advertises them as such — not a CI-hygiene one.
+
+So the gates are now honest about the code the repo CONTAINS, and silent
+about the code a user RECEIVES. Two things follow, and neither is implied by
+a green check:
+
+- A pack regression is caught before merge, but a released binary is not
+  exercised in the configuration it ships in. The reverse is also true: a
+  Perl-only build could break in a way no gate sees, because nothing now
+  builds one.
+- "CI tests cpp" must not be read as "releases contain tested cpp." Until
+  the product decision lands, those are different binaries.
+
+Closing this means deciding what releases ship, then making the gate build
+match it — not adding a flag.


### PR DESCRIPTION
Five lines across two workflows, plus a `KNOWN-GAPS.md` entry. No code touched.

## What was wrong

Every CI job built a Perl-only binary, so the pack half of the repo went unchecked while every run stayed green.

| | plain build (what CI did) | `--features cpp` |
|---|---|---|
| `cargo test` | **1,526** passed | **1,587** passed |
| gold PASS | **252** | **503** |
| gold **lang-skip** | **255** | **0** |

Both measured on this tip, not inferred. The 61 unit tests were never compiled; the 255 gold rows were **skipped**, and a skip does not fail a run — CI's own log names them one by one as `(lang=cpp; binary serves: perl)` and exits 0.

That is the dangerous half. A missing test is absent; a skipped row is *reported*, in a section nobody reads, under a green check. `CLAUDE.md` warns about exactly this in its build block — "half the corpus silently unexercised, reported as skips, not failures. Check `lang-skip 0` in the summary" — and CI did not follow its own instruction.

`release.yml`'s gold gate had the identical hole, so releases were gated the same way.

## What changed

| site | effect |
|---|---|
| `ci.yml` Build / Test | +61 unit tests |
| `ci.yml` gold build | +251 gold rows, `lang-skip` 255 → 0 |
| `ci.yml` e2e build | **no test change today** — see below |
| `release.yml` gold build | same fix for the release gate |
| `release.yml` per-target build | **untouched** — see below |

**The e2e line is a deliberate no-op.** `e2e/run.sh` drives a hardcoded, Perl-only suite list, so the flag adds nothing there. It is included so the four build lines do not diverge, and the reason is written **in the YAML** rather than only here — "why is this one built differently" is a question the workflow raises every time someone edits it, whereas a PR body is read once.

**The shipped artifacts are deliberately untouched.** Whether the pack languages ship enabled is a product decision — they are beta and `--languages` says so — not CI hygiene. Bundling it would smuggle a release-content change into a gate fix.

That leaves a real gap, and it is logged in `gold-corpus/KNOWN-GAPS.md` rather than left to be inferred: **the gates now test a configuration the releases do not ship.** A pack regression is caught before merge, but no gate exercises a released binary in the configuration it ships in — and now that nothing builds Perl-only, the reverse is true too. "CI tests cpp" must not be read as "releases contain tested cpp."

## Not in this PR

`e2e/run-cpp.sh` — 8 suites, 24 tests — **is invoked by no workflow at all.** It builds its own `--features all-langs` release and drives the pack suites through the same lua harness; `grep -rn "run-cpp" .github/` is empty. So the lane has never executed in CI. It passes today (24 passed, 0 failed, exit 0, measured on this tip), and it carries a **python** suite as well, so it is not a cpp-only step.

Wiring it adds a job rather than a flag, so it is its own PR, next.

## Verification

Full bar at `7366232a`, with the flag:

- `cargo test` — **1,526 passed, 0 failed, 6 ignored** (unflagged, for the comparison above)
- `cargo test --features cpp` — **1,587 passed, 0 failed, 6 ignored**
- `./e2e/run.sh` — **113 passed, 0 failed** (nvim v0.11.0, the version CI pins)
- gold — **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · 0 CRASH · lang-skip 0**, and the warm lane from #153 clean at **warm-FAIL 0 · warm-XPASS 0**

The gate tightens without reddening anyone: the 251 rows and 61 tests it newly runs all pass on this tip.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_