### PR TITLE
Parallelise the --check diagnostics sweep — 1.00 core to 3.5, 2.69x end-to-end

### DIFF
--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1135,6 +1135,49 @@ fn enriched_tree_diagnostics(
     all
 }
 
+/// One file's enriched diagnostics. Lifted out of the sweep so the serial and
+/// parallel drivers cannot drift — the thread-locals it touches (the stall
+/// watchdog's current file, the sweep memo, `enriched_snapshot`'s cycle guard
+/// and depth counter) are per-worker by construction, which is what makes the
+/// body safe to run concurrently.
+fn sweep_one_file(
+    idx: &module_index::ModuleIndex,
+    options: symbols::DiagnosticOptions,
+    path: &std::path::Path,
+    fa: &std::sync::Arc<file_analysis::FileAnalysis>,
+) -> Vec<(String, tower_lsp::lsp_types::Diagnostic)> {
+    let file = path.display().to_string();
+    // Names the file on stderr if this one unit runs long. The sweep is
+    // where a single pathological file can grind for minutes while the run
+    // looks merely slow — and a run that never finishes never reaches an
+    // after-the-fact report, so the warning has to come from a watchdog
+    // while the unit is still held.
+    crate::util::timings::set_current_file(Some(path));
+    let cached = std::sync::Arc::new(file_analysis::CachedModule::new(
+        path.to_path_buf(),
+        std::sync::Arc::clone(fa),
+    ));
+    let _sweep = crate::util::ghost_stats::SweepScope::start();
+    let _memo = module_index::SweepMemoGuard::open();
+    // The region the four `diag.*` tags did NOT cover, and the one that holds
+    // the volume: enriching a file pulls its providers' analyses, and that
+    // happens BEFORE `collect_diagnostics` is entered. Bounding the callee
+    // from the inside is worth nothing if the caller is outside every region.
+    let _g_enrich = crate::util::ghost_stats::ScopedNs::start("diag.0_enriched_snapshot");
+    let diags = match idx.enriched_snapshot(&cached) {
+        Some(fa) => symbols::collect_diagnostics(&fa, idx, options),
+        None => {
+            // Index copies may be refs/bag-evicted; diagnostics read refs AND
+            // the bag, so degrade to the whole-on-both-axes view, not the
+            // resident copy.
+            let whole = file_analysis::CrossFileLookup::whole_present(idx, &cached);
+            symbols::collect_diagnostics(&whole, idx, options)
+        }
+    };
+    crate::util::timings::set_current_file(None);
+    diags.into_iter().map(|d| (file.clone(), d)).collect()
+}
+
 /// The per-file diagnostics sweep, streamed: `emit` runs as each file's
 /// diagnostics are computed, so `--check` produces output THROUGHOUT a
 /// corpus-scale run instead of buffering hours of work into one final
