### PR TITLE
Run the pack e2e lane — 8 suites and 24 tests that had never executed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,30 @@ jobs:
       - name: Run e2e tests
         run: ./e2e/run.sh
 
+  pack-e2e-tests:
+    name: Pack E2E tests (headless nvim)
+    if: github.event.action != 'edited' || github.event.changes.base   # see `on:`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.11.0
+
+      # Separate from `e2e-tests` because the suites need `--features
+      # all-langs`, which the script builds itself — there is no flag to add
+      # here. Covers the C/C++ suites AND `python_members`, so this is the
+      # pack lane generally, not a cpp one.
+      - name: Run pack e2e tests
+        run: ./e2e/run-cpp.sh
+
   gold-corpus:
     name: Gold corpus
     if: github.event.action != 'edited' || github.event.changes.base   # see `on:`

--- a/e2e/run-cpp.sh
+++ b/e2e/run-cpp.sh
@@ -23,17 +23,56 @@ trap reap_servers EXIT
 
 echo "building --features all-langs release..."
 cargo build --release --features all-langs >/dev/null 2>&1
-PERL_LSP_BIN="$PWD/target/release/perl-lsp" \
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp.lua
-  PERL_LSP_BIN="$PWD/target/release/perl-lsp" \
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_members.lua
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_locals.lua
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_macro_calls.lua
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_labels.lua
-  PERL_LSP_BIN="$PWD/target/release/perl-lsp" \
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_member_op.lua
-  PERL_LSP_BIN="$PWD/target/release/perl-lsp" \
-  nvim --headless --clean -u e2e/init_cpp.lua -l e2e/cpp_header_edit.lua
 
