### PR TITLE
Three scripts for the reading errors, not the gates

### DIFF
--- a/scripts/board.sh
+++ b/scripts/board.sh
@@ -44,15 +44,61 @@ _state_dir() {
   printf '%s/board-state/%s' "$root" "$issue"
 }
 
+# --- transport -------------------------------------------------------------
+# Prefer `gh`; fall back to unauthenticated curl, because some agent sandboxes
+# have no gh CLI at all (GitHub reaches those through MCP tools instead). This
+# repo is public, so READS work unauthenticated, at a lower rate limit; POSTING
+# still needs gh or $GITHUB_TOKEN. Anyone with neither should follow the four
+# rules in the header BY HAND — they are the contract, and this script is only
+# one implementation of it.
+# BOARD_NO_GH=1 forces the curl path — the only way to exercise the fallback on
+# a box that has gh, and therefore the only way it stays working.
+HAVE_GH=0
+if [ "${BOARD_NO_GH:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then HAVE_GH=1; fi
+
+_curl_pages() {  # walk pages explicitly; never trust a single page to be all
+  local path="$1" page=1 body
+  local auth=(); [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  while :; do
+    body="$(curl -sSf "${auth[@]}" -H 'Accept: application/vnd.github+json' \
+             "https://api.github.com/$path?per_page=100&page=$page" 2>/dev/null)" || break
+    [ "$(jq 'length' <<<"$body" 2>/dev/null || echo 0)" -eq 0 ] && break
+    printf '%s\n' "$body"
+    page=$((page+1))
+  done
+}
+
+_jqfmt() { printf '%s' '"\u001b[36m─── #\(.id)  \(.user.login)  \(.created_at)  \(.html_url)\u001b[0m\n\(.body)\n"'; }
+
 # All comment ids, ascending. The one place that talks to the API.
 _all_ids() {
-  gh api --paginate "repos/$REPO/issues/$1/comments" --jq '.[].id' | sort -n
+  if [ $HAVE_GH -eq 1 ]; then
+    gh api --paginate "repos/$REPO/issues/$1/comments" --jq '.[].id' | sort -n
+  else
+    _curl_pages "repos/$REPO/issues/$1/comments" | jq -r '.[].id' | sort -n
+  fi
 }
 
 _render() {
-  local id="$1"
-  gh api "repos/$REPO/issues/comments/$id" \
-    --jq '"[36m─── #\(.id)  \(.user.login)  \(.created_at)  \(.html_url)[0m\n\(.body)\n"'
+  local id="$1" fmt; fmt="$(_jqfmt)"
+  if [ $HAVE_GH -eq 1 ]; then
+    gh api "repos/$REPO/issues/comments/$id" --jq "$fmt"
+  else
+    local auth=(); [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    curl -sSf "${auth[@]}" -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/$REPO/issues/comments/$id" | jq -r "$fmt"
+  fi
+}
+
+_brief() {  # one line, for the watch loop / Monitor
+  local id="$1" fmt='"[#\(.id)] \(.body[0:400] | gsub("\n";" "))"'
+  if [ $HAVE_GH -eq 1 ]; then
+    gh api "repos/$REPO/issues/comments/$id" --jq "$fmt" 2>/dev/null
+  else
+    local auth=(); [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    curl -sSf "${auth[@]}" -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/$REPO/issues/comments/$id" 2>/dev/null | jq -r "$fmt"
+  fi
 }
 
 _unseen() {
@@ -103,8 +149,7 @@ cmd_watch() {
     if [ -n "$ids" ]; then
       while read -r id; do
         [ -n "$id" ] || continue
-        gh api "repos/$REPO/issues/comments/$id" \
-          --jq '"[#\(.id)] \(.body[0:400] | gsub("\n";" "))"' 2>/dev/null || true
+        _brief "$id" || true
       done <<< "$ids"
       printf '%s\n' "$ids" | _mark "$issue"
     fi
@@ -115,6 +160,14 @@ cmd_watch() {
 cmd_post() {
   local file="$1" issue="${2:-$DEFAULT_ISSUE}" url id dir
   [ -f "$file" ] || { echo "no such file: $file" >&2; return 1; }
+  if [ $HAVE_GH -eq 0 ]; then
+    # Posting needs a write credential. Say so plainly rather than failing with
+    # "gh: command not found" three frames down.
+    echo "board.sh post needs the gh CLI (not found)." >&2
+    echo "Reads work without it; posting does not. Use your sandbox's GitHub" >&2
+    echo "tooling to comment, then: scripts/board.sh catchup $issue" >&2
+    return 127
+  fi
   url="$(gh issue comment "$issue" --repo "$REPO" --body-file "$file")"
   id="${url##*-}"
   dir="$(_state_dir "$issue")"; mkdir -p "$dir"

--- a/scripts/board.sh
+++ b/scripts/board.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Message-board client for a GitHub issue used as a multi-agent channel.
+#
+# Every agent on an arc posts to and reads from one issue. Doing that with a
+# bare `gh api` call is wrong in four ways that all fail SILENTLY — the caller
+# gets plausible output and no error. Each is encoded here so nobody rediscovers
+# it:
+#
+#   1. `?per_page=100` returns the FIRST page. On a thread past 100 comments the
+#      newest are on page 2+, so `.[-1]` freezes on a stale comment and a watcher
+#      built on it goes quiet while the board is active. Fix: `--paginate`.
+#   2. `sort=created&direction=desc` is IGNORED by the issue-comments endpoint.
+#      It does not error; it returns the OLDEST page. Fix: never sort server-side,
+#      order by id locally.
+#   3. Under `--paginate`, gh runs the jq filter ONCE PER PAGE, so `.[-1].id`
+#      emits one id per page, not one id total. It looks like a single value
+#      when the thread is short and silently becomes N lines when it grows;
+#      taking any one of them without ordering (or reading the first) gives a
+#      stale comment. Fix: order by id explicitly, never trust array position.
+#   4. Filtering by author to skip your own posts silences EVERYONE when the
+#      agents share one GitHub account, which they do. Fix: record the ids of
+#      comments this script posts, and skip exactly those.
+#
+# Usage:
+#   scripts/board.sh new [issue]           unseen comments, oldest first; marks seen
+#   scripts/board.sh peek [issue]          same, but does NOT mark seen
+#   scripts/board.sh watch [issue] [secs]  poll; print each new comment as it lands
+#   scripts/board.sh post <file> [issue]   post a comment, record it as self
+#   scripts/board.sh catchup [issue]       mark everything seen without printing
+#   scripts/board.sh show <comment-id>     print one comment in full
+#
+# State lives in .git/board-state/<issue>/ — inside .git so it is per-clone,
+# never committed, and survives a worktree switch.
+set -euo pipefail
+
+REPO="${BOARD_REPO:-tree-sitter-perl/perl-lsp}"
+DEFAULT_ISSUE="${BOARD_ISSUE:-120}"
+
+_state_dir() {
+  local issue="$1" root
+  root="$(git rev-parse --git-common-dir 2>/dev/null || echo .git)"
+  # --git-common-dir is relative in some worktrees; anchor it.
+  case "$root" in /*) ;; *) root="$(cd "$root" && pwd)" ;; esac
+  printf '%s/board-state/%s' "$root" "$issue"
+}
+
+# All comment ids, ascending. The one place that talks to the API.
+_all_ids() {
+  gh api --paginate "repos/$REPO/issues/$1/comments" --jq '.[].id' | sort -n
+}
+
+_render() {
+  local id="$1"
+  gh api "repos/$REPO/issues/comments/$id" \
+    --jq '"[36m─── #\(.id)  \(.user.login)  \(.created_at)  \(.html_url)[0m\n\(.body)\n"'
+}
+
+_unseen() {
+  local issue="$1" dir seen
+  dir="$(_state_dir "$issue")"; mkdir -p "$dir"
+  seen="$dir/seen"; touch "$seen"
+  # comm needs lexically-sorted input; ids are fixed-width enough in practice,
+  # but sort -n then re-sort as text keeps comm correct regardless.
+  comm -23 <(_all_ids "$issue" | sort) <(sort "$seen") | sort -n
+}
+
+_mark() {
+  local issue="$1" dir; dir="$(_state_dir "$issue")"; mkdir -p "$dir"
+  cat >> "$dir/seen"
+  sort -u -o "$dir/seen" "$dir/seen"
+}
+
+cmd_new() {
+  local issue="${1:-$DEFAULT_ISSUE}" ids n=0
+  ids="$(_unseen "$issue")"
+  [ -z "$ids" ] && { echo "no new comments on #$issue"; return 0; }
+  while read -r id; do [ -n "$id" ] || continue; _render "$id"; n=$((n+1)); done <<< "$ids"
+  printf '%s\n' "$ids" | _mark "$issue"
+  echo "($n new on #$issue, now marked seen)"
+}
+
+cmd_peek() {
+  local issue="${1:-$DEFAULT_ISSUE}" ids
+  ids="$(_unseen "$issue")"
+  [ -z "$ids" ] && { echo "no new comments on #$issue"; return 0; }
+  while read -r id; do [ -n "$id" ] || continue; _render "$id"; done <<< "$ids"
+  echo "(not marked seen — use 'new' to consume)"
+}
+
+cmd_catchup() {
+  local issue="${1:-$DEFAULT_ISSUE}" ids
+  ids="$(_unseen "$issue")"
+  [ -z "$ids" ] && { echo "already caught up on #$issue"; return 0; }
+  printf '%s\n' "$ids" | _mark "$issue"
+  echo "marked $(printf '%s\n' "$ids" | grep -c .) comment(s) seen on #$issue"
+}
+
+# One line per new comment, so it can drive a Monitor. Never exits on its own.
+cmd_watch() {
+  local issue="${1:-$DEFAULT_ISSUE}" every="${2:-60}" ids
+  while true; do
+    ids="$(_unseen "$issue" || true)"
+    if [ -n "$ids" ]; then
+      while read -r id; do
+        [ -n "$id" ] || continue
+        gh api "repos/$REPO/issues/comments/$id" \
+          --jq '"[#\(.id)] \(.body[0:400] | gsub("\n";" "))"' 2>/dev/null || true
+      done <<< "$ids"
+      printf '%s\n' "$ids" | _mark "$issue"
+    fi
+    sleep "$every"
+  done
+}
+
+cmd_post() {
+  local file="$1" issue="${2:-$DEFAULT_ISSUE}" url id dir
+  [ -f "$file" ] || { echo "no such file: $file" >&2; return 1; }
+  url="$(gh issue comment "$issue" --repo "$REPO" --body-file "$file")"
+  id="${url##*-}"
+  dir="$(_state_dir "$issue")"; mkdir -p "$dir"
+  # Record as seen AND as self, so the watcher never reports our own post back
+  # to us. Exact by construction — no marker string to forget, and no author
+  # filter (which would silence every agent sharing this account).
+  printf '%s\n' "$id" | _mark "$issue"
+  printf '%s\n' "$id" >> "$dir/self"
+  echo "$url"
+}
+
+cmd_show() { _render "$1"; }
+
+case "${1:-}" in
+  new)     shift; cmd_new "$@" ;;
+  peek)    shift; cmd_peek "$@" ;;
+  watch)   shift; cmd_watch "$@" ;;
+  post)    shift; cmd_post "$@" ;;
+  catchup) shift; cmd_catchup "$@" ;;
+  show)    shift; cmd_show "$@" ;;
+  *) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 1 ;;
+esac

--- a/scripts/docs-audit.sh
+++ b/scripts/docs-audit.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Mechanical staleness in the prose corpus: claims that are checkable WITHOUT
+# judgement. Everything here is a fact about whether a named thing exists, so a
+# hit is a hit — no reading required, and no agent should spend tokens on it.
+#
+# What this deliberately does NOT do: anything needing judgement. "X is the only
+# writer of Y", "this is deferred", "the chase is 61.6%" — those are claims about
+# behaviour, status, and measurements, and a grep cannot adjudicate them. They
+# are the reason a human or an agent reads the doc. This script exists so that
+# reading starts from the interesting part.
+#
+# Two kinds of deliberate staleness exist in this repo and are NOT bugs:
+#   - struck-through text (~~...~~) is kept on purpose when workaround code
+#     written against the old behaviour still exists (see the `right:` field
+#     note in CLAUDE.md). Lines containing ~~ are skipped.
+#   - forward-compat references to things that do not exist YET (the
+#     `parenthesized_expression` arms). Those are flagged but marked LIKELY-OK
+#     when the surrounding line says so.
+#
+# Usage: scripts/docs-audit.sh [--quiet]   (exit 1 if anything found)
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+QUIET=0; [ "${1:-}" = "--quiet" ] && QUIET=1
+
+# A mixed tree makes every result meaningless: audit docs from one commit
+# against code from another and you get confident nonsense. This bit me
+# immediately — a tree 27 commits behind reported `PackageSymbol` "absent from
+# src/" in 18 docs, when the rename that introduced it simply had not been
+# pulled. Refuse rather than warn; a warning gets skimmed.
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  UP="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  if [ -n "$UP" ]; then
+    git fetch -q origin 2>/dev/null || true
+    BEHIND="$(git rev-list --count "HEAD..$UP" 2>/dev/null || echo 0)"
+    if [ "${BEHIND:-0}" -gt 0 ]; then
+      echo "REFUSING: working tree is $BEHIND commit(s) behind $UP." >&2
+      echo "Docs and code must come from the SAME tree or every finding is suspect." >&2
+      echo "Run: git merge --ff-only $UP" >&2
+      exit 2
+    fi
+  fi
+fi
+RED=$'\033[31m'; YEL=$'\033[33m'; DIM=$'\033[2m'; OFF=$'\033[0m'
+# `hit` runs inside pipelines, i.e. subshells, so a FOUND=1 there is lost and
+# the summary contradicts the output it just printed. Count through a file.
+HITS="$(mktemp)"; trap 'rm -f "$HITS"' EXIT
+CORPUS=$(find docs -name '*.md' 2>/dev/null; ls CLAUDE.md README.md 2>/dev/null; \
+         ls gold-corpus/README.md gold-corpus/KNOWN-GAPS.md bench/RESULTS.md 2>/dev/null)
+
+hdr() { [ $QUIET -eq 1 ] || printf '\n%s── %s%s\n' "$DIM" "$1" "$OFF"; }
+hit() { echo 1 >> "$HITS"; printf '  %s%s%s  %s\n' "$RED" "$1" "$OFF" "$2"; }
+
+# Lines that are deliberately historical/forward-looking are exempt.
+_live_lines() {  # file -> "lineno:text" excluding struck-through
+  grep -n '' "$1" 2>/dev/null | grep -v '~~'
+}
+
+# ---- 1. referenced source paths that do not exist -------------------------
+hdr "source paths referenced in prose that do not exist"
+for f in $CORPUS; do
+  _live_lines "$f" | grep -oE '^[0-9]+:.*' | while IFS= read -r line; do
+    n="${line%%:*}"
+    echo "$line" | grep -oE '\b(src|e2e|gold-corpus|scripts|bench|frameworks)/[A-Za-z0-9_./-]+\.(rs|pl|sh|lua|rhai|json|md)\b' \
+    | while read -r p; do
+        [ -e "$p" ] || echo "MISS|$f:$n|$p"
+      done
+  done
+done | sort -u -t'|' -k3 | while IFS='|' read -r _ loc p; do hit "$p" "$loc"; done
+
+# ---- 2. env vars documented but absent from the tree ----------------------
+hdr "PERL_LSP_* documented but not present in src/"
+comm -23 \
+  <(for f in $CORPUS; do _live_lines "$f" | grep -oE 'PERL_LSP_[A-Z0-9_]+'; done | sort -u) \
+  <(grep -rhoE 'PERL_LSP_[A-Z0-9_]+' src/ 2>/dev/null | sort -u) \
+| while read -r v; do
+    [ -n "$v" ] || continue
+    hit "$v" "$(grep -rln "$v" $CORPUS 2>/dev/null | paste -sd, )"
+  done
+
+# ---- 3. CLI flags documented but not in the arg parser --------------------
+hdr "perl-lsp --flags documented but not found in src/"
+for f in $CORPUS; do _live_lines "$f" | grep -oE '\-\-[a-z][a-z0-9-]{3,}'; done | sort -u \
+| while read -r flag; do
+    [ -n "$flag" ] || continue
+    grep -rqF "\"$flag\"" src/ 2>/dev/null && continue
+    grep -rqF "$flag" src/ 2>/dev/null && continue
+    # only report flags that look like ours (documented next to perl-lsp)
+    grep -rqE "perl-lsp[^\\n]*$flag" $CORPUS 2>/dev/null && \
+      hit "$flag" "$(grep -rlE "perl-lsp[^\\n]*$flag" $CORPUS 2>/dev/null | head -3 | paste -sd, )"
+  done
+
+# ---- 4. doc -> doc links that dangle --------------------------------------
+hdr "cross-references to docs that do not exist"
+for f in $CORPUS; do
+  _live_lines "$f" | grep -oE '\b(docs/[A-Za-z0-9_./-]+\.md)\b' | sort -u \
+  | while read -r p; do [ -e "$p" ] || hit "$p" "$f"; done
+done
+
+# ---- 5. Rust items named in prose that no longer exist --------------------
+# Only backticked CamelCase / snake_case::path forms, to keep the false-positive
+# rate survivable. A miss here is worth a look, not an automatic edit.
+hdr "backticked Rust items not found anywhere in src/ (review, not gospel)"
+for f in $CORPUS; do
+  _live_lines "$f" | grep -oE '`[A-Z][A-Za-z0-9]{4,}`' | tr -d '`' | sort -u \
+  | while read -r sym; do
+      grep -rqE "\b$sym\b" src/ 2>/dev/null || echo "$sym|$f"
+    done
+done | cut -d'|' -f1 | sort -u | while read -r sym; do
+  # a type named in only one doc is usually a design sketch, not a stale claim
+  cnt=$(grep -rl "\`$sym\`" $CORPUS 2>/dev/null | wc -l)
+  [ "$cnt" -ge 2 ] && hit "$sym" "in $cnt docs, absent from src/"
+done
+
+N=$(wc -l < "$HITS" 2>/dev/null || echo 0); N=${N// /}
+[ $QUIET -eq 1 ] || {
+  echo
+  if [ "$N" -eq 0 ]; then echo "no mechanical staleness found"
+  else echo "${YEL}$N mechanical finding(s) — these need no agent, only an edit${OFF}"; fi
+}
+[ "$N" -eq 0 ]

--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Is this PR actually safe to merge? Answers the four questions that a green
+# checkmark on the PR page does NOT answer.
+#
+# Every one of these produced a wrong call on this repo:
+#
+#   1. "Green" can include CANCELLED. `statusCheckRollup` keeps HISTORICAL
+#      entries, so a check appears once per run — and `cancel-in-progress` in
+#      ci.yml guarantees a CANCELLED entry beside the real one after every
+#      force-push. A filter of `conclusion != "SUCCESS"` therefore reports
+#      three failures on a fully green PR. Fix: group by check name, take the
+#      latest, ignore CANCELLED.
+#
+#   2. "Green" can be green on a DIFFERENT COMMIT. `pull_request` does not fire
+#      on a base retarget (`edited` is not in the default type set), and
+#      cancel-in-progress eats the force-push run. A restacked PR can therefore
+#      show zero checks, or checks belonging to the pre-restack SHA. Fix: match
+#      each run's headSha against the PR's CURRENT head.
+#
+#   3. "Green" can be green against a MOVED BASE. A verdict is only about the
+#      tree it was computed on. Fix: report how far behind the integration tip
+#      the PR is — and, because demanding a rebase for every unrelated commit
+#      never converges when several agents are landing work, report whether the
+#      PR's files actually INTERSECT what the tip gained. No overlap means the
+#      base move cannot break this tree.
+#
+#   4. Squash-merging a PR that is the BASE of another orphans the rest of the
+#      stack: the squash creates one new commit, so the child still carries the
+#      originals and conflicts against content that is already upstream. Fix:
+#      detect dependents and say `--merge`.
+#
+# Usage:  scripts/pr-status.sh <pr> [<pr>...]
+set -uo pipefail
+
+REPO="${BOARD_REPO:-tree-sitter-perl/perl-lsp}"
+INTEGRATION="${INTEGRATION_BRANCH:-claude/project-rewrite-cpp-yqutwf}"
+RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; OFF=$'\033[0m'
+
+[ $# -eq 0 ] && { sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+
+git fetch origin --quiet 2>/dev/null || true
+TIP="$(git rev-parse "origin/$INTEGRATION" 2>/dev/null)"
+echo "integration tip: ${TIP:0:8} ($INTEGRATION)"
+echo
+
+overall=0
+for pr in "$@"; do
+  meta="$(gh pr view "$pr" --repo "$REPO" --json number,title,headRefName,headRefOid,baseRefName,mergeable,state 2>/dev/null)" || {
+    echo "${RED}#$pr: cannot read${OFF}"; overall=1; continue; }
+  head="$(jq -r .headRefOid <<<"$meta")"
+  branch="$(jq -r .headRefName <<<"$meta")"
+  base="$(jq -r .baseRefName <<<"$meta")"
+  state="$(jq -r .state <<<"$meta")"
+  mrg="$(jq -r .mergeable <<<"$meta")"
+  title="$(jq -r .title <<<"$meta")"
+  echo "── #$pr ${title:0:60}"
+  echo "   head=${head:0:8} base=$base state=$state mergeable=$mrg"
+
+  ok=1
+
+  # (1) checks: latest per name, CANCELLED ignored
+  rollup="$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup 2>/dev/null)"
+  verdict="$(jq -r '
+    [.statusCheckRollup[]? | select(.conclusion != "CANCELLED")]
+    | group_by(.name) | map(last)
+    | if length == 0 then "NONE"
+      elif any(.status != "COMPLETED") then "PENDING"
+      elif all(.conclusion == "SUCCESS") then "GREEN"
+      else "FAILED: " + ([.[] | select(.conclusion != "SUCCESS") | .name] | join(","))
+      end' <<<"$rollup")"
+  case "$verdict" in
+    GREEN)   echo "   ${GRN}checks: GREEN${OFF}" ;;
+    NONE)    echo "   ${RED}checks: NONE — CI never ran on this head (base retarget? see note 2)${OFF}"; ok=0 ;;
+    PENDING) echo "   ${YEL}checks: PENDING${OFF}"; ok=0 ;;
+    *)       echo "   ${RED}checks: $verdict${OFF}"; ok=0 ;;
+  esac
+
+  # (2) do those checks belong to the CURRENT head?
+  runs_on_head="$(gh run list --repo "$REPO" --limit 40 --json headSha,conclusion \
+      --jq "[.[] | select(.headSha == \"$head\")] | length" 2>/dev/null || echo 0)"
+  if [ "${runs_on_head:-0}" -eq 0 ]; then
+    echo "   ${RED}no workflow run exists for head ${head:0:8} — any green belongs to another commit${OFF}"
+    ok=0
+  else
+    echo "   runs on current head: $runs_on_head"
+  fi
+
+  # (3) behind the tip, and does it matter?
+  if git fetch origin "$branch" --quiet 2>/dev/null; then
+    bh="$(git rev-list --count FETCH_HEAD.."$TIP" 2>/dev/null || echo '?')"
+    if [ "$bh" = "0" ]; then
+      echo "   behind tip: 0"
+    else
+      mb="$(git merge-base FETCH_HEAD "$TIP" 2>/dev/null)"
+      inter="$(comm -12 \
+        <(git diff --name-only "$mb"..FETCH_HEAD 2>/dev/null | sort) \
+        <(git diff --name-only "$mb".."$TIP" 2>/dev/null | sort))"
+      if [ -z "$inter" ]; then
+        echo "   behind tip: $bh commits, ${GRN}no file overlap${OFF} — base move cannot break this tree"
+      else
+        echo "   behind tip: $bh commits, ${YEL}OVERLAPS:${OFF}"
+        printf '     %s\n' $inter
+        ok=0
+      fi
+    fi
+  fi
+
+  # (4) is anything stacked on this PR?
+  deps="$(gh pr list --repo "$REPO" --state open --json number,baseRefName \
+      --jq "[.[] | select(.baseRefName == \"$branch\") | .number] | join(\", \")" 2>/dev/null)"
+  if [ -n "$deps" ] && [ "$deps" != "" ]; then
+    echo "   ${YEL}dependents: #$deps — merge with --merge, NOT --squash (squash orphans them)${OFF}"
+  fi
+
+  if [ $ok -eq 1 ]; then echo "   ${GRN}=> safe to merge${OFF}"; else echo "   ${RED}=> NOT clear${OFF}"; overall=1; fi
+  echo
+done
+exit $overall

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Run the verification bar and keep every byte of output.
+#
+# WHY THIS EXISTS. Each gate below already reports correctly. What kept going
+# wrong was the READING of them, always in one of three ways:
+#
+#   A. Truncated capture. `... | tail -6` catches the timing block and cuts the
+#      verdict; `grep -E 'PASS|FAIL' | tail -4` catches the banner and not the
+#      counts. Both look like a result. Fix: never pipe a gate through head/tail
+#      — the full log is written to disk and the summary is extracted from the
+#      file afterwards, so a bad extraction costs a re-read, not a re-run.
+#
+#   B. Grep as the verdict. A suite's EXIT CODE is the verdict; grep is for the
+#      human summary only. Nothing here decides pass/fail from matched text.
+#
+#   C. An unasserted PREMISE — the one that actually bit hardest. A gate can run
+#      correctly, exit 0, and have tested half of what you think:
+#        - gold EXCLUDES lang-skip from its exit code ON PURPOSE, because a
+#          perl-only build legitimately cannot serve cpp rows. So a build that
+#          forgot `--features cpp` skips 255 rows, reports them as skips, and
+#          EXITS 0. That is not gold's bug; gold cannot know what you meant to
+#          build. Only the caller knows, so the caller asserts it.
+#        - e2e/run-cpp.sh existed for months wired to no workflow. "e2e-cpp 0"
+#          was zero RUNS, not zero failures. A gate that did not run must never
+#          read as a gate that passed, so a missing prerequisite is a HARD ERROR
+#          here, never a skip.
+#
+# Usage:
+#   scripts/verify.sh                 # every gate
+#   scripts/verify.sh unit gold       # only these
+#   scripts/verify.sh --list          # gate names
+#   KEEP=20 scripts/verify.sh         # keep N run dirs (default 10)
+#
+# Gates: unit unit-cpp gold e2e e2e-cpp
+# Logs:  /tmp/perl-lsp-verify/<stamp>/<gate>.log, with `latest` symlinked.
+set -uo pipefail   # deliberately NOT -e: a failing gate must not abort the rest
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOGDIR="/tmp/perl-lsp-verify/$STAMP"
+mkdir -p "$LOGDIR"
+ln -sfn "$LOGDIR" /tmp/perl-lsp-verify/latest
+
+RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; DIM=$'\033[2m'; OFF=$'\033[0m'
+declare -a RESULTS=()
+FAILED=0
+
+note()  { printf '%s\n' "$*"; }
+record() {  # gate verdict detail
+  RESULTS+=("$1|$2|$3")
+  [ "$2" = PASS ] || FAILED=1
+}
+
+# Run a command, tee the FULL output to a log, return its real exit code.
+# `set -o pipefail` above makes the tee not swallow it.
+run_logged() {
+  local gate="$1"; shift
+  local log="$LOGDIR/$gate.log"
+  printf '%s$ %s%s\n' "$DIM" "$*" "$OFF"
+  { "$@"; } >"$log" 2>&1
+  local rc=$?
+  printf '%s  → %s (rc=%d)%s\n' "$DIM" "$log" "$rc" "$OFF"
+  return $rc
+}
+
+# ---- premise checks -------------------------------------------------------
+# These answer "did the gate test what I meant?", which no gate can answer for
+# itself. Each one corresponds to a real miss on this project.
+
+require_bin() {  # a missing prerequisite is a hard error, never a silent skip
+  command -v "$1" >/dev/null 2>&1 && return 0
+  record "$2" ERROR "prerequisite '$1' not found — gate did NOT run"
+  note "  ${RED}✗ $2: '$1' missing. A gate that did not run is not a gate that passed.${OFF}"
+  [ -n "${3:-}" ] && note "    $3"
+  return 1
+}
+
+# ---- gates ----------------------------------------------------------------
+
+gate_unit() {
+  run_logged unit cargo test
+  local rc=$?
+  local n; n="$(grep -oE '^test result: ok\. [0-9]+ passed' "$LOGDIR/unit.log" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) t+=$i} END{print t+0}')"
+  echo "$n" > "$LOGDIR/.unit-count"
+  [ $rc -eq 0 ] && record unit PASS "$n passed" || record unit FAIL "rc=$rc — see unit.log"
+}
+
+gate_unit_cpp() {
+  run_logged unit-cpp cargo test --features cpp
+  local rc=$?
+  local n; n="$(grep -oE '^test result: ok\. [0-9]+ passed' "$LOGDIR/unit-cpp.log" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) t+=$i} END{print t+0}')"
+  if [ $rc -ne 0 ]; then record unit-cpp FAIL "rc=$rc — see unit-cpp.log"; return; fi
+  # PREMISE: the cpp build must run strictly MORE tests than the perl-only one.
+  # Equal counts mean the feature did not actually take, which exits 0.
+  local base=0; [ -f "$LOGDIR/.unit-count" ] && base="$(cat "$LOGDIR/.unit-count")"
+  if [ "$base" -gt 0 ] && [ "$n" -le "$base" ]; then
+    record unit-cpp FAIL "$n tests vs perl-only $base — cpp feature did not add tests"
+  else
+    record unit-cpp PASS "$n passed$([ "$base" -gt 0 ] && echo " (+$((n-base)) over perl-only)")"
+  fi
+}
+
+gate_gold() {
+  run_logged gold-build cargo build --release --features cpp
+  [ $? -ne 0 ] && { record gold FAIL "release --features cpp build failed — see gold-build.log"; return; }
+  run_logged gold perl gold-corpus/run.pl
+  local rc=$?
+  local log="$LOGDIR/gold.log"
+  local get; get() { grep -oE "^  $1 +[0-9]+" "$log" | grep -oE '[0-9]+$' | tail -1; }
+  local pass fail langskip skip crash xpass
+  pass="$(get PASS)"; fail="$(get FAIL)"; langskip="$(get lang-skip)"
+  skip="$(get skip)"; crash="$(get CRASH)"; xpass="$(get XPASS)"
+  local detail="PASS=${pass:-?} FAIL=${fail:-?} XPASS=${xpass:-?} CRASH=${crash:-?} skip=${skip:-?} lang-skip=${langskip:-?}"
+  if [ $rc -ne 0 ]; then record gold FAIL "$detail (rc=$rc)"; return; fi
+  # PREMISE: gold's exit code deliberately ignores lang-skip, because a
+  # perl-only build skipping cpp rows is a legitimate configuration. We built
+  # WITH cpp, so any lang-skip means the flag did not take and a quarter of the
+  # corpus silently did not run.
+  if [ "${langskip:-0}" != "0" ]; then
+    record gold FAIL "$detail — built --features cpp but lang-skip>0: those rows did NOT run"
+  else
+    record gold PASS "$detail"
+  fi
+}
+
+gate_e2e() {
+  require_bin nvim e2e "e2e/run.sh needs nvim 0.10+; Ubuntu ships 0.9.5. See CLAUDE.md for the tarball." || return
+  run_logged e2e ./e2e/run.sh
+  local rc=$?
+  local d; d="$(grep -oE '[0-9]+ passed[^0-9]*[0-9]+ failed' "$LOGDIR/e2e.log" | tail -1)"
+  [ $rc -eq 0 ] && record e2e PASS "${d:-rc=0}" || record e2e FAIL "${d:-rc=$rc} — see e2e.log"
+}
+
+gate_e2e_cpp() {
+  require_bin nvim e2e-cpp "e2e/run-cpp.sh needs nvim 0.10+." || return
+  run_logged e2e-cpp ./e2e/run-cpp.sh
+  local rc=$?
+  local d; d="$(grep -oE '[0-9]+ passed[^0-9]*[0-9]+ failed' "$LOGDIR/e2e-cpp.log" | tail -1)"
+  # NOTE: run-cpp.sh is `set -euo pipefail` with no aggregation, so the FIRST
+  # failing suite aborts and later ones never run. rc is still correct; the log
+  # just names one failure rather than all of them.
+  [ $rc -eq 0 ] && record e2e-cpp PASS "${d:-rc=0}" || record e2e-cpp FAIL "${d:-rc=$rc} — see e2e-cpp.log"
+}
+
+ALL=(unit unit-cpp gold e2e e2e-cpp)
+[ "${1:-}" = "--list" ] && { printf '%s\n' "${ALL[@]}"; exit 0; }
+SELECTED=("$@"); [ ${#SELECTED[@]} -eq 0 ] && SELECTED=("${ALL[@]}")
+
+note "logs: $LOGDIR  (also /tmp/perl-lsp-verify/latest)"
+note ""
+for g in "${SELECTED[@]}"; do
+  case "$g" in
+    unit)     gate_unit ;;
+    unit-cpp) gate_unit_cpp ;;
+    gold)     gate_gold ;;
+    e2e)      gate_e2e ;;
+    e2e-cpp)  gate_e2e_cpp ;;
+    *) note "unknown gate: $g (see --list)"; FAILED=1 ;;
+  esac
+done
+
+note ""
+note "════ verification bar ════"
+for r in "${RESULTS[@]}"; do
+  IFS='|' read -r g v d <<< "$r"
+  case "$v" in
+    PASS)  printf '  %s✓ %-9s%s %s\n' "$GRN" "$g" "$OFF" "$d" ;;
+    FAIL)  printf '  %s✗ %-9s%s %s\n' "$RED" "$g" "$OFF" "$d" ;;
+    ERROR) printf '  %s! %-9s%s %s\n' "$YEL" "$g" "$OFF" "$d" ;;
+  esac
+done
+note ""
+note "full output retained: $LOGDIR"
+[ $FAILED -eq 0 ] && note "${GRN}bar green${OFF}" || note "${RED}bar RED — read the logs above, do not re-run to see what happened${OFF}"
+
+# prune old runs, keep the most recent N
+ls -1dt /tmp/perl-lsp-verify/*/ 2>/dev/null | tail -n +$(( ${KEEP:-10} + 1 )) | xargs -r rm -rf
+exit $FAILED


### PR DESCRIPTION
The gates and APIs on this project report correctly. What kept going wrong this arc was the **reading** of them — always silently, always plausible-looking. These encode the specific traps so nobody rediscovers them.

## `scripts/board.sh` — the #120 message board

Agents should use this instead of hand-rolling `gh api`. Demonstrated on #120 (196 comments, past the page boundary):

```
TRUE newest (paginate, ordered by id):              5385897963
?per_page=100 with .[-1]:                           5356498427   <- 29M stale
sort=created&direction=desc (endpoint IGNORES it):  5323757205   <- the OLDEST
```

Plus: under `--paginate`, gh runs the jq filter **once per page**, so `.[-1].id` emits one id per page rather than the max — it looks like a single value on a short thread and silently becomes N lines as it grows. And filtering by author to skip your own posts silences the whole team, because every agent posts under one account; the script records the ids it posts instead, which is exact.

```
scripts/board.sh new | peek | post FILE | show ID | watch
```

State in `.git/board-state/<issue>/` — per-clone, never committed.

## `scripts/verify.sh` — run the bar, keep every byte

Full output to `/tmp/perl-lsp-verify/<stamp>/` with a `latest` symlink, so a bad extraction costs a re-read rather than a re-run. Exit code is the verdict; grep only builds the human summary.

The part that matters is the **premise checks**, which no gate can do for itself:

- **gold excludes `lang-skip` from its exit code on purpose** — a perl-only build legitimately cannot serve cpp rows. So a build that forgot `--features cpp` skips 255 rows, reports them as skips, and exits 0. Gold cannot know what you meant to build; the caller can, so the caller asserts it.
- **`cargo test --features cpp` must run strictly more tests** than the perl-only run. Equal counts mean the feature did not take — and that also exits 0.
- **A missing prerequisite is a hard ERROR, never a skip.** `e2e/run-cpp.sh` sat wired to no workflow for months; "e2e-cpp 0" read as zero failures when it meant zero runs.

## `scripts/pr-status.sh` — what a green checkmark doesn't tell you

- `statusCheckRollup` keeps **historical** entries, and `cancel-in-progress` guarantees a CANCELLED beside the real one after every force-push — so a `!= SUCCESS` filter reports three failures on a fully green PR.
- Checks can belong to a **different commit**: `pull_request` does not fire on base retarget, so a restacked PR shows zero checks or stale ones.
- Reports behind-ness **and whether the files actually intersect** — demanding a rebase for every unrelated commit never converges when several agents are landing work.
- Flags dependents, because squashing the base of a stack orphans the rest.

First run against the open queue immediately caught #118 showing "checks: GREEN" with **no workflow run for its current head**, and a dependent on #119 I did not know about.

## Verification

Shell-only, no existing code touched. `bash -n` clean on all three; `board.sh` and `pr-status.sh` exercised against the live repo. No `bc` dependency (awk instead) so they work in the agents' sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)