@@ -1147,42 +1190,34 @@ fn for_each_enriched_diagnostic(
     options: symbols::DiagnosticOptions,
     emit: &mut dyn FnMut(&str, tower_lsp::lsp_types::Diagnostic),
 ) {
-    for entry in ws.workspace_raw().iter() {
-        let file = entry.key().display().to_string();
-        // Names the file on stderr if this one unit runs long. The sweep is
-        // where a single pathological file can grind for minutes while the
-        // run looks merely slow — and a run that never finishes never
-        // reaches an after-the-fact report, so the warning has to come from
-        // a watchdog while the unit is still held.
-        crate::util::timings::set_current_file(Some(entry.key()));
-        let cached = std::sync::Arc::new(file_analysis::CachedModule::new(
-            entry.key().clone(),
-            std::sync::Arc::clone(entry.value()),
-        ));
-        let _sweep = crate::util::ghost_stats::SweepScope::start();
-        let _memo = module_index::SweepMemoGuard::open();
-        // The region the four `diag.*` tags did NOT cover, and the one that
-        // holds the volume: enriching a file pulls its providers' analyses,
-        // and that happens BEFORE `collect_diagnostics` is entered. Bounding
-        // the callee from the inside is worth nothing if the caller is
-        // outside every region.
-        let _g_enrich = crate::util::ghost_stats::ScopedNs::start("diag.0_enriched_snapshot");
-        let diags = match idx.enriched_snapshot(&cached) {
-            Some(fa) => symbols::collect_diagnostics(&fa, idx, options),
-            None => {
-                // Index copies may be refs/bag-evicted; diagnostics read
-                // refs AND the bag, so degrade to the whole-on-both-axes
-                // view, not the resident copy.
-                let whole =
-                    file_analysis::CrossFileLookup::whole_present(idx, &cached);
-                symbols::collect_diagnostics(&whole, idx, options)
-            }
-        };
-        for d in diags {
+    // Snapshot before working: values are `Arc`s, so this is a pointer copy
+    // per file, and it releases the DashMap shard guards an `iter()` would
+    // otherwise hold closed to writers for the whole sweep.
+    let entries: Vec<(std::path::PathBuf, std::sync::Arc<file_analysis::FileAnalysis>)> = ws
+        .workspace_raw()
+        .iter()
+        .map(|e| (e.key().clone(), std::sync::Arc::clone(e.value())))
+        .collect();
+    // Streaming survives the parallelism: workers send as each file finishes
+    // and the calling thread drains, so `--check` still produces output
+    // THROUGHOUT the run rather than buffering it into a final print a
+    // timeout discards whole (`docs/adr/instrument-blindness.md`). `emit` is
+    // `&mut` and stays on this thread — only the diagnostics cross.
+    let (tx, rx) =
+        std::sync::mpsc::channel::<(String, tower_lsp::lsp_types::Diagnostic)>();
+    std::thread::scope(|scope| {
+        scope.spawn(move || {
+            use rayon::prelude::*;
+            entries.par_iter().for_each_with(tx, |tx, (path, fa)| {
+                for (file, d) in sweep_one_file(idx, options, path, fa) {
+                    let _ = tx.send((file, d));
+                }
+            });
+        });
+        for (file, d) in rx {
             emit(&file, d);
         }
-        crate::util::timings::set_current_file(None);
-    }
+    });
     // Pack-language files (C++/…) live in the per-language sub-indexes, not the
     // Perl-only `FileStore` above. Mirror the backend's language dispatch: they
     // get `pack_diagnostics` (Mode B — member-op swap + peel), so `--batch


### PR DESCRIPTION
The sweep ran at **exactly 1.00 core** while indexing used 2.4–2.8 of 4 — 177s of a 187s run with three cores idle. Now rayon-parallel.

| | serial | parallel |
|---|---|---|
| indexing | 2.4–2.8 cores | 2.8–3.3 |
| **sweep** | **1.00, dead flat, 177s** | **3.5–3.7 sustained, ~59s** |
| wall, 8k corpus | 188s | **70s** — 2.69× |
| wall, CPAN substrate | 15s | 12s |

88–92% of 4 cores through the entire sweep.

## Why it parallelises — measured, and it corrected my first read

Reading `enriched_snapshot` predicts contention: every cache **hit** takes a global mutex and does an O(64) `retain` over a `VecDeque<PathBuf>` under it. That prediction is wrong for this workload, and the counters say why:

| | 8k synthetic | CPAN substrate |
|---|---|---|
| `enriched_snapshot.hit` | **0** | **0** |
| `enriched_snapshot.build` | 8,272 — *= file count* | 3,360 — *= file count* |
| recursion | none, all `depth.01` | none, all `depth.01` |

`--check` visits each file exactly once and nothing recurses, so the overlay never hits, the mutex is never entered, and **100% of the cost is the lock-free build path**. Rehydration and the bag-cache LRU don't bind either — that is what the sustained 88–92% utilisation demonstrates.

Worth recording for whoever reads a 47.4% hit rate elsewhere: that figure is a **different cache**. The sweep memo here runs 724,368 hits / 643,148 misses — 53% hit, 47% miss.

## Streaming survives

The `&mut FnMut` exists because `--check` must produce output *throughout* a corpus-scale run rather than buffering hours of work into a final print a timeout discards whole (`docs/adr/instrument-blindness.md`). That property is preserved: workers send per file over an `mpsc`, the calling thread drains and calls `emit`. `emit` stays `&mut` on one thread; only diagnostics cross.

Two incidental wins: snapshotting entries into a `Vec` first releases the DashMap shard guards an `iter()` would hold closed to writers for the whole sweep, and it sidesteps needing dashmap's `rayon` feature at all.

## Why it is safe

The per-file body moved into `sweep_one_file`, so **one** driver does the work rather than a serial and a parallel copy free to drift — the sibling-fork shape `docs/adr/sibling-forks.md` exists to prevent.

Every thread-local it touches is per-worker by construction: the stall watchdog's current file, the sweep memo, and `enriched_snapshot`'s cycle guard and depth counter. The cycle guard is arguably *more* correct this way — a shared one would have threads declining each other's cycles.

## Equivalence

**2,095 real diagnostics on the CPAN substrate, byte-identical to serial** (sorted; parallel emits in completion order), and identical again on **three repeat runs** — determinism, not one lucky pass.

Getting to that number took four attempts, and the first three passed vacuously: an 8k corpus that emits zero diagnostics, then the wrong file descriptor (human-format goes to `eprintln!`, I was capturing stdout), then counting status lines as findings. Each returned "IDENTICAL" and each was worthless. The check now prints its N and **refuses below 100** — a bare pass/fail hides an empty input, a pass/fail with its sample size beside it cannot. The 8k corpus is excluded from the equivalence claim for exactly that reason: it emits nothing even at `--severity hint`.

## Declared costs and limits

- **The sweep memo is thread-local**, so each worker keeps its own and the aggregate hit rate falls with worker count. Part of this win is bought back from that cache. It does not show up in any core-utilisation graph.
- **This is a 4-core result and does not extrapolate to 20.** More workers mean more pressure on whatever shared state exists, and the 20-core box's *indexing* phase only reached 13.7 (68%). The utilisation curve is here; the ceiling there needs measuring there.
- **Parallelism buys a constant factor against a superlinear curve.** Wall goes as `files^1.63` and per-file cost rises with corpus size (7.3 ms at 2k, ~20 ms at 8–12k) because enrichment chases providers. Dividing by cores moves the point where a run becomes infeasible; it does not remove the exponent.

## Gate

At `c720c371`:

- `cargo test` — **1,526 passed, 0 failed, 6 ignored**
- `cargo test --features cpp` — **1,587 passed, 0 failed, 6 ignored**
- `./e2e/run.sh` — **113 passed, 0 failed** (nvim v0.11.0)
- gold — **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · 0 CRASH · lang-skip 0**, warm lane clean

---
_Generated by [Claude Code](https://claude.ai/code/session_017qMRr69h1L2K3wxBHC1VgV)_