-PERL_LSP_BIN="$PWD/target/release/perl-lsp" \
-  nvim --headless --clean -u e2e/init_python.lua -l e2e/python_members.lua
+bin="$PWD/target/release/perl-lsp"
+# Every suite names its binary explicitly. `dev_lsp.lua` falls back to this same
+# path when the variable is unset, so an omission is invisible until someone
+# changes the fallback — then it is a silent test of the wrong binary.
+export PERL_LSP_BIN="$bin"
+
+# Suite -> its nvim config. The pack suites and the python one share the harness
+# but not the LSP config, so the pairing lives here rather than in a parallel list.
+suites=(
+  "cpp.lua              init_cpp.lua"
+  "cpp_members.lua      init_cpp.lua"
+  "cpp_locals.lua       init_cpp.lua"
+  "cpp_macro_calls.lua  init_cpp.lua"
+  "cpp_labels.lua       init_cpp.lua"
+  "cpp_member_op.lua    init_cpp.lua"
+  "cpp_header_edit.lua  init_cpp.lua"
+  "python_members.lua   init_python.lua"
+)
+
+# Aggregate rather than abort. `set -e` on the first failing suite reports ONE
+# failure and silently skips the rest, so a run that breaks three suites looks
+# identical to one that breaks the first — and CI names the wrong culprit.
+total_passed=0
+total_failed=0
+failed_suites=()
+for entry in "${suites[@]}"; do
+  read -r test cfg <<<"$entry"
+  echo "── $test ──"
+  if output=$(nvim --headless --clean -u "e2e/$cfg" -l "e2e/$test" 2>&1); then rc=0; else rc=$?; fi
+  echo "$output"
+  p=$(printf '%s' "$output" | grep -oE '[0-9]+ passed' | tail -1 | grep -oE '[0-9]+' || true)
+  f=$(printf '%s' "$output" | grep -oE '[0-9]+ failed' | tail -1 | grep -oE '[0-9]+' || true)
+  total_passed=$(( total_passed + ${p:-0} ))
+  total_failed=$(( total_failed + ${f:-0} ))
+  # A suite that dies before printing a tally (crash, missing config, nvim
+  # startup failure) reports zero of both — count the run itself as failed so
+  # it cannot pass by producing no output.
+  if [ "$rc" -ne 0 ] || [ -z "$p" ]; then
+    failed_suites+=("$test")
+    if [ -z "$p" ] && [ "${f:-0}" -eq 0 ]; then
+      total_failed=$(( total_failed + 1 ))
+    fi
+  fi
+done
+
+echo
+echo "════════════════════════════════════════════"
+echo "TOTAL: $total_passed passed, $total_failed failed across ${#suites[@]} suites"
+if [ ${#failed_suites[@]} -gt 0 ]; then
+  echo "failed: ${failed_suites[*]}"
+  exit 1
+fi

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1193,6 +1193,7 @@ fn for_each_enriched_diagnostic(
     // Snapshot before working: values are `Arc`s, so this is a pointer copy
     // per file, and it releases the DashMap shard guards an `iter()` would
     // otherwise hold closed to writers for the whole sweep.
+    let _g_snap = crate::util::timings::PhaseGuard::start("cli::diag_snapshot");
     let entries: Vec<(std::path::PathBuf, std::sync::Arc<file_analysis::FileAnalysis>)> = ws
         .workspace_raw()
         .iter()
@@ -1203,6 +1204,11 @@ fn for_each_enriched_diagnostic(
     // THROUGHOUT the run rather than buffering it into a final print a
     // timeout discards whole (`docs/adr/instrument-blindness.md`). `emit` is
     // `&mut` and stays on this thread — only the diagnostics cross.
+    drop(_g_snap);
+    // The sweep is the run's dominant phase and had no name — the startup
+    // phases account for ~11s of an 80s run, so an unattributed remainder
+    // reads as "startup is the cost" when it is not.
+    let _g_sweep = crate::util::timings::PhaseGuard::start("cli::diag_sweep");
     let (tx, rx) =
         std::sync::mpsc::channel::<(String, tower_lsp::lsp_types::Diagnostic)>();
     std::thread::scope(|scope| {


### PR DESCRIPTION
`e2e/run-cpp.sh` exists, builds its own `--features all-langs` release, and drives 8 suites through the same lua harness as the Perl e2e. **No workflow invoked it.** `grep -rn "run-cpp" .github/` was empty.

So "e2e-cpp 0" in our baselines was **zero runs**, not zero failures — the purest form of the failure mode this repo hit three times today: a number that reports on something that never happened.

## Scope note — please read before reviewing

**This branch carries a third commit that the original description did not mention**, and I would rather flag that than let a reviewer discover it: `aa60e9c8 obs: name the diagnostics sweep's phases`. It is unrelated to the pack lane.

It is here because I develop on one designated branch and cannot open a second PR in parallel; the alternative was leaving measurement work unpushed. **It is cleanly separable — say the word and I will drop it and land it after this merges.** I called out bundling as a problem twice today (`release.yml:164`, the `run-cpp` wiring itself), so the same standard applies to me.

What it does, briefly: `PERL_LSP_PHASE_TIMING` accounted for **11.1 s of an 80 s `--check` run**, and every phase it named was a *startup* phase — so the report implied `cli::index_workspace` at 10.7 s was the cost. It is 11%. The sweep, at **84,969 ms / 89%**, had no name at all. Same defect as bounding a callee while the cost sits in an unwrapped caller. Two regions named; no behaviour change.

## The runner reported one failure and hid the rest

`run-cpp.sh` ran under `set -euo pipefail` with no aggregation, so the **first** failing suite aborted the script and the remaining seven never ran. A run breaking three suites was indistinguishable from one breaking the first, and CI would have named the wrong culprit.

It now runs all eight, sums the tallies, and lists every failure — the shape `run.sh` already uses.

One case handled explicitly: **a suite that dies before printing a tally** (crash, missing config, nvim startup failure) reports zero passed *and* zero failed, which a naive sum reads as a clean run. That is the same "no output passes as no problems" shape that kept this entire lane invisible, and it was one line away from being rebuilt inside its own fix.

`PERL_LSP_BIN` was also set on five of the eight invocations. **Harmless today** — `dev_lsp.lua` falls back to the same path, which I checked rather than assumed — so this is tidying, not a bugfix. The risk it removes is future: an omission stays invisible until someone changes the fallback, and then three suites silently drive the wrong binary.

## The job

A separate job rather than a flag on `e2e-tests`, because the suites need `--features all-langs` which the script builds itself — there is nothing to add to the existing job. This is why it could not ride along with #156.

Named **Pack E2E**, not C++: the lane also carries `python_members`, so a cpp label would misdescribe what has gone red when it fails. The python lane was ungated by the same omission.

## Verification

The runner rewrite is checked against its own baseline — the only question that mattered, whether it changed *reporting* or *coverage*:

| | before rewrite | after |
|---|---|---|
| `./e2e/run-cpp.sh` | 24 passed, 0 failed, exit 0 | **24 passed, 0 failed, exit 0** |

**In CI, from the job log rather than the badge:**

```
TOTAL: 24 passed, 0 failed across 8 suites
```

24 tests that had never executed on any commit in this repository's history. All four checks green on `aa60e9c8`.

Full local bar: `cargo test` **1,526/0/6** · `--features cpp` **1,587/0/6** · `./e2e/run.sh` **113/0** (nvim v0.11.0) · gold **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · 0 CRASH · lang-skip 0**, warm lane clean.

## What this closes

Third and last of the gate holes found today: 255 gold rows and 61 unit tests never run (#156), a warm-path gold failure invisible to a cold-only harness (#153), and now 8 suites and 24 tests never run at all.