### PR TITLE
The conclusion layer: bake the registry chase, and stop decoding to learn nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,19 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 # Cancel superseded runs when a PR branch is re-pushed.
+#
+# The no-op runs get their OWN group, and that is not a nicety. Every job here
+# carries `action != 'edited' || changes.base`, so a title or description edit
+# produces a run whose jobs all skip — but the run still exists, and under one
+# shared group `cancel-in-progress` had it CANCEL the real run in flight for
+# the same ref. Editing a PR description therefore killed its CI and left the
+# PR showing three skipped checks: a green-looking result from a run that did
+# nothing, which is the one failure mode a status check must never produce.
+# Keying the no-op runs on `run_id` gives each of them a group of its own, so
+# they cancel nothing; real runs keep sharing a group and keep superseding
+# each other.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}-${{ (github.event.action == 'edited' && !github.event.changes.base) && github.run_id || 'real' }}
   cancel-in-progress: true
 
 env:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,77 @@
+//! Derives the conclusion fingerprint at compile time.
+//!
+//! A baked conclusion has a staleness class the witness bag does not: editing
+//! a reducer changes what the right answer IS while the stored bytes stay
+//! perfectly well-formed. Nothing downstream can catch that — the bytes
+//! decode, the shape validates, the answer is simply wrong — so the guard has
+//! to be a fingerprint that moves on its own when the derivation moves.
+//! `docs/prompt-conclusion-layer.md` owns the decision.
+//!
+//! Two properties this file exists to guarantee, both of which fail silently
+//! if broken:
+//!
+//! 1. **Every hashed file is declared to cargo.** A source edit that does not
+//!    re-run this script leaves the constant stale, which is a hand-maintained
+//!    version with extra steps and a false sense of safety. `rerun-if-changed`
+//!    on a DIRECTORY only watches that directory's own mtime — cargo does not
+//!    walk it — so every file is named individually.
+//! 2. **The hash is order-independent and rename-sensitive.** Directory
+//!    iteration order is not stable, so paths are sorted; and the path is
+//!    hashed alongside the bytes, because moving a file between layers changes
+//!    behaviour here (`layering_tests`) while leaving byte content identical.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let mut files = Vec::new();
+    collect(Path::new("src"), &mut files);
+    // Dependencies change fold outcomes too — a grammar bump reshapes the CST,
+    // which reshapes the witnesses. The lock file is the cheapest complete
+    // statement of what we built against.
+    if Path::new("Cargo.lock").is_file() {
+        files.push(PathBuf::from("Cargo.lock"));
+    }
+    files.sort();
+
+    let mut acc: u64 = 0xcbf2_9ce4_8422_2325;
+    for path in &files {
+        // Cargo reruns this script when any declared path changes. Declaring
+        // the file we just hashed — rather than a directory above it — is what
+        // keeps the constant honest.
+        println!("cargo:rerun-if-changed={}", path.display());
+        let Ok(bytes) = std::fs::read(path) else { continue };
+        // The separator makes the concatenation unambiguous: without it,
+        // moving a trailing byte from one file's name into the next file's
+        // contents would hash identically.
+        fnv(&mut acc, path.to_string_lossy().as_bytes());
+        fnv(&mut acc, b"\0");
+        fnv(&mut acc, &bytes);
+        fnv(&mut acc, b"\0");
+    }
+
+    // FNV-1a rather than DefaultHasher: the std hasher's algorithm is
+    // explicitly unspecified across releases, and while that would be
+    // survivable here (a different toolchain is a legitimately different
+    // build), an unspecified hash is a poor thing to hang a cache invariant
+    // on when the specified one is four lines.
+    println!("cargo:rustc-env=PERL_LSP_CONCLUSION_FINGERPRINT={acc:016x}");
+}
+
+fn collect(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(t) if t.is_dir() => collect(&path, out),
+            Ok(t) if t.is_file() => out.push(path),
+            _ => {}
+        }
+    }
+}
+
+fn fnv(acc: &mut u64, bytes: &[u8]) {
+    for b in bytes {
+        *acc ^= *b as u64;
+        *acc = acc.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+}

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -1,0 +1,125 @@
+# Design brief: a residualizing mode for the reducer registry
+
+**Status: open question, evidence gathered, no implementation.** Written for a
+design session. The conclusion layer (`docs/prompt-conclusion-layer.md`) is
+built and landed; this is the one thing standing between it and most of its
+value.
+
+## The gap, in one number
+
+Over a warm substrate `--check`, the consult path's conclusion lookups split:
+
+| outcome | count | what it costs |
+|---|---|---|
+| `OpenNone` → decode | **91,525** | full blob decode + full chase |
+| absent → proven `None` | 60,947 | nothing |
+| `Link` → follow | 4 | — |
+| `Value` / `ReturnOf` → answered | 1,301 | a hash lookup |
+
+**57% of lookups land in `OpenNone`.** The layer exists to remove decodes, and
+on more than half of its opportunities it declines to.
+
+`Link` — the form whose entire purpose is "the answer is in another file" —
+fires **44 times across 2,693 files**. It is, in practice, not implemented.
+
+## Why the bake cannot mint the `Link`
+
+The bake runs with `module_index: None`, deliberately: a materialized
+cross-file value would freeze a world that can change without this file
+changing (`docs/prompt-conclusion-layer.md`, "Edges, not values"). So a chase
+that leaves the file returns `None` at bake time.
+
+The bake then cannot distinguish two cases that look identical from inside:
+
+1. **The bag genuinely has no answer.** The live path also answers `None`.
+2. **The chase would have exited cross-file.** The live path has a real answer.
+
+Today both become `OpenNone`, which is sound and expensive.
+
+Treating them both as absent instead is unsound, and measurably so — **56
+equivalence breaks per substrate check** under `PERL_LSP_CONCL_EQUIV`, all the
+same shape:
+
+```
+MethodOnClass{ Log::Log4perl, get_logger }        => ClassName("Log::Log4perl::Logger")
+MethodOnClass{ URI, new }                         => ClassName("URI::_foreign")
+MethodOnClass{ Dist::Zilla::Role::TextTemplate, fill_in_string } => Optional(String)
+MethodOnClass{ Plack::Request, uri }              => ClassName("URI")
+```
+
+Each is case 2. Each would have been served as "no answer" forever.
+
+## Why `sole_foreign_edge` does not reach them
+
+The existing `Link` minting looks for an attachment whose sole witness is
+`Edge(MethodOnClass{class, name})` with `class` not declared locally. That
+catches a direct foreign edge and nothing else — hence 44.
+
+The cases above hold `Edge(Symbol(sid))`: a **local** symbol whose own chase
+leaves the file, through its imports. Nothing local names the target, so there
+is no key to point a `Link` at without re-deriving the chase — which is the
+thing being avoided.
+
+## The question for the session
+
+**Can the registry report where it would have gone, instead of only what it
+found?**
+
+Concretely: a mode in which a chase that reaches a point requiring
+`module_index` returns not `None` but something like `Residual(ConclusionKey)`
+— the portable key it was about to consult. The bake stores that as `Link`;
+the consult path follows it into the target file's map instead of decoding.
+
+Sub-questions worth settling there, in rough priority:
+
+1. **Is the exit point always nameable as a `ConclusionKey`?** The four
+   observed shapes are `MethodOnClass`, which is portable. Are there exits that
+   can only be named by a file-internal attachment (`Expr(span)`,
+   `Expression(refidx)`)? Those must stay `OpenNone`, and knowing the ratio
+   decides how much of the 57% is actually reachable.
+
+2. **One residual, or several?** A chase may branch — several candidates, an
+   inheritance fan-out. `Link` as specified holds one target. Either the form
+   grows a set, or a multi-exit chase degrades to `OpenNone` and we measure how
+   often that is.
+
+3. **Where does the mode live?** A flag on `ReducerQuery`, a distinct entry
+   point beside `query_rec`, or a `BagContext` whose `module_index` is a
+   recording stub rather than `None`. The third is appealing — the stub records
+   the key and answers `None`, so no reducer changes — but it makes the chase's
+   *first* exit the recorded one, which may not be the one that would have
+   answered.
+
+4. **Termination and cost.** The bake is 592 µs/file today (~1.2% of gold
+   wall). A residualizing chase does strictly more work per key than the one
+   that bails at `None`. Budget before building.
+
+5. **Does the `Link` follow need a cycle guard of its own?** The consult path
+   would now traverse map-to-map across files. `VisitedKey` guards the live
+   chase; the projection needs the equivalent, and `(file, key, receiver,
+   arity)` is the shape the spec already names.
+
+## Acceptance test, ready-made
+
+`PERL_LSP_CONCL_EQUIV=1` with `PERL_LSP_ABSENT_ON_NO_ANSWER=1`.
+
+That flag combination is currently **56 breaks**. It is exactly the population
+this work must convert: every one of those is a chase that exits cross-file and
+should have produced a `Link`. When the residualizing mode is right, those 56
+become `Link`s and the run goes green — with the no-answer case now genuinely
+meaning no answer.
+
+Then the win is measurable as `consult.baked_open` falling from 91,525.
+
+## What is already true, so the session does not re-derive it
+
+- The bake is deterministic (`the_bake_does_not_depend_on_map_iteration_order`,
+  mutation-verified), which the diff-propagation driver depends on.
+- Absence is sound, and only because closedness is asked of the INDEX via
+  `parents_of` — a per-file bake cannot establish it, because Perl packages are
+  open and any file may reopen one without repeating its `@ISA`.
+- End-to-end checks cannot score this work. Gold stayed 502/0 and
+  `--dump-package` stayed byte-identical across 312 KB under a version with 633
+  soundness breaks, because the ladder routes around a missing answer and only
+  the cost differs. **Score changes here with `PERL_LSP_CONCL_EQUIV`, which
+  compares at the point of the claim.**

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -123,3 +123,52 @@ Then the win is measurable as `consult.baked_open` falling from 91,525.
   soundness breaks, because the ladder routes around a missing answer and only
   the cost differs. **Score changes here with `PERL_LSP_CONCL_EQUIV`, which
   compares at the point of the claim.**
+
+---
+
+## Slice 0 measurement: the bridge poison is sound and nearly always vacuous
+
+Instrumented per the design answer's sub-question 1 (`residual.nameable` /
+`residual.poisoned` / per-site), over one substrate `--check`.
+
+| exit site | count | nameable? |
+|---|---|---|
+| `moc_primary` | 46,590 | yes |
+| `parent_walk` | 46,590 | yes |
+| `bridge` | 46,572 | **no — poisons** |
+| `slot_type` | 533 | yes |
+
+Read per EXIT that is 66.8% nameable. Read per CHASE it is far worse, and the
+per-chase reading is the one that governs: the three big sites are sequential
+fallbacks of the SAME chase (primary → parents → bridges), so a chase that ends
+with no answer has hit all three, and one poisoned exit poisons the chase.
+46,572 of 46,590 — **99.96% of chases touch the poisoning site.**
+
+That would have ended this line of work. It is also wrong, and the thing that
+makes it wrong is not visible from the bake.
+
+**In LIVE mode, the bridge consult yields nothing 131,658 times against 2,251
+that yield — it is vacuous 98.3% of the time.** A would-be consult that would
+have returned nothing is not a dependence, and counting it as one makes the
+poison rate look total when the real one is ~1.7%.
+
+So the bake-time rule "a bridge exit poisons" is SOUND but pessimistic by a
+factor of ~59, and the pessimism costs essentially the whole reachable
+population. The bake cannot currently do better, because whether any file
+bridges to class C is index-side knowledge and the bake has no index — by
+design.
+
+**Proposed refinement to the staging.** Make bridge-existence knowable at bake
+time, so the exit poisons only when it would really have found something:
+
+- an index-side set of classes that ANY file bridges to, consulted at bake —
+  cheap to build (the bridge registry already exists for
+  `for_each_entity_bridged_to`), and a set membership test rather than a walk;
+- or the same fact recorded per class in the map, decided consult-side where
+  the index is present — the shape the closedness check already uses, and it
+  has the same "the property is global, not per-file" character that made
+  closedness wrong to compute locally.
+
+Either way the measurement to re-run afterwards is the per-chase poison rate,
+not the per-exit ratio. **Whoever picks this up should not size the work from
+the 66.8%.**

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -211,3 +211,105 @@ it removes the last place where a conclusion form degrades to a decode for a
 reason the layer could in principle represent. Anyone sizing it from the raw
 `OpenNone` population (91,525) will be disappointed — that population is
 dominated by other causes.
+
+---
+
+## The ladder-frame rule's other half, and what it cost the `Link`
+
+Recording says where a chase would have gone. It does not say whether the
+chase's answer IS what it finds there. `Link{targets}` claims "the first of
+these keys that answers"; that is only the enclosing query's answer if every
+frame between them returns the exit's answer unchanged.
+
+Implemented as an **opaque-frame counter** on `QueryState`. `materialize`
+enters one around every sub-chase that transforms rather than forwards, and
+`note_exit` poisons instead of recording a rung while inside one. Nesting is
+why it is a counter and not a flag: the recording site is the innermost frame
+and has to know whether ANY ancestor is opaque.
+
+Which frames are opaque, and why:
+
+| frame | why it is not a rung |
+|---|---|
+| `Edge(Variable)` | the scope walk defers a rep-only answer and lets an outer class identity beat it — the value is chosen ACROSS scopes |
+| `Edge(…)` with siblings | the answer is folded with the other witnesses at the attachment |
+| `Edge(…)` re-dispatched | `fresh_dispatch_receiver` substitutes a different receiver; `ReturnExpr::Receiver` at the far end then answers about the wrong object |
+| `CallReturn` | substitutes the call site's arity AND the dispatch receiver |
+| `QualifiedCallReturn` | same, and the lookup class and receiver class deliberately differ |
+| `Projected` | returns a value drilled OUT of the sub-chase's answer |
+| depth cap | `None` because it ran out of frames, not because there is no answer |
+
+The memo carries a "this subtree recorded an exit" bit alongside each value.
+Without it a subtree first reached transparently, then re-reached from inside a
+combining frame, returns from the memo and never re-runs `note_exit` — the
+second reach silently launders into a rung.
+
+**Result: follow breaks 44 → 0.** The 8 disagreements that remain are all one
+shape (`PPI::Token::content`) and all classified `concl.follow_break_guarded`:
+the shared cycle guard had that candidate key on the path, so the chase
+returned without walking a rung, while the outer frame still standing on it
+goes on to walk them. Reproducible across runs.
+
+### And it is worth nothing on this substrate
+
+| | minting off | minting on |
+|---|---|---|
+| `bagcache.decode` | 4103 | 4104 |
+| `consult.baked_open` | 92,393 | 83,983 |
+| `consult.baked_follow_incomplete` | 4 | 7,992 |
+| `consult.baked_follow` | — | 34 |
+
+Decodes do not move. `follow_one` abandons at the first rung whose map says
+`Decode`, and with 84k `OpenNone` still in the maps that is nearly every walk —
+the consult then falls through to the decode it would have done anyway. **The
+`Link` cannot pay off while `OpenNone` dominates the rungs.** Leverage is in
+shrinking that 84k, not in `Link` fidelity.
+
+`PERL_LSP_MINT_LINKS` therefore stays OFF — now for a measured cost reason
+rather than a soundness one.
+
+Two findings worth carrying forward:
+
+- **The self-rung.** The cross-file primary records the key being baked as its
+  own first rung, which is true of the ladder and useless as a `Link`: the
+  consult reached this map by doing exactly that. Left in, it converted
+  essentially the whole `OpenNone` population into `Link`s that burn two follow
+  hops and abandon — 14,923 incomplete against 15 answered. Filtered in
+  `bake_one`.
+- **`CallReturn` is the shape a widened `Link` would need**, and it is the one
+  the form cannot express: `Link` carries ONE arity and ONE receiver rule, and
+  a call frame substitutes both. Widening means residuals that carry their
+  binders. Do not build it until the `OpenNone` population is smaller.
+
+### Two measurement traps, both of which produced confident wrong numbers
+
+- **A probe that re-runs the chase changes the run it measures.** Diagnosing
+  the last breaks with an extra `attempt` on a fresh `QueryState` took breaks
+  from 8 to 2030 and follows from 34 to 4084 — reproducibly, so it read as a
+  real regression rather than as the instrument.
+- **A classifier that cannot fail is not a classifier.** The first "is this
+  break excusable?" probe asked whether a LINK TARGET was on the visited path.
+  Before self-rungs were filtered the targets included the key being chased, so
+  it matched every time and reported 100% of breaks as cycle-guard artifacts.
+  The guard actually cuts on the CANDIDATE key.
+
+### Two defects found on the way, one fixed
+
+- **Fixed: the conclusion fingerprint hashed source but not the env that steers
+  the bake.** One `--check` under `PERL_LSP_MINT_LINKS=1` leaves maps that every
+  later run reads, and it took a gold row from PASS to FAIL until the cache was
+  wiped by hand — looking exactly like a code regression. Bake-steering flags
+  now join the fingerprint (`schema.rs::conclusion_fingerprint`); consult-side
+  flags deliberately do not.
+- **Open: a fingerprint change clears conclusions and nothing re-bakes them.**
+  `validate_conclusion_fingerprint` keeps the blobs "because the repair is a
+  re-bake", but no one drives that re-bake — the file is not re-persisted, so
+  the layer stays dark until a full `--clear-cache`. `conclcache.known_absent`
+  reads 156,746 in that state. This is answer-neutral (absent means decode) and
+  purely a cost, but it means any measurement taken after a source edit without
+  a full clear is measuring an empty layer. It belongs with the flush driver.
+- **Open, and NOT ours: `gold-corpus/run.pl` fails
+  `diagnostics/loader-config-conf-shape-closed` on a WARM cache and passes on a
+  cold one.** Confirmed identical at `f337fc7` with no changes applied, so it
+  predates this work. Cold 502/0, warm 501/1, reproducible on both trees. Worth
+  a row of its own: the harness is normally run cold, which hides it.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -308,8 +308,41 @@ Two findings worth carrying forward:
   reads 156,746 in that state. This is answer-neutral (absent means decode) and
   purely a cost, but it means any measurement taken after a source edit without
   a full clear is measuring an empty layer. It belongs with the flush driver.
-- **Open, and NOT ours: `gold-corpus/run.pl` fails
-  `diagnostics/loader-config-conf-shape-closed` on a WARM cache and passes on a
-  cold one.** Confirmed identical at `f337fc7` with no changes applied, so it
-  predates this work. Cold 502/0, warm 501/1, reproducible on both trees. Worth
-  a row of its own: the harness is normally run cold, which hides it.
+- **Fixed on the base, and it was ours: the warm-cache gold failure.**
+  `gold-corpus/run.pl` failed `diagnostics/loader-config-conf-shape-closed` on
+  a WARM cache and passed cold (502/0 cold, 501/1 warm, on both trees, so it
+  predated this arc's commits). Root cause was the bag-column split:
+  `record_loader_shapes` resolved each plugin's config value by asking the
+  witness bag, and both warm scans decode without the bag column, so the
+  projection silently produced nothing on every run after the first.
+
+  Independently diagnosed and fixed on the base (#155) while this arc was in
+  flight, by the better of the two available repairs: the warm scans now decode
+  through `decode_analysis_parts`, so the copy is MARKED bag-evicted and a type
+  query rehydrates instead of reading an empty bag as "no facts". That fixes
+  every reader of a warm copy rather than the one that happened to be caught.
+
+  The general form is worth naming either way: **a span plus "go ask the bag"
+  is not a fact that survives a strip, and a copy that cannot say which axes it
+  is missing makes every such reader silently wrong.** The residency discipline
+  covers who may hold a whole copy; it does not yet cover who may DERIVE from
+  one, nor require a stripped copy to be honest about it.
+
+  Sweep of the other bag reads reachable from an index path, done after the
+  fact: `module_resolver/thread.rs`'s transitive `symbol_return_type_via_bag`
+  is safe (`strip_import_copy_one` clones and evicts the CLONE, and the walk
+  only runs for names not already cached, i.e. right after a fresh parse), and
+  `resolve/definitions.rs` / `resolve/hierarchy.rs` read the cursor's own open
+  document, never stripped. The loader shape was the only one.
+
+  One residual worth landing separately, which #155 does not cover: **the
+  config shape is not on the Surface.** An edit that only adds a key to a
+  plugin's config hash changes no member anywhere, so the verdict reads
+  Unchanged, no open consumer re-enriches, and every one of them keeps
+  diagnosing against the old closed key set for the rest of the session. That
+  is a second bug of the same family and independent of how the shape is read.
+
+  It also says something about the harness — which the base has since acted on
+  (#153): gold ran once against whatever cache was on the box, so the only run
+  that still worked was the one being scored. It now runs cold and warm against
+  a private throwaway cache dir, with a `warm: xfail` status for known gaps.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -335,12 +335,14 @@ Two findings worth carrying forward:
   `resolve/definitions.rs` / `resolve/hierarchy.rs` read the cursor's own open
   document, never stripped. The loader shape was the only one.
 
-  One residual worth landing separately, which #155 does not cover: **the
-  config shape is not on the Surface.** An edit that only adds a key to a
-  plugin's config hash changes no member anywhere, so the verdict reads
-  Unchanged, no open consumer re-enriches, and every one of them keeps
-  diagnosing against the old closed key set for the rest of the session. That
-  is a second bug of the same family and independent of how the shape is read.
+  One residual #155 does not cover, fixed here: **the config shape was not on
+  the Surface.** An edit that only adds a key to a plugin's config hash changes
+  no member anywhere, so the verdict read Unchanged, no open consumer
+  re-enriched, and every one of them kept diagnosing against the old closed key
+  set for the rest of the session. #155 fixes how the shape is READ; this is
+  its invalidation, and the two are independent. Projected in
+  `Surface::project`, which already runs on the whole analysis before any
+  eviction — so it needs no second copy of the answer to keep in sync.
 
   It also says something about the harness — which the base has since acted on
   (#153): gold ran once against whatever cache was on the box, so the only run

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -495,3 +495,65 @@ work: it reported 555 failures of a mechanism that was behaving correctly. Both
 times the fix was to make the comparison ask the question the claim actually
 makes — the same correction as the `Link` classifier that excused every break
 because it tested the wrong key.
+
+---
+
+## The verb-declared enrichment profile (SPEC 2)
+
+`LanguageScope`'s shape, one tier down: the verb declares what its consumers
+read, and enrichment obeys without ever learning which verb it serves.
+Soundness is by construction rather than by freshness — a product no consumer
+reads need not be produced, and that argument does not decay the way a cache's
+does.
+
+`--check` declares `EnrichmentProfile::diagnostics()`, which omits the
+`MethodCall` dispatch-target re-stamp.
+
+**CLI-only, unconditionally.** A one-shot CLI process serves exactly one verb,
+and the `enriched_snapshot` overlay is resident rather than persisted, so a
+partial copy cannot outlive the process or reach a fuller verb. The
+profile-in-the-overlay-key form is required only when a SERVER verb wants a
+partial profile — the overlay there is shared and fingerprint-keyed, so a
+partial copy under a profile-blind key would be served to a verb that reads
+more, silently, as a missing answer rather than an error. Nothing wants that
+today, so it is deliberately not built; the reason is in the code so its
+absence does not read as an oversight.
+
+| | full (control) | diagnostics profile |
+|---|---|---|
+| `diag.0_enriched_snapshot` | 7,531 / 7,977 / 7,691 ms | **6,537 / 6,834 / 6,356 ms** |
+| `consult.attempt` | 455.9 ms / 14,647 | **246.7 ms / 7,665** |
+
+**13–15% off `--check`'s enrichment**, three runs each way. The estimate going
+in was ~20%; the measured range is lower and that is the number.
+
+### The control is the part worth guarding
+
+`PERL_LSP_FULL_ENRICHMENT=1` forces the full profile back. Without it the full
+behaviour becomes unreachable the moment a verb declares a partial one, and
+"output is set-identical" turns unfalsifiable — a claim that cannot be re-run
+is not evidence. `PERL_LSP_SKIP_MC_STAMP` cannot serve: it skips *harder*, the
+same direction as the profile.
+
+That precedence is unit-tested, because getting it backwards fails nothing —
+it just quietly disables the control. Same shape as a watcher that cannot tell
+quiet from blind.
+
+### The gate, and what it took to run it at all
+
+Set-valued, per [E]: `--check`'s output order comes from a DashMap walk, so
+byte-diff is the wrong instrument. **N=2,431, only-A=0, only-B=0,
+set-identical**, with a same-arm noise floor run first.
+
+Getting a usable N took three corrections, all the same family:
+
+- The default `--severity warning` filters out the hint-severity lanes, so the
+  substrate looked empty.
+- The QA lanes are opt-in flags; without all six the volume is small.
+- **Human-mode diagnostics go to stderr.** My first three attempts measured
+  stdout and reported `N=0` — and the comparator I had just written refused
+  them, which is the only reason I did not publish "set-identical" over an
+  empty set for the second time today.
+
+The floor in that comparator (refuse a comparison below N) earned its keep
+within minutes of being written, against its own author.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -391,9 +391,36 @@ and the parents are the one thing the bake genuinely knows. An absent key would
 then evaluate to a `Follow` constructed at consult time from the name being
 asked, instead of a decode whose entire job is to walk to the same parents.
 
-Stated as a hypothesis, not a finding, because one number would confirm or kill
-it and I have not taken it: **of those 64,901, how many are answered by a parent
-rung rather than by the candidate file itself?** If most are, the per-class form
-converts them; if most resolve locally after the decode, it does not. That is
-the measurement the next step should start from — the same "read the composition
-before sizing the fix" discipline that produced this table.
+### The number that decides it, taken
+
+`Outcome::Decode` now carries its cause, so a decode's OUTCOME can be attributed
+back to the reason it happened. "Wasted" = the chase this decode paid for
+answered nothing for that candidate; the answer, if any, came from the next
+candidate, a parent rung, or the bridge arm.
+
+| cause | chase answered nothing | chase answered | wasted |
+|---|---|---|---|
+| absent, class not provably closed | **43,465** | 558 | **98.7%** |
+| no answer, chase opaque | 6,074 | 333 | 94.8% |
+| no answer, linkable rungs | 5,033 | 49 | 99.0% |
+| no answer, self-rung only | 3,748 | 20 | 99.5% |
+| binder-dependent | 6 | **508** | 1.2% |
+
+**58,326 decodes per warm check are spent on a chase that answers nothing.**
+
+The hypothesis is confirmed and its shape is sharper than stated. The dominant
+population decodes a file only to discover the method is not in it and walk to a
+parent — which is exactly what a per-class "any absent key on C inherits from
+these parents" fact would let the map say without the decode.
+
+And the inverse is the sanity check that makes the table believable:
+**`binder_dependent` is 98.8% PAID.** It is the one cause whose decode is
+genuinely earning its keep, and it is 0.6% of the population. A metric where
+every row pointed the same way would be measuring something other than what it
+claims.
+
+Note the totals: 43,465 + 558 is less than the 66,476 `absent_not_closed`
+consults, because a candidate can be skipped before the chase runs (the
+self-bag `ptr::eq` continue, an exhausted consult budget). The wasted/paid split
+is over decodes that actually ran a chase, which is the population the question
+is about.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -519,13 +519,42 @@ more, silently, as a missing answer rather than an error. Nothing wants that
 today, so it is deliberately not built; the reason is in the code so its
 absence does not read as an oversight.
 
+**Measured twice, because the workload changed underneath the first
+measurement.** The sweep was serialised when I measured it and parallel by the
+time I published; the numbers are not interchangeable and the second set is the
+one that describes the shipping product.
+
+On the SERIAL sweep (the workload that no longer exists):
+
 | | full (control) | diagnostics profile |
 |---|---|---|
-| `diag.0_enriched_snapshot` | 7,531 / 7,977 / 7,691 ms | **6,537 / 6,834 / 6,356 ms** |
-| `consult.attempt` | 455.9 ms / 14,647 | **246.7 ms / 7,665** |
+| `diag.0_enriched_snapshot` | 7,531 / 7,977 / 7,691 ms | 6,537 / 6,834 / 6,356 ms |
+| `consult.attempt` | 455.9 ms / 14,647 | 246.7 ms / 7,665 |
 
-**13–15% off `--check`'s enrichment**, three runs each way. The estimate going
-in was ~20%; the measured range is lower and that is the number.
+13–15% off the enrichment region. On the PARALLEL sweep, same corpus, same
+flags, n=8 per arm interleaved:
+
+| | full (control) | diagnostics profile |
+|---|---|---|
+| wall, median | 4.36 s (4.20–4.80) | **4.12 s (3.99–4.56)** |
+| `diag.0_enriched_snapshot` | 10,762 ms | 10,049 ms |
+
+**~5% of wall.** The ranges overlap — profile's slowest sample exceeds full's
+fastest — so the honest evidence is the shift, not the gap: **six of eight
+profile samples fall strictly below the full arm's minimum.** A single pair
+would have shown anything from 12% to nothing; the fourth pair I ran showed
+4.20 vs 4.21.
+
+Note the enrichment region grew from ~7,500 ms to ~10,800 ms while wall FELL to
+4.2 s. It accumulates per thread, so it now sums to 2.5× the wall it sits
+inside. It remains usable as a same-thread-count A/B ratio and is worthless as
+a cost — which is the general rule, not a footnote: **a nesting per-thread
+region cannot be compared across thread counts, and cannot be read as wall at
+any thread count.**
+
+The estimate going in was ~20% of enrichment. Enrichment CPU is down 6.6% and
+wall about 5%; the estimate was of a term that had already stopped being the
+bottleneck.
 
 ### The control is the part worth guarding
 

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -172,3 +172,42 @@ time, so the exit poisons only when it would really have found something:
 Either way the measurement to re-run afterwards is the per-chase poison rate,
 not the per-exit ratio. **Whoever picks this up should not size the work from
 the 66.8%.**
+
+---
+
+## Per-class bridge yield histogram (round-2 point 3)
+
+The 98.3%-vacuous figure is per CALL; the guard is per CLASS. If the real yields
+concentrate, those classes stay guarded-off permanently and the decode cost
+lands exactly where bridges are real. Measured over one substrate `--check`:
+
+**All 2,251 real yields fall in 13 distinct classes.**
+
+```
+415  Mojolicious::_AppSurface
+389  Mojo::Server
+281  Mojo::UserAgent
+269  Mojolicious::Controller
+264  Mojo::IOLoop
+214  Mojolicious::Plugin::DefaultHelpers
+124  Minion::Worker
+ 94  Mojo::IOLoop::Stream
+```
+
+Top eight are 2,050 of 2,251 — 91%. Every one is a Mojo/Minion app surface,
+which is what the round-2 answer predicted.
+
+Two consequences, and they point opposite ways:
+
+**The guard is nearly free.** Thirteen classes lose trusted absence. Everything
+else keeps it, so the guard costs approximately nothing against the ~127k
+absences a check performs — it is not a tax on the layer, it is a fence around
+a small pen.
+
+**The follow-on is now sized, and it is small.** Refining "bridged → decode"
+into "bridged → consult the bridging files' maps" recovers 2,251 consults, all
+in 13 classes. Worth doing for correctness of shape rather than for the number:
+it removes the last place where a conclusion form degrades to a decode for a
+reason the layer could in principle represent. Anyone sizing it from the raw
+`OpenNone` population (91,525) will be disappointed — that population is
+dominated by other causes.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -424,3 +424,74 @@ consults, because a candidate can be skipped before the chase runs (the
 self-bag `ptr::eq` continue, an exhausted consult budget). The wasted/paid split
 is over decodes that actually ran a chase, which is the population the question
 is about.
+
+---
+
+## The third absence verdict, built — and the biggest win of the arc
+
+Not a new conclusion form. `Outcome::NotLocal`, a third answer to "the key is
+absent":
+
+| class | verdict | licence |
+|---|---|---|
+| closed (every ancestor declared here) | `None` | absence is a proven no-answer |
+| enumerated but not closed | **`NotLocal`** | skip THIS candidate, ladder continues |
+| never declared here | `Decode` | the bake never looked |
+
+Deliberately not a constructed `Follow` at the class's parents. A `Follow` from
+candidate 1's map jumps to the parent walk and never asks candidates 2..n — and
+a REOPENED package's method lives in exactly such a later candidate
+(`PPI::XSAccessor` reopening `PPI::Token`, which has already cost this layer 75
+breaks once). Continuing the loop keeps candidates-before-parents and the bridge
+guard correct by construction instead of by re-derivation. Pinned by
+`a_not_local_verdict_does_not_skip_a_later_candidate`.
+
+| | verdict off | verdict on |
+|---|---|---|
+| `consult.attempt` | 1,715.0 ms / 63,950 calls | **453.9 ms / 14,293** |
+| `moc.provider_fetched` | 105,670 | **33,986** |
+| `bagcache.decode` | 2,443.8 ms / 4,251 | 2,344.6 ms / 4,262 |
+
+**A 1.26 s saving per warm substrate check, and a 74% cut in the chase.** Note
+`bagcache.decode` barely moves: the saving is in the CHASE, not in bytes
+decoded — the resident/LRU tier was already absorbing repeats, and `consult.attempt`
+is the term that was actually paying.
+
+### The soundness gap, which is where the whole difficulty lived
+
+First measurement: **555 breaks.** Every one an inherited accessor the verdict
+was RIGHT about — the check compared against the candidate's full chase, which
+walks its own parents. A check that fires on correct behaviour is worse than
+none; it would have sent me hunting a gap that was not there. The comparison has
+to be against an INDEX-LESS chase of that file — the same context the bake ran
+under — because the failure being guarded is "the file had a local answer and
+the bake missed it".
+
+Corrected check: **40 breaks**, all real, all one shape:
+
+```
+PackageSymbol{Mojo::Server::Daemon, app} => ClassName("Mojolicious")
+```
+
+No local symbol, no attachment at that key, and not an app-surface consumer —
+and an index-less chase still answers. The answer comes from
+`PackageSymbol{Mojo::Server, app}`, whose key **this same map holds**: the file's
+bag carries witnesses about a parent whose code lives elsewhere.
+
+So absence of a KEY is not the question the chase asks. The chase composes over
+the CLASS. `ConclusionMap` now carries each enumerated class's declared parents
+and walks them before judging an absence — depth-capped rather than
+cycle-guarded, because a declared-parent chain inside one file is short and a
+`HashSet` allocation per lookup is not free on a path taken 31,000 times a check.
+
+Breaks went 40 → **0**, and `concl.inherited_hit` reads exactly 40: the same
+population, now answered instead of misjudged.
+
+### What generalises
+
+**A verdict about a key cannot be validated against a chase about a class.** The
+first check was not weakly wrong, it was wrong in the direction that manufactures
+work: it reported 555 failures of a mechanism that was behaving correctly. Both
+times the fix was to make the comparison ask the question the claim actually
+makes — the same correction as the `Link` classifier that excused every break
+because it tested the wrong key.

--- a/docs/prompt-residualizing-registry.md
+++ b/docs/prompt-residualizing-registry.md
@@ -348,3 +348,52 @@ Two findings worth carrying forward:
   (#153): gold ran once against whatever cache was on the box, so the only run
   that still worked was the one being scored. It now runs cold and warm against
   a private throwaway cache dir, with a `warm: xfail` status for known gaps.
+
+---
+
+## The `OpenNone` population, attributed by cause — and the widening premise is dead
+
+`Conclusion::OpenNone` now carries an `OpenReason`, counted at the CONSULT
+rather than at the bake. That distinction is the whole point: a bake-side tally
+counts KEYS, and the question a widening has to answer is which cause drives
+DECODES. The two differ by however often each key is asked, which is exactly
+the kind of unweighted total that has mis-sized every step of this arc.
+
+One warm substrate `--check`, 92,256 decodes:
+
+| cause | consults | share |
+|---|---|---|
+| absent, class known to the map but not provably closed | 64,901 | **70.3%** |
+| no answer, chase was opaque (poisoned / recorded nothing) | 9,732 | 10.5% |
+| no answer, chase named rungs a `Link` could carry | **8,583** | **9.3%** |
+| no answer, only rung was the key being baked | 6,945 | 7.5% |
+| absent, class the map has never heard of | 1,567 | 1.7% |
+| binder-dependent (answer moved under receiver/arity) | 532 | 0.6% |
+
+Two conclusions, and the first was not visible before this split.
+
+**Widening the `Link` form addresses at most 9.3%, and realistically far less.**
+`no_answer_linkable` is the ONLY population a binder-carrying residual could
+convert. We already know from the minting measurement that a `Link` mostly
+abandons at the first rung whose own map says `Decode` — 7,992 incomplete
+follows against 34 answered — so the realizable fraction of that 9.3% is a
+fraction of a fraction. **Do not build binder-carrying residuals.**
+
+**The lever is the 70.3%, and it is a different shape entirely.** These are
+absences on a class the map DOES conclude about, where the only thing stopping
+the absence from being trusted is that the class inherits from somewhere this
+file cannot see. The bake cannot enumerate an inherited method — it has no key
+to attach anything to, because the name could be anything.
+
+That points at a form this layer does not have: not per-key, but **per-class**.
+"Any key absent for class C inherits from these parents" is one fact per class,
+and the parents are the one thing the bake genuinely knows. An absent key would
+then evaluate to a `Follow` constructed at consult time from the name being
+asked, instead of a decode whose entire job is to walk to the same parents.
+
+Stated as a hypothesis, not a finding, because one number would confirm or kill
+it and I have not taken it: **of those 64,901, how many are answered by a parent
+rung rather than by the candidate file itself?** If most are, the per-class form
+converts them; if most resolve locally after the decode, it does not. That is
+the measurement the next step should start from — the same "read the composition
+before sizing the fix" discipline that produced this table.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -77,6 +77,7 @@ suites=(
   mojo_events.lua
   dbic_parametric.lua
   roles.lua
+  saved_dep_edit.lua
 )
 
 total_passed=0

--- a/e2e/saved_dep_edit.lua
+++ b/e2e/saved_dep_edit.lua
@@ -1,0 +1,120 @@
+-- E2E: a SAVED edit to a dependency becomes visible to its consumer
+-- mid-session, no restart — through a cross-file RETURN TYPE, which is the
+-- path the conclusion layer answers on.
+--
+-- The consumer's receiver comes from `Provider::build`'s return type, so the
+-- verb under test resolves through the provider's baked conclusion map rather
+-- than through anything in the consumer's own file. A bake that outlived the
+-- blob it came from answers this with full confidence from the PREVIOUS
+-- version of the provider, and every other cross-file test still passes.
+-- Usage: PERL_LSP_BIN=target/release/perl-lsp \
+--          nvim --headless --clean -u e2e/init.lua -l e2e/saved_dep_edit.lua
+vim.opt.rtp:prepend(".")
+local t   = require("test.runner")
+local lsp = require("test.lsp")
+
+-- Fresh workspace in a temp dir (never dirties the repo). A `.git` marker
+-- makes it the LSP root so the workspace index covers it.
+local ws = vim.fn.tempname()
+vim.fn.mkdir(ws .. "/Widget", "p")
+vim.fn.mkdir(ws .. "/.git", "p")
+
+local provider = ws .. "/Provider.pm"
+local consumer = ws .. "/Consumer.pm"
+
+vim.fn.writefile({
+  "package Widget::One;",
+  "sub go { return 1 }",
+  "1;",
+}, ws .. "/Widget/One.pm")
+vim.fn.writefile({
+  "package Widget::Two;",
+  "sub go { return 2 }",
+  "1;",
+}, ws .. "/Widget/Two.pm")
+
+local provider_v1 = {
+  "package Provider;",
+  "sub build { return bless {}, 'Widget::One' }",
+  "1;",
+}
+local provider_v2 = {
+  "package Provider;",
+  "sub build { return bless {}, 'Widget::Two' }",
+  "1;",
+}
+vim.fn.writefile(provider_v1, provider)
+vim.fn.writefile({
+  "package Consumer;",
+  "use Provider;",
+  "sub run {",
+  "    my $w = Provider->build;",
+  "    return $w->go;",
+  "}",
+  "1;",
+}, consumer)
+
+local buf = lsp.open_and_attach(consumer)
+
+-- `$w->go` on row 4; the cursor sits inside `go`.
+local function go_def() return lsp.def_location(buf, 4, 15) end
+
+local ready = false
+for _ = 1, 60 do
+  local loc = go_def()
+  if loc and loc.uri:find("One%.pm$") then
+    ready = true
+    break
+  end
+  vim.wait(500)
+end
+
+t.test("baseline: the consumer resolves through the provider's return type", function()
+  local N = "baseline cross-file return type"
+  if t.ok(N, ready, "$w->go never resolved into Widget/One.pm") then t.pass(N) end
+end)
+
+t.test("a saved dependency edit reaches the consumer without restart", function()
+  local N = "saved dep edit visible"
+  if not t.ok(N, ready, "baseline never warmed; nothing to invalidate") then return end
+
+  vim.cmd("edit " .. vim.fn.fnameescape(provider))
+  local pbuf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_lines(pbuf, 0, -1, false, provider_v2)
+  vim.cmd("write")
+
+  local got
+  for _ = 1, 60 do
+    got = go_def()
+    if got and got.uri:find("Two%.pm$") then break end
+    vim.wait(500)
+  end
+  if not t.ok(N, got, "$w->go became unresolvable after the provider save") then return end
+  local ok = t.ok(N, got.uri:find("Two%.pm$") ~= nil,
+    "still answering from the previous version of the provider: " .. tostring(got.uri))
+  if ok then t.pass(N) end
+end)
+
+-- With the provider's buffer CLOSED, the open-document tier no longer answers
+-- and the query reaches the cached copy — and its baked conclusion map, which
+-- the cross-file primary consults BEFORE it decodes anything. A map that
+-- outlived the blob it came from answers here, with full confidence, from the
+-- version before the save; the previous assertion cannot see that, because an
+-- open document outranks the cache.
+t.test("the answer survives closing the dependency's buffer", function()
+  local N = "closed dep still fresh"
+  vim.cmd("edit " .. vim.fn.fnameescape(provider))
+  vim.cmd("bdelete!")
+  vim.cmd("buffer " .. buf)
+  local got
+  for _ = 1, 40 do
+    got = go_def()
+    if got and got.uri:find("Two%.pm$") then break end
+    vim.wait(250)
+  end
+  if not t.ok(N, got, "$w->go unresolvable once the provider buffer closed") then return end
+  if t.ok(N, got.uri:find("Two%.pm$") ~= nil,
+    "a cached derivation outlived the save: " .. tostring(got.uri)) then t.pass(N) end
+end)
+
+t.finish()

--- a/e2e/saved_dep_edit.lua
+++ b/e2e/saved_dep_edit.lua
@@ -54,6 +54,24 @@ vim.fn.writefile({
   "1;",
 }, consumer)
 
+-- Warm this workspace's cache before the server sees it, the same way
+-- `run.sh` warms the repo fixtures: `--check` runs `cli_full_startup`, which
+-- indexes and PERSISTS — including each file's baked conclusion map.
+--
+-- Without it the server races its own background persist, `conclusions_for`
+-- misses for the whole run, and the assertions below exercise the live chase
+-- rather than the baked layer. Warm is also the realistic state: a developer's
+-- second session, not their first. Deliberately a warm and not a sleep — the
+-- cache either exists when `--check` returns or the run failed loudly.
+--
+-- It does NOT reach the stale-conclusion-map case; that is still unit-covered
+-- only. See `invalidating_a_generation_drops_the_bake_that_came_with_it`.
+local bin = vim.env.PERL_LSP_BIN
+  and vim.fn.fnamemodify(vim.env.PERL_LSP_BIN, ":p")
+  or (vim.fn.getcwd() .. "/target/release/perl-lsp")
+vim.fn.system({ bin, "--clear-cache", ws })
+vim.fn.system({ bin, "--check", ws, "--severity", "warning" })
+
 local buf = lsp.open_and_attach(consumer)
 
 -- `$w->go` on row 4; the cursor sits inside `go`.

--- a/src/index/conclusion_cache.rs
+++ b/src/index/conclusion_cache.rs
@@ -1,0 +1,155 @@
+//! A byte-bounded resident cache of baked conclusion maps.
+//!
+//! The consult path reads a map per candidate per query, so it cannot go to
+//! SQLite each time — that would trade a decode for a round trip and win
+//! nothing. It also cannot be unbounded: the residency discipline
+//! (`CLAUDE.md`) is that every derived-copy cache is byte-accounted, because
+//! an unbounded one is invisible until a corpus is large enough to hurt, and
+//! then it is a memory regression no functional test can see.
+//!
+//! Maps are small — 27.1% of the bag's bincode bytes over the substrate, about
+//! 15 MB for 2,693 files — so the default cap holds a realistic workspace
+//! outright and the eviction path is the exception rather than the rule.
+//!
+//! **A miss is "not cached", never "no conclusions".** The loader returning
+//! `None` means the store has nothing for this path at this generation, which
+//! sends the caller to a decode. That is a different statement from a KEY
+//! being absent within a map, which means the bag deterministically answers
+//! `None`. Collapsing the two would turn every unbaked file into a file that
+//! concludes nothing.
+
+use crate::model::witnesses::ConclusionMap;
+use dashmap::DashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// What a lookup found, kept distinct so a caller cannot accidentally read
+/// "nothing stored" as "nothing concluded".
+pub enum Cached {
+    /// The store has a map for this path.
+    Map(Arc<ConclusionMap>),
+    /// The store has no map for this path — it was never baked, or its bake
+    /// was cleared. Decode.
+    NotBaked,
+}
+
+type Loader = Box<dyn Fn(&Path) -> Option<ConclusionMap> + Send + Sync>;
+
+pub struct ConclusionCache {
+    entries: DashMap<PathBuf, (Arc<ConclusionMap>, usize)>,
+    /// Paths the loader has already reported absent. Without this, every
+    /// consult against an unbaked file re-queries SQLite forever — the
+    /// negative answer is the one a hot loop hits most while a workspace is
+    /// still being baked.
+    absent: DashMap<PathBuf, ()>,
+    bytes: AtomicUsize,
+    cap_bytes: usize,
+    loader: Loader,
+}
+
+impl ConclusionCache {
+    pub fn new(
+        cap_bytes: usize,
+        loader: impl Fn(&Path) -> Option<ConclusionMap> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            entries: DashMap::new(),
+            absent: DashMap::new(),
+            bytes: AtomicUsize::new(0),
+            cap_bytes,
+            loader: Box::new(loader),
+        }
+    }
+
+    pub fn get(&self, path: &Path) -> Cached {
+        if let Some(hit) = self.entries.get(path) {
+            crate::util::ghost_stats::count("conclcache.hit");
+            return Cached::Map(hit.value().0.clone());
+        }
+        if self.absent.contains_key(path) {
+            crate::util::ghost_stats::count("conclcache.known_absent");
+            return Cached::NotBaked;
+        }
+        crate::util::ghost_stats::count("conclcache.miss");
+        let Some(map) = crate::util::ghost_stats::timed("conclcache.load", || {
+            (self.loader)(path)
+        }) else {
+            self.absent.insert(path.to_path_buf(), ());
+            return Cached::NotBaked;
+        };
+        let sz = estimate_bytes(&map);
+        let arc = Arc::new(map);
+        if self.cap_bytes > 0 {
+            self.bytes.fetch_add(sz, Ordering::Relaxed);
+            if let Some((_, old)) = self.entries.insert(path.to_path_buf(), (arc.clone(), sz)) {
+                self.bytes.fetch_sub(old.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
+            }
+            self.evict_to_cap(path);
+        }
+        Cached::Map(arc)
+    }
+
+    /// Forget one path — its file changed, so its bake is void.
+    pub fn invalidate(&self, path: &Path) {
+        if let Some((_, (_, sz))) = self.entries.remove(path) {
+            self.bytes
+                .fetch_sub(sz.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
+        }
+        // The negative memo must go too, or a file baked AFTER being probed
+        // stays permanently "not baked" and never serves a conclusion.
+        self.absent.remove(path);
+    }
+
+    /// Forget everything — the derivation changed, so every map is void.
+    pub fn clear(&self) {
+        self.entries.clear();
+        self.absent.clear();
+        self.bytes.store(0, Ordering::Relaxed);
+    }
+
+    pub fn resident_bytes(&self) -> usize {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Drop entries until within cap, never evicting `keep`.
+    ///
+    /// Eviction order is unspecified rather than LRU. Maps are near-uniform in
+    /// size and the access pattern over a consult storm is close to uniform
+    /// too, so a recency structure would cost more to maintain than it saves —
+    /// and pretending to an LRU that is really insertion-order is worse than
+    /// saying it is arbitrary.
+    fn evict_to_cap(&self, keep: &Path) {
+        while self.bytes.load(Ordering::Relaxed) > self.cap_bytes {
+            let victim = self
+                .entries
+                .iter()
+                .map(|e| e.key().clone())
+                .find(|p| p != keep);
+            let Some(victim) = victim else { break };
+            if let Some((_, (_, sz))) = self.entries.remove(&victim) {
+                self.bytes
+                    .fetch_sub(sz.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
+                crate::util::ghost_stats::count("conclcache.evicted");
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// Rough resident size of a map.
+///
+/// Deliberately an estimate: an exact figure would need a deep walk of every
+/// `InferredType`, which costs more than the accounting is worth. It only has
+/// to be proportional and never zero — a cap enforced against a zero estimate
+/// is not a cap.
+fn estimate_bytes(map: &ConclusionMap) -> usize {
+    // Key + enum discriminant + a typical small payload, plus the hash slot.
+    const PER_ENTRY: usize = 160;
+    64 + map.len() * PER_ENTRY
+}
+
+#[cfg(test)]
+#[path = "conclusion_cache_tests.rs"]
+mod conclusion_cache_tests;

--- a/src/index/conclusion_cache.rs
+++ b/src/index/conclusion_cache.rs
@@ -102,12 +102,14 @@ impl ConclusionCache {
     }
 
     /// Forget everything — the derivation changed, so every map is void.
+    #[allow(dead_code)] // wholesale drop; production invalidates per path
     pub fn clear(&self) {
         self.entries.clear();
         self.absent.clear();
         self.bytes.store(0, Ordering::Relaxed);
     }
 
+    #[allow(dead_code)] // byte accounting, read by the cap tests
     pub fn resident_bytes(&self) -> usize {
         self.bytes.load(Ordering::Relaxed)
     }

--- a/src/index/conclusion_cache_tests.rs
+++ b/src/index/conclusion_cache_tests.rs
@@ -1,0 +1,84 @@
+//! Tests for the conclusion cache.
+
+use super::*;
+use crate::model::witnesses::{Conclusion, ConclusionKey};
+use std::sync::atomic::AtomicUsize;
+
+fn map_of(n: usize) -> ConclusionMap {
+    let mut m = std::collections::HashMap::new();
+    for i in 0..n {
+        m.insert(
+            ConclusionKey::SubByName(format!("f{i}")),
+            Conclusion::OpenNone,
+        );
+    }
+    ConclusionMap(m)
+}
+
+/// A path the store has nothing for must be re-queried at most once.
+///
+/// While a workspace is still being baked, the negative answer is the one a
+/// consult storm hits most. Without the memo, every one of those goes to
+/// SQLite — trading the decode this layer exists to avoid for a round trip,
+/// which is not obviously better and is certainly not what was measured.
+#[test]
+fn an_absent_path_is_not_reloaded_forever() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let c = calls.clone();
+    let cache = ConclusionCache::new(1 << 20, move |_p| {
+        c.fetch_add(1, Ordering::Relaxed);
+        None
+    });
+    let p = Path::new("/nope.pm");
+    for _ in 0..5 {
+        assert!(matches!(cache.get(p), Cached::NotBaked));
+    }
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "the loader was asked repeatedly for a path it already reported absent"
+    );
+}
+
+/// Invalidation must clear the NEGATIVE memo too.
+///
+/// A file probed before its bake landed is remembered as absent. If
+/// invalidation only dropped positive entries, that file would stay "not
+/// baked" for the rest of the session and silently keep paying for a decode
+/// while its conclusions sat unused in the store.
+#[test]
+fn invalidating_clears_the_absent_memo() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let c = calls.clone();
+    let cache = ConclusionCache::new(1 << 20, move |_p| {
+        if c.fetch_add(1, Ordering::Relaxed) == 0 {
+            None
+        } else {
+            Some(map_of(1))
+        }
+    });
+    let p = Path::new("/later.pm");
+    assert!(matches!(cache.get(p), Cached::NotBaked));
+    cache.invalidate(p);
+    assert!(
+        matches!(cache.get(p), Cached::Map(_)),
+        "a file baked after being probed stayed permanently 'not baked'"
+    );
+}
+
+/// The cache stays within its byte cap.
+#[test]
+fn the_cache_respects_its_cap() {
+    let one = 64 + 10 * 160;
+    let cache = ConclusionCache::new(one * 2, |_p| Some(map_of(10)));
+    for i in 0..20 {
+        cache.get(&PathBuf::from(format!("/f{i}.pm")));
+    }
+    assert!(
+        cache.resident_bytes() <= one * 2,
+        "cache held {} bytes against a {} cap — an unbounded derived cache is \
+         a memory regression no functional test can see",
+        cache.resident_bytes(),
+        one * 2
+    );
+}

--- a/src/index/conclusion_cache_tests.rs
+++ b/src/index/conclusion_cache_tests.rs
@@ -12,7 +12,7 @@ fn map_of(n: usize) -> ConclusionMap {
             Conclusion::OpenNone,
         );
     }
-    ConclusionMap(m)
+    ConclusionMap(m, Default::default())
 }
 
 /// A path the store has nothing for must be re-queried at most once.

--- a/src/index/conclusion_cache_tests.rs
+++ b/src/index/conclusion_cache_tests.rs
@@ -9,7 +9,7 @@ fn map_of(n: usize) -> ConclusionMap {
     for i in 0..n {
         m.insert(
             ConclusionKey::SubByName(format!("f{i}")),
-            Conclusion::OpenNone,
+            Conclusion::OpenNone(crate::model::witnesses::OpenReason::NoAnswerOpaque),
         );
     }
     ConclusionMap(m, Default::default())

--- a/src/index/conclusion_cache_tests.rs
+++ b/src/index/conclusion_cache_tests.rs
@@ -12,7 +12,7 @@ fn map_of(n: usize) -> ConclusionMap {
             Conclusion::OpenNone(crate::model::witnesses::OpenReason::NoAnswerOpaque),
         );
     }
-    ConclusionMap(m, Default::default())
+    ConclusionMap(m, Default::default(), Default::default(), Default::default())
 }
 
 /// A path the store has nothing for must be re-queried at most once.

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -14,9 +14,14 @@
 //! tell the two apart — see
 //! `conclusions_tests::a_chain_needs_the_evaluated_surface_not_the_map`.
 
-use crate::model::witnesses::EvaluatedSurface;
+use crate::index::module_cache;
+use crate::index::module_cache::Generation;
+use crate::model::witnesses::{ConclusionMap, EvaluatedSurface};
+use rusqlite::Connection;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Rounds a single flush may take before it is declared non-convergent.
 ///
@@ -114,6 +119,214 @@ pub fn run_flush(
     out
 }
 
+
+/// The world one flush evaluates against: a frozen generation underneath, the
+/// maps this flush has already re-baked on top.
+///
+/// The overlay is the whole reason a wave moves past its first hop. B's map is
+/// index-free, so re-baking B after A changed yields BYTE-IDENTICAL bytes; the
+/// only thing that moved is what B's `Link`s chase THROUGH. Evaluating B
+/// against the frozen store would therefore reproduce B's frozen surface
+/// exactly, cut, and starve B's consumers — the map-equality failure
+/// `EvaluatedSurface` exists to avoid, arriving through the resolver instead
+/// of through the diff.
+///
+/// Its two map sources are closures rather than a `Connection` for the same
+/// reason `follow_link_with` takes a resolver: the overlay is delicate, and a
+/// world that can only be built from a store is a world only exercised by
+/// whatever a corpus happens to contain.
+struct FlushWorld<'a> {
+    frozen_src: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
+    re_bake: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
+    candidates_of: &'a dyn Fn(&str) -> Vec<PathBuf>,
+    frozen: RefCell<HashMap<PathBuf, Option<Arc<ConclusionMap>>>>,
+    fresh: RefCell<HashMap<PathBuf, Option<Arc<ConclusionMap>>>>,
+}
+
+impl<'a> FlushWorld<'a> {
+    fn new(
+        frozen_src: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
+        re_bake: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
+        candidates_of: &'a dyn Fn(&str) -> Vec<PathBuf>,
+    ) -> Self {
+        FlushWorld {
+            frozen_src,
+            re_bake,
+            candidates_of,
+            frozen: RefCell::new(HashMap::new()),
+            fresh: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn frozen_map(&self, path: &Path) -> Option<Arc<ConclusionMap>> {
+        if let Some(hit) = self.frozen.borrow().get(path) {
+            return hit.clone();
+        }
+        let loaded = (self.frozen_src)(path).map(Arc::new);
+        self.frozen.borrow_mut().insert(path.to_path_buf(), loaded.clone());
+        loaded
+    }
+
+    /// This flush's bake of a file, memoized.
+    ///
+    /// Memoized because the bake is a pure function of the file's own blob —
+    /// nothing about it depends on the round, so a file revisited by a cycle
+    /// or a fan-in re-EVALUATES (which is the point) but never re-BAKES.
+    fn fresh_map(&self, path: &Path) -> Option<Arc<ConclusionMap>> {
+        if let Some(hit) = self.fresh.borrow().get(path) {
+            return hit.clone();
+        }
+        let baked = (self.re_bake)(path).map(Arc::new);
+        self.fresh.borrow_mut().insert(path.to_path_buf(), baked.clone());
+        baked
+    }
+
+    fn resolve(&self, class: &str, overlay: bool) -> Vec<(String, Option<Arc<ConclusionMap>>)> {
+        (self.candidates_of)(class)
+            .into_iter()
+            .map(|p| {
+                // Overlay reads only what this flush ALREADY baked — it never
+                // bakes on demand. Baking a candidate here would pull the
+                // whole reachable graph into a flush seeded by one file, and
+                // the pull would be invisible: every candidate of every class
+                // any evaluated key mentions, transitively.
+                let map = if overlay {
+                    self.fresh.borrow().get(p.as_path()).cloned().flatten()
+                } else {
+                    None
+                };
+                let map = map.or_else(|| self.frozen_map(&p));
+                (p.to_string_lossy().into_owned(), map)
+            })
+            .collect()
+    }
+
+    fn evaluate(&self, path: &Path) -> Option<EvaluatedSurface> {
+        let map = self.fresh_map(path)?;
+        Some(map.evaluated_surface(&|class| self.resolve(class, true)))
+    }
+
+    /// The file's surface as of the frozen generation — the thing "moved" is
+    /// measured against. Evaluated WITHOUT the overlay on purpose: it is the
+    /// answer the world gave before this flush started.
+    fn baseline(&self, path: &Path) -> Option<EvaluatedSurface> {
+        let map = self.frozen_map(path)?;
+        Some(map.evaluated_surface(&|class| self.resolve(class, false)))
+    }
+}
+
+/// Propagate over a world and hand back the maps that must be written.
+///
+/// Two publication rules, and they answer different questions:
+///
+/// * A file the propagation found MOVED is written because its consumers'
+///   answers depend on it.
+/// * A SEED is written whether or not its surface moved, because its own blob
+///   changed. The surface is evaluated with no binders, so a change visible
+///   only under a receiver or an arity is invisible to it — cutting a seed on
+///   surface equality would leave the store serving a map its file no longer
+///   has. The cutoff governs PROPAGATION, never whether the file that changed
+///   gets its own row refreshed.
+fn flush_over_world(
+    world: &FlushWorld<'_>,
+    dirty: Vec<PathBuf>,
+    consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
+) -> (FlushOutcome, Vec<(PathBuf, Arc<ConclusionMap>)>) {
+    let seeds = dirty.clone();
+    let outcome = run_flush(
+        dirty,
+        &|p| world.evaluate(p),
+        &|p| world.baseline(p),
+        consumers_of,
+    );
+    if outcome.non_convergent {
+        return (outcome, Vec::new());
+    }
+    let mut paths: Vec<PathBuf> = outcome.changed.iter().map(|(p, _)| p.clone()).collect();
+    paths.extend(seeds);
+    paths.sort();
+    paths.dedup();
+    let writes = paths
+        .into_iter()
+        .filter_map(|p| world.fresh_map(&p).map(|m| (p, m)))
+        .collect();
+    (outcome, writes)
+}
+
+/// What one store-backed flush did.
+#[derive(Debug)]
+pub struct FlushReport {
+    pub outcome: FlushOutcome,
+    /// Files whose map landed in the new generation.
+    pub published: usize,
+    /// The generation a reader should pin AFTER this flush. Unchanged from
+    /// the frozen one when nothing was published — including on a
+    /// non-convergent flush, which publishes nothing by construction.
+    pub generation: Generation,
+}
+
+/// Run one flush against the store and publish the result as one generation.
+///
+/// `dirty` is the frontier — the files whose blobs just changed.
+/// `consumers_of` is the freshness reverse-dep walk (`dirty_consumers`);
+/// `candidates_of` maps a class to the files that declare it, the same
+/// relation the live `follow_link` resolves through.
+///
+/// The generation is read ONCE and frozen for the whole flush: a round that
+/// re-read it could compose answers from two worlds, which is the failure the
+/// pin exists to prevent.
+pub fn flush_to_store(
+    conn: &Connection,
+    dirty: Vec<PathBuf>,
+    consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
+    candidates_of: &dyn Fn(&str) -> Vec<PathBuf>,
+) -> FlushReport {
+    let at = module_cache::current_generation(conn);
+    let frozen_src = |path: &Path| {
+        module_cache::load_conclusions(conn, &path.to_string_lossy(), at)
+    };
+    let re_bake = |path: &Path| {
+        // WITH the bag, for the reason the repair path takes it: a bagless
+        // decode bakes a map that concludes nothing while looking like a
+        // successful re-bake, and the flush would then publish that emptiness
+        // over a good map.
+        let fa = module_cache::load_one_diag(conn, &path.to_string_lossy(), true).ok()?;
+        Some(module_cache::bake_conclusion_map(&fa, &fa.witnesses))
+    };
+    let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of);
+    let (outcome, writes) = flush_over_world(&world, dirty, consumers_of);
+    if writes.is_empty() {
+        // Nothing to say. Advancing the generation anyway would retire every
+        // reader's pin for no new information and leave a generation whose
+        // rows are all inherited from the one below it.
+        return FlushReport { outcome, published: 0, generation: at };
+    }
+
+    let entries: Vec<(String, ConclusionMap)> = writes
+        .iter()
+        .map(|(p, m)| (p.to_string_lossy().into_owned(), (**m).clone()))
+        .collect();
+    let next = Generation(at.0 + 1);
+    match module_cache::publish_generation(conn, next, &entries) {
+        Ok(()) => {
+            crate::util::ghost_stats::count_by("flush.published", entries.len() as u64);
+            FlushReport { outcome, published: entries.len(), generation: next }
+        }
+        Err(e) => {
+            // The publish is one transaction, so a failure left gen N intact.
+            // Reporting the OLD generation is what keeps that true for the
+            // caller: a reader pinned to it reads a complete world.
+            log::warn!("conclusion flush: publish failed, generation {} stands: {e}", at.0);
+            crate::util::ghost_stats::count("flush.publish_failed");
+            FlushReport { outcome, published: 0, generation: at }
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "conclusion_flush_tests.rs"]
 mod conclusion_flush_tests;
+
+#[cfg(test)]
+#[path = "conclusion_flush_store_tests.rs"]
+mod conclusion_flush_store_tests;

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -1,0 +1,119 @@
+//! The flush driver's worklist: propagate a change until the answers stop
+//! moving, then publish one generation.
+//!
+//! `docs/prompt-enrichment-alternatives.md` §3c′/§3c″ owns the design. What
+//! lives here is the loop and its two hard properties — the cutoff and
+//! termination — factored so both are testable without a store, a thread, or a
+//! corpus.
+//!
+//! **The diff artifact is the EVALUATED surface, never the persisted map.** A
+//! map is index-free by construction, so when C changes B's map is
+//! byte-identical while B's answers have moved; cutting on map equality stops
+//! the wave at B and starves B's consumers. That is the whole soundness of the
+//! cutoff, it passes every two-file fixture either way, and only a chain can
+//! tell the two apart — see
+//! `conclusions_tests::a_chain_needs_the_evaluated_surface_not_the_map`.
+
+use crate::model::witnesses::EvaluatedSurface;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// Rounds a single flush may take before it is declared non-convergent.
+///
+/// The all-builds safety net, same role as `MAX_FOLD_ITERATIONS` one tier
+/// down: convergence is a property of the lattice, not of this number, and a
+/// flush that reaches the cap has found a bug rather than a deep chain. Real
+/// dependency chains in a workspace are single digits.
+pub const MAX_FLUSH_ROUNDS: usize = 32;
+
+/// What one flush did. Returned rather than logged so a caller — and a test —
+/// can assert on the shape of the propagation, not just its result.
+#[derive(Debug, Default, PartialEq)]
+pub struct FlushOutcome {
+    /// Files whose evaluated surface moved, with the surface that will be
+    /// published. A file evaluated and found unchanged is deliberately absent:
+    /// the cutoff is the point.
+    pub changed: Vec<(PathBuf, EvaluatedSurface)>,
+    /// How many worklist rounds ran. `1` means the frontier cut immediately.
+    pub rounds: usize,
+    /// Files evaluated, including those that cut. The propagation's real cost.
+    pub evaluated: usize,
+    /// The round cap fired: the surfaces never stopped moving. The flush is
+    /// abandoned rather than published — a half-propagated generation is worse
+    /// than none, because a consult pinned to it would compose answers from a
+    /// wave that never finished.
+    pub non_convergent: bool,
+}
+
+/// Run one flush to quiescence.
+///
+/// `evaluate` re-bakes a file and evaluates its surface against the FROZEN
+/// generation; `baseline` is that file's surface as of the same generation;
+/// `consumers_of` is the freshness reverse-dep walk.
+///
+/// The cutoff compares against the surface recorded EARLIER IN THIS FLUSH when
+/// there is one, and against the baseline otherwise. That distinction is what
+/// makes a cycle terminate: on the second visit A is compared to A-as-just-
+/// recorded, so an unchanged re-derivation cuts instead of re-enqueuing B
+/// forever. Comparing against the baseline every time would make any cycle run
+/// until the cap.
+pub fn run_flush(
+    dirty: impl IntoIterator<Item = PathBuf>,
+    evaluate: &dyn Fn(&Path) -> Option<EvaluatedSurface>,
+    baseline: &dyn Fn(&Path) -> Option<EvaluatedSurface>,
+    consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
+) -> FlushOutcome {
+    let mut recorded: HashMap<PathBuf, EvaluatedSurface> = HashMap::new();
+    let mut frontier: Vec<PathBuf> = dirty.into_iter().collect();
+    let mut out = FlushOutcome::default();
+
+    while !frontier.is_empty() {
+        out.rounds += 1;
+        if out.rounds > MAX_FLUSH_ROUNDS {
+            crate::util::ghost_stats::count("flush.non_convergent");
+            log::error!(
+                "conclusion flush did not converge in {MAX_FLUSH_ROUNDS} rounds; \
+                 abandoning rather than publishing a half-propagated generation"
+            );
+            out.non_convergent = true;
+            return out;
+        }
+        let round = std::mem::take(&mut frontier);
+        // Deduped per round: a file reached by three consumers in one round is
+        // one re-bake, not three. Without this a wide fan-in multiplies the
+        // round's cost by its width for no additional information.
+        let mut seen_this_round: HashSet<PathBuf> = HashSet::new();
+        for path in round {
+            if !seen_this_round.insert(path.clone()) {
+                continue;
+            }
+            out.evaluated += 1;
+            let Some(surface) = evaluate(&path) else {
+                // Cannot evaluate — a file that vanished, or one whose map is
+                // gone. Cutting here is right: we have nothing to say about it
+                // and inventing a change would propagate noise.
+                crate::util::ghost_stats::count("flush.unevaluable");
+                continue;
+            };
+            let prior = recorded.get(&path).cloned().or_else(|| baseline(&path));
+            if prior.as_ref() == Some(&surface) {
+                crate::util::ghost_stats::count("flush.cut");
+                continue;
+            }
+            crate::util::ghost_stats::count("flush.moved");
+            recorded.insert(path.clone(), surface);
+            frontier.extend(consumers_of(&path));
+        }
+    }
+
+    out.changed = recorded.into_iter().collect();
+    // Sorted for the same reason the surface itself is: the caller publishes
+    // this and compares it, and a `HashMap` drain order would make two equal
+    // flushes look different.
+    out.changed.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+#[cfg(test)]
+#[path = "conclusion_flush_tests.rs"]
+mod conclusion_flush_tests;

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -270,114 +270,84 @@ impl<'a> FlushWorld<'a> {
     }
 }
 
-/// Propagate over a world, and hand back the seeds' fresh maps.
+/// Propagate over a world.
 ///
-/// The two halves of the result answer different questions, and conflating
-/// them is the mistake this shape exists to prevent:
-///
-/// * `FlushOutcome::changed` is the **refresh set** — the files whose ANSWERS
-///   moved. It is what the wave is computed for: whoever consumes these must
-///   re-enrich, re-diagnose, or re-publish. Their maps are untouched.
-/// * The returned maps are the **write set**, and it is exactly the seeds. A
-///   seed is written whether or not its surface moved: the surface is
-///   evaluated with no binders, so a change visible only under a receiver or
-///   an arity is invisible to it, and cutting a seed on surface equality would
-///   leave the store serving a map its file no longer has. The cutoff governs
-///   propagation, never whether the file that changed gets its own row
-///   refreshed.
+/// The result is the **refresh set**: the files whose ANSWERS moved, and whose
+/// consumers must therefore re-enrich, re-diagnose or re-publish. No map is
+/// written — a map goes stale only when its own blob changes, so every file
+/// the wave reaches already has the right one in the store.
 fn flush_over_world(
     world: &FlushWorld<'_>,
-    dirty: Vec<PathBuf>,
+    frontier: Vec<PathBuf>,
     consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
-) -> (FlushOutcome, Vec<(PathBuf, Arc<ConclusionMap>)>) {
-    let mut seeds = dirty.clone();
-    let outcome = run_flush(
-        dirty,
+) -> FlushOutcome {
+    run_flush(
+        frontier,
         &|p| world.evaluate(p),
         &|p| world.baseline(p),
         consumers_of,
-    );
-    if outcome.non_convergent {
-        return (outcome, Vec::new());
-    }
-    seeds.sort();
-    seeds.dedup();
-    let writes = seeds
-        .into_iter()
-        .filter_map(|p| world.baked(&p).map(|m| (p, m)))
-        .collect();
-    (outcome, writes)
+    )
 }
 
-/// What one store-backed flush did.
-#[derive(Debug)]
-pub struct FlushReport {
-    pub outcome: FlushOutcome,
-    /// Files whose map landed in the new generation — the seeds, and only
-    /// the seeds. `outcome.changed` is the larger, different set.
-    pub published: usize,
-    /// The generation a reader should pin AFTER this flush. Unchanged from
-    /// the frozen one when nothing was published — including on a
-    /// non-convergent flush, which publishes nothing by construction.
-    pub generation: Generation,
-}
-
-/// Run one flush against the store and publish the result as one generation.
+/// Compute the refresh set for a set of just-changed files.
 ///
-/// `dirty` is the frontier — the files whose blobs just changed.
+/// `fresh` carries each CHANGED file's newly baked map. The caller bakes,
+/// because the caller is the one that just built the analysis; making the
+/// flush decode a blob to re-derive a map already in RAM would be this
+/// layer's own antipattern, and at the seam this is wired to
+/// (`didChangeWatchedFiles`) the blob has already been invalidated, so there
+/// would be nothing to decode. With `fresh` supplied, the wave reads
+/// conclusion maps and nothing else.
+///
+/// `frontier` is where the wave STARTS, which is not always `fresh`'s keys. A
+/// DELETED file has no fresh map and nothing to evaluate, so it enters as its
+/// direct consumers instead — they now resolve through a file the store has
+/// forgotten, which is a move, and the wave carries it onward from there.
+///
 /// `consumers_of` is the freshness reverse-dep walk (`dirty_consumers`);
 /// `candidates_of` maps a class to the files that declare it, the same
 /// relation the live `follow_link` resolves through.
 ///
-/// The generation is read ONCE and frozen for the whole flush: a round that
-/// re-read it could compose answers from two worlds, which is the failure the
+/// Deliberately does NOT publish. The seeds' fresh maps belong in the store —
+/// that is what keeps a consult on a just-edited file cheap — but their blobs
+/// were invalidated a moment ago, and a conclusion row with no `modules` row
+/// behind it can never be caught by a stamp check, because the stamp lives on
+/// the `modules` row. Writing one would re-open, by a different door, exactly
+/// the "a bake outlived its blob" hole that `invalidate_generation` was just
+/// taught to close. Publishing wants the conclusions table to carry its own
+/// freshness stamp first.
+///
+/// The generation is read ONCE and frozen for the whole wave: reading it again
+/// mid-flush could compose answers from two worlds, which is the failure the
 /// pin exists to prevent.
-pub fn flush_to_store(
+pub fn flush_refresh_set(
     conn: &Connection,
-    dirty: Vec<PathBuf>,
+    fresh: Vec<(PathBuf, ConclusionMap)>,
+    frontier: Vec<PathBuf>,
     consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
     candidates_of: &dyn Fn(&str) -> Vec<PathBuf>,
-) -> FlushReport {
+) -> FlushOutcome {
     let at = module_cache::current_generation(conn);
+    let supplied: HashMap<PathBuf, ConclusionMap> = fresh.into_iter().collect();
+    let seeds: Vec<PathBuf> = supplied.keys().cloned().collect();
     let frozen_src = |path: &Path| {
         module_cache::load_conclusions(conn, &path.to_string_lossy(), at)
     };
+    // A seed's map comes from the caller. Anything else is only ever asked for
+    // under `PERL_LSP_FLUSH_EQUIV`, which has to pay the blob decode precisely
+    // because that is the assumption being checked — and with the bag, for the
+    // reason the repair path takes it: a bagless decode bakes a map that
+    // concludes nothing while looking like a clean re-bake, and the checker
+    // would then report every file as a break.
     let re_bake = |path: &Path| {
-        // WITH the bag, for the reason the repair path takes it: a bagless
-        // decode bakes a map that concludes nothing while looking like a
-        // successful re-bake, and the flush would then publish that emptiness
-        // over a good map.
+        if let Some(m) = supplied.get(path) {
+            return Some(m.clone());
+        }
         let fa = module_cache::load_one_diag(conn, &path.to_string_lossy(), true).ok()?;
         Some(module_cache::bake_conclusion_map(&fa, &fa.witnesses))
     };
-    let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of, dirty.clone());
-    let (outcome, writes) = flush_over_world(&world, dirty, consumers_of);
-    if writes.is_empty() {
-        // Nothing to say. Advancing the generation anyway would retire every
-        // reader's pin for no new information and leave a generation whose
-        // rows are all inherited from the one below it.
-        return FlushReport { outcome, published: 0, generation: at };
-    }
-
-    let entries: Vec<(String, ConclusionMap)> = writes
-        .iter()
-        .map(|(p, m)| (p.to_string_lossy().into_owned(), (**m).clone()))
-        .collect();
-    let next = Generation(at.0 + 1);
-    match module_cache::publish_generation(conn, next, &entries) {
-        Ok(()) => {
-            crate::util::ghost_stats::count_by("flush.published", entries.len() as u64);
-            FlushReport { outcome, published: entries.len(), generation: next }
-        }
-        Err(e) => {
-            // The publish is one transaction, so a failure left gen N intact.
-            // Reporting the OLD generation is what keeps that true for the
-            // caller: a reader pinned to it reads a complete world.
-            log::warn!("conclusion flush: publish failed, generation {} stands: {e}", at.0);
-            crate::util::ghost_stats::count("flush.publish_failed");
-            FlushReport { outcome, published: 0, generation: at }
-        }
-    }
+    let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of, seeds);
+    flush_over_world(&world, frontier, consumers_of)
 }
 
 #[cfg(test)]

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -45,6 +45,15 @@ pub struct FlushOutcome {
     pub rounds: usize,
     /// Files evaluated, including those that cut. The propagation's real cost.
     pub evaluated: usize,
+    /// Every file the wave ENQUEUED because a provider's answers moved —
+    /// including those that then cut.
+    ///
+    /// Distinct from `changed` on purpose, and the difference is the whole
+    /// point of the re-stamp gate: a consumer whose own conclusion answers did
+    /// not move can still DISPATCH differently now that its provider changed,
+    /// because a dispatch target is resolved through the index rather than
+    /// read off a surface. Marking only what moved would skip exactly those.
+    pub enqueued: Vec<PathBuf>,
     /// The round cap fired: the surfaces never stopped moving. The flush is
     /// abandoned rather than published — a half-propagated generation is worse
     /// than none, because a consult pinned to it would compose answers from a
@@ -109,10 +118,14 @@ pub fn run_flush(
             }
             crate::util::ghost_stats::count("flush.moved");
             recorded.insert(path.clone(), surface);
-            frontier.extend(consumers_of(&path));
+            let consumers = consumers_of(&path);
+            out.enqueued.extend(consumers.iter().cloned());
+            frontier.extend(consumers);
         }
     }
 
+    out.enqueued.sort();
+    out.enqueued.dedup();
     out.changed = recorded.into_iter().collect();
     // Sorted for the same reason the surface itself is: the caller publishes
     // this and compares it, and a `HashMap` drain order would make two equal

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -35,9 +35,11 @@ pub const MAX_FLUSH_ROUNDS: usize = 32;
 /// can assert on the shape of the propagation, not just its result.
 #[derive(Debug, Default, PartialEq)]
 pub struct FlushOutcome {
-    /// Files whose evaluated surface moved, with the surface that will be
-    /// published. A file evaluated and found unchanged is deliberately absent:
-    /// the cutoff is the point.
+    /// The REFRESH set: files whose evaluated surface moved, with the surface
+    /// it moved to. Whoever consumes these must re-enrich, re-diagnose or
+    /// re-publish — their conclusion maps are untouched, because a map goes
+    /// stale only when its own blob changes. A file evaluated and found
+    /// unchanged is deliberately absent: the cutoff is the point.
     pub changed: Vec<(PathBuf, EvaluatedSurface)>,
     /// How many worklist rounds ran. `1` means the frontier cut immediately.
     pub rounds: usize,
@@ -52,9 +54,9 @@ pub struct FlushOutcome {
 
 /// Run one flush to quiescence.
 ///
-/// `evaluate` re-bakes a file and evaluates its surface against the FROZEN
-/// generation; `baseline` is that file's surface as of the same generation;
-/// `consumers_of` is the freshness reverse-dep walk.
+/// `evaluate` gives a file's surface in the world this flush is building;
+/// `baseline` gives it as of the frozen generation; `consumers_of` is the
+/// freshness reverse-dep walk.
 ///
 /// The cutoff compares against the surface recorded EARLIER IN THIS FLUSH when
 /// there is one, and against the baseline otherwise. That distinction is what
@@ -121,26 +123,53 @@ pub fn run_flush(
 
 
 /// The world one flush evaluates against: a frozen generation underneath, the
-/// maps this flush has already re-baked on top.
+/// seeds this flush re-baked on top.
 ///
-/// The overlay is the whole reason a wave moves past its first hop. B's map is
-/// index-free, so re-baking B after A changed yields BYTE-IDENTICAL bytes; the
-/// only thing that moved is what B's `Link`s chase THROUGH. Evaluating B
-/// against the frozen store would therefore reproduce B's frozen surface
-/// exactly, cut, and starve B's consumers — the map-equality failure
-/// `EvaluatedSurface` exists to avoid, arriving through the resolver instead
-/// of through the diff.
+/// **A map goes stale only when its OWN file's blob changes.** The bake runs
+/// with the index deliberately withheld, so it cannot produce a value that
+/// depended on another file — anything cross-file comes out as a `Link` that
+/// chases at read time, or as `OpenNone`. A downstream change therefore moves
+/// a consumer's ANSWERS without moving its MAP, which is why the propagation
+/// re-bakes nothing past the frontier: it decodes one map per reached file and
+/// no blobs at all. `module_cache_tests::a_cleared_conclusion_row_is_re_baked_
+/// to_the_same_map` is the standing evidence that a re-bake of an unchanged
+/// blob reproduces the stored map exactly.
 ///
-/// Its two map sources are closures rather than a `Connection` for the same
-/// reason `follow_link_with` takes a resolver: the overlay is delicate, and a
-/// world that can only be built from a store is a world only exercised by
-/// whatever a corpus happens to contain.
+/// The overlay is what lets the wave move past its first hop. B's map is
+/// index-free, so it reads identically before and after A changes; the only
+/// thing that moved is what B's `Link`s chase THROUGH. Evaluating B against
+/// the frozen store would reproduce B's frozen surface exactly, cut, and
+/// starve B's consumers — the map-equality failure `EvaluatedSurface` exists
+/// to avoid, arriving through the resolver instead of through the diff.
+///
+/// Its map sources are closures rather than a `Connection` for the same reason
+/// `follow_link_with` takes a resolver: the overlay is delicate, and a world
+/// that can only be built from a store is a world only exercised by whatever a
+/// corpus happens to contain.
 struct FlushWorld<'a> {
     frozen_src: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
     re_bake: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
     candidates_of: &'a dyn Fn(&str) -> Vec<PathBuf>,
+    /// The files whose blobs changed — the only ones re-baked.
+    seeds: HashSet<PathBuf>,
     frozen: RefCell<HashMap<PathBuf, Option<Arc<ConclusionMap>>>>,
     fresh: RefCell<HashMap<PathBuf, Option<Arc<ConclusionMap>>>>,
+    /// Re-bake-equals-frozen breaks found under `PERL_LSP_FLUSH_EQUIV`.
+    breaks: std::cell::Cell<usize>,
+}
+
+/// Re-bake every reached file, not just the seeds, and score the invariant the
+/// propagation rests on.
+///
+/// The invariant is load-bearing and its violation is SILENT: a bake that
+/// learned to consult an index would make non-seed maps genuinely stale, the
+/// wave would evaluate the old ones, and the only symptom would be consumers
+/// that quietly stopped being refreshed. Same discipline as
+/// `PERL_LSP_CONCL_EQUIV` one tier down — the assumption ships with the switch
+/// that checks it.
+fn flush_equiv_enabled() -> bool {
+    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *V.get_or_init(|| std::env::var("PERL_LSP_FLUSH_EQUIV").is_ok())
 }
 
 impl<'a> FlushWorld<'a> {
@@ -148,13 +177,16 @@ impl<'a> FlushWorld<'a> {
         frozen_src: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
         re_bake: &'a dyn Fn(&Path) -> Option<ConclusionMap>,
         candidates_of: &'a dyn Fn(&str) -> Vec<PathBuf>,
+        seeds: impl IntoIterator<Item = PathBuf>,
     ) -> Self {
         FlushWorld {
             frozen_src,
             re_bake,
             candidates_of,
+            seeds: seeds.into_iter().collect(),
             frozen: RefCell::new(HashMap::new()),
             fresh: RefCell::new(HashMap::new()),
+            breaks: std::cell::Cell::new(0),
         }
     }
 
@@ -167,18 +199,41 @@ impl<'a> FlushWorld<'a> {
         loaded
     }
 
-    /// This flush's bake of a file, memoized.
+    /// A seed's re-bake, memoized.
     ///
     /// Memoized because the bake is a pure function of the file's own blob —
-    /// nothing about it depends on the round, so a file revisited by a cycle
+    /// nothing about it depends on the round, so a seed revisited by a cycle
     /// or a fan-in re-EVALUATES (which is the point) but never re-BAKES.
-    fn fresh_map(&self, path: &Path) -> Option<Arc<ConclusionMap>> {
+    fn baked(&self, path: &Path) -> Option<Arc<ConclusionMap>> {
         if let Some(hit) = self.fresh.borrow().get(path) {
             return hit.clone();
         }
         let baked = (self.re_bake)(path).map(Arc::new);
         self.fresh.borrow_mut().insert(path.to_path_buf(), baked.clone());
         baked
+    }
+
+    /// The map this flush believes a file has: its re-bake if its blob
+    /// changed, its stored map otherwise.
+    fn current_map(&self, path: &Path) -> Option<Arc<ConclusionMap>> {
+        if self.seeds.contains(path) {
+            return self.baked(path);
+        }
+        let frozen = self.frozen_map(path);
+        if flush_equiv_enabled() {
+            let baked = (self.re_bake)(path);
+            if baked.is_some() && baked.as_ref() != frozen.as_deref() {
+                self.breaks.set(self.breaks.get() + 1);
+                crate::util::ghost_stats::count("flushequiv.break");
+                log::warn!(
+                    "flush equiv: re-baking '{}' did not reproduce its stored \
+                     map — a downstream change moved a map, which the \
+                     propagation assumes cannot happen",
+                    path.display()
+                );
+            }
+        }
+        frozen
     }
 
     fn resolve(&self, class: &str, overlay: bool) -> Vec<(String, Option<Arc<ConclusionMap>>)> {
@@ -202,7 +257,7 @@ impl<'a> FlushWorld<'a> {
     }
 
     fn evaluate(&self, path: &Path) -> Option<EvaluatedSurface> {
-        let map = self.fresh_map(path)?;
+        let map = self.current_map(path)?;
         Some(map.evaluated_surface(&|class| self.resolve(class, true)))
     }
 
@@ -215,24 +270,27 @@ impl<'a> FlushWorld<'a> {
     }
 }
 
-/// Propagate over a world and hand back the maps that must be written.
+/// Propagate over a world, and hand back the seeds' fresh maps.
 ///
-/// Two publication rules, and they answer different questions:
+/// The two halves of the result answer different questions, and conflating
+/// them is the mistake this shape exists to prevent:
 ///
-/// * A file the propagation found MOVED is written because its consumers'
-///   answers depend on it.
-/// * A SEED is written whether or not its surface moved, because its own blob
-///   changed. The surface is evaluated with no binders, so a change visible
-///   only under a receiver or an arity is invisible to it — cutting a seed on
-///   surface equality would leave the store serving a map its file no longer
-///   has. The cutoff governs PROPAGATION, never whether the file that changed
-///   gets its own row refreshed.
+/// * `FlushOutcome::changed` is the **refresh set** — the files whose ANSWERS
+///   moved. It is what the wave is computed for: whoever consumes these must
+///   re-enrich, re-diagnose, or re-publish. Their maps are untouched.
+/// * The returned maps are the **write set**, and it is exactly the seeds. A
+///   seed is written whether or not its surface moved: the surface is
+///   evaluated with no binders, so a change visible only under a receiver or
+///   an arity is invisible to it, and cutting a seed on surface equality would
+///   leave the store serving a map its file no longer has. The cutoff governs
+///   propagation, never whether the file that changed gets its own row
+///   refreshed.
 fn flush_over_world(
     world: &FlushWorld<'_>,
     dirty: Vec<PathBuf>,
     consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
 ) -> (FlushOutcome, Vec<(PathBuf, Arc<ConclusionMap>)>) {
-    let seeds = dirty.clone();
+    let mut seeds = dirty.clone();
     let outcome = run_flush(
         dirty,
         &|p| world.evaluate(p),
@@ -242,13 +300,11 @@ fn flush_over_world(
     if outcome.non_convergent {
         return (outcome, Vec::new());
     }
-    let mut paths: Vec<PathBuf> = outcome.changed.iter().map(|(p, _)| p.clone()).collect();
-    paths.extend(seeds);
-    paths.sort();
-    paths.dedup();
-    let writes = paths
+    seeds.sort();
+    seeds.dedup();
+    let writes = seeds
         .into_iter()
-        .filter_map(|p| world.fresh_map(&p).map(|m| (p, m)))
+        .filter_map(|p| world.baked(&p).map(|m| (p, m)))
         .collect();
     (outcome, writes)
 }
@@ -257,7 +313,8 @@ fn flush_over_world(
 #[derive(Debug)]
 pub struct FlushReport {
     pub outcome: FlushOutcome,
-    /// Files whose map landed in the new generation.
+    /// Files whose map landed in the new generation — the seeds, and only
+    /// the seeds. `outcome.changed` is the larger, different set.
     pub published: usize,
     /// The generation a reader should pin AFTER this flush. Unchanged from
     /// the frozen one when nothing was published — including on a
@@ -293,7 +350,7 @@ pub fn flush_to_store(
         let fa = module_cache::load_one_diag(conn, &path.to_string_lossy(), true).ok()?;
         Some(module_cache::bake_conclusion_map(&fa, &fa.witnesses))
     };
-    let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of, dirty.clone());
     let (outcome, writes) = flush_over_world(&world, dirty, consumers_of);
     if writes.is_empty() {
         // Nothing to say. Advancing the generation anyway would retire every

--- a/src/index/conclusion_flush_store_tests.rs
+++ b/src/index/conclusion_flush_store_tests.rs
@@ -1,0 +1,320 @@
+//! The flush over a WORLD: the overlay, the seed rule, and the atomic publish.
+//!
+//! `conclusion_flush_tests` covers the loop's own properties (cutoff,
+//! termination, fan-in). What is tested here is everything the loop needs a
+//! world for — which maps a round evaluates against, and what a converged
+//! round writes.
+
+use super::*;
+use crate::model::file_analysis::InferredType;
+use crate::model::witnesses::{Conclusion, ConclusionKey, ReceiverRule};
+use std::collections::BTreeMap;
+
+fn key(class: &str, name: &str) -> ConclusionKey {
+    ConclusionKey::MethodOnClass { class: class.into(), name: name.into() }
+}
+
+/// A map holding one key, with `class` enumerated so absence elsewhere in it
+/// reads as `NotLocal` rather than a proven `None`.
+fn map_of(class: &str, name: &str, c: Conclusion) -> ConclusionMap {
+    let mut m = HashMap::new();
+    m.insert(key(class, name), c);
+    let mut enumerated = HashSet::new();
+    enumerated.insert(class.to_string());
+    ConclusionMap(m, HashSet::new(), enumerated, HashMap::new())
+}
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+/// The hop that only an overlay can make.
+///
+/// B's map holds a `Link` into A's class, so B's bytes say the same thing
+/// before and after A changes — that is what makes the map useless as a change
+/// signal. B's ANSWER moves only if the resolver B is evaluated against sees
+/// A's fresh bake. Frozen-only resolution reproduces B's old surface exactly,
+/// cuts, and starves C.
+///
+/// Base-verify by flipping `resolve`'s `overlay` argument to `false` in
+/// `evaluate`: B then cuts, `evaluated` drops to 2, and C is never reached —
+/// with every other assertion in the suite still passing.
+#[test]
+fn a_consumer_is_evaluated_against_the_seeds_fresh_bake_not_the_frozen_one() {
+    let a_old = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let a_new = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    // B answers by walking to A. Byte-identical in both worlds, deliberately.
+    let b = map_of(
+        "B",
+        "m",
+        Conclusion::Link {
+            targets: vec![key("A", "m")],
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    );
+    let c = map_of("C", "m", Conclusion::Value(InferredType::String));
+
+    let frozen_src = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => Some(a_old.clone()),
+        "/B.pm" => Some(b.clone()),
+        "/C.pm" => Some(c.clone()),
+        _ => None,
+    };
+    let re_bake = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => Some(a_new.clone()),
+        "/B.pm" => Some(b.clone()),
+        "/C.pm" => Some(c.clone()),
+        _ => None,
+    };
+    let candidates_of = |class: &str| match class {
+        "A" => vec![p("/A.pm")],
+        "B" => vec![p("/B.pm")],
+        "C" => vec![p("/C.pm")],
+        _ => Vec::new(),
+    };
+    let consumers_of = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => vec![p("/B.pm")],
+        "/B.pm" => vec![p("/C.pm")],
+        _ => Vec::new(),
+    };
+
+    // Precondition, asserted rather than assumed: B's map really is unchanged.
+    // Without this the test could pass for the wrong reason — B moving because
+    // B's own bytes moved proves nothing about the overlay.
+    assert_eq!(
+        re_bake(Path::new("/B.pm")),
+        frozen_src(Path::new("/B.pm")),
+        "precondition: B's map is byte-identical across the change"
+    );
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+
+    assert!(!outcome.non_convergent);
+    let moved: Vec<&PathBuf> = outcome.changed.iter().map(|(q, _)| q).collect();
+    assert_eq!(
+        moved,
+        vec![&p("/A.pm"), &p("/B.pm")],
+        "A moved, and B moved THROUGH it — B's own bytes never changed"
+    );
+    assert_eq!(outcome.evaluated, 3, "the wave reached C, which then cut");
+
+    let written: Vec<&PathBuf> = writes.iter().map(|(q, _)| q).collect();
+    assert_eq!(written, vec![&p("/A.pm"), &p("/B.pm")]);
+}
+
+/// A seed's own row is refreshed even when its surface did not move.
+///
+/// The surface is evaluated with no binders, so a change visible only under a
+/// receiver or an arity is invisible to it. Cutting the seed on surface
+/// equality would leave the store serving a map the file no longer has — the
+/// cutoff governs propagation, not whether the file that changed is rewritten.
+#[test]
+fn a_seed_is_written_even_when_its_surface_did_not_move() {
+    let same = map_of("A", "m", Conclusion::Value(InferredType::String));
+    let frozen_src = |_: &Path| Some(same.clone());
+    let re_bake = |_: &Path| Some(same.clone());
+    let candidates_of = |_: &str| vec![p("/A.pm")];
+    let reached = std::cell::RefCell::new(Vec::<PathBuf>::new());
+    let consumers_of = |path: &Path| {
+        reached.borrow_mut().push(path.to_path_buf());
+        vec![p("/B.pm")]
+    };
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+
+    assert!(outcome.changed.is_empty(), "the surface did not move");
+    assert_eq!(outcome.evaluated, 1);
+    assert!(
+        reached.borrow().is_empty(),
+        "a cut file's consumers are never even enumerated — the reverse-dep \
+         walk is part of what the cutoff saves"
+    );
+    assert_eq!(
+        writes.iter().map(|(q, _)| q.clone()).collect::<Vec<_>>(),
+        vec![p("/A.pm")],
+        "the seed is written regardless — its blob changed"
+    );
+}
+
+/// A seed whose blob cannot be decoded writes nothing and propagates nothing.
+///
+/// Publishing an empty map for it would be worse than leaving the old row:
+/// absence in a map is read as a proven `None`, so an "empty because we could
+/// not look" map answers `None` to every key the file used to conclude.
+#[test]
+fn an_unbakeable_seed_writes_nothing() {
+    let frozen_src = |_: &Path| None;
+    let re_bake = |_: &Path| None;
+    let candidates_of = |_: &str| Vec::new();
+    let consumers_of = |_: &Path| vec![p("/B.pm")];
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    assert_eq!(outcome.evaluated, 1);
+    assert!(outcome.changed.is_empty());
+    assert!(writes.is_empty(), "nothing decodable, nothing to publish");
+}
+
+/// A file is re-EVALUATED per round but re-BAKED once per flush.
+///
+/// The bake is a pure function of the file's own blob; only the evaluation
+/// depends on the round. Z is reached on two DIFFERENT rounds here — not the
+/// same-round fan-in `a_fan_in_evaluates_each_file_once_per_round` covers,
+/// which the round's dedup handles and which would pass with no memo at all.
+#[test]
+fn a_file_reached_on_two_rounds_is_baked_once() {
+    let bakes = std::cell::RefCell::new(BTreeMap::<String, usize>::new());
+    let seed = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    let old = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let sink = map_of("Z", "m", Conclusion::Value(InferredType::String));
+
+    // Only A has a frozen map. Everything downstream is new to the store, so
+    // its first visit moves and its second cuts — which is what puts Z on two
+    // rounds without contriving a value that oscillates.
+    let frozen_src = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => Some(old.clone()),
+        _ => None,
+    };
+    let re_bake = |path: &Path| {
+        *bakes
+            .borrow_mut()
+            .entry(path.to_string_lossy().into_owned())
+            .or_default() += 1;
+        match path.to_string_lossy().as_ref() {
+            "/A.pm" => Some(seed.clone()),
+            _ => Some(sink.clone()),
+        }
+    };
+    let candidates_of = |_: &str| Vec::new();
+    // A→B→Z is two hops; A→C→D→Z is three. Z therefore arrives on round 3 and
+    // again on round 4.
+    let consumers_of = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => vec![p("/B.pm"), p("/C.pm")],
+        "/B.pm" => vec![p("/Z.pm")],
+        "/C.pm" => vec![p("/D.pm")],
+        "/D.pm" => vec![p("/Z.pm")],
+        _ => Vec::new(),
+    };
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let (outcome, _) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    assert!(!outcome.non_convergent);
+    assert_eq!(outcome.rounds, 4);
+    assert_eq!(
+        outcome.evaluated, 6,
+        "A, B, C, Z, D, Z — Z is evaluated on both rounds it is reached on"
+    );
+    assert_eq!(
+        bakes.borrow().get("/Z.pm").copied(),
+        Some(1),
+        "two evaluations, one bake"
+    );
+}
+
+// ---- against a real store ----
+
+fn store_db() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    crate::index::module_cache::init_schema(&conn).unwrap();
+    conn
+}
+
+/// A converged flush advances the generation by exactly one, and a reader
+/// still pinned to the old one keeps reading the old world.
+///
+/// The retention half is the one that fails silently: rows are keyed
+/// `(path, generation)` precisely so publishing N+1 does not REPLACE the gen-N
+/// row. Under path-keying a pinned reader finds nothing, and absence in this
+/// layer means a proven `None` — the pin would have become a way to get wrong
+/// answers instead of a way to avoid them.
+#[test]
+fn a_published_flush_advances_one_generation_and_leaves_the_old_one_readable() {
+    use crate::index::module_cache::{load_conclusions, publish_generation, Generation};
+    let conn = store_db();
+    let path = "/store/A.pm";
+
+    // A deliberate gen-1 world, written directly rather than through a
+    // persist: the persist path bakes its own conclusions, which would make
+    // the baseline whatever the bake happens to produce instead of a value
+    // this test controls.
+    let before = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let after = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    publish_generation(&conn, Generation(1), &[(path.to_string(), before.clone())])
+        .expect("baseline");
+
+    let re_bake = |_: &Path| Some(after.clone());
+    let frozen_src =
+        |q: &Path| load_conclusions(&conn, &q.to_string_lossy(), Generation(1));
+    let candidates_of = |_: &str| vec![p(path)];
+    let consumers_of = |_: &Path| Vec::new();
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let (_, writes) = flush_over_world(&world, vec![p(path)], &consumers_of);
+    let entries: Vec<(String, ConclusionMap)> = writes
+        .iter()
+        .map(|(q, m)| (q.to_string_lossy().into_owned(), (**m).clone()))
+        .collect();
+    publish_generation(&conn, Generation(2), &entries).expect("publish");
+
+    assert_eq!(
+        crate::index::module_cache::current_generation(&conn),
+        Generation(2)
+    );
+    assert_eq!(
+        load_conclusions(&conn, path, Generation(2)),
+        Some(after),
+        "a fresh reader gets the flush's map"
+    );
+    assert_eq!(
+        load_conclusions(&conn, path, Generation(1)),
+        Some(before),
+        "a reader pinned to gen 1 still reads gen 1 — the pin is the whole \
+         point of freezing a generation for the duration of a consult"
+    );
+}
+
+/// `flush_to_store` end to end: a real blob in, a real conclusion row out at
+/// the next generation.
+#[test]
+fn flush_to_store_republishes_a_real_blob() {
+    use crate::index::module_cache::{current_generation, load_conclusions, save_to_db};
+    let conn = store_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("perl_lsp_flush_store_A.pm");
+    std::fs::write(
+        &pm,
+        "package FlushStoreA;\nsub val { return 'x' }\n1;\n",
+    )
+    .unwrap();
+    let source = std::fs::read_to_string(&pm).unwrap();
+
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
+    let tree = parser.parse(&source, None).unwrap();
+    let fa = crate::build::builder::build(&tree, source.as_bytes());
+    let cached = std::sync::Arc::new(crate::index::module_index::CachedModule::new(
+        pm.clone(),
+        std::sync::Arc::new(fa),
+    ));
+    assert!(save_to_db(&conn, &pm.to_string_lossy(), &Some(cached), "workspace"));
+
+    let before = current_generation(&conn);
+    let report = flush_to_store(&conn, vec![pm.clone()], &|_| Vec::new(), &|_| Vec::new());
+    assert_eq!(report.published, 1, "the seed is always written");
+    assert_eq!(report.generation, Generation(before.0 + 1));
+    assert_eq!(current_generation(&conn), report.generation);
+
+    let published = load_conclusions(&conn, &pm.to_string_lossy(), report.generation)
+        .expect("the flush wrote a map at the new generation");
+    assert!(
+        !published.is_empty(),
+        "a re-bake WITH the bag concludes something; an empty map here would \
+         mean the decode dropped the witnesses and the flush published the \
+         emptiness over a good row"
+    );
+
+    let _ = std::fs::remove_file(&pm);
+}

--- a/src/index/conclusion_flush_store_tests.rs
+++ b/src/index/conclusion_flush_store_tests.rs
@@ -89,7 +89,7 @@ fn a_consumer_is_evaluated_against_the_seeds_fresh_bake_not_the_frozen_one() {
     );
 
     let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
-    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    let outcome = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
 
     assert!(!outcome.non_convergent);
     let moved: Vec<&PathBuf> = outcome.changed.iter().map(|(q, _)| q).collect();
@@ -100,24 +100,16 @@ fn a_consumer_is_evaluated_against_the_seeds_fresh_bake_not_the_frozen_one() {
     );
     assert_eq!(outcome.evaluated, 3, "the wave reached C, which then cut");
 
-    let written: Vec<&PathBuf> = writes.iter().map(|(q, _)| q).collect();
-    assert_eq!(
-        written,
-        vec![&p("/A.pm")],
-        "B's ANSWERS moved, so B is in the refresh set — but B's MAP did not, \
-         so B is not written. Conflating the two would rewrite every reached \
-         file's row with a byte-identical copy of itself"
-    );
 }
 
-/// A seed's own row is refreshed even when its surface did not move.
+/// A seed whose surface did not move stops the wave dead — its consumers are
+/// not even enumerated.
 ///
-/// The surface is evaluated with no binders, so a change visible only under a
-/// receiver or an arity is invisible to it. Cutting the seed on surface
-/// equality would leave the store serving a map the file no longer has — the
-/// cutoff governs propagation, not whether the file that changed is rewritten.
+/// The reverse-dep walk is part of what the cutoff saves, not just the
+/// evaluation. A driver that computed the consumer set first and then asked
+/// whether it needed it would have paid the walk on every no-op save.
 #[test]
-fn a_seed_is_written_even_when_its_surface_did_not_move() {
+fn a_seed_that_did_not_move_never_enumerates_its_consumers() {
     let same = map_of("A", "m", Conclusion::Value(InferredType::String));
     let frozen_src = |_: &Path| Some(same.clone());
     let re_bake = |_: &Path| Some(same.clone());
@@ -129,39 +121,31 @@ fn a_seed_is_written_even_when_its_surface_did_not_move() {
     };
 
     let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
-    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    let outcome = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
 
     assert!(outcome.changed.is_empty(), "the surface did not move");
     assert_eq!(outcome.evaluated, 1);
-    assert!(
-        reached.borrow().is_empty(),
-        "a cut file's consumers are never even enumerated — the reverse-dep \
-         walk is part of what the cutoff saves"
-    );
-    assert_eq!(
-        writes.iter().map(|(q, _)| q.clone()).collect::<Vec<_>>(),
-        vec![p("/A.pm")],
-        "the seed is written regardless — its blob changed"
-    );
+    assert!(reached.borrow().is_empty());
 }
 
-/// A seed whose blob cannot be decoded writes nothing and propagates nothing.
+/// A file with no map at all is not a change — it is an absence of evidence.
 ///
-/// Publishing an empty map for it would be worse than leaving the old row:
-/// absence in a map is read as a proven `None`, so an "empty because we could
-/// not look" map answers `None` to every key the file used to conclude.
+/// Inventing a move for it would propagate noise from a file we cannot read,
+/// and the wave's whole value is that it stops where the answers stop moving.
+/// A DELETED file is handled at the caller instead, by entering the wave as
+/// its direct consumers: they resolve through a file the store has forgotten,
+/// which is a real move with real evidence behind it.
 #[test]
-fn an_unbakeable_seed_writes_nothing() {
+fn a_file_with_no_map_cuts_rather_than_inventing_a_move() {
     let frozen_src = |_: &Path| None;
     let re_bake = |_: &Path| None;
     let candidates_of = |_: &str| Vec::new();
     let consumers_of = |_: &Path| vec![p("/B.pm")];
 
     let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
-    let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    let outcome = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
     assert_eq!(outcome.evaluated, 1);
     assert!(outcome.changed.is_empty());
-    assert!(writes.is_empty(), "nothing decodable, nothing to publish");
 }
 
 /// The propagation decodes maps, never blobs.
@@ -207,7 +191,7 @@ fn the_propagation_never_re_bakes_past_the_frontier() {
     };
 
     let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
-    let (outcome, _) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    let outcome = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
     assert!(!outcome.non_convergent);
     assert!(outcome.evaluated > 1, "precondition: the wave did reach past A");
     assert_eq!(
@@ -259,7 +243,7 @@ fn a_seed_revisited_by_a_cycle_is_baked_once() {
     };
 
     let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
-    let (outcome, _) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    let outcome = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
     assert!(
         !outcome.non_convergent,
         "the cycle terminates by cutting, not by the round cap"
@@ -276,99 +260,64 @@ fn store_db() -> rusqlite::Connection {
     conn
 }
 
-/// A converged flush advances the generation by exactly one, and a reader
-/// still pinned to the old one keeps reading the old world.
+/// `flush_refresh_set` end to end, over a real store: the caller's fresh map
+/// beats the stored one, and the wave reaches the consumer that answers
+/// through it.
 ///
-/// The retention half is the one that fails silently: rows are keyed
-/// `(path, generation)` precisely so publishing N+1 does not REPLACE the gen-N
-/// row. Under path-keying a pinned reader finds nothing, and absence in this
-/// layer means a proven `None` — the pin would have become a way to get wrong
-/// answers instead of a way to avoid them.
+/// Also pins the thing that made this entry point worth reshaping: it reads
+/// the caller's map for the seed and the store's map for everyone else, and
+/// decodes no blob at either. At the seam it is wired to, the seed's blob has
+/// already been invalidated, so a version that re-derived the seed's map from
+/// the store would quietly find nothing and cut on its own frontier.
 #[test]
-fn a_published_flush_advances_one_generation_and_leaves_the_old_one_readable() {
-    use crate::index::module_cache::{load_conclusions, publish_generation, Generation};
+fn flush_refresh_set_moves_a_consumer_over_a_real_store() {
+    use crate::index::module_cache::{publish_generation, Generation};
     let conn = store_db();
-    let path = "/store/A.pm";
+    let a = p("/store/A.pm");
+    let b = p("/store/B.pm");
 
-    // A deliberate gen-1 world, written directly rather than through a
-    // persist: the persist path bakes its own conclusions, which would make
-    // the baseline whatever the bake happens to produce instead of a value
-    // this test controls.
-    let before = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
-    let after = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
-    publish_generation(&conn, Generation(1), &[(path.to_string(), before.clone())])
-        .expect("baseline");
-
-    let re_bake = |_: &Path| Some(after.clone());
-    let frozen_src =
-        |q: &Path| load_conclusions(&conn, &q.to_string_lossy(), Generation(1));
-    let candidates_of = |_: &str| vec![p(path)];
-    let consumers_of = |_: &Path| Vec::new();
-
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p(path)]);
-    let (_, writes) = flush_over_world(&world, vec![p(path)], &consumers_of);
-    let entries: Vec<(String, ConclusionMap)> = writes
-        .iter()
-        .map(|(q, m)| (q.to_string_lossy().into_owned(), (**m).clone()))
-        .collect();
-    publish_generation(&conn, Generation(2), &entries).expect("publish");
-
-    assert_eq!(
-        crate::index::module_cache::current_generation(&conn),
-        Generation(2)
+    let a_old = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let a_new = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    let b_map = map_of(
+        "B",
+        "m",
+        Conclusion::Link {
+            targets: vec![key("A", "m")],
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
     );
-    assert_eq!(
-        load_conclusions(&conn, path, Generation(2)),
-        Some(after),
-        "a fresh reader gets the flush's map"
-    );
-    assert_eq!(
-        load_conclusions(&conn, path, Generation(1)),
-        Some(before),
-        "a reader pinned to gen 1 still reads gen 1 — the pin is the whole \
-         point of freezing a generation for the duration of a consult"
-    );
-}
-
-/// `flush_to_store` end to end: a real blob in, a real conclusion row out at
-/// the next generation.
-#[test]
-fn flush_to_store_republishes_a_real_blob() {
-    use crate::index::module_cache::{current_generation, load_conclusions, save_to_db};
-    let conn = store_db();
-    let dir = std::env::temp_dir();
-    let pm = dir.join("perl_lsp_flush_store_A.pm");
-    std::fs::write(
-        &pm,
-        "package FlushStoreA;\nsub val { return 'x' }\n1;\n",
+    publish_generation(
+        &conn,
+        Generation(1),
+        &[
+            (a.to_string_lossy().into_owned(), a_old),
+            (b.to_string_lossy().into_owned(), b_map),
+        ],
     )
-    .unwrap();
-    let source = std::fs::read_to_string(&pm).unwrap();
+    .expect("baseline");
 
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&ts_parser_perl::LANGUAGE.into()).unwrap();
-    let tree = parser.parse(&source, None).unwrap();
-    let fa = crate::build::builder::build(&tree, source.as_bytes());
-    let cached = std::sync::Arc::new(crate::index::module_index::CachedModule::new(
-        pm.clone(),
-        std::sync::Arc::new(fa),
-    ));
-    assert!(save_to_db(&conn, &pm.to_string_lossy(), &Some(cached), "workspace"));
+    let candidates_of = |class: &str| match class {
+        "A" => vec![a.clone()],
+        "B" => vec![b.clone()],
+        _ => Vec::new(),
+    };
+    let consumers_of = |path: &Path| {
+        if path == a.as_path() { vec![b.clone()] } else { Vec::new() }
+    };
 
-    let before = current_generation(&conn);
-    let report = flush_to_store(&conn, vec![pm.clone()], &|_| Vec::new(), &|_| Vec::new());
-    assert_eq!(report.published, 1, "the seed is always written");
-    assert_eq!(report.generation, Generation(before.0 + 1));
-    assert_eq!(current_generation(&conn), report.generation);
-
-    let published = load_conclusions(&conn, &pm.to_string_lossy(), report.generation)
-        .expect("the flush wrote a map at the new generation");
-    assert!(
-        !published.is_empty(),
-        "a re-bake WITH the bag concludes something; an empty map here would \
-         mean the decode dropped the witnesses and the flush published the \
-         emptiness over a good row"
+    let out = flush_refresh_set(
+        &conn,
+        vec![(a.clone(), a_new)],
+        vec![a.clone()],
+        &consumers_of,
+        &candidates_of,
     );
 
-    let _ = std::fs::remove_file(&pm);
+    let moved: Vec<PathBuf> = out.changed.into_iter().map(|(q, _)| q).collect();
+    assert_eq!(
+        moved,
+        vec![a.clone(), b.clone()],
+        "A moved, and B moved through it — B's stored map never changed"
+    );
 }

--- a/src/index/conclusion_flush_store_tests.rs
+++ b/src/index/conclusion_flush_store_tests.rs
@@ -88,7 +88,7 @@ fn a_consumer_is_evaluated_against_the_seeds_fresh_bake_not_the_frozen_one() {
         "precondition: B's map is byte-identical across the change"
     );
 
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
     let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
 
     assert!(!outcome.non_convergent);
@@ -101,7 +101,13 @@ fn a_consumer_is_evaluated_against_the_seeds_fresh_bake_not_the_frozen_one() {
     assert_eq!(outcome.evaluated, 3, "the wave reached C, which then cut");
 
     let written: Vec<&PathBuf> = writes.iter().map(|(q, _)| q).collect();
-    assert_eq!(written, vec![&p("/A.pm"), &p("/B.pm")]);
+    assert_eq!(
+        written,
+        vec![&p("/A.pm")],
+        "B's ANSWERS moved, so B is in the refresh set — but B's MAP did not, \
+         so B is not written. Conflating the two would rewrite every reached \
+         file's row with a byte-identical copy of itself"
+    );
 }
 
 /// A seed's own row is refreshed even when its surface did not move.
@@ -122,7 +128,7 @@ fn a_seed_is_written_even_when_its_surface_did_not_move() {
         vec![p("/B.pm")]
     };
 
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
     let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
 
     assert!(outcome.changed.is_empty(), "the surface did not move");
@@ -151,32 +157,36 @@ fn an_unbakeable_seed_writes_nothing() {
     let candidates_of = |_: &str| Vec::new();
     let consumers_of = |_: &Path| vec![p("/B.pm")];
 
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
     let (outcome, writes) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
     assert_eq!(outcome.evaluated, 1);
     assert!(outcome.changed.is_empty());
     assert!(writes.is_empty(), "nothing decodable, nothing to publish");
 }
 
-/// A file is re-EVALUATED per round but re-BAKED once per flush.
+/// The propagation decodes maps, never blobs.
 ///
-/// The bake is a pure function of the file's own blob; only the evaluation
-/// depends on the round. Z is reached on two DIFFERENT rounds here — not the
-/// same-round fan-in `a_fan_in_evaluates_each_file_once_per_round` covers,
-/// which the round's dedup handles and which would pass with no memo at all.
+/// A map goes stale only when its own file's blob changes — the bake runs with
+/// the index withheld, so a cross-file answer is a `Link` chased at read time
+/// rather than a value baked in. Re-baking past the frontier would therefore
+/// pay a blob decode and a bake per reached file to reproduce, byte for byte,
+/// the map already in the store.
+///
+/// `PERL_LSP_FLUSH_EQUIV` is the switch that checks that assumption on a real
+/// corpus; this is the switch's default side.
 #[test]
-fn a_file_reached_on_two_rounds_is_baked_once() {
+fn the_propagation_never_re_bakes_past_the_frontier() {
     let bakes = std::cell::RefCell::new(BTreeMap::<String, usize>::new());
     let seed = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
     let old = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
     let sink = map_of("Z", "m", Conclusion::Value(InferredType::String));
 
     // Only A has a frozen map. Everything downstream is new to the store, so
-    // its first visit moves and its second cuts — which is what puts Z on two
-    // rounds without contriving a value that oscillates.
+    // its first visit moves and its second cuts — which drives the wave all
+    // the way to Z without contriving a value that oscillates.
     let frozen_src = |path: &Path| match path.to_string_lossy().as_ref() {
         "/A.pm" => Some(old.clone()),
-        _ => None,
+        _ => Some(sink.clone()),
     };
     let re_bake = |path: &Path| {
         *bakes
@@ -189,29 +199,73 @@ fn a_file_reached_on_two_rounds_is_baked_once() {
         }
     };
     let candidates_of = |_: &str| Vec::new();
-    // A→B→Z is two hops; A→C→D→Z is three. Z therefore arrives on round 3 and
-    // again on round 4.
     let consumers_of = |path: &Path| match path.to_string_lossy().as_ref() {
         "/A.pm" => vec![p("/B.pm"), p("/C.pm")],
         "/B.pm" => vec![p("/Z.pm")],
         "/C.pm" => vec![p("/D.pm")],
-        "/D.pm" => vec![p("/Z.pm")],
         _ => Vec::new(),
     };
 
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
     let (outcome, _) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
     assert!(!outcome.non_convergent);
-    assert_eq!(outcome.rounds, 4);
+    assert!(outcome.evaluated > 1, "precondition: the wave did reach past A");
     assert_eq!(
-        outcome.evaluated, 6,
-        "A, B, C, Z, D, Z — Z is evaluated on both rounds it is reached on"
+        bakes.borrow().keys().cloned().collect::<Vec<_>>(),
+        vec!["/A.pm".to_string()],
+        "only the seed is re-baked; every other reached file is read from the \
+         store as it stands"
     );
-    assert_eq!(
-        bakes.borrow().get("/Z.pm").copied(),
-        Some(1),
-        "two evaluations, one bake"
+}
+
+/// A seed revisited by a cycle is evaluated twice and baked once.
+///
+/// The bake is a pure function of the file's own blob, so nothing about it
+/// depends on the round. Only the evaluation does.
+#[test]
+fn a_seed_revisited_by_a_cycle_is_baked_once() {
+    let bakes = std::cell::Cell::new(0usize);
+    let old = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let new = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    // B answers by walking into A, so A's fresh bake moves B and B re-enqueues
+    // A — a cycle whose second visit to A has something real to re-evaluate.
+    let b = map_of(
+        "B",
+        "m",
+        Conclusion::Link {
+            targets: vec![key("A", "m")],
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
     );
+
+    let frozen_src = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => Some(old.clone()),
+        _ => Some(b.clone()),
+    };
+    let re_bake = |path: &Path| {
+        assert_eq!(path, Path::new("/A.pm"), "only the seed is ever re-baked");
+        bakes.set(bakes.get() + 1);
+        Some(new.clone())
+    };
+    let candidates_of = |class: &str| match class {
+        "A" => vec![p("/A.pm")],
+        _ => Vec::new(),
+    };
+    let consumers_of = |path: &Path| match path.to_string_lossy().as_ref() {
+        "/A.pm" => vec![p("/B.pm")],
+        "/B.pm" => vec![p("/A.pm")],
+        _ => Vec::new(),
+    };
+
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p("/A.pm")]);
+    let (outcome, _) = flush_over_world(&world, vec![p("/A.pm")], &consumers_of);
+    assert!(
+        !outcome.non_convergent,
+        "the cycle terminates by cutting, not by the round cap"
+    );
+    assert_eq!(outcome.evaluated, 3, "A, B, then A again — which cuts");
+    assert_eq!(bakes.get(), 1, "two evaluations of A, one bake");
 }
 
 // ---- against a real store ----
@@ -251,7 +305,7 @@ fn a_published_flush_advances_one_generation_and_leaves_the_old_one_readable() {
     let candidates_of = |_: &str| vec![p(path)];
     let consumers_of = |_: &Path| Vec::new();
 
-    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of);
+    let world = FlushWorld::new(&frozen_src, &re_bake, &candidates_of, vec![p(path)]);
     let (_, writes) = flush_over_world(&world, vec![p(path)], &consumers_of);
     let entries: Vec<(String, ConclusionMap)> = writes
         .iter()

--- a/src/index/conclusion_flush_tests.rs
+++ b/src/index/conclusion_flush_tests.rs
@@ -193,3 +193,38 @@ fn a_fan_in_evaluates_each_file_once_per_round() {
     );
     assert_eq!(out.changed.len(), 4);
 }
+
+/// The enqueued set includes consumers the wave then CUT.
+///
+/// It is not `changed`, and the difference is the whole point of the re-stamp
+/// gate it feeds. A consumer whose own conclusion answers did not move can
+/// still DISPATCH differently now that its provider changed, because a
+/// dispatch target resolves through the index rather than off a surface.
+/// Marking only what moved would skip exactly those — silently, since a frozen
+/// `MethodTarget` that is never re-derived just keeps answering.
+#[test]
+fn the_enqueued_set_covers_consumers_that_cut() {
+    let base = surface(&[("m", "Old")]);
+    let moved = surface(&[("m", "New")]);
+    let evaluate = |p: &Path| {
+        Some(if p == Path::new("/A.pm") { moved.clone() } else { base.clone() })
+    };
+    let baseline = |_: &Path| Some(base.clone());
+    let consumers_of = |p: &Path| {
+        if p == Path::new("/A.pm") { vec![PathBuf::from("/B.pm")] } else { Vec::new() }
+    };
+
+    let out = run_flush(vec![PathBuf::from("/A.pm")], &evaluate, &baseline, &consumers_of);
+
+    assert_eq!(
+        out.changed.iter().map(|(p, _)| p.clone()).collect::<Vec<_>>(),
+        vec![PathBuf::from("/A.pm")],
+        "B's surface matched its baseline, so B did not move"
+    );
+    assert_eq!(
+        out.enqueued,
+        vec![PathBuf::from("/B.pm")],
+        "B was still enqueued because its provider moved — that is what the \
+         re-stamp gate needs to know, and `changed` does not say it"
+    );
+}

--- a/src/index/conclusion_flush_tests.rs
+++ b/src/index/conclusion_flush_tests.rs
@@ -122,14 +122,16 @@ fn a_dependency_cycle_terminates_by_cutting_not_by_the_cap() {
     assert_eq!(out.changed.len(), 2, "both files moved, once each");
 }
 
-/// A surface that never settles is ABANDONED, not published.
+/// A surface that never settles is ABANDONED, and reports an EMPTY refresh
+/// set rather than the half of one it managed to compute.
 ///
-/// A half-propagated generation is worse than no generation: a consult pinned
-/// to it composes answers from a wave that never finished, and nothing in the
-/// result says so. Abandoning leaves gen N intact, which is merely stale — and
-/// stale is a cost, where half-propagated is a wrong answer.
+/// A partial refresh set is worse than none: a caller acting on it refreshes
+/// some consumers and leaves the rest silently stale, with nothing in the
+/// result saying which is which. An empty set with `non_convergent` set is at
+/// least legible — the caller can fall back to its own coarser rule, which is
+/// exactly what the one-hop `dirty_consumers` walk still provides.
 #[test]
-fn a_non_convergent_flush_publishes_nothing() {
+fn a_non_convergent_flush_reports_no_refresh_set() {
     // Per-PATH, not per-call. A global flip alternates with the visit order and
     // can line up so each file sees the same value twice running — which cuts,
     // and the fixture then passes while testing nothing. My first version did

--- a/src/index/conclusion_flush_tests.rs
+++ b/src/index/conclusion_flush_tests.rs
@@ -1,0 +1,193 @@
+use super::*;
+use crate::model::file_analysis::InferredType;
+use crate::model::witnesses::{ConclusionKey, EvaluatedAnswer, EvaluatedSurface};
+
+fn surface(v: &[(&str, &str)]) -> EvaluatedSurface {
+    EvaluatedSurface(
+        v.iter()
+            .map(|(name, ty)| {
+                (
+                    ConclusionKey::MethodOnClass {
+                        class: "K".into(),
+                        name: (*name).into(),
+                    },
+                    EvaluatedAnswer::Answer(InferredType::ClassName((*ty).into())),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+/// An unchanged surface CUTS: its consumers are not enqueued.
+///
+/// This is the entire point of the driver. Without the cut a single edit walks
+/// the whole reverse-dependency closure, which is the "re-enrich everything"
+/// behaviour the flush exists to replace — and it would still look correct,
+/// just slow, which is why it needs a test rather than an eyeball.
+#[test]
+fn an_unchanged_surface_cuts_the_chain() {
+    let moved = surface(&[("m", "After")]);
+    let same = surface(&[("m", "Same")]);
+    let evaluate = |path: &Path| -> Option<EvaluatedSurface> {
+        match path.to_str().unwrap() {
+            "/a.pm" => Some(moved.clone()),
+            _ => Some(same.clone()),
+        }
+    };
+    // B's baseline already equals what it evaluates to: A moved, but B's
+    // answers did not follow.
+    let baseline = |path: &Path| -> Option<EvaluatedSurface> {
+        match path.to_str().unwrap() {
+            "/a.pm" => Some(surface(&[("m", "Before")])),
+            _ => Some(same.clone()),
+        }
+    };
+    let consumers = |path: &Path| -> Vec<PathBuf> {
+        match path.to_str().unwrap() {
+            "/a.pm" => vec![p("/b.pm")],
+            "/b.pm" => vec![p("/c.pm")],
+            _ => vec![],
+        }
+    };
+    let out = run_flush([p("/a.pm")], &evaluate, &baseline, &consumers);
+    assert_eq!(
+        out.changed.iter().map(|(x, _)| x.clone()).collect::<Vec<_>>(),
+        vec![p("/a.pm")],
+        "only A moved"
+    );
+    assert_eq!(
+        out.evaluated, 2,
+        "A and B are evaluated; C is never reached, because B cut"
+    );
+}
+
+/// A change that keeps moving keeps propagating — the other half of the cut.
+///
+/// Paired with the test above deliberately: a driver that cut everything would
+/// pass that one and fail this, and a driver that cut nothing would pass this
+/// and fail that. Neither test is meaningful alone.
+#[test]
+fn a_moving_surface_propagates_to_the_end_of_the_chain() {
+    let evaluate = |_: &Path| -> Option<EvaluatedSurface> { Some(surface(&[("m", "After")])) };
+    let baseline = |_: &Path| -> Option<EvaluatedSurface> { Some(surface(&[("m", "Before")])) };
+    let consumers = |path: &Path| -> Vec<PathBuf> {
+        match path.to_str().unwrap() {
+            "/a.pm" => vec![p("/b.pm")],
+            "/b.pm" => vec![p("/c.pm")],
+            _ => vec![],
+        }
+    };
+    let out = run_flush([p("/a.pm")], &evaluate, &baseline, &consumers);
+    assert_eq!(out.evaluated, 3, "the wave reaches C");
+    assert_eq!(out.changed.len(), 3);
+    assert!(!out.non_convergent);
+}
+
+/// A dependency CYCLE terminates, and terminates by cutting rather than by
+/// hitting the cap.
+///
+/// This is what the compare-against-this-flush's-record rule buys. Compared to
+/// the pre-flush baseline every time, A's second visit would look like a change
+/// again — A's surface differs from its baseline, permanently — and the pair
+/// would ping-pong until `MAX_FLUSH_ROUNDS`. The cap would contain it, so the
+/// bug would present as "flushes are slow", not as a hang.
+///
+/// Base-verify by comparing against `baseline` only: `rounds` runs to the cap
+/// and `non_convergent` is set.
+#[test]
+fn a_dependency_cycle_terminates_by_cutting_not_by_the_cap() {
+    let evaluate = |_: &Path| -> Option<EvaluatedSurface> { Some(surface(&[("m", "After")])) };
+    let baseline = |_: &Path| -> Option<EvaluatedSurface> { Some(surface(&[("m", "Before")])) };
+    let consumers = |path: &Path| -> Vec<PathBuf> {
+        match path.to_str().unwrap() {
+            "/a.pm" => vec![p("/b.pm")],
+            "/b.pm" => vec![p("/a.pm")],
+            _ => vec![],
+        }
+    };
+    let out = run_flush([p("/a.pm")], &evaluate, &baseline, &consumers);
+    assert!(
+        !out.non_convergent,
+        "a cycle must terminate by cutting, not by exhausting the round cap"
+    );
+    assert!(
+        out.rounds < MAX_FLUSH_ROUNDS,
+        "took {} rounds — a two-file cycle should cut on the second visit",
+        out.rounds
+    );
+    assert_eq!(out.changed.len(), 2, "both files moved, once each");
+}
+
+/// A surface that never settles is ABANDONED, not published.
+///
+/// A half-propagated generation is worse than no generation: a consult pinned
+/// to it composes answers from a wave that never finished, and nothing in the
+/// result says so. Abandoning leaves gen N intact, which is merely stale — and
+/// stale is a cost, where half-propagated is a wrong answer.
+#[test]
+fn a_non_convergent_flush_publishes_nothing() {
+    // Per-PATH, not per-call. A global flip alternates with the visit order and
+    // can line up so each file sees the same value twice running — which cuts,
+    // and the fixture then passes while testing nothing. My first version did
+    // exactly that.
+    let visits: std::cell::RefCell<std::collections::HashMap<PathBuf, usize>> =
+        Default::default();
+    let evaluate = |path: &Path| -> Option<EvaluatedSurface> {
+        let mut v = visits.borrow_mut();
+        let n = v.entry(path.to_path_buf()).or_insert(0);
+        *n += 1;
+        Some(surface(&[("m", if *n % 2 == 1 { "Odd" } else { "Even" })]))
+    };
+    let baseline = |_: &Path| -> Option<EvaluatedSurface> { None };
+    let consumers = |path: &Path| -> Vec<PathBuf> {
+        match path.to_str().unwrap() {
+            "/a.pm" => vec![p("/b.pm")],
+            _ => vec![p("/a.pm")],
+        }
+    };
+    let out = run_flush([p("/a.pm")], &evaluate, &baseline, &consumers);
+    assert!(out.non_convergent, "an oscillating surface must be detected");
+    assert!(
+        out.changed.is_empty(),
+        "an abandoned flush must publish NOTHING — a half-propagated generation \
+         is a wrong answer, where a stale one is only a cost"
+    );
+}
+
+/// One re-bake per file per round, however many consumers reach it.
+///
+/// A wide fan-in — one utility module imported by two hundred files — would
+/// otherwise multiply a round's cost by its width for no extra information,
+/// and the answer would be identical every time.
+#[test]
+fn a_fan_in_evaluates_each_file_once_per_round() {
+    let calls = std::cell::Cell::new(0usize);
+    let evaluate = |_: &Path| -> Option<EvaluatedSurface> {
+        calls.set(calls.get() + 1);
+        Some(surface(&[("m", "After")]))
+    };
+    let baseline = |_: &Path| -> Option<EvaluatedSurface> { Some(surface(&[("m", "Before")])) };
+    // Three roots all consumed by one file.
+    let consumers = |path: &Path| -> Vec<PathBuf> {
+        match path.to_str().unwrap() {
+            "/hub.pm" => vec![],
+            _ => vec![p("/hub.pm")],
+        }
+    };
+    let out = run_flush(
+        [p("/a.pm"), p("/b.pm"), p("/c.pm")],
+        &evaluate,
+        &baseline,
+        &consumers,
+    );
+    assert_eq!(
+        calls.get(),
+        4,
+        "three roots plus ONE evaluation of the hub they share, not three"
+    );
+    assert_eq!(out.changed.len(), 4);
+}

--- a/src/index/file_store.rs
+++ b/src/index/file_store.rs
@@ -174,7 +174,10 @@ impl FileStore {
         }
         crate::util::ghost_stats::count("enrich_open.perl");
         let mut fa = (*base).clone();
-        fa.enrich_imported_types_with_keys(Some(idx));
+        fa.enrich_imported_types_with_keys_for(
+            Some(idx),
+            url.to_file_path().ok().as_deref(),
+        );
         let enriched = Arc::new(fa);
         if let Some(mut doc) = self.open.get_mut(url) {
             if Arc::ptr_eq(&doc.analysis, &base) {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -9,5 +9,6 @@ pub mod module_cache;
 pub mod module_index;
 pub mod module_resolver;
 pub mod pack_bag_cache;
+pub mod conclusion_cache;
 pub mod pack_invalidator;
 pub mod resolve;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -10,5 +10,6 @@ pub mod module_index;
 pub mod module_resolver;
 pub mod pack_bag_cache;
 pub mod conclusion_cache;
+pub mod conclusion_flush;
 pub mod pack_invalidator;
 pub mod resolve;

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -188,10 +188,30 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
         Vec::new()
     } else {
     crate::util::ghost_stats::timed("persist.bake", || {
-        let map = crate::model::witnesses::bake(
+        // Every declared sub/method becomes a key, not just those the bag
+        // indexed — see `bake_with_symbols`. Without this, a method resolved
+        // purely through edges is absent from the map, and absence is read as
+        // a proven `None`.
+        let syms: Vec<(Option<String>, String, bool)> = fa
+            .symbols()
+            .iter()
+            .map(|s| {
+                (
+                    s.package.clone(),
+                    s.name.clone(),
+                    matches!(
+                        s.kind,
+                        crate::model::file_analysis::SymKind::Sub
+                            | crate::model::file_analysis::SymKind::Method
+                    ),
+                )
+            })
+            .collect();
+        let map = crate::model::witnesses::bake_with_symbols(
             &bag,
             crate::model::witnesses::shared_registry(),
             &fa.packages.keys().cloned().collect(),
+            &syms,
         );
         bincode::serialize(&map)
             .ok()
@@ -877,10 +897,26 @@ mod bake_probe {
             build_nanos += tb.elapsed().as_nanos() as u64;
             let before_demoted = demoted;
             let t0 = std::time::Instant::now();
-            let map = crate::model::witnesses::bake(
+            let syms: Vec<(Option<String>, String, bool)> = fa
+                .symbols()
+                .iter()
+                .map(|s| {
+                    (
+                        s.package.clone(),
+                        s.name.clone(),
+                        matches!(
+                            s.kind,
+                            crate::model::file_analysis::SymKind::Sub
+                                | crate::model::file_analysis::SymKind::Method
+                        ),
+                    )
+                })
+                .collect();
+            let map = crate::model::witnesses::bake_with_symbols(
                 &fa.witnesses,
                 &registry,
                 &fa.packages.keys().cloned().collect(),
+                &syms,
             );
             bake_nanos += t0.elapsed().as_nanos() as u64;
             let _ = before_demoted;

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -212,12 +212,22 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
             .keys()
             .map(|c| (c.clone(), fa.declared_parents(c).to_vec()))
             .collect();
-        let map = crate::model::witnesses::bake_full(
+        // The file's OWN context, index deliberately withheld. Without this
+        // the bake could not walk even a local parent chain.
+        let local_ctx = crate::model::witnesses::BagContext {
+            scopes: &fa.scopes,
+            package_framework: &fa.packages,
+            module_index: None,
+            package_parents: &fa.packages,
+            app_surface_consumers: &fa.plugin.app_surface_consumers,
+        };
+        let map = crate::model::witnesses::bake_in_context(
             &bag,
             crate::model::witnesses::shared_registry(),
             &fa.packages.keys().cloned().collect(),
             &syms,
             &parents,
+            Some(&local_ctx),
         );
         bincode::serialize(&map)
             .ok()
@@ -918,11 +928,25 @@ mod bake_probe {
                     )
                 })
                 .collect();
-            let map = crate::model::witnesses::bake_with_symbols(
+            let parents: Vec<(String, Vec<String>)> = fa
+                .packages
+                .keys()
+                .map(|c| (c.clone(), fa.declared_parents(c).to_vec()))
+                .collect();
+            let local_ctx = crate::model::witnesses::BagContext {
+                scopes: &fa.scopes,
+                package_framework: &fa.packages,
+                module_index: None,
+                package_parents: &fa.packages,
+                app_surface_consumers: &fa.plugin.app_surface_consumers,
+            };
+            let map = crate::model::witnesses::bake_in_context(
                 &fa.witnesses,
                 &registry,
                 &fa.packages.keys().cloned().collect(),
                 &syms,
+                &parents,
+                Some(&local_ctx),
             );
             bake_nanos += t0.elapsed().as_nanos() as u64;
             let _ = before_demoted;

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -207,11 +207,17 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
                 )
             })
             .collect();
-        let map = crate::model::witnesses::bake_with_symbols(
+        let parents: Vec<(String, Vec<String>)> = fa
+            .packages
+            .keys()
+            .map(|c| (c.clone(), fa.declared_parents(c).to_vec()))
+            .collect();
+        let map = crate::model::witnesses::bake_full(
             &bag,
             crate::model::witnesses::shared_registry(),
             &fa.packages.keys().cloned().collect(),
             &syms,
+            &parents,
         );
         bincode::serialize(&map)
             .ok()

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -114,6 +114,12 @@ pub(super) fn closure_stamp(
 pub struct EncodedAnalysis {
     /// The analysis with its witness bag taken out.
     pub analysis: Vec<u8>,
+    /// The baked conclusions for this analysis, zstd+bincode. Rides with the
+    /// other halves for the same reason they ride with each other: a writer
+    /// that persisted the blob and forgot the map would leave the store
+    /// answering ABSENT for the file, and absent means "no answer" rather than
+    /// "not baked".
+    pub conclusions: Vec<u8>,
     /// The witness bag alone. NEVER empty for a row this code writes — the
     /// `bag IS NULL` test is how a reader tells a pre-split row (bag inline
     /// in `analysis`) from a post-split one, so an empty encoding here would
@@ -125,7 +131,7 @@ pub struct EncodedAnalysis {
 impl EncodedAnalysis {
     /// Total stored size, for the writers' byte accounting.
     pub fn len(&self) -> usize {
-        self.analysis.len() + self.bag.len()
+        self.analysis.len() + self.bag.len() + self.conclusions.len()
     }
 
     /// Re-decode both halves into the analysis they came from.
@@ -137,6 +143,12 @@ impl EncodedAnalysis {
     /// that answers every type query with silence.
     pub fn decode_whole(&self) -> Option<FileAnalysis> {
         decode_analysis_parts(&self.analysis, Some(&self.bag), true)
+    }
+
+    /// The baked map, decoded.
+    pub fn conclusion_map(&self) -> Option<crate::model::witnesses::ConclusionMap> {
+        let bin = zstd::decode_all(self.conclusions.as_slice()).ok()?;
+        bincode::deserialize(&bin).ok()
     }
 }
 
@@ -161,9 +173,37 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
     let bin = bincode::serialize(bagless).ok()?;
     let analysis = zstd::encode_all(bin.as_slice(), ZSTD_LEVEL).ok()?;
     let bag_bin = bincode::serialize(&bag).ok()?;
-    let bag = zstd::encode_all(bag_bin.as_slice(), ZSTD_LEVEL).ok()?;
-    debug_assert!(!bag.is_empty(), "an empty bag blob would read as a pre-split row");
-    Some(EncodedAnalysis { analysis, bag })
+    let bag_blob = zstd::encode_all(bag_bin.as_slice(), ZSTD_LEVEL).ok()?;
+    debug_assert!(
+        !bag_blob.is_empty(),
+        "an empty bag blob would read as a pre-split row"
+    );
+    // Baked here rather than in the writer so the map cannot be forgotten:
+    // the same reason the bag and the analysis travel together. Measured at
+    // 0.31 ms/file against a 5.4 ms build — 5.8%.
+    // Escape hatch and A/B control, same shape as `PERL_LSP_PD_NO_COMBINE`:
+    // a new cost on the persist path should be switchable off without a
+    // rebuild, so its price can be measured rather than argued about.
+    let conclusions = if std::env::var("PERL_LSP_NO_BAKE").is_ok() {
+        Vec::new()
+    } else {
+    crate::util::ghost_stats::timed("persist.bake", || {
+        let map = crate::model::witnesses::bake(
+            &bag,
+            crate::model::witnesses::shared_registry(),
+            &fa.packages.keys().cloned().collect(),
+        );
+        bincode::serialize(&map)
+            .ok()
+            .and_then(|b| zstd::encode_all(b.as_slice(), ZSTD_LEVEL).ok())
+            .unwrap_or_default()
+    })
+    };
+    Some(EncodedAnalysis {
+        analysis,
+        bag: bag_blob,
+        conclusions,
+    })
 }
 
 /// Decompress + deserialize an analysis blob, installing `bag` when the
@@ -474,10 +514,39 @@ pub fn save_blob_to_db_stamped(
     if let Err(e) = r {
         log::warn!("Failed to save module blob for '{}': {}", module_name, e);
     }
+    persist_conclusions(conn, &path.to_string_lossy(), blob);
     // A rewritten modules row orphans any prior stub for the path — a stale
     // skeleton paired with a fresh stamp would be served as valid on the
     // next warm. Writers that have a fresh stub re-insert it right after.
     delete_stub(conn, &path.to_string_lossy());
+}
+
+/// Write the baked map beside the blob it was derived from.
+///
+/// At the CURRENT generation, not a new one: persisting a file is that file
+/// joining the world as it stands, not a round advancing it. Only a flush
+/// advances a generation, and the flush driver is not built yet — until it is,
+/// every reader pins the same generation and the retention machinery is
+/// correct-but-idle rather than wrong.
+///
+/// A failure here is logged, never fatal. The blob is already written and
+/// remains the derivation of record; a missing map costs a decode, which is
+/// the cost we had before this layer existed.
+fn persist_conclusions(conn: &Connection, path: &str, enc: &EncodedAnalysis) {
+    if enc.conclusions.is_empty() {
+        // The bake produced nothing encodable. Leaving no row is right: absent
+        // from the STORE means "not baked" (the reader falls back to a decode),
+        // which is a different question from a key being absent from a map.
+        return;
+    }
+    let at = current_generation(conn);
+    let r = conn.execute(
+        "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
+        params![path, at.0, enc.conclusions],
+    );
+    if let Err(e) = r {
+        log::warn!("Failed to save conclusions for '{path}': {e}");
+    }
 }
 
 /// Recompute a persisted row's `deps_stamp` from CURRENT disk state without
@@ -562,6 +631,9 @@ pub fn save_to_db(
         }
     };
     if !path_str.is_empty() {
+        if let Some(enc) = analysis_blob.as_ref() {
+            persist_conclusions(conn, &path_str, enc);
+        }
         // Same stale-stub guard as `save_blob_to_db_stamped`.
         delete_stub(conn, &path_str);
     }
@@ -792,19 +864,25 @@ mod bake_probe {
         let (mut value, mut return_of, mut open, mut link) = (0usize, 0usize, 0usize, 0usize);
         let (mut demoted, mut no_bare) = (0usize, 0usize);
         let (mut map_bytes, mut bag_bytes, mut n) = (0usize, 0usize, 0usize);
+        let mut bake_nanos: u64 = 0;
+        let mut build_nanos: u64 = 0;
         for path in files.iter() {
             let Ok(src) = std::fs::read_to_string(path) else { continue };
             if src.len() > 1_000_000 {
                 continue;
             }
             let Some(tree) = parser.parse(&src, None) else { continue };
+            let tb = std::time::Instant::now();
             let fa = crate::build::builder::build(&tree, src.as_bytes());
+            build_nanos += tb.elapsed().as_nanos() as u64;
             let before_demoted = demoted;
+            let t0 = std::time::Instant::now();
             let map = crate::model::witnesses::bake(
                 &fa.witnesses,
                 &registry,
                 &fa.packages.keys().cloned().collect(),
             );
+            bake_nanos += t0.elapsed().as_nanos() as u64;
             let _ = before_demoted;
             for c in map.0.values() {
                 match c {
@@ -828,6 +906,16 @@ mod bake_probe {
         println!(
             "\nmap {map_bytes} bincode bytes vs bag {bag_bytes} — {:.1}% of the bag",
             pct(map_bytes, bag_bytes)
+        );
+        // The bake's MARGINAL cost against the build it would ride along with.
+        // A bake that costs as much as the analysis it summarizes cannot live
+        // in the persist path, whatever it saves later.
+        println!(
+            "bake {:.0} ms over {n} files ({:.2} ms/file) vs build {:.0} ms — bake is {:.1}% of build",
+            bake_nanos as f64 / 1e6,
+            bake_nanos as f64 / 1e6 / n.max(1) as f64,
+            build_nanos as f64 / 1e6,
+            pct(bake_nanos as usize, build_nanos as usize)
         );
     }
 

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -569,7 +569,7 @@ pub fn save_to_db(
 }
 
 #[cfg(test)]
-mod bag_share_probe {
+pub(super) mod bag_share_probe {
     //! What share of a stored FileAnalysis is the witness bag?
     //!
     //! `rows_for_diag` decodes the whole blob and then strips the bag, so a
@@ -766,5 +766,72 @@ mod bag_share_probe {
                 out.push(p);
             }
         }
+    }
+}
+
+/// How the conclusion bake classifies a real corpus, and how big the map is
+/// next to the bag it summarizes.
+///
+/// `cargo test --release probe_conclusion_bake -- --ignored --nocapture`
+#[cfg(test)]
+mod bake_probe {
+    #[test]
+    #[ignore]
+    fn probe_conclusion_bake() {
+        let root = std::path::Path::new("gold-corpus/local/lib/perl5");
+        if !root.is_dir() {
+            eprintln!("substrate absent — skipping");
+            return;
+        }
+        let mut files: Vec<std::path::PathBuf> = Vec::new();
+        super::bag_share_probe::collect_pm(root, &mut files, 0);
+        files.sort();
+        let mut parser = crate::build::builder::create_parser();
+        let registry = crate::model::witnesses::ReducerRegistry::with_defaults();
+
+        let (mut value, mut return_of, mut open, mut link) = (0usize, 0usize, 0usize, 0usize);
+        let (mut demoted, mut no_bare) = (0usize, 0usize);
+        let (mut map_bytes, mut bag_bytes, mut n) = (0usize, 0usize, 0usize);
+        for path in files.iter() {
+            let Ok(src) = std::fs::read_to_string(path) else { continue };
+            if src.len() > 1_000_000 {
+                continue;
+            }
+            let Some(tree) = parser.parse(&src, None) else { continue };
+            let fa = crate::build::builder::build(&tree, src.as_bytes());
+            let before_demoted = demoted;
+            let map = crate::model::witnesses::bake(
+                &fa.witnesses,
+                &registry,
+                &fa.packages.keys().cloned().collect(),
+            );
+            let _ = before_demoted;
+            for c in map.0.values() {
+                match c {
+                    crate::model::witnesses::Conclusion::Value(_) => value += 1,
+                    crate::model::witnesses::Conclusion::ReturnOf(_) => return_of += 1,
+                    crate::model::witnesses::Conclusion::Link { .. } => link += 1,
+                    crate::model::witnesses::Conclusion::OpenNone => open += 1,
+                }
+            }
+            map_bytes += bincode::serialize(&map).map(|v| v.len()).unwrap_or(0);
+            bag_bytes += bincode::serialize(&fa.witnesses).map(|v| v.len()).unwrap_or(0);
+            n += 1;
+        }
+        let _ = (&mut demoted, &mut no_bare);
+        let total = value + return_of + open + link;
+        println!("\n{n} files, {total} conclusions");
+        println!("  Value      {value:>7} ({:.1}%)", pct(value, total));
+        println!("  ReturnOf   {return_of:>7} ({:.1}%)", pct(return_of, total));
+        println!("  Link       {link:>7} ({:.1}%)", pct(link, total));
+        println!("  OpenNone   {open:>7} ({:.1}%)", pct(open, total));
+        println!(
+            "\nmap {map_bytes} bincode bytes vs bag {bag_bytes} — {:.1}% of the bag",
+            pct(map_bytes, bag_bytes)
+        );
+    }
+
+    fn pct(a: usize, b: usize) -> f64 {
+        if b == 0 { 0.0 } else { 100.0 * a as f64 / b as f64 }
     }
 }

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -187,6 +187,30 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
     let conclusions = if std::env::var("PERL_LSP_NO_BAKE").is_ok() {
         Vec::new()
     } else {
+    bake_conclusions_blob(fa, &bag)
+    };
+    Some(EncodedAnalysis {
+        analysis,
+        bag: bag_blob,
+        conclusions,
+    })
+}
+
+
+/// Bake one analysis's conclusions and encode them for the store.
+///
+/// Factored out of `encode_analysis` because the REPAIR path bakes the same
+/// thing from an already-persisted blob, and two bakes that could drift is
+/// precisely the failure the derivation fingerprint exists to catch: bytes
+/// that decode cleanly and answer wrongly. One speller, two callers.
+///
+/// The bag is a parameter rather than read off `fa` because the persist path
+/// has already taken it out (it travels in its own column); the repair path
+/// passes the analysis's own.
+pub fn bake_conclusions_blob(
+    fa: &FileAnalysis,
+    bag: &crate::model::witnesses::WitnessBag,
+) -> Vec<u8> {
     crate::util::ghost_stats::timed("persist.bake", || {
         // Every declared sub/method becomes a key, not just those the bag
         // indexed — see `bake_with_symbols`. Without this, a method resolved
@@ -233,12 +257,6 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
             .ok()
             .and_then(|b| zstd::encode_all(b.as_slice(), ZSTD_LEVEL).ok())
             .unwrap_or_default()
-    })
-    };
-    Some(EncodedAnalysis {
-        analysis,
-        bag: bag_blob,
-        conclusions,
     })
 }
 

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -130,6 +130,7 @@ pub struct EncodedAnalysis {
 
 impl EncodedAnalysis {
     /// Total stored size, for the writers' byte accounting.
+    #[allow(dead_code)] // byte accounting for a writer that now measures its own chunks
     pub fn len(&self) -> usize {
         self.analysis.len() + self.bag.len() + self.conclusions.len()
     }
@@ -146,6 +147,7 @@ impl EncodedAnalysis {
     }
 
     /// The baked map, decoded.
+    #[allow(dead_code)] // decodes the encoded map; the flush takes `bake_conclusion_map` instead
     pub fn conclusion_map(&self) -> Option<crate::model::witnesses::ConclusionMap> {
         let bin = zstd::decode_all(self.conclusions.as_slice()).ok()?;
         bincode::deserialize(&bin).ok()

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -211,6 +211,23 @@ pub fn bake_conclusions_blob(
     fa: &FileAnalysis,
     bag: &crate::model::witnesses::WitnessBag,
 ) -> Vec<u8> {
+    let map = bake_conclusion_map(fa, bag);
+    bincode::serialize(&map)
+        .ok()
+        .and_then(|b| zstd::encode_all(b.as_slice(), ZSTD_LEVEL).ok())
+        .unwrap_or_default()
+}
+
+/// The bake itself, before encoding.
+///
+/// The flush driver wants the map, not the bytes: it evaluates the fresh map
+/// against the rest of the store to decide whether the file's answers moved,
+/// and only the files that moved get encoded. Going through the blob would
+/// serialize-and-decode every candidate to throw most of them away.
+pub fn bake_conclusion_map(
+    fa: &FileAnalysis,
+    bag: &crate::model::witnesses::WitnessBag,
+) -> crate::model::witnesses::ConclusionMap {
     crate::util::ghost_stats::timed("persist.bake", || {
         // Every declared sub/method becomes a key, not just those the bag
         // indexed — see `bake_with_symbols`. Without this, a method resolved
@@ -253,10 +270,7 @@ pub fn bake_conclusions_blob(
             &parents,
             Some(&local_ctx),
         );
-        bincode::serialize(&map)
-            .ok()
-            .and_then(|b| zstd::encode_all(b.as_slice(), ZSTD_LEVEL).ok())
-            .unwrap_or_default()
+        map
     })
 }
 

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -973,7 +973,7 @@ mod bake_probe {
                     crate::model::witnesses::Conclusion::Value(_) => value += 1,
                     crate::model::witnesses::Conclusion::ReturnOf(_) => return_of += 1,
                     crate::model::witnesses::Conclusion::Link { .. } => link += 1,
-                    crate::model::witnesses::Conclusion::OpenNone => open += 1,
+                    crate::model::witnesses::Conclusion::OpenNone(_) => open += 1,
                 }
             }
             map_bytes += bincode::serialize(&map).map(|v| v.len()).unwrap_or(0);

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -1,0 +1,173 @@
+//! Persistence for the conclusion layer.
+//!
+//! The store is **generation-stamped**, which is not decoration. The driver
+//! this feeds (`docs/prompt-enrichment-alternatives.md` §3c′) processes a
+//! dirty frontier as one round against a FROZEN generation, and publishes the
+//! next generation atomically when the round's diffs go empty. Two properties
+//! follow, and both are the store's job rather than the driver's:
+//!
+//! * A reader pins a generation. A consult that begins during a flush must see
+//!   gen N throughout — never a half-built N+1 — or it can compose an answer
+//!   out of two different worlds and be wrong in a way that reproduces on
+//!   neither.
+//! * A round's writes land together. `publish_generation` is one transaction,
+//!   so a crash mid-flush leaves gen N intact rather than a mixture.
+//!
+//! Invalidation is NOT the blob stamp alone. A conclusion also goes stale when
+//! the derivation that produced it changes, which leaves the bytes valid and
+//! the meaning wrong — `validate_conclusion_fingerprint` owns that, and it
+//! clears conclusions while keeping blobs, because the repair is a re-bake and
+//! a re-bake wants the blob.
+
+use super::*;
+use crate::model::witnesses::ConclusionMap;
+
+/// The generation a reader is pinned to.
+///
+/// A newtype rather than a bare `i64` so a caller cannot pass the file's
+/// mtime, a row id, or "the current one" by accident — every one of which
+/// would read as a plausible number and silently select the wrong world.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Generation(pub i64);
+
+impl Generation {
+    /// The generation a store has before anything is published into it.
+    pub const INITIAL: Generation = Generation(0);
+}
+
+/// The store's current generation — what a fresh reader should pin.
+pub fn current_generation(conn: &Connection) -> Generation {
+    conn.query_row(
+        "SELECT value FROM meta WHERE key = 'conclusion_generation'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .and_then(|v| v.parse::<i64>().ok())
+    .map(Generation)
+    .unwrap_or(Generation::INITIAL)
+}
+
+/// Load one file's conclusions AS OF a pinned generation.
+///
+/// The newest row at or below `at`. Two halves, and both are load-bearing:
+///
+/// Rows ABOVE `at` are invisible, because mid-flush the writer may already
+/// have published part of gen N+1 and a reader pinned to N must not see it.
+///
+/// Rows BELOW `at` survive, because the key is `(path, generation)` rather
+/// than `path`. Keying on path alone would make publishing N+1 REPLACE the
+/// gen-N row, and a reader still pinned to N would then find nothing — which
+/// the evaluator reads as a definite `None`, the one meaning absence must
+/// never carry. The pin would have silently become a way to get wrong
+/// answers instead of a way to avoid them.
+pub fn load_conclusions(
+    conn: &Connection,
+    path: &str,
+    at: Generation,
+) -> Option<ConclusionMap> {
+    let blob: Vec<u8> = conn
+        .query_row(
+            "SELECT map FROM conclusions WHERE path = ?1 AND generation <= ?2 \
+             ORDER BY generation DESC LIMIT 1",
+            params![path, at.0],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let bin = zstd::decode_all(blob.as_slice()).ok()?;
+    bincode::deserialize(&bin).ok()
+}
+
+/// Write one file's conclusions at a generation.
+///
+/// Caller-supplied generation, not "current + 1": a round writes MANY files at
+/// one generation, and letting each write pick its own would scatter a single
+/// logical round across several, which is exactly the half-built state the
+/// pinning is designed to prevent.
+pub fn save_conclusions(
+    conn: &Connection,
+    path: &str,
+    at: Generation,
+    map: &ConclusionMap,
+) -> bool {
+    let Ok(bin) = bincode::serialize(map) else {
+        return false;
+    };
+    let Ok(blob) = zstd::encode_all(bin.as_slice(), ZSTD_LEVEL) else {
+        return false;
+    };
+    conn.execute(
+        "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
+        params![path, at.0, blob],
+    )
+    .is_ok()
+}
+
+/// Publish a completed round: every entry lands, then the generation advances,
+/// in ONE transaction.
+///
+/// The ordering inside matters and is the reverse of what reads natural. Rows
+/// are written first and the generation stamp last, so a reader that catches
+/// the transaction mid-flight still sees the OLD stamp and therefore ignores
+/// the new rows. Stamping first would publish a generation whose rows do not
+/// all exist yet, and `load_conclusions` would serve absence — which the
+/// evaluator reads as a definite `None`, the one thing absence must never
+/// mean.
+pub fn publish_generation(
+    conn: &Connection,
+    at: Generation,
+    entries: &[(String, ConclusionMap)],
+) -> rusqlite::Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = (|| -> rusqlite::Result<()> {
+        for (path, map) in entries {
+            if !save_conclusions(conn, path, at, map) {
+                // An entry that will not encode cannot be published, and
+                // publishing the rest under this generation would present a
+                // partial round as complete. Fail the round instead.
+                return Err(rusqlite::Error::InvalidParameterName(format!(
+                    "conclusion encode failed for {path}"
+                )));
+            }
+        }
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('conclusion_generation', ?1)",
+            params![at.0.to_string()],
+        )?;
+        Ok(())
+    })();
+    match &result {
+        Ok(()) => conn.execute_batch("COMMIT")?,
+        Err(_) => {
+            let _ = conn.execute_batch("ROLLBACK");
+        }
+    }
+    result
+}
+
+/// Drop one path's conclusions — the file changed, so its bake is void.
+pub fn forget_conclusions(conn: &Connection, path: &str) {
+    let _ = conn.execute("DELETE FROM conclusions WHERE path = ?1", params![path]);
+}
+
+/// Discard superseded rows once no reader can still be pinned below `keep`.
+///
+/// Retaining old generations is what makes a pin safe, so the table grows one
+/// row per file per round until something reclaims them — and the caller is
+/// the only one who knows when the last reader let go. Deliberately not
+/// automatic: a sweep that guessed would delete the generation a live consult
+/// is reading, which is the same absence-as-answer failure the retention
+/// exists to prevent, arriving by a different door.
+pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
+    // Keep the newest row at or below `keep` for each path — that is the one a
+    // reader pinned at `keep` still resolves to. Only rows OLDER than that are
+    // genuinely unreachable.
+    conn.execute(
+        "DELETE FROM conclusions WHERE generation < ?1 AND generation < (
+             SELECT MAX(c2.generation) FROM conclusions c2
+             WHERE c2.path = conclusions.path AND c2.generation <= ?1
+         )",
+        params![keep.0],
+    )
+    .unwrap_or(0)
+}

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -171,3 +171,113 @@ pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
     )
     .unwrap_or(0)
 }
+
+/// Paths holding a valid blob but no conclusion row a reader could use.
+///
+/// The repair frontier. `validate_conclusion_fingerprint` clears conclusions
+/// and deliberately keeps the blobs, "because the repair is a re-bake" — but
+/// nothing drove that re-bake, so after any source edit the layer stayed dark
+/// until someone ran a full `--clear-cache` by hand
+/// (`conclcache.known_absent` read 156,746 in that state). Answer-neutral —
+/// absent from the STORE means decode, not "no answer" — and purely a cost,
+/// but a permanent one, and it silently made every measurement taken after a
+/// rebuild a measurement of an empty layer.
+///
+/// Enumerated by QUERY rather than by remembering what the clear touched, so
+/// it also covers a file whose bake failed to encode, one written by a
+/// `PERL_LSP_NO_BAKE` run, and any future path that persists a blob without a
+/// map. "Which rows are missing" is a question the store can always answer;
+/// "which rows did we drop" is one only the dropper knows.
+///
+/// Version-filtered: a row below `EXTRACT_VERSION` is going to be re-parsed
+/// anyway, and baking it would spend the work twice.
+pub fn paths_missing_conclusions(conn: &Connection, at: Generation) -> Vec<String> {
+    let mut stmt = match conn.prepare(
+        "SELECT DISTINCT m.path FROM modules m \
+         WHERE m.analysis IS NOT NULL AND m.extract_version = ?1 \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM conclusions c \
+             WHERE c.path = m.path AND c.generation <= ?2 \
+           )",
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("conclusion repair: could not enumerate frontier: {e}");
+            return Vec::new();
+        }
+    };
+    let rows = stmt.query_map(params![EXTRACT_VERSION, at.0], |r| r.get::<_, String>(0));
+    match rows {
+        Ok(it) => it.filter_map(|r| r.ok()).collect(),
+        Err(e) => {
+            log::warn!("conclusion repair: frontier query failed: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// How many paths one repair slice takes.
+///
+/// Small on purpose. The slice runs where the resolver thread would otherwise
+/// be blocked on its condvar, so its length is the worst-case delay a real
+/// resolve request waits behind — this is a latency bound, not a throughput
+/// knob. Bigger chunks would amortize the transaction better and make the
+/// server less responsive, which is the wrong trade for work that has no
+/// deadline.
+pub const REPAIR_SLICE: usize = 32;
+
+/// Re-bake one slice of the frontier and store it. Returns how many landed.
+///
+/// The decode and the bake happen OUTSIDE the transaction, and only the writes
+/// go inside it: a slice is tens of milliseconds of CPU, and holding SQLite's
+/// write lock across that would stall every other writer for the duration of
+/// work that is not writing.
+pub fn repair_conclusions_slice(
+    conn: &Connection,
+    paths: &[String],
+    at: Generation,
+) -> usize {
+    let baked: Vec<(&String, Vec<u8>)> = paths
+        .iter()
+        .filter_map(|path| {
+            // WITH the bag: the bake reads witnesses, and a bagless decode
+            // would produce a map that concludes nothing while looking like a
+            // successful repair — the same silent-empty shape this whole
+            // repair exists to undo.
+            let fa = super::load_one_diag(conn, path, true).ok()?;
+            let blob = super::bake_conclusions_blob(&fa, &fa.witnesses);
+            if blob.is_empty() {
+                // Nothing encodable. Leaving the row absent is right: the
+                // reader falls back to a decode, which is where it already was.
+                crate::util::ghost_stats::count("repair.nothing_to_bake");
+                return None;
+            }
+            Some((path, blob))
+        })
+        .collect();
+    if baked.is_empty() {
+        return 0;
+    }
+    let mut landed = 0usize;
+    if conn.execute_batch("BEGIN IMMEDIATE").is_err() {
+        log::warn!("conclusion repair: txn open failed; the slice defers to the next pass");
+        return 0;
+    }
+    for (path, blob) in &baked {
+        let r = conn.execute(
+            "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
+            params![path, at.0, blob],
+        );
+        match r {
+            Ok(_) => landed += 1,
+            Err(e) => log::warn!("conclusion repair: store failed for '{path}': {e}"),
+        }
+    }
+    if let Err(e) = conn.execute_batch("COMMIT") {
+        log::warn!("conclusion repair: commit failed: {e}");
+        let _ = conn.execute_batch("ROLLBACK");
+        return 0;
+    }
+    crate::util::ghost_stats::count_by("repair.baked", landed as u64);
+    landed
+}

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -84,6 +84,12 @@ pub fn load_conclusions(
 /// one generation, and letting each write pick its own would scatter a single
 /// logical round across several, which is exactly the half-built state the
 /// pinning is designed to prevent.
+/// Deliberately driver-less: the flush stopped publishing once it became
+/// clear that a conclusion row with no `modules` row behind it can never be
+/// caught by a stamp check. Publication waits on the conclusions table
+/// carrying its own freshness stamp; the store side is built and tested for
+/// when it does.
+#[allow(dead_code)]
 pub fn save_conclusions(
     conn: &Connection,
     path: &str,
@@ -113,6 +119,7 @@ pub fn save_conclusions(
 /// all exist yet, and `load_conclusions` would serve absence — which the
 /// evaluator reads as a definite `None`, the one thing absence must never
 /// mean.
+#[allow(dead_code)] // see `save_conclusions` — publication awaits a conclusions-row stamp
 pub fn publish_generation(
     conn: &Connection,
     at: Generation,
@@ -158,6 +165,7 @@ pub fn forget_conclusions(conn: &Connection, path: &str) {
 /// automatic: a sweep that guessed would delete the generation a live consult
 /// is reading, which is the same absence-as-answer failure the retention
 /// exists to prevent, arriving by a different door.
+#[allow(dead_code)] // reclaims what publication would produce; see `save_conclusions`
 pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
     // Keep the newest row at or below `keep` for each path — that is the one a
     // reader pinned at `keep` still resolves to. Only rows OLDER than that are

--- a/src/index/module_cache/conn.rs
+++ b/src/index/module_cache/conn.rs
@@ -34,7 +34,7 @@ pub fn cache_dir_for_workspace(workspace_root: Option<&str>) -> Option<PathBuf> 
 /// pack language gets its own `modules-{lang}.db` so names never comingle on
 /// disk (a Perl `Box` and a C++ class `Box` live in different files). The
 /// ONE spelling both openers share.
-pub(super) fn db_path_for(dir: &std::path::Path, lang: &str) -> PathBuf {
+pub fn db_path_for(dir: &std::path::Path, lang: &str) -> PathBuf {
     if lang == "perl" {
         dir.join("modules.db")
     } else {

--- a/src/index/module_cache/mod.rs
+++ b/src/index/module_cache/mod.rs
@@ -32,6 +32,8 @@ mod schema;
 pub use schema::*;
 mod stubs;
 pub use stubs::*;
+mod conclusions_store;
+pub use conclusions_store::*;
 mod warm;
 pub use warm::*;
 

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1664,3 +1664,103 @@ fn the_conclusion_fingerprint_is_not_stale() {
          the guard is describing a tree that no longer exists"
     );
 }
+
+/// A reader pinned to a generation must keep seeing it while a later one is
+/// published.
+///
+/// This is the failure the `(path, generation)` key exists to prevent. Keyed
+/// on `path` alone, publishing N+1 REPLACES the gen-N row, and a reader still
+/// pinned to N finds nothing — which the evaluator reads as a definite `None`.
+/// The pin would then be a way to GET wrong answers rather than avoid them,
+/// and nothing downstream could tell, because "this file concludes nothing"
+/// is a perfectly ordinary thing for the store to say.
+#[test]
+fn a_pinned_reader_does_not_see_a_later_generation() {
+    use crate::model::witnesses::{Conclusion, ConclusionKey, ConclusionMap};
+    let conn = test_db();
+    let mk = |t: &str| {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            ConclusionKey::SubByName("f".into()),
+            Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
+        );
+        ConclusionMap(m)
+    };
+
+    let g1 = Generation(1);
+    publish_generation(&conn, g1, &[("/a.pm".to_string(), mk("One"))]).expect("publish 1");
+    assert_eq!(current_generation(&conn), g1);
+
+    let pinned = load_conclusions(&conn, "/a.pm", g1).expect("gen 1 visible at gen 1");
+
+    let g2 = Generation(2);
+    publish_generation(&conn, g2, &[("/a.pm".to_string(), mk("Two"))]).expect("publish 2");
+
+    // The pin still resolves, and to the OLD content.
+    let after = load_conclusions(&conn, "/a.pm", g1).expect(
+        "a reader pinned to gen 1 lost its row when gen 2 published — it would \
+         read absence as a definite None",
+    );
+    assert_eq!(after, pinned, "the pin resolved to a different generation");
+
+    // And a fresh reader sees the new one.
+    let fresh = load_conclusions(&conn, "/a.pm", current_generation(&conn)).expect("gen 2");
+    assert_ne!(fresh, pinned, "gen 2 served gen 1's content");
+}
+
+/// Pruning must not delete the row a live pin resolves to.
+#[test]
+fn pruning_keeps_what_the_pin_still_needs() {
+    use crate::model::witnesses::{Conclusion, ConclusionKey, ConclusionMap};
+    let conn = test_db();
+    let mk = |t: &str| {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            ConclusionKey::SubByName("f".into()),
+            Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
+        );
+        ConclusionMap(m)
+    };
+    for g in 1..=4i64 {
+        publish_generation(&conn, Generation(g), &[("/a.pm".to_string(), mk(&format!("G{g}")))])
+            .expect("publish");
+    }
+    // A reader is pinned at 3; everything strictly older than what gen 3
+    // resolves to is unreachable, and gen 3's own row is not.
+    prune_generations_below(&conn, Generation(3));
+    assert!(
+        load_conclusions(&conn, "/a.pm", Generation(3)).is_some(),
+        "pruning deleted the row a pin at gen 3 resolves to"
+    );
+    assert!(
+        load_conclusions(&conn, "/a.pm", Generation(4)).is_some(),
+        "pruning deleted a generation newer than the prune floor"
+    );
+}
+
+/// A failed round must not advance the generation.
+///
+/// Half a round published under a complete-looking generation is the same
+/// absence-as-answer failure: the files that did land are read as current, the
+/// ones that did not are read as concluding nothing.
+#[test]
+fn a_failed_round_leaves_the_previous_generation_intact() {
+    use crate::model::witnesses::ConclusionMap;
+    let conn = test_db();
+    publish_generation(&conn, Generation(1), &[("/a.pm".to_string(), ConclusionMap::default())])
+        .expect("publish 1");
+    // Force a failure mid-round by dropping the table the second write needs.
+    conn.execute_batch("DROP TABLE conclusions").unwrap();
+    let r = publish_generation(
+        &conn,
+        Generation(2),
+        &[("/b.pm".to_string(), ConclusionMap::default())],
+    );
+    assert!(r.is_err(), "a round that could not write reported success");
+    assert_eq!(
+        current_generation(&conn),
+        Generation(1),
+        "a failed round advanced the generation, so its partial writes would \
+         be served as complete"
+    );
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1684,7 +1684,7 @@ fn a_pinned_reader_does_not_see_a_later_generation() {
             ConclusionKey::SubByName("f".into()),
             Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
         );
-        ConclusionMap(m)
+        ConclusionMap(m, Default::default())
     };
 
     let g1 = Generation(1);
@@ -1719,7 +1719,7 @@ fn pruning_keeps_what_the_pin_still_needs() {
             ConclusionKey::SubByName("f".into()),
             Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
         );
-        ConclusionMap(m)
+        ConclusionMap(m, Default::default())
     };
     for g in 1..=4i64 {
         publish_generation(&conn, Generation(g), &[("/a.pm".to_string(), mk(&format!("G{g}")))])

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1597,3 +1597,70 @@ fn pre_split_rows_are_filtered_not_guessed() {
     );
     let _ = std::fs::remove_file(&pm);
 }
+
+
+/// The conclusion fingerprint must describe the tree as it is RIGHT NOW.
+///
+/// The failure this catches is a stale constant: if `build.rs` ever stops
+/// re-running when a source file changes — a directory-level
+/// `rerun-if-changed`, a path it hashes but forgets to declare — the compiled
+/// constant keeps describing an older tree. Every baked conclusion then
+/// validates against a fingerprint that no longer means anything, which is
+/// exactly the hand-maintained version the derived one exists to replace, only
+/// now with nobody watching it.
+///
+/// The hash is recomputed here rather than shared with `build.rs`. A shared
+/// helper would agree with itself whatever it computed; two independent
+/// spellings that must agree is the only arrangement that can fail.
+#[test]
+fn the_conclusion_fingerprint_is_not_stale() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else { return };
+        for e in entries.flatten() {
+            let p = e.path();
+            match e.file_type() {
+                Ok(t) if t.is_dir() => walk(&p, out),
+                Ok(t) if t.is_file() => out.push(p),
+                _ => {}
+            }
+        }
+    }
+    walk(&root.join("src"), &mut files);
+    if root.join("Cargo.lock").is_file() {
+        files.push(root.join("Cargo.lock"));
+    }
+    files.sort();
+    assert!(
+        files.len() > 100,
+        "walked only {} files — this test would pass vacuously",
+        files.len()
+    );
+
+    let mut acc: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut fnv = |acc: &mut u64, bytes: &[u8]| {
+        for b in bytes {
+            *acc ^= *b as u64;
+            *acc = acc.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    };
+    for path in &files {
+        let Ok(bytes) = std::fs::read(path) else { continue };
+        // Paths are hashed relative to the manifest, so the fingerprint does
+        // not change when the same tree is checked out somewhere else — a
+        // worktree and its origin must agree or every worktree re-bakes.
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        fnv(&mut acc, rel.to_string_lossy().as_bytes());
+        fnv(&mut acc, b"\0");
+        fnv(&mut acc, &bytes);
+        fnv(&mut acc, b"\0");
+    }
+    assert_eq!(
+        format!("{acc:016x}"),
+        CONCLUSION_FINGERPRINT,
+        "the compiled-in conclusion fingerprint does not match the current \
+         source tree — build.rs did not re-run for some file it hashes, so \
+         the guard is describing a tree that no longer exists"
+    );
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1764,3 +1764,75 @@ fn a_failed_round_leaves_the_previous_generation_intact() {
          be served as complete"
     );
 }
+
+/// Persisting an analysis persists its conclusions, and they come back.
+///
+/// The bake rides inside `encode_analysis` precisely so a writer cannot
+/// persist the blob and forget the map. This is the test that says so: it
+/// exercises the real writer, not the bake in isolation.
+#[test]
+fn persisting_an_analysis_persists_its_conclusions() {
+    let conn = test_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("concl_roundtrip.pm");
+    std::fs::write(
+        &pm,
+        "package CR;\nsub build { return LWP::UserAgent->new }\nsub s { return 'x' }\n1;\n",
+    )
+    .unwrap();
+    let cached = parse_source_to_cached(&std::fs::read_to_string(&pm).unwrap(), &pm);
+    let pm_str = pm.to_string_lossy().into_owned();
+    save_to_db(&conn, &pm_str, &Some(cached), "workspace");
+
+    let map = load_conclusions(&conn, &pm_str, current_generation(&conn)).expect(
+        "the writer persisted a blob but no conclusions — the store answers \
+         'not baked' for a file that was just baked",
+    );
+    assert!(!map.is_empty(), "an empty map round-tripped as success");
+
+    use crate::model::witnesses::{ConclusionKey, Outcome};
+    let key = ConclusionKey::MethodOnClass {
+        class: "CR".into(),
+        name: "build".into(),
+    };
+    match map.evaluate(&key, None, None, &[]) {
+        Outcome::Answer(t) => assert_eq!(
+            t.class_name().as_deref(),
+            Some("LWP::UserAgent"),
+            "the round-tripped conclusion changed meaning"
+        ),
+        other => panic!("expected a baked answer for {key:?}, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&pm);
+}
+
+/// A derivation change clears conclusions and KEEPS blobs.
+///
+/// The repair for a stale conclusion is one re-bake, which needs the blob.
+/// Dropping blobs here would turn it into a corpus re-parse for nothing — and
+/// the failure would be invisible, since everything still works, just slowly.
+#[test]
+fn a_derivation_change_clears_conclusions_but_keeps_blobs() {
+    let conn = test_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("concl_fingerprint.pm");
+    std::fs::write(&pm, "package CF;\nsub f { return 'x' }\n1;\n").unwrap();
+    let cached = parse_source_to_cached(&std::fs::read_to_string(&pm).unwrap(), &pm);
+    let pm_str = pm.to_string_lossy().into_owned();
+    save_to_db(&conn, &pm_str, &Some(cached), "workspace");
+    assert!(load_conclusions(&conn, &pm_str, current_generation(&conn)).is_some());
+
+    validate_conclusion_fingerprint(&conn, "a-different-derivation").unwrap();
+
+    assert!(
+        load_conclusions(&conn, &pm_str, current_generation(&conn)).is_none(),
+        "conclusions survived a derivation change — they now describe a \
+         derivation that no longer exists, and nothing downstream can tell"
+    );
+    assert!(
+        load_one_diag(&conn, &pm_str, true).is_ok(),
+        "the blob was dropped along with the conclusions — the re-bake it \
+         exists to feed now costs a re-parse instead of a decode"
+    );
+    let _ = std::fs::remove_file(&pm);
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1656,6 +1656,34 @@ fn the_conclusion_fingerprint_is_not_stale() {
         fnv(&mut acc, &bytes);
         fnv(&mut acc, b"\0");
     }
+    // A tree edited AFTER this binary was built is a tree this test cannot
+    // conclude anything about: the fingerprint compiled in describes the
+    // sources as they were at build time, and comparing it to the sources as
+    // they are now measures the edit, not the guard. That is an ordinary
+    // developer workflow — a test run racing an editor — and failing on it
+    // reports a stale-fingerprint bug that does not exist. Say "I could not
+    // look" instead of "nothing there"; the same rule the instruments in this
+    // arc keep having to learn.
+    let built_at = std::env::current_exe()
+        .and_then(|p| p.metadata())
+        .and_then(|m| m.modified())
+        .ok();
+    if let Some(built_at) = built_at {
+        let edited_after = files.iter().any(|p| {
+            std::fs::metadata(p)
+                .and_then(|m| m.modified())
+                .map(|t| t > built_at)
+                .unwrap_or(false)
+        });
+        if edited_after {
+            eprintln!(
+                "the_conclusion_fingerprint_is_not_stale: SKIPPED — a hashed \
+                 source file is newer than this test binary, so the tree moved \
+                 after the build and the comparison would measure the edit"
+            );
+            return;
+        }
+    }
     assert_eq!(
         format!("{acc:016x}"),
         conclusion_fingerprint(),

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1911,3 +1911,45 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
         "a repaired file must leave the frontier, or the background pass never ends"
     );
 }
+
+/// A changed file's blob is dropped; its BAKE must go with it.
+///
+/// `invalidate_generation` is the "this path's persisted derivation is void"
+/// eraser — it takes the modules row, the stub and the ref rows. The
+/// conclusion map is a derivation of that same blob, and leaving it behind is
+/// not a cost, it is a WRONG ANSWER: `moc_cross_file_primary` consults the map
+/// before it decodes anything, and `Outcome::Answer` short-circuits the chase.
+/// The file's next consult would then be answered, with full confidence, from
+/// the source the user just edited away.
+#[test]
+fn invalidating_a_generation_drops_the_bake_that_came_with_it() {
+    let conn = test_db();
+    let dir = std::env::temp_dir();
+    let pm = dir.join("perl_lsp_invalidate_bake.pm");
+    std::fs::write(&pm, "package InvBake;\nsub val { return 'x' }\n1;\n").unwrap();
+    let source = std::fs::read_to_string(&pm).unwrap();
+    let path_str = pm.to_string_lossy().into_owned();
+    let cached = parse_source_to_cached(&source, &pm);
+    assert!(save_to_db(&conn, &path_str, &Some(cached), "workspace"));
+
+    let at = current_generation(&conn);
+    assert!(
+        load_conclusions(&conn, &path_str, at).is_some(),
+        "precondition: the persist wrote a map beside the blob"
+    );
+
+    invalidate_generation(&conn, &path_str);
+
+    assert!(
+        load_one_diag(&conn, &path_str, true).is_err(),
+        "precondition: the blob is gone"
+    );
+    assert!(
+        load_conclusions(&conn, &path_str, at).is_none(),
+        "the map outlived the blob it was baked from — a consult would be \
+         answered from the previous version of the file, and nothing \
+         downstream can tell"
+    );
+
+    let _ = std::fs::remove_file(&pm);
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1944,11 +1944,17 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
 ///
 /// `invalidate_generation` is the "this path's persisted derivation is void"
 /// eraser — it takes the modules row, the stub and the ref rows. The
-/// conclusion map is a derivation of that same blob, and leaving it behind is
-/// not a cost, it is a WRONG ANSWER: `moc_cross_file_primary` consults the map
-/// before it decodes anything, and `Outcome::Answer` short-circuits the chase.
-/// The file's next consult would then be answered, with full confidence, from
-/// the source the user just edited away.
+/// conclusion map is a derivation of that same blob, and leaving it behind
+/// risks a wrong answer rather than a slow one: `moc_cross_file_primary`
+/// consults the map before it decodes anything, and `Outcome::Answer`
+/// short-circuits the chase.
+///
+/// Scope, stated because it was overstated once: this pins the INVARIANT. No
+/// end-to-end path is known that actually reads an orphaned map — the routes
+/// that produce one re-persist the file or answer from the open-document tier
+/// first. The invariant is still worth holding, because "a derivation outlives
+/// its source" has consequences that stay invisible until some future caller
+/// order exposes them.
 #[test]
 fn invalidating_a_generation_drops_the_bake_that_came_with_it() {
     let conn = test_db();

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1658,7 +1658,7 @@ fn the_conclusion_fingerprint_is_not_stale() {
     }
     assert_eq!(
         format!("{acc:016x}"),
-        CONCLUSION_FINGERPRINT,
+        conclusion_fingerprint(),
         "the compiled-in conclusion fingerprint does not match the current \
          source tree — build.rs did not re-run for some file it hashes, so \
          the guard is describing a tree that no longer exists"

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1684,7 +1684,7 @@ fn a_pinned_reader_does_not_see_a_later_generation() {
             ConclusionKey::SubByName("f".into()),
             Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
         );
-        ConclusionMap(m, Default::default())
+        ConclusionMap(m, Default::default(), Default::default(), Default::default())
     };
 
     let g1 = Generation(1);
@@ -1719,7 +1719,7 @@ fn pruning_keeps_what_the_pin_still_needs() {
             ConclusionKey::SubByName("f".into()),
             Conclusion::Value(crate::model::file_analysis::InferredType::ClassName(t.into())),
         );
-        ConclusionMap(m, Default::default())
+        ConclusionMap(m, Default::default(), Default::default(), Default::default())
     };
     for g in 1..=4i64 {
         publish_generation(&conn, Generation(g), &[("/a.pm".to_string(), mk(&format!("G{g}")))])

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1836,3 +1836,78 @@ fn a_derivation_change_clears_conclusions_but_keeps_blobs() {
     );
     let _ = std::fs::remove_file(&pm);
 }
+
+/// A blob whose map the fingerprint gate cleared must get its map back, and
+/// the map it gets back must be the one the persist path would have written.
+///
+/// Both halves matter and they fail differently. Without the enumeration the
+/// layer stays dark after every source edit until someone runs a full
+/// `--clear-cache` by hand — `conclcache.known_absent` read 156,746 in that
+/// state, which is purely a cost but a permanent one, and it silently made
+/// every measurement taken after a rebuild a measurement of an empty layer.
+/// Without the SHARED bake, the repair writes well-formed bytes carrying a
+/// different answer than the persist path — the exact failure mode the
+/// derivation fingerprint exists to catch, arriving through the repair that
+/// fingerprint triggers.
+///
+/// Base-verify by dropping `paths_missing_conclusions`' `NOT EXISTS` clause:
+/// the frontier then also contains the file that already has a map, and the
+/// repair rewrites rows nothing asked for.
+#[test]
+fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
+    let conn = test_db();
+    let path = std::path::Path::new("/repair/App.pm");
+    let cached = parse_source_to_cached(
+        "package My::App;\nuse Mojolicious::Lite;\n\
+         plugin 'CloveApp', { alpha => 1, beta => 2 };\n\
+         sub helper { return 'x' }\n1;\n",
+        path,
+    );
+    let some = Some(cached.clone());
+    assert!(save_to_db(&conn, "My::App", &some, "workspace"));
+
+    let at = current_generation(&conn);
+    let persisted = load_conclusions(&conn, "/repair/App.pm", at)
+        .expect("precondition: the persist path writes a map");
+
+    // What `validate_conclusion_fingerprint` does: clear the maps, keep the
+    // blobs, on the promise that each file re-bakes from the blob it has.
+    conn.execute("DELETE FROM conclusions", []).unwrap();
+    assert!(
+        load_conclusions(&conn, "/repair/App.pm", at).is_none(),
+        "precondition: the map is gone"
+    );
+
+    let frontier = paths_missing_conclusions(&conn, at);
+    assert_eq!(
+        frontier,
+        vec!["/repair/App.pm".to_string()],
+        "the file holds a blob and no map, so it is the repair frontier"
+    );
+
+    assert_eq!(repair_conclusions_slice(&conn, &frontier, at), 1);
+    let repaired = load_conclusions(&conn, "/repair/App.pm", at)
+        .expect("the repair puts a map back");
+
+    // Same map, not merely A map. A repair that concluded something else
+    // would look identical to a working one from every angle but this.
+    assert_eq!(
+        repaired.0.len(),
+        persisted.0.len(),
+        "the repair baked a different number of keys than the persist path"
+    );
+    for (k, v) in persisted.0.iter() {
+        assert_eq!(
+            repaired.0.get(k),
+            Some(v),
+            "key {k:?} concludes differently after a repair than it did at persist"
+        );
+    }
+
+    // Idempotent: nothing is left on the frontier, so a second pass is a no-op
+    // rather than a rewrite loop.
+    assert!(
+        paths_missing_conclusions(&conn, at).is_empty(),
+        "a repaired file must leave the frontier, or the background pass never ends"
+    );
+}

--- a/src/index/module_cache/rows.rs
+++ b/src/index/module_cache/rows.rs
@@ -237,11 +237,18 @@ pub fn invalidate_generation(conn: &Connection, path: &str) {
 
 /// Drop a path's baked map once no blob is left to have derived it.
 ///
-/// The bake is a derivation of the blob, so it must not outlive it — and this
-/// is not a cost question, it is a wrong-answer question: the cross-file
-/// primary consults the map BEFORE it decodes anything, and an
-/// `Outcome::Answer` short-circuits the chase, so an orphaned map answers with
-/// full confidence from the source the user just edited away.
+/// The bake is a derivation of the blob, so it must not outlive it. What an
+/// orphaned map RISKS is a wrong answer rather than a slow one — the
+/// cross-file primary consults the map before it decodes anything, and an
+/// `Outcome::Answer` short-circuits the chase.
+///
+/// Honest about its own reach: no end-to-end path has been demonstrated that
+/// reads an orphaned map. Both routes that produce one re-persist the file
+/// (blob and map together) or answer from the open-document tier before any
+/// consult reaches the stale row. This closes the invariant, not a reproduced
+/// bug — and it is worth closing regardless, because "a derivation outlives
+/// its source" is exactly the shape whose consequences are invisible until a
+/// future caller order makes them visible.
 ///
 /// Conditioned on the modules row rather than unconditional, because the
 /// tier-scoped eraser legitimately leaves one behind: a dual-homed file whose

--- a/src/index/module_cache/rows.rs
+++ b/src/index/module_cache/rows.rs
@@ -232,6 +232,37 @@ pub fn invalidate_generation(conn: &Connection, path: &str) {
     let _ = conn.execute("DELETE FROM modules WHERE path = ?1", params![path]);
     delete_stub(conn, path);
     delete_ref_rows(conn, path);
+    forget_orphaned_conclusions(conn, path);
+}
+
+/// Drop a path's baked map once no blob is left to have derived it.
+///
+/// The bake is a derivation of the blob, so it must not outlive it — and this
+/// is not a cost question, it is a wrong-answer question: the cross-file
+/// primary consults the map BEFORE it decodes anything, and an
+/// `Outcome::Answer` short-circuits the chase, so an orphaned map answers with
+/// full confidence from the source the user just edited away.
+///
+/// Conditioned on the modules row rather than unconditional, because the
+/// tier-scoped eraser legitimately leaves one behind: a dual-homed file whose
+/// import-tier rows the walk GC'd still has a valid workspace blob, and its
+/// map still describes it. Dropping maps for every tier eviction would darken
+/// the layer across a whole GC sweep and put the survivors on the repair
+/// frontier for nothing.
+///
+/// The RAM twin is `ModuleIndex::invalidate_conclusions`; both halves are
+/// needed and neither is sufficient.
+fn forget_orphaned_conclusions(conn: &Connection, path: &str) {
+    let still_persisted: bool = conn
+        .query_row(
+            "SELECT 1 FROM modules WHERE path = ?1 LIMIT 1",
+            params![path],
+            |_| Ok(()),
+        )
+        .is_ok();
+    if !still_persisted {
+        super::forget_conclusions(conn, path);
+    }
 }
 
 /// Tier-scoped eraser: drops the generation ONLY when its rows carry
@@ -262,6 +293,7 @@ pub fn invalidate_generation_tier(conn: &Connection, path: &str, source: &str) {
         "DELETE FROM files WHERE path = ?1 AND source = ?2",
         params![path, source],
     );
+    forget_orphaned_conclusions(conn, path);
 }
 
 /// Remove a deleted file's rows (the removal half of `shred_derived_rows`).

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -81,6 +81,12 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_syms_name ON syms(name_id);
         CREATE INDEX IF NOT EXISTS idx_syms_key ON syms(key_id);
         CREATE INDEX IF NOT EXISTS idx_syms_file ON syms(file_id);
+        CREATE TABLE IF NOT EXISTS conclusions (
+            path       TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            map        BLOB NOT NULL,
+            PRIMARY KEY (path, generation)
+        ) WITHOUT ROWID;
         CREATE TABLE IF NOT EXISTS stubs (
             path TEXT PRIMARY KEY,
             stub BLOB NOT NULL
@@ -177,6 +183,17 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     // `EXTRACT_VERSION` and every reader filters on it. So they age out by
     // re-resolution rather than needing a migration or a format probe.
     let _ = conn.execute_batch("ALTER TABLE modules ADD COLUMN bag BLOB;");
+    // Pre-existing DBs predate the conclusion store; create it rather than
+    // bumping SCHEMA_VERSION, which drops every blob row. An empty store is
+    // correct on arrival — absent means "not baked", never "no answer".
+    let _ = conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS conclusions (
+            path       TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            map        BLOB NOT NULL,
+            PRIMARY KEY (path, generation)
+        ) WITHOUT ROWID;",
+    );
     // Stub generation gate — stamped here so every fresh DB is writable by
     // the persist writers (their per-chunk `stub_version_current` check
     // would otherwise fail-closed until the first warm scan stamped it).
@@ -371,6 +388,59 @@ pub fn hydrate_builtins(conn: &Connection) -> rusqlite::Result<DashMap<String, S
         }
     }
     Ok(map)
+}
+
+/// Drop the conclusion store when the derivation that produced it changed.
+///
+/// Deliberately NOT a `modules` wipe. A source change invalidates what the
+/// conclusions MEAN while leaving every blob perfectly valid, so the right
+/// cost is one re-bake per file — a decode of a blob we already have, which
+/// is precisely the decode stage 1 made cheaper. Dropping blobs here would
+/// turn a re-bake into a re-parse of the whole corpus for no reason.
+///
+/// Same meta-row shape as `validate_plugin_fingerprint`, including the
+/// IMMEDIATE transaction: two validators racing on a missing stamp would both
+/// clear, and the second would delete rows the first had just written.
+pub fn validate_conclusion_fingerprint(
+    conn: &Connection,
+    fingerprint: &str,
+) -> rusqlite::Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = validate_conclusion_fingerprint_inner(conn, fingerprint);
+    match &result {
+        Ok(()) => conn.execute_batch("COMMIT")?,
+        Err(_) => {
+            let _ = conn.execute_batch("ROLLBACK");
+        }
+    }
+    result
+}
+
+fn validate_conclusion_fingerprint_inner(
+    conn: &Connection,
+    fingerprint: &str,
+) -> rusqlite::Result<()> {
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'conclusion_fingerprint'",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    if stored.as_deref() != Some(fingerprint) {
+        log::info!(
+            "Conclusion derivation changed (was {:?}, now {}), clearing conclusions \
+             (blobs kept — each file re-bakes from the blob it already has)",
+            stored,
+            fingerprint
+        );
+        conn.execute("DELETE FROM conclusions", [])?;
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('conclusion_fingerprint', ?1)",
+            params![fingerprint],
+        )?;
+    }
+    Ok(())
 }
 
 /// Drop the module cache when the plugin set has changed since the last

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -18,6 +18,17 @@ pub const EXTRACT_VERSION: i64 = 184;
 /// next warm re-shreds rows from the already-decoded analyses for free.
 pub(super) const REF_ROWS_VERSION: &str = "6";
 
+/// Fingerprint over everything that can change what a derivation CONCLUDES,
+/// computed by `build.rs` at compile time.
+///
+/// Deliberately not a hand-maintained integer like its neighbours above. Those
+/// guard SHAPE: a stale one is caught the moment a decode fails loudly. This
+/// guards MEANING — a reducer edit leaves bytes that decode perfectly and
+/// answer wrongly — and there is nothing downstream to notice. A version
+/// someone has to remember to bump is the wrong instrument for a failure
+/// nothing else can see (`docs/prompt-conclusion-layer.md`).
+pub const CONCLUSION_FINGERPRINT: &str = env!("PERL_LSP_CONCLUSION_FINGERPRINT");
+
 pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS meta (

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -27,7 +27,86 @@ pub(super) const REF_ROWS_VERSION: &str = "6";
 /// answer wrongly — and there is nothing downstream to notice. A version
 /// someone has to remember to bump is the wrong instrument for a failure
 /// nothing else can see (`docs/prompt-conclusion-layer.md`).
-pub const CONCLUSION_FINGERPRINT: &str = env!("PERL_LSP_CONCLUSION_FINGERPRINT");
+const CONCLUSION_SOURCE_FINGERPRINT: &str = env!("PERL_LSP_CONCLUSION_FINGERPRINT");
+
+/// The source fingerprint, plus the ENV that steers what a bake produces.
+///
+/// Source alone is not the derivation. `PERL_LSP_MINT_LINKS` and
+/// `PERL_LSP_NO_BAKE` change what gets STORED, and their output outlives the
+/// process that wrote it — so one measurement run under a flag leaves every
+/// later run reading maps it would never have baked, with nothing to notice.
+/// Caught the honest way: a `--check` under `MINT_LINKS=1` took a gold row from
+/// PASS to FAIL for every subsequent run until the cache was wiped by hand, and
+/// the failure looked exactly like a code regression.
+///
+/// Consult-side flags (`PERL_LSP_CONCL_EQUIV`, `PERL_LSP_NO_TRUST_ABSENT`)
+/// deliberately stay OUT: they change how a stored map is READ, not what it
+/// contains, so folding them in would discard a good cache on every
+/// measurement.
+pub fn conclusion_fingerprint() -> &'static str {
+    static FP: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    FP.get_or_init(|| {
+        let set: Vec<bool> = BAKE_STEERING_FLAGS
+            .iter()
+            .map(|f| std::env::var(f).is_ok())
+            .collect();
+        fingerprint_with(CONCLUSION_SOURCE_FINGERPRINT, &set)
+    })
+}
+
+/// The env vars that change what a bake STORES. Consult-side flags do not
+/// belong here — see `conclusion_fingerprint`.
+const BAKE_STEERING_FLAGS: [&str; 2] = ["PERL_LSP_MINT_LINKS", "PERL_LSP_NO_BAKE"];
+
+/// Split from the env read so the property — a set flag yields a DIFFERENT
+/// fingerprint — is testable. `conclusion_fingerprint` memoizes into a
+/// `OnceLock` on first use, so a test that set the variable could never observe
+/// it.
+fn fingerprint_with(source: &str, set: &[bool]) -> String {
+    let mut fp = source.to_string();
+    for (flag, on) in BAKE_STEERING_FLAGS.iter().zip(set) {
+        if *on {
+            fp.push('+');
+            fp.push_str(flag);
+        }
+    }
+    fp
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::*;
+
+    /// A bake-steering flag must move the fingerprint, because its output
+    /// OUTLIVES the process that wrote it.
+    ///
+    /// Base-verify by returning `source.to_string()` unconditionally: this
+    /// fails, and the failure it stands in for does not — one `--check` under
+    /// `PERL_LSP_MINT_LINKS=1` left a gold row failing for every later run
+    /// until the cache was wiped by hand, looking exactly like a code
+    /// regression.
+    #[test]
+    fn a_bake_steering_flag_changes_the_fingerprint() {
+        let plain = fingerprint_with("abc", &[false, false]);
+        assert_eq!(plain, "abc", "no flag set must leave the source alone");
+        for i in 0..BAKE_STEERING_FLAGS.len() {
+            let mut set = vec![false; BAKE_STEERING_FLAGS.len()];
+            set[i] = true;
+            assert_ne!(
+                fingerprint_with("abc", &set),
+                plain,
+                "{} does not move the fingerprint, so a run under it silently \
+                 leaves its maps for every later run to read",
+                BAKE_STEERING_FLAGS[i]
+            );
+        }
+        // And they must not collide with each other.
+        assert_ne!(
+            fingerprint_with("abc", &[true, false]),
+            fingerprint_with("abc", &[false, true]),
+        );
+    }
+}
 
 pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(

--- a/src/index/module_index/index_core.rs
+++ b/src/index/module_index/index_core.rs
@@ -89,6 +89,10 @@ pub(crate) struct IndexCore {
     /// install stays visible to them. See `docs/adr/memory-slice-2-lru.md`.
     pub(crate) bag_cache:
         Arc<std::sync::RwLock<Option<Arc<crate::index::pack_bag_cache::PackBagCache>>>>,
+    /// Resident baked conclusions, byte-bounded. Installed alongside the bag
+    /// cache; absent on an index with no store, which simply keeps decoding.
+    pub(crate) conclusion_cache:
+        Arc<std::sync::RwLock<Option<Arc<crate::index::conclusion_cache::ConclusionCache>>>>,
 }
 
 impl IndexCore {
@@ -118,6 +122,7 @@ impl IndexCore {
             shape_bumps: std::sync::atomic::AtomicU64::new(0),
             long_lived: std::sync::atomic::AtomicBool::new(false),
             bag_cache: Arc::new(std::sync::RwLock::new(None)),
+            conclusion_cache: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 

--- a/src/index/module_index/index_core.rs
+++ b/src/index/module_index/index_core.rs
@@ -71,6 +71,21 @@ pub(crate) struct IndexCore {
     /// missed bump is silent staleness, so mutators bump even when a gen
     /// mint usually accompanies them.
     pub(crate) shape_bumps: std::sync::atomic::AtomicU64,
+    /// The flush clock, and the per-file marks compared against it.
+    ///
+    /// The re-stamp gate's whole mechanism: a flush bumps `flush_epoch` once,
+    /// then records that epoch for every consumer it enqueued
+    /// (`provider_diff_gen`). A file whose own `stamped_at` is at or past its
+    /// mark has had no provider move since it last stamped, so its re-stamp is
+    /// re-deriving what it already froze.
+    ///
+    /// Sessional on purpose: `FileAnalysis::stamped_at` is `#[serde(skip)]`,
+    /// so both halves die with the process and a fresh one fails open. A
+    /// persisted mark table paired with sessional stamps would be sound; a
+    /// persisted STAMP paired with sessional marks would silently skip a
+    /// re-stamp that was owed, so neither half may outlive the other.
+    pub(crate) flush_epoch: std::sync::atomic::AtomicU64,
+    pub(crate) provider_diff_gen: DashMap<std::path::PathBuf, u64>,
     /// The witness seams' fallback-on-miss enriched retries only pay off
     /// when the process lives long enough to amortize the overlay (each
     /// miss is a whole-analysis deep copy + enrich). Off by default; the
@@ -120,6 +135,8 @@ impl IndexCore {
             registration_gen: DashMap::new(),
             gen_counter: std::sync::atomic::AtomicU64::new(1),
             shape_bumps: std::sync::atomic::AtomicU64::new(0),
+            flush_epoch: std::sync::atomic::AtomicU64::new(0),
+            provider_diff_gen: DashMap::new(),
             long_lived: std::sync::atomic::AtomicBool::new(false),
             bag_cache: Arc::new(std::sync::RwLock::new(None)),
             conclusion_cache: Arc::new(std::sync::RwLock::new(None)),

--- a/src/index/module_index/index_core.rs
+++ b/src/index/module_index/index_core.rs
@@ -84,6 +84,16 @@ pub(crate) struct IndexCore {
     /// persisted mark table paired with sessional stamps would be sound; a
     /// persisted STAMP paired with sessional marks would silently skip a
     /// re-stamp that was owed, so neither half may outlive the other.
+    ///
+    /// **A dedicated clock, and not the conclusion store's generation** — the
+    /// obvious-looking consolidation, ruled out on purpose. A comparison clock
+    /// must share its lifetime with the operands it orders, and these operands
+    /// are sessional. A persistent clock over sessional operands fails the
+    /// mirror of the half-persistence case above: a restart resets stamps and
+    /// marks while the store generation carries on, so any path that ever
+    /// seeded `stamped_at` from a persisted value would compare a new-session
+    /// stamp against an old-session clock. This counter cannot express that
+    /// bug. If the marks are ever persisted, all three move together.
     pub(crate) flush_epoch: std::sync::atomic::AtomicU64,
     pub(crate) provider_diff_gen: DashMap<std::path::PathBuf, u64>,
     /// The witness seams' fallback-on-miss enriched retries only pay off

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -330,6 +330,22 @@ impl CrossFileLookup for ModuleIndex {
         self.enriched_snapshot(cached)
             .unwrap_or_else(|| self.bag_present(cached))
     }
+    fn conclusions_for(
+        &self,
+        path: &std::path::Path,
+    ) -> Option<std::sync::Arc<crate::model::witnesses::ConclusionMap>> {
+        use crate::index::conclusion_cache::Cached;
+        match self.conclusion_cache_ref()?.get(path) {
+            // The Arc, not a clone of what it holds. Handing back an owned map
+            // deep-copies a ~72-entry HashMap per consult, and the consult path
+            // runs this tens of thousands of times per check — measured at a
+            // 6.7% REGRESSION against no conclusions at all, which is the whole
+            // saving spent on copying the thing that produced it.
+            Cached::Map(m) => Some(m),
+            Cached::NotBaked => None,
+        }
+    }
+
     fn bag_present(&self, cached: &Arc<CachedModule>) -> Arc<FileAnalysis> {
         // Never-evicted copy (open docs, degraded files kept whole): a cheap
         // Arc bump, no I/O.

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -330,6 +330,18 @@ impl CrossFileLookup for ModuleIndex {
         self.enriched_snapshot(cached)
             .unwrap_or_else(|| self.bag_present(cached))
     }
+    fn class_is_bridged_to(&self, class: &str) -> bool {
+        // Bucket NON-EMPTY, not key-present: `purge_module` can leave an empty
+        // bucket behind, and a key-exists test would then report a bridge that
+        // no longer exists — permanently pessimising a class that used to be
+        // bridged.
+        self.core
+            .edges
+            .bridges
+            .get(class)
+            .is_some_and(|b| !b.is_empty())
+    }
+
     fn conclusions_for(
         &self,
         path: &std::path::Path,

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -242,6 +242,38 @@ impl CrossFileLookup for ModuleIndex {
         self.enrichment_epoch()
     }
 
+    fn flush_epoch(&self) -> u64 {
+        self.core.flush_epoch.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn restamp_owed(&self, path: &std::path::Path, stamped_at: Option<u64>) -> bool {
+        // Never stamped: owed, unconditionally. Every rehydrated copy reads
+        // `None` (the field is `serde(skip)`), so this is the arm that keeps a
+        // cold process behaving exactly as it did before the gate existed.
+        let Some(stamped_at) = stamped_at else {
+            crate::util::ghost_stats::count("restamp.owed_never_stamped");
+            return true;
+        };
+        match self.core.provider_diff_gen.get(path) {
+            Some(mark) if stamped_at >= *mark => {
+                crate::util::ghost_stats::count("restamp.skipped");
+                false
+            }
+            Some(_) => {
+                crate::util::ghost_stats::count("restamp.owed_provider_moved");
+                true
+            }
+            // No mark at all. Not "no provider moved" — "no wave has ever
+            // spoken about this file", which is also what a lost mark, a
+            // never-flushed session and an uncovered freshness edge all look
+            // like. Fail open; the gate is worth only what it can prove.
+            None => {
+                crate::util::ghost_stats::count("restamp.owed_no_mark");
+                true
+            }
+        }
+    }
+
     fn get_cached(&self, module_name: &str) -> Option<Arc<CachedModule>> {
         self.get_cached(module_name)
     }

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2330,3 +2330,46 @@ fn invalidating_derived_copies_takes_the_bake_as_well_as_the_bag() {
          consult would be answered from the previous version of the file"
     );
 }
+
+/// The push half of the re-stamp gate, over the real index.
+///
+/// What IS tested here: a mark postdates every clock reading taken before it,
+/// so a stamp from before the wave is owed a re-stamp; a second wave re-opens
+/// the debt; and never-stamped is owed regardless.
+///
+/// What is NOT: the `max` on the mark guards two waves whose writes interleave
+/// across threads, which this single-threaded API cannot produce. It rests on
+/// the argument in `mark_provider_diff`, not on this test — said plainly so
+/// nobody reads a green suite as covering it.
+#[test]
+fn a_mark_postdates_every_stamp_that_preceded_it() {
+    use crate::model::file_analysis::CrossFileLookup;
+    let idx = ModuleIndex::new_for_cli();
+    let a = std::path::PathBuf::from("/mark/A.pm");
+
+    let before = idx.flush_epoch();
+    assert!(
+        idx.restamp_owed(&a, Some(before)),
+        "no mark yet: the gate has nothing to prove a skip with, so it fails open"
+    );
+
+    let e1 = idx.mark_provider_diff([a.clone()]);
+    assert!(
+        e1 > before,
+        "the mark postdates every clock reading a racing stamp could have taken"
+    );
+    assert!(
+        idx.restamp_owed(&a, Some(before)),
+        "a stamp taken before the wave is owed a re-stamp, even though it \
+         happened after this file's previous one"
+    );
+    assert!(!idx.restamp_owed(&a, Some(e1)), "stamped after the wave: covered");
+
+    let e2 = idx.mark_provider_diff([a.clone()]);
+    assert!(e2 > e1, "the clock is monotone across waves");
+    assert!(idx.restamp_owed(&a, Some(e1)), "a second wave re-opens the debt");
+    assert!(
+        idx.restamp_owed(&a, None),
+        "never stamped is owed regardless — a rehydrated copy always reads None"
+    );
+}

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2289,3 +2289,44 @@ fn provider_edges_replay_for_a_symbol_evicted_copy() {
         "the stripped copy's provider edge must come from the pre-strip record"
     );
 }
+
+/// One eraser drops BOTH derived copies.
+///
+/// They are void for the same reason and at the same moment, and dropping only
+/// one is silently wrong in different ways — a stale bag costs a wrong
+/// reference walk, a stale map costs a wrong ANSWER, because the cross-file
+/// primary consults the map before it decodes anything and an
+/// `Outcome::Answer` short-circuits the chase. The conclusion half sat unwired
+/// for as long as it was a separate method a caller had to remember; this
+/// pins that it no longer can be.
+#[test]
+fn invalidating_derived_copies_takes_the_bake_as_well_as_the_bag() {
+    use crate::index::conclusion_cache::{Cached, ConclusionCache};
+    use crate::model::witnesses::ConclusionMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let path = std::path::PathBuf::from("/derived/A.pm");
+    let loads = Arc::new(AtomicUsize::new(0));
+    let l = Arc::clone(&loads);
+    let cache = Arc::new(ConclusionCache::new(1 << 20, move |_p| {
+        l.fetch_add(1, Ordering::Relaxed);
+        Some(ConclusionMap::default())
+    }));
+
+    let idx = ModuleIndex::new_for_cli();
+    idx.set_conclusion_cache(Arc::clone(&cache));
+
+    assert!(matches!(cache.get(&path), Cached::Map(_)));
+    assert!(matches!(cache.get(&path), Cached::Map(_)));
+    assert_eq!(loads.load(Ordering::Relaxed), 1, "precondition: memoized");
+
+    idx.invalidate_derived_copies(&path);
+
+    assert!(matches!(cache.get(&path), Cached::Map(_)));
+    assert_eq!(
+        loads.load(Ordering::Relaxed),
+        2,
+        "the baked map survived a derived-copy invalidation — the next \
+         consult would be answered from the previous version of the file"
+    );
+}

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -67,6 +67,7 @@ impl ModuleIndex {
         // evicted once persisted; queries that need the whole analysis
         // rehydrate through this, same as the pack sub-indexes. Fixed
         // 128 MiB cap (Perl analyses are 10-100x smaller than cpp ones).
+        let ckey = key.clone();
         let loader = move |path: &std::path::Path, want_bag: bool| {
             // Raw walk path first (preserves the pre-diag behavior), canonical
             // as a fallback spelling; the discriminated helper survives the
@@ -101,6 +102,29 @@ impl ModuleIndex {
             "perl-hub",
             loader,
         )));
+
+        // Conclusions ride the same cache-key. 16 MiB rather than the bag
+        // cache's 128: the whole substrate's maps measured 15.4 MB, so this
+        // holds a realistic workspace outright and eviction is the exception.
+
+        let concl_cap = std::env::var("PERL_LSP_CONCL_CACHE_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|mb| mb * 1024 * 1024)
+            .unwrap_or(16 * 1024 * 1024);
+        self.set_conclusion_cache(Arc::new(
+            crate::index::conclusion_cache::ConclusionCache::new(concl_cap, move |path| {
+                let dir = crate::index::module_cache::cache_dir_for_workspace(ckey.as_deref())?;
+                let db = crate::index::module_cache::db_path_for(&dir, "perl");
+                let conn = crate::index::module_cache::open_reader_retrying(&db).ok()?;
+                let at = crate::index::module_cache::current_generation(&conn);
+                crate::index::module_cache::load_conclusions(
+                    &conn,
+                    &path.to_string_lossy(),
+                    at,
+                )
+            }),
+        ));
     }
 
     /// Get the workspace root URI if set.

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -914,6 +914,31 @@ impl ModuleIndex {
         self.core.bag_cache.read().ok().and_then(|g| g.clone())
     }
 
+    pub fn set_conclusion_cache(
+        &self,
+        cache: Arc<crate::index::conclusion_cache::ConclusionCache>,
+    ) {
+        if let Ok(mut g) = self.core.conclusion_cache.write() {
+            *g = Some(cache);
+        }
+    }
+
+    pub(super) fn conclusion_cache_ref(
+        &self,
+    ) -> Option<Arc<crate::index::conclusion_cache::ConclusionCache>> {
+        self.core.conclusion_cache.read().ok().and_then(|g| g.clone())
+    }
+
+    /// A changed file's bake is void — drop it from the resident cache as well
+    /// as the store. Called beside `invalidate_bag_cache`, and for the same
+    /// reason: a resident derived copy outliving its source is how a stale
+    /// answer gets served with full confidence.
+    pub fn invalidate_conclusions(&self, path: &std::path::Path) {
+        if let Some(c) = self.conclusion_cache_ref() {
+            c.invalidate(path);
+        }
+    }
+
     /// Install the relational ref index's read-connection opener (once).
     /// Callable post-`Arc` (interior `OnceLock`) because the hub is shared
     /// before the workspace root — and therefore the cache path — is known.

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -929,15 +929,6 @@ impl ModuleIndex {
         self.core.conclusion_cache.read().ok().and_then(|g| g.clone())
     }
 
-    /// A changed file's bake is void — drop it from the resident cache as well
-    /// as the store. Called beside `invalidate_bag_cache`, and for the same
-    /// reason: a resident derived copy outliving its source is how a stale
-    /// answer gets served with full confidence.
-    pub fn invalidate_conclusions(&self, path: &std::path::Path) {
-        if let Some(c) = self.conclusion_cache_ref() {
-            c.invalidate(path);
-        }
-    }
 
     /// Install the relational ref index's read-connection opener (once).
     /// Callable post-`Arc` (interior `OnceLock`) because the hub is shared
@@ -959,9 +950,23 @@ impl ModuleIndex {
     /// changed/saved file's copy is stale). Pack sub-indexes AND the Perl
     /// hub each carry one — the watcher and the bulk-index writers rely on
     /// this taking effect on both.
-    pub fn invalidate_bag_cache(&self, path: &std::path::Path) {
+    /// Drop every resident copy DERIVED from a path's blob — the decoded bag
+    /// and the baked conclusion map together.
+    ///
+    /// One call rather than two because they are void for the same reason and
+    /// at the same moment, and dropping only one is silently wrong in
+    /// different ways: a stale bag costs a wrong reference walk, a stale map
+    /// costs a wrong ANSWER (the cross-file primary consults it before it
+    /// decodes anything, and an `Outcome::Answer` short-circuits the chase).
+    /// The conclusion half went unwired for exactly as long as it was a
+    /// separate method someone had to remember. The store-side twin is
+    /// `module_cache::invalidate_generation`.
+    pub fn invalidate_derived_copies(&self, path: &std::path::Path) {
         if let Some(bc) = self.bag_cache_ref() {
             bc.invalidate(path);
+        }
+        if let Some(c) = self.conclusion_cache_ref() {
+            c.invalidate(path);
         }
     }
 

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -537,7 +537,7 @@ impl ModuleIndex {
         // them back — an enriched copy of a DEGRADED analysis claimed to be
         // whole. Clone carries them.
         let mut copy: FileAnalysis = (*whole).clone();
-        copy.enrich_imported_types_with_keys(Some(self));
+        copy.enrich_imported_types_with_keys_for(Some(self), Some(&cached.path));
         let arc = Arc::new(copy);
         // Cycle-tainted: some dep declined mid-enrich (mutual imports), so
         // this copy baked a RAW view of that dep. Caching it would serve
@@ -950,6 +950,42 @@ impl ModuleIndex {
     /// changed/saved file's copy is stale). Pack sub-indexes AND the Perl
     /// hub each carry one — the watcher and the bulk-index writers rely on
     /// this taking effect on both.
+    /// Record that a provider of each path moved. Returns the epoch used.
+    ///
+    /// The push half of the re-stamp gate. The epoch is minted before the
+    /// marks are written, which is safe only because the CALLER has already
+    /// registered the changed files' fresh analyses by the time it gets here:
+    /// a stamp that reads the new clock therefore also sees the new provider,
+    /// so honouring its own mark is correct. A caller that marked BEFORE
+    /// publishing the change would break that and needs a different ordering —
+    /// stated here rather than left as an accident of one call site.
+    ///
+    /// Called with the wave's ENQUEUED set, not its moved set: a consumer
+    /// whose own answers did not move can still dispatch differently once its
+    /// provider changed, and cutting the mark where the wave cut would skip
+    /// exactly those.
+    pub fn mark_provider_diff(
+        &self,
+        paths: impl IntoIterator<Item = std::path::PathBuf>,
+    ) -> u64 {
+        use std::sync::atomic::Ordering;
+        let epoch = self.core.flush_epoch.fetch_add(1, Ordering::Relaxed) + 1;
+        let mut n = 0u64;
+        for p in paths {
+            // Max, not overwrite: marks arrive from concurrent waves and the
+            // gate is a `>=` against the LATEST provider move. A lower epoch
+            // landing last would license a skip the newer wave forbade.
+            self.core
+                .provider_diff_gen
+                .entry(p)
+                .and_modify(|g| *g = (*g).max(epoch))
+                .or_insert(epoch);
+            n += 1;
+        }
+        crate::util::ghost_stats::count_by("restamp.marked", n);
+        epoch
+    }
+
     /// Drop every resident copy DERIVED from a path's blob — the decoded bag
     /// and the baked conclusion map together.
     ///

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -358,13 +358,13 @@ pub fn index_pack_languages(
                         // Stale-pin clear BEFORE the stripped copy is
                         // reachable, so its first rehydration reads the
                         // just-committed blob.
-                        pack_index_writer.invalidate_bag_cache(&e.path);
+                        pack_index_writer.invalidate_derived_copies(&e.path);
                         if let Some(parts) = e.parts {
                             pack_index_writer.register_symbols_inner(e.path, parts);
                         }
                     },
                     |e: FreshEntry| {
-                        pack_index_writer.invalidate_bag_cache(&e.path);
+                        pack_index_writer.invalidate_derived_copies(&e.path);
                         if let Some(fa) = e.blob.decode_whole() {
                             let bytes = fa.heap_estimate().total();
                             if fallback_bytes.saturating_add(bytes) <= FALLBACK_WHOLE_BYTE_CAP {

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -132,6 +132,13 @@ pub fn index_workspace_with_index(
             conn,
             &crate::build::plugin::rhai_host::plugin_fingerprint(),
         );
+        // Beside the plugin gate, and for the same reason: a cached artifact
+        // that describes a derivation we no longer run. This one clears
+        // conclusions only — the blobs stay, because the repair is a re-bake.
+        let _ = module_cache::validate_conclusion_fingerprint(
+            conn,
+            module_cache::CONCLUSION_FINGERPRINT,
+        );
     }
     // Persistence and eviction are independent: blobs + rows are written
     // whenever a DB exists (the parity harness runs under PERL_LSP_NO_EVICT

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -339,7 +339,7 @@ pub fn index_workspace_with_index(
                         // Clear any stale LRU pin BEFORE the stripped copy
                         // becomes reachable, so its first rehydration reads
                         // the just-committed blob.
-                        idx.invalidate_bag_cache(&e.path);
+                        idx.invalidate_derived_copies(&e.path);
                     }
                     if e.deferred {
                         files.insert_workspace_arc(e.path.clone(), e.arc.clone());
@@ -355,7 +355,7 @@ pub fn index_workspace_with_index(
                     // beyond the persistence itself (disk full / lock storm
                     // stays loud AND self-heals) — up to the budget.
                     if let Some(idx) = module_index {
-                        idx.invalidate_bag_cache(&e.path);
+                        idx.invalidate_derived_copies(&e.path);
                     }
                     if let Some(fa) = e.blob.decode_whole() {
                         let bytes = fa.heap_estimate().total();

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -137,7 +137,7 @@ pub fn index_workspace_with_index(
         // conclusions only — the blobs stay, because the repair is a re-bake.
         let _ = module_cache::validate_conclusion_fingerprint(
             conn,
-            module_cache::CONCLUSION_FINGERPRINT,
+            module_cache::conclusion_fingerprint(),
         );
     }
     // Persistence and eviction are independent: blobs + rows are written

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -35,6 +35,13 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
             conn,
             &crate::build::plugin::rhai_host::plugin_fingerprint(),
         );
+        // Beside the plugin gate, and for the same reason: a cached artifact
+        // that describes a derivation we no longer run. This one clears
+        // conclusions only — the blobs stay, because the repair is a re-bake.
+        let _ = module_cache::validate_conclusion_fingerprint(
+            conn,
+            module_cache::CONCLUSION_FINGERPRINT,
+        );
         if server.is_some() {
             // Hydrate Perl builtin hover docs (cached in SQLite, re-parsed
             // from perlfunc.pod only when the perl version tag changes).

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -136,9 +136,35 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
         }
     }
 
+    // The conclusion-repair frontier: paths holding a valid blob whose map the
+    // derivation-fingerprint gate cleared. Enumerated ONCE here rather than
+    // re-queried per slice — the set only shrinks as we drain it, and a
+    // re-query per slice would be an O(corpus) scan for every 32 files.
+    //
+    // Deliberately NOT drained before the loop. It has no deadline, and the
+    // resolver thread is what answers a real cross-file request; a corpus-sized
+    // repair run ahead of the loop would put minutes in front of the first
+    // resolve. It runs in the gap where this thread would otherwise be blocked
+    // on its condvar, which is the definition of "post-ready background".
+    let mut repair_frontier: Vec<String> = db
+        .as_ref()
+        .map(|conn| {
+            let at = module_cache::current_generation(conn);
+            let f = module_cache::paths_missing_conclusions(conn, at);
+            if !f.is_empty() {
+                log::info!(
+                    "Conclusion repair: {} file(s) hold a blob with no map; \
+                     re-baking in the background",
+                    f.len()
+                );
+            }
+            f
+        })
+        .unwrap_or_default();
+
     // Main resolve loop — drain priority first, then pending.
     loop {
-        let batch = drain_next_batch(&core.queue);
+        let batch = drain_or_repair(&core.queue, &mut repair_frontier, db.as_ref());
 
         // One diagnostics refresh per drained BATCH, not per module: a
         // resolve takes longer than the refresh debounce's settle window,
@@ -343,6 +369,55 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
 ///
 /// Lock order here is pending-then-priority; producers must never hold
 /// `priority` while acquiring `pending`.
+/// `drain_next_batch`, except the idle wait is spent re-baking conclusions.
+///
+/// Real work always wins: the queue is checked before every slice, so a resolve
+/// request waits at most one slice (32 files) behind repair rather than behind
+/// the whole frontier. When the frontier is empty this is exactly the old
+/// blocking drain.
+fn drain_or_repair(
+    queue: &ResolveQueue,
+    frontier: &mut Vec<String>,
+    db: Option<&rusqlite::Connection>,
+) -> Vec<String> {
+    while !frontier.is_empty() {
+        if let Some(batch) = try_drain_next_batch(queue) {
+            return batch;
+        }
+        let Some(conn) = db else {
+            // No store to repair into; forget the frontier rather than
+            // spinning on it forever.
+            frontier.clear();
+            break;
+        };
+        let take = module_cache::REPAIR_SLICE.min(frontier.len());
+        let slice: Vec<String> = frontier.split_off(frontier.len() - take);
+        let at = module_cache::current_generation(conn);
+        module_cache::repair_conclusions_slice(conn, &slice, at);
+        if frontier.is_empty() {
+            log::info!("Conclusion repair: frontier drained");
+        }
+    }
+    drain_next_batch(queue)
+}
+
+/// The non-blocking half of `drain_next_batch`. `None` means "nothing queued
+/// right now", which is a different answer from the blocking form's "nothing
+/// queued, so I waited".
+fn try_drain_next_batch(queue: &ResolveQueue) -> Option<Vec<String>> {
+    let mut pending = queue.pending.lock().unwrap();
+    {
+        let mut priority = queue.priority.lock().unwrap();
+        if !priority.is_empty() {
+            return Some(std::mem::take(&mut *priority));
+        }
+    }
+    if !pending.is_empty() {
+        return Some(std::mem::take(&mut *pending));
+    }
+    None
+}
+
 pub(super) fn drain_next_batch(queue: &ResolveQueue) -> Vec<String> {
     let mut pending = queue.pending.lock().unwrap();
     loop {

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -40,7 +40,7 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
         // conclusions only — the blobs stay, because the repair is a re-bake.
         let _ = module_cache::validate_conclusion_fingerprint(
             conn,
-            module_cache::CONCLUSION_FINGERPRINT,
+            module_cache::conclusion_fingerprint(),
         );
         if server.is_some() {
             // Hydrate Perl builtin hover docs (cached in SQLite, re-parsed

--- a/src/index/pack_invalidator.rs
+++ b/src/index/pack_invalidator.rs
@@ -529,7 +529,7 @@ impl PackInvalidator {
         // Drop the stale LRU pin BEFORE the new copy becomes reachable — a
         // query racing this re-register must not rehydrate the pre-edit
         // generation against the new registration.
-        pack.invalidate_bag_cache(path);
+        pack.invalidate_derived_copies(path);
         if landed && !arc.degraded && crate::index::module_resolver::eviction_enabled() {
             // Registration-owned strip (feeds read the whole copy).
             let _ = pack.register_symbols_stripping(path.to_path_buf(), (**arc).clone(), crate::model::file_analysis::Residency::Skeleton);

--- a/src/lsp/backend/indexing.rs
+++ b/src/lsp/backend/indexing.rs
@@ -4,6 +4,160 @@
 use super::*;
 
 impl Backend {
+
+    /// Re-index Perl files whose bytes on disk changed, and name everyone who
+    /// must be refreshed because of it.
+    ///
+    /// Two seams reach this, and for a while only one of them existed.
+    /// `didChangeWatchedFiles` is the obvious one — and it is the one that does
+    /// not fire when the editor saves a buffer it has open, which is how a
+    /// developer actually edits a dependency. `did_save` is the other, and its
+    /// absence meant that saving a module left every consumer in the session
+    /// answering from the version before the save, for the rest of the
+    /// session. The pack languages were given this (`schedule_pack_invalidate`,
+    /// the H1 fix); Perl was not. `e2e/saved_dep_edit.lua` is the guard.
+    pub(super) async fn reindex_saved_perl(
+        &self,
+        perl_changes: Vec<(PathBuf, FileChangeType)>,
+    ) {
+        if perl_changes.is_empty() {
+            return;
+        }
+        let files = Arc::clone(&self.files);
+        let module_index = Arc::clone(&self.module_index);
+        let dirty = tokio::task::spawn_blocking(move || {
+            // Externally changed deps break their consumers' enrichment too
+            // — collect the dirty closure while the records are in hand and
+            // hand it back for the open-doc republish below.
+            let mut dirty_all: std::collections::HashSet<PathBuf> = Default::default();
+            // Each changed file's fresh map, and where the refresh wave
+            // starts. They differ for a DELETED file: it has no map and
+            // nothing to evaluate, so it enters the wave as its direct
+            // consumers instead.
+            let mut fresh: Vec<(PathBuf, crate::model::witnesses::ConclusionMap)> = Vec::new();
+            let mut frontier: Vec<PathBuf> = Vec::new();
+            // The persisted generation (blob + ref rows) is now stale for
+            // these paths; drop it so warm starts re-parse and the
+            // relational retrieval can't serve outdated spans. The fresh
+            // in-RAM copy registered below is FULL (never stripped), so the
+            // resident sweep covers it until the next bulk index persists a
+            // new generation.
+            let ws_key = module_index.workspace_root();
+            let conn = crate::index::module_cache::open_cache_db(ws_key.as_deref(), "perl");
+            for (path, typ) in perl_changes {
+                // A DELETED file can't canonicalize (it's gone) — resolve the
+                // parent instead so the spelling still matches the canonical
+                // keys everything was registered/persisted under.
+                let canon = path.canonicalize().unwrap_or_else(|_| {
+                    match (path.parent(), path.file_name()) {
+                        (Some(dir), Some(name)) => std::fs::canonicalize(dir)
+                            .map(|d| d.join(name))
+                            .unwrap_or_else(|_| path.clone()),
+                        _ => path.clone(),
+                    }
+                });
+                if let Some(ref conn) = conn {
+                    crate::index::module_cache::invalidate_generation(conn, &canon.to_string_lossy());
+                    if canon != path {
+                        crate::index::module_cache::invalidate_generation(
+                            conn,
+                            &path.to_string_lossy(),
+                        );
+                    }
+                }
+                module_index.invalidate_derived_copies(&canon);
+                match typ {
+                    FileChangeType::DELETED => {
+                        files.remove_workspace(&path);
+                        files.remove_workspace(&canon);
+                        // Consumers of the departed file's packages, BEFORE
+                        // the record (and its provided names) are removed.
+                        dirty_all.extend(module_index.dirty_consumers(&canon));
+                        // Consumers that answered through the departed file
+                        // now resolve to nothing — a move, and the wave
+                        // carries it onward from them.
+                        frontier.extend(module_index.dirty_consumers(&canon));
+                        // The hub's path/name registrations must go too, or
+                        // the dead file stays a retrieval candidate and a
+                        // phantom module in name lookups.
+                        module_index.unregister_workspace_path(&canon);
+                    }
+                    _ => {
+                        // Re-index the file (created or changed). The fresh
+                        // copy registers WHOLE (refs + bag) in both stores:
+                        // its persisted generation was just invalidated, so
+                        // the resident copy is the only source until the
+                        // next bulk index re-persists.
+                        if let Ok(source) = std::fs::read_to_string(&path) {
+                            let mut parser = crate::index::module_resolver::create_parser();
+                            if let Some(tree) = parser.parse(&source, None) {
+                                let analysis = crate::build::builder::build(&tree, source.as_bytes());
+                                let arc = Arc::new(analysis);
+                                files.insert_workspace_arc(canon.clone(), arc.clone());
+                                module_index.record_workspace_projections(&canon, &arc);
+                                // register_workspace_resident routes through
+                                // record_and_dirty: the dirty set is bound to
+                                // the record, so a re-register can't drop it.
+                                let sd = module_index
+                                    .register_workspace_resident(canon.clone(), arc.clone());
+                                dirty_all.extend(sd.dirty);
+                                // The caller bakes: the analysis is in hand
+                                // and its blob was just invalidated, so the
+                                // flush has nothing to decode it from.
+                                fresh.push((
+                                    canon.clone(),
+                                    crate::index::module_cache::bake_conclusion_map(
+                                        &arc,
+                                        &arc.witnesses,
+                                    ),
+                                ));
+                                frontier.push(canon.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            // The refresh wave. `dirty_consumers` names DIRECT consumers only,
+            // so a change two hops away has never refreshed anything — the
+            // wave carries it as far as the answers actually move and stops
+            // there, which is the bound a transitive closure would not have.
+            // Additive to the one-hop set rather than replacing it: a file
+            // whose surface did not move can still need re-enrichment for
+            // reasons this layer does not model.
+            if let Some(ref conn) = conn {
+                let candidates_of = |class: &str| -> Vec<PathBuf> {
+                    use crate::model::file_analysis::CrossFileLookup;
+                    module_index
+                        .visible_def_candidates(class)
+                        .iter()
+                        .map(|c| c.path.clone())
+                        .collect()
+                };
+                let consumers_of = |p: &std::path::Path| -> Vec<PathBuf> {
+                    module_index.dirty_consumers(p).into_iter().collect()
+                };
+                let out = crate::util::timings::phase("flush.wave", || {
+                    crate::index::conclusion_flush::flush_refresh_set(
+                        conn,
+                        fresh,
+                        frontier,
+                        &consumers_of,
+                        &candidates_of,
+                    )
+                });
+                crate::util::ghost_stats::count_by(
+                    "flush.refresh_set",
+                    out.changed.len() as u64,
+                );
+                dirty_all.extend(out.changed.into_iter().map(|(p, _)| p));
+            }
+            dirty_all
+        })
+        .await
+        .unwrap_or_default();
+        // Off-pipeline: each republish re-enriches.
+        self.spawn_republish(dirty);
+    }
     pub(super) fn diagnostic_options(&self) -> symbols::DiagnosticOptions {
         *self.diag_options.lock().unwrap()
     }

--- a/src/lsp/backend/indexing.rs
+++ b/src/lsp/backend/indexing.rs
@@ -149,6 +149,14 @@ impl Backend {
                     "flush.refresh_set",
                     out.changed.len() as u64,
                 );
+                // The push half of the re-stamp gate: every consumer this
+                // wave enqueued has had a provider move, so its next
+                // enrichment owes a re-stamp. One epoch for the whole wave —
+                // a stamp taken during it must not look newer than the wave
+                // that caused it.
+                if !out.non_convergent {
+                    module_index.mark_provider_diff(out.enqueued.iter().cloned());
+                }
                 dirty_all.extend(out.changed.into_iter().map(|(p, _)| p));
             }
             dirty_all

--- a/src/lsp/backend/indexing.rs
+++ b/src/lsp/backend/indexing.rs
@@ -4,6 +4,46 @@
 use super::*;
 
 impl Backend {
+    /// Fire-and-forget re-index for one saved file.
+    ///
+    /// Spawned rather than awaited, the same shape `schedule_pack_invalidate`
+    /// uses and for the same reason: tower-lsp runs notifications on one task,
+    /// so awaiting a re-parse + re-register inside `did_save` would hold every
+    /// following didChange behind it — and a save is the most frequent trigger
+    /// this path has.
+    pub(super) fn spawn_reindex_saved_perl(&self, path: PathBuf) {
+        let files = Arc::clone(&self.files);
+        let module_index = Arc::clone(&self.module_index);
+        let ctx = self.diag_ctx();
+        tokio::spawn(async move {
+            let dirty = Self::reindex_perl_blocking(
+                files,
+                module_index,
+                vec![(path, FileChangeType::CHANGED)],
+            )
+            .await;
+            if !dirty.is_empty() {
+                ctx.republish_dirty(&dirty).await;
+            }
+        });
+    }
+
+    /// Re-index changed Perl files and refresh whoever depended on them,
+    /// awaiting the result. `didChangeWatchedFiles` uses this; a save uses the
+    /// spawned twin above.
+    pub(super) async fn reindex_saved_perl(
+        &self,
+        perl_changes: Vec<(PathBuf, FileChangeType)>,
+    ) {
+        let dirty = Self::reindex_perl_blocking(
+            Arc::clone(&self.files),
+            Arc::clone(&self.module_index),
+            perl_changes,
+        )
+        .await;
+        // Off-pipeline: each republish re-enriches.
+        self.spawn_republish(dirty);
+    }
 
     /// Re-index Perl files whose bytes on disk changed, and name everyone who
     /// must be refreshed because of it.
@@ -16,16 +56,17 @@ impl Backend {
     /// answering from the version before the save, for the rest of the
     /// session. The pack languages were given this (`schedule_pack_invalidate`,
     /// the H1 fix); Perl was not. `e2e/saved_dep_edit.lua` is the guard.
-    pub(super) async fn reindex_saved_perl(
-        &self,
+    ///
+    /// Over Arcs only, so the spawned caller can move it into a task.
+    async fn reindex_perl_blocking(
+        files: Arc<crate::index::file_store::FileStore>,
+        module_index: Arc<ModuleIndex>,
         perl_changes: Vec<(PathBuf, FileChangeType)>,
-    ) {
+    ) -> std::collections::HashSet<PathBuf> {
         if perl_changes.is_empty() {
-            return;
+            return Default::default();
         }
-        let files = Arc::clone(&self.files);
-        let module_index = Arc::clone(&self.module_index);
-        let dirty = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             // Externally changed deps break their consumers' enrichment too
             // — collect the dirty closure while the records are in hand and
             // hand it back for the open-doc republish below.
@@ -162,9 +203,7 @@ impl Backend {
             dirty_all
         })
         .await
-        .unwrap_or_default();
-        // Off-pipeline: each republish re-enriches.
-        self.spawn_republish(dirty);
+        .unwrap_or_default()
     }
     pub(super) fn diagnostic_options(&self) -> symbols::DiagnosticOptions {
         *self.diag_options.lock().unwrap()

--- a/src/lsp/backend/server.rs
+++ b/src/lsp/backend/server.rs
@@ -479,11 +479,22 @@ impl LanguageServer for Backend {
             self.schedule_diag_refresh(uri.clone());
         }
         // The saved bytes are on disk: re-register this file's indexed copy,
-        // evict the macro/closure caches it participates in, and refresh its
-        // open consumers (H1 — a saved header must become visible to its
-        // includers without a restart). Runs regardless of includeText.
-        if let Some(path) = pack_path {
-            self.schedule_pack_invalidate(path, false);
+        // evict the caches it participates in, and refresh its open consumers
+        // (H1 — a saved dependency must become visible to its consumers
+        // without a restart). Runs regardless of includeText.
+        //
+        // Both language families need this and only the pack half had it.
+        // `didChangeWatchedFiles` looks like it should cover the hub — it
+        // does not fire when the editor saves a buffer it has open, which is
+        // exactly how a dependency gets edited, so a saved `.pm` left every
+        // consumer in the session answering from the version before the save.
+        match pack_path {
+            Some(path) => self.schedule_pack_invalidate(path, false),
+            None => {
+                if let Ok(path) = uri.to_file_path() {
+                    self.reindex_saved_perl(vec![(path, FileChangeType::CHANGED)]).await;
+                }
+            }
         }
     }
 
@@ -1612,88 +1623,7 @@ impl LanguageServer for Backend {
                 }
             }
         }
-        if perl_changes.is_empty() {
-            return;
-        }
-        let files = Arc::clone(&self.files);
-        let module_index = Arc::clone(&self.module_index);
-        let dirty = tokio::task::spawn_blocking(move || {
-            // Externally changed deps break their consumers' enrichment too
-            // — collect the dirty closure while the records are in hand and
-            // hand it back for the open-doc republish below.
-            let mut dirty_all: std::collections::HashSet<PathBuf> = Default::default();
-            // The persisted generation (blob + ref rows) is now stale for
-            // these paths; drop it so warm starts re-parse and the
-            // relational retrieval can't serve outdated spans. The fresh
-            // in-RAM copy registered below is FULL (never stripped), so the
-            // resident sweep covers it until the next bulk index persists a
-            // new generation.
-            let ws_key = module_index.workspace_root();
-            let conn = crate::index::module_cache::open_cache_db(ws_key.as_deref(), "perl");
-            for (path, typ) in perl_changes {
-                // A DELETED file can't canonicalize (it's gone) — resolve the
-                // parent instead so the spelling still matches the canonical
-                // keys everything was registered/persisted under.
-                let canon = path.canonicalize().unwrap_or_else(|_| {
-                    match (path.parent(), path.file_name()) {
-                        (Some(dir), Some(name)) => std::fs::canonicalize(dir)
-                            .map(|d| d.join(name))
-                            .unwrap_or_else(|_| path.clone()),
-                        _ => path.clone(),
-                    }
-                });
-                if let Some(ref conn) = conn {
-                    crate::index::module_cache::invalidate_generation(conn, &canon.to_string_lossy());
-                    if canon != path {
-                        crate::index::module_cache::invalidate_generation(
-                            conn,
-                            &path.to_string_lossy(),
-                        );
-                    }
-                }
-                module_index.invalidate_derived_copies(&canon);
-                match typ {
-                    FileChangeType::DELETED => {
-                        files.remove_workspace(&path);
-                        files.remove_workspace(&canon);
-                        // Consumers of the departed file's packages, BEFORE
-                        // the record (and its provided names) are removed.
-                        dirty_all.extend(module_index.dirty_consumers(&canon));
-                        // The hub's path/name registrations must go too, or
-                        // the dead file stays a retrieval candidate and a
-                        // phantom module in name lookups.
-                        module_index.unregister_workspace_path(&canon);
-                    }
-                    _ => {
-                        // Re-index the file (created or changed). The fresh
-                        // copy registers WHOLE (refs + bag) in both stores:
-                        // its persisted generation was just invalidated, so
-                        // the resident copy is the only source until the
-                        // next bulk index re-persists.
-                        if let Ok(source) = std::fs::read_to_string(&path) {
-                            let mut parser = crate::index::module_resolver::create_parser();
-                            if let Some(tree) = parser.parse(&source, None) {
-                                let analysis = crate::build::builder::build(&tree, source.as_bytes());
-                                let arc = Arc::new(analysis);
-                                files.insert_workspace_arc(canon.clone(), arc.clone());
-                                module_index.record_workspace_projections(&canon, &arc);
-                                // register_workspace_resident routes through
-                                // record_and_dirty: the dirty set is bound to
-                                // the record, so a re-register can't drop it.
-                                let sd = module_index
-                                    .register_workspace_resident(canon.clone(), arc);
-                                dirty_all.extend(sd.dirty);
-                            }
-                        }
-                    }
-                }
-            }
-            dirty_all
-        })
-        .await
-        .unwrap_or_default();
-        // Off-pipeline: each republish re-enriches.
-        self.spawn_republish(dirty);
+        self.reindex_saved_perl(perl_changes).await;
     }
 
     async fn range_formatting(

--- a/src/lsp/backend/server.rs
+++ b/src/lsp/backend/server.rs
@@ -491,8 +491,13 @@ impl LanguageServer for Backend {
         match pack_path {
             Some(path) => self.schedule_pack_invalidate(path, false),
             None => {
+                // Spawned, not awaited — the same shape `schedule_pack_invalidate`
+                // uses, and for the same reason: tower-lsp runs notifications on
+                // one task, so awaiting a re-parse + re-register here would hold
+                // every following didChange behind it. A save is the most
+                // frequent trigger this path has.
                 if let Ok(path) = uri.to_file_path() {
-                    self.reindex_saved_perl(vec![(path, FileChangeType::CHANGED)]).await;
+                    self.spawn_reindex_saved_perl(path);
                 }
             }
         }

--- a/src/lsp/backend/server.rs
+++ b/src/lsp/backend/server.rs
@@ -1651,7 +1651,7 @@ impl LanguageServer for Backend {
                         );
                     }
                 }
-                module_index.invalidate_bag_cache(&canon);
+                module_index.invalidate_derived_copies(&canon);
                 match typ {
                     FileChangeType::DELETED => {
                         files.remove_workspace(&path);

--- a/src/lsp/cli/mod.rs
+++ b/src/lsp/cli/mod.rs
@@ -315,6 +315,13 @@ fn cli_full_startup(
             conn,
             &plugin::rhai_host::plugin_fingerprint(),
         );
+        // Beside the plugin gate, and for the same reason: a cached artifact
+        // that describes a derivation we no longer run. This one clears
+        // conclusions only — the blobs stay, because the repair is a re-bake.
+        let _ = module_cache::validate_conclusion_fingerprint(
+            conn,
+            module_cache::CONCLUSION_FINGERPRINT,
+        );
         let (warmed, stale) = timings::phase("cli::warm_inc_cache", || {
             module_cache::warm_cache(
                 conn,

--- a/src/lsp/cli/mod.rs
+++ b/src/lsp/cli/mod.rs
@@ -320,7 +320,7 @@ fn cli_full_startup(
         // conclusions only — the blobs stay, because the repair is a re-bake.
         let _ = module_cache::validate_conclusion_fingerprint(
             conn,
-            module_cache::CONCLUSION_FINGERPRINT,
+            module_cache::conclusion_fingerprint(),
         );
         let (warmed, stale) = timings::phase("cli::warm_inc_cache", || {
             module_cache::warm_cache(

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1334,6 +1334,17 @@ pub(crate) fn cli_rename(root: &str, cursor: &[String], new_name: &str) {
     }
 }
 
+/// Put every file declaring a package into a stable order.
+///
+/// Extracted so the property has a name and a test: this verb must collect
+/// ALL declaring files and order them, never take whichever one an unordered
+/// map yields first. `workspace_raw()` is a `DashMap`, so a `break` on the
+/// first hit made the answer for any reopened package vary run to run.
+fn order_declaring_files<T>(mut matches: Vec<(String, T)>) -> Vec<(String, T)> {
+    matches.sort_by(|a, b| a.0.cmp(&b.0));
+    matches
+}
+
 /// --dump-package <root> <package> — Dump every sub in a package with
 /// derived type info. Debugging aid for the witness/reducer pipeline:
 /// prints the raw `return_type` baked into the Symbol, the witness-bag
@@ -1352,7 +1363,20 @@ pub(crate) fn cli_dump_package(root: &str, package_name: &str) {
     // Find a FileAnalysis whose package matches. Workspace first; fall
     // back to cached @INC modules. No bespoke discovery — only what
     // the normal startup populated.
-    let mut found: Option<(String, Arc<file_analysis::CachedModule>)> = None;
+    //
+    // EVERY match, then sorted — not the first the iteration reaches. A Perl
+    // package is open: `PPI::XSAccessor` reopens `PPI::Token`, so two
+    // workspace files declare it, and `workspace_raw()` is a `DashMap` whose
+    // iteration order varies run to run. This verb used to `break` on the
+    // first hit, which made its answer for any reopened package a coin flip —
+    // `--dump-package PPI::Token` alternated between `Token.pm` and
+    // `XSAccessor.pm` across five consecutive runs of the same binary.
+    //
+    // That is worse than an arbitrary choice, because this output is used as a
+    // comparison ORACLE ("byte-identical across 312 KB" appears in this
+    // project's own measurement notes). A flaky oracle silently launders a
+    // real difference into noise, and noise into a real difference.
+    let mut matches: Vec<(String, Arc<file_analysis::CachedModule>)> = Vec::new();
     for entry in ws.workspace_raw().iter() {
         let cm = std::sync::Arc::new(file_analysis::CachedModule::new(
             entry.key().clone(),
@@ -1364,10 +1388,25 @@ pub(crate) fn cli_dump_package(root: &str, package_name: &str) {
                 && s.name == package_name
         });
         if has_package {
-            found = Some((entry.key().display().to_string(), cm));
-            break;
+            matches.push((entry.key().display().to_string(), cm));
         }
     }
+    let matches = order_declaring_files(matches);
+    if matches.len() > 1 {
+        // Named, not just deduped. A reopened package is exactly the situation
+        // where "why does this return X?" has a different answer per file, so
+        // dumping one of them without saying the others exist answers a
+        // question the user did not ask.
+        eprintln!(
+            "note: '{}' is declared in {} files; dumping the first and listing the rest:",
+            package_name,
+            matches.len()
+        );
+        for (p, _) in &matches {
+            eprintln!("  {p}");
+        }
+    }
+    let mut found = matches.into_iter().next();
     if found.is_none() {
         if let Some(cached) = module_index.get_cached(package_name) {
             found = Some((cached.path.display().to_string(), cached));
@@ -1609,4 +1648,50 @@ pub(crate) fn cli_workspace_symbol(root: &str, query: &str) {
     // workspace-symbol emits engine-coordinated spans (0-based/byte) directly,
     // independent of the location seam; the dialect here is nominal.
     print_run_one(&ws, &idx, &req, CoordFmt::ZeroBasedByte);
+}
+
+#[cfg(test)]
+mod declaring_file_tests {
+    use super::order_declaring_files;
+
+    /// `--dump-package` must consider EVERY file declaring a package, in a
+    /// stable order — not whichever one an unordered map happens to yield.
+    ///
+    /// Perl packages are open. `PPI::XSAccessor` reopens `PPI::Token`, so two
+    /// workspace files declare it, and the store this verb scans is a
+    /// `DashMap`. Taking the first hit made the answer a coin flip:
+    /// `--dump-package PPI::Token` alternated between `Token.pm` and
+    /// `XSAccessor.pm` across five consecutive runs of one binary.
+    ///
+    /// That matters beyond tidiness because this output is used as a
+    /// comparison ORACLE elsewhere in the project. A flaky oracle launders a
+    /// real difference into noise and noise into a real difference, in both
+    /// directions, silently.
+    ///
+    /// Base-verify by restoring the `break` in the collection loop: only one
+    /// match survives and the length assertion fails.
+    #[test]
+    fn every_declaring_file_is_kept_and_ordered() {
+        let unordered = vec![
+            ("/w/PPI/XSAccessor.pm".to_string(), 2u8),
+            ("/w/PPI/Token.pm".to_string(), 1u8),
+        ];
+        let ordered = order_declaring_files(unordered);
+        assert_eq!(
+            ordered.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["/w/PPI/Token.pm", "/w/PPI/XSAccessor.pm"],
+            "a reopened package's files must be kept and ordered, so the verb's \
+             answer does not depend on map iteration order"
+        );
+        // Reversing the input must not reverse the answer.
+        let other_way = order_declaring_files(vec![
+            ("/w/PPI/Token.pm".to_string(), 1u8),
+            ("/w/PPI/XSAccessor.pm".to_string(), 2u8),
+        ]);
+        assert_eq!(
+            ordered.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            other_way.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            "the order must come from the paths, not from the input's order"
+        );
+    }
 }

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -22,6 +22,14 @@ pub(crate) fn cli_check(args: &[String]) {
     }
     timings::enable_from_env();
 
+    // Declared BEFORE startup, because startup enriches: the profile has to be
+    // in force by the time the first analysis is enriched, not by the time the
+    // first diagnostic is asked for.
+    //
+    // Sound because this is a one-shot CLI process serving exactly one verb —
+    // see `declare_enrichment_profile`. A server verb must not do this.
+    file_analysis::declare_enrichment_profile(file_analysis::EnrichmentProfile::diagnostics());
+
     // `--check` reports diagnostics for pack files too (the pack-index
     // sweep below), so it needs every family.
     let (ws, module_index) = cli_full_startup(root, language_driver::LanguageScope::All);

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -430,6 +430,22 @@ pub trait CrossFileLookup {
     fn resolution_epoch(&self) -> u64 {
         0
     }
+    /// This file's baked conclusions, if the store has them at the reader's
+    /// pinned generation.
+    ///
+    /// `None` means NOT BAKED — the caller decodes, exactly as before this
+    /// layer existed. It emphatically does not mean "no answer": that is what
+    /// a key being absent from a returned map means, and conflating the two
+    /// turns an unbaked file into a file that concludes nothing.
+    ///
+    /// Defaulted so an index with no store (tests, pack sub-indexes) is
+    /// unaffected and simply keeps decoding.
+    fn conclusions_for(
+        &self,
+        _path: &std::path::Path,
+    ) -> Option<std::sync::Arc<crate::model::witnesses::ConclusionMap>> {
+        None
+    }
     fn get_cached(&self, module_name: &str) -> Option<std::sync::Arc<CachedModule>>;
     /// `get_cached` scoped to a querying file's VISIBILITY set (its own path +
     /// its `#include` closure) — see `ModuleIndex::get_cached_scoped`. Default:

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -430,6 +430,37 @@ pub trait CrossFileLookup {
     fn resolution_epoch(&self) -> u64 {
         0
     }
+
+    /// Is a MethodCall re-stamp owed for `path`, last stamped at
+    /// `stamped_at`?
+    ///
+    /// The re-stamp is the dominant driver of cross-file bag rehydration, and
+    /// most of it re-derives an answer the build already froze. What licenses
+    /// skipping it is knowing that no provider of this file has moved since
+    /// the last stamp — which is a question about the FLUSH, not about this
+    /// file, and answering it by walking `providers(F)` here would resurrect
+    /// the transitive closure the enrichment-key memo exists to contain.
+    ///
+    /// So the flush PUSHES: enqueuing a consumer stamps that consumer's mark,
+    /// and this is an O(1) comparison against it. Every unknown — never
+    /// stamped, no mark recorded, no index, a caller with no path — **fails
+    /// open to today's behavior**, which is why the gate can land before the
+    /// flush is the standing path and simply do nothing until it is.
+    ///
+    /// The gate is exactly as sound as the freshness edge coverage it rides
+    /// on, and no more: a provider whose change never reaches
+    /// `dirty_consumers` never marks anyone, and the skip would then be
+    /// wrong. New and deleted files are covered because registration and
+    /// removal already route through `record_and_dirty`.
+    fn restamp_owed(&self, _path: &std::path::Path, _stamped_at: Option<u64>) -> bool {
+        true
+    }
+
+    /// The monotone flush clock a stamp records itself against. Sessional and
+    /// deliberately not persisted — see `FileAnalysis::stamped_at`.
+    fn flush_epoch(&self) -> u64 {
+        0
+    }
     /// Does ANY file bridge plugin-synthesized entities onto `class`?
     ///
     /// The guard on every conclusion form that encodes "everything before the

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -430,6 +430,31 @@ pub trait CrossFileLookup {
     fn resolution_epoch(&self) -> u64 {
         0
     }
+    /// Does ANY file bridge plugin-synthesized entities onto `class`?
+    ///
+    /// The guard on every conclusion form that encodes "everything before the
+    /// bridge arm answered None" — trusted absence and `Link`. The live ladder
+    /// is local → primary → parents → bridges, so a baked `Value`/`ReturnOf`
+    /// came from an arm that beats bridges in every world and needs no guard;
+    /// the other two are exactly the set that could be contradicted by a
+    /// bridged answer they never saw.
+    ///
+    /// Asked HERE rather than baked, and that is the whole point. A bake-time
+    /// "no file bridges to C" is a negative GLOBAL fact stored in a map whose
+    /// invalidation covers the derivation code and the file's own stamp —
+    /// foreign registry state is covered by neither, by design. A newly indexed
+    /// file that starts bridging to C would change nothing about the consumer,
+    /// no re-bake would fire, and the stale map would durably skip the bridged
+    /// answer. Asking the index at trust time is self-healing in both
+    /// directions with no invalidation machinery at all.
+    ///
+    /// Defaults to `true` — the conservative answer. An index that cannot say
+    /// makes its callers decode rather than trust, which is slow and never
+    /// wrong.
+    fn class_is_bridged_to(&self, _class: &str) -> bool {
+        true
+    }
+
     /// This file's baked conclusions, if the store has them at the reader's
     /// pinned generation.
     ///

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -224,6 +224,112 @@ impl FileAnalysis {
         self.rebuild_enrichment_indices();
     }
 
+}
+
+/// What a verb's consumers actually READ out of enrichment.
+///
+/// `LanguageScope`'s shape, applied one tier down: the verb declares what it
+/// needs and the machinery obeys, never asking which verb it serves. Soundness
+/// is by construction rather than by freshness — a product no consumer reads
+/// need not be produced, and that argument does not decay the way a cache's
+/// does.
+///
+/// The license for the first profile is an ablation, not a reading of the
+/// code: `--check`'s diagnostics lanes type invocants through the bag and
+/// resolve methods directly, so none of them consults `method_target()`. The
+/// re-stamp that fills it is therefore pure cost for that verb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnrichmentProfile {
+    stamp_method_targets: bool,
+}
+
+impl EnrichmentProfile {
+    /// Everything. The default, and what every server verb gets.
+    pub const fn full() -> Self {
+        EnrichmentProfile { stamp_method_targets: true }
+    }
+
+    /// Diagnostics only — no `MethodCall` dispatch-target re-stamp.
+    pub const fn diagnostics() -> Self {
+        EnrichmentProfile { stamp_method_targets: false }
+    }
+
+    /// Asked of the profile, never derived from a verb name by a consumer.
+    pub const fn stamps_method_targets(self) -> bool {
+        self.stamp_method_targets
+    }
+}
+
+/// The process's declared profile. `full()` until a verb says otherwise.
+static PROFILE: std::sync::OnceLock<EnrichmentProfile> = std::sync::OnceLock::new();
+
+/// Declare the profile for this process. **One-shot CLI verbs only.**
+///
+/// A process-wide cell is the verb's declaration precisely because a one-shot
+/// CLI process serves exactly one verb: there is no second consumer to be
+/// surprised, and nothing it enriches outlives the process — the
+/// `enriched_snapshot` overlay is resident, not persisted.
+///
+/// A SERVER verb must never call this. The overlay there is shared and
+/// fingerprint-keyed, so a partial copy cached under a profile-blind key would
+/// be served to a verb that reads more than it does — silently, and as a
+/// missing answer rather than an error. If a server verb ever wants a partial
+/// profile, the profile belongs IN the overlay key, and this cell is the wrong
+/// mechanism rather than one to extend. That form is deliberately not built:
+/// nothing wants it yet, and building it now would be a key change with no
+/// consumer to validate it.
+pub fn declare_enrichment_profile(profile: EnrichmentProfile) {
+    let _ = PROFILE.set(profile);
+}
+
+/// The profile in force. `full()` when nobody declared one.
+///
+/// `PERL_LSP_FULL_ENRICHMENT=1` overrides any declaration back to `full()`.
+/// That is the A/B CONTROL, and it is not optional decoration: once a verb
+/// declares a partial profile, the full behaviour is no longer reachable, and
+/// a claim of "set-identical output" becomes unfalsifiable the moment it
+/// cannot be re-run. `PERL_LSP_SKIP_MC_STAMP` only skips harder — it is the
+/// same direction as the profile, so it cannot serve as the control.
+pub fn enrichment_profile() -> EnrichmentProfile {
+    static FULL_OVERRIDE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let forced = *FULL_OVERRIDE
+        .get_or_init(|| std::env::var_os("PERL_LSP_FULL_ENRICHMENT").is_some());
+    resolve_profile(PROFILE.get().copied(), forced)
+}
+
+/// The precedence rule, separated from the cells that hold it so it can be
+/// tested. Both cells are `OnceLock`s — a test that set either would decide
+/// the answer for every other test in the process, so the rule has to be
+/// reachable without them.
+///
+/// This is where a mistake would be quiet rather than loud: get the precedence
+/// backwards and the CONTROL stops working, which does not fail anything — it
+/// just makes every future "set-identical" claim unfalsifiable, because the
+/// full behaviour is no longer reachable to compare against.
+pub(crate) fn resolve_profile(
+    declared: Option<EnrichmentProfile>,
+    full_override: bool,
+) -> EnrichmentProfile {
+    if full_override {
+        return EnrichmentProfile::full();
+    }
+    declared.unwrap_or_else(EnrichmentProfile::full)
+}
+
+/// Does this run fill the `MethodCall` dispatch-target edge?
+///
+/// Two independent reasons not to, and they are different in kind: the PROFILE
+/// is policy (no consumer of this verb reads the edge) and the ABLATION is
+/// measurement (the flag that licensed the policy, kept alive so the claim
+/// stays re-checkable). Either suppresses; neither implies the other.
+pub(crate) fn should_stamp_method_targets(
+    profile: EnrichmentProfile,
+    ablation_set: bool,
+) -> bool {
+    profile.stamps_method_targets() && !ablation_set
+}
+
+impl FileAnalysis {
     pub fn enrich_imported_types_with_keys(
         &mut self,
         module_index: Option<&dyn CrossFileLookup>,
@@ -619,11 +725,26 @@ impl FileAnalysis {
         // edge; this re-derives it with the index so cross-file-typed
         // invocants resolve. Single-sourced: refs_to / find_def / hover
         // read this frozen edge, never re-derive at query time.
-        // ABLATION GATE (measurement, not a mode): `PERL_LSP_SKIP_MC_STAMP=1`
-        // skips the re-stamp so a verb can be diffed byte-for-byte with and
-        // without it — the decisive test for "does this verb read the edge".
-        if std::env::var_os("PERL_LSP_SKIP_MC_STAMP").is_none() {
+        // Two gates, and they are different things.
+        //
+        // The PROFILE is policy: a verb whose consumers never read
+        // `method_target()` does not pay to fill it. Asked of the profile, so
+        // this code never learns which verb it serves.
+        //
+        // `PERL_LSP_SKIP_MC_STAMP` stays as MEASUREMENT: it is how the profile
+        // was licensed in the first place ("does this verb read the edge?"),
+        // and keeping the A/B alive is what lets the next person re-check the
+        // claim instead of trusting this comment.
+        let profile_wants = enrichment_profile().stamps_method_targets();
+        let ablation = std::env::var_os("PERL_LSP_SKIP_MC_STAMP").is_some();
+        if should_stamp_method_targets(enrichment_profile(), ablation) {
             self.stamp_method_call_targets(module_index);
+        } else {
+            crate::util::ghost_stats::count(if profile_wants {
+                "enrich.mc_stamp_skipped_by_ablation"
+            } else {
+                "enrich.mc_stamp_skipped_by_profile"
+            });
         }
         self.rebuild_enrichment_indices();
     }
@@ -1077,4 +1198,51 @@ impl FileAnalysis {
     }
 
 
+}
+
+#[cfg(test)]
+mod profile_tests {
+    use super::*;
+
+    /// The A/B control must win over a declared profile.
+    ///
+    /// Get this backwards and nothing fails: the control silently stops
+    /// working, and every future "output is set-identical with the profile"
+    /// claim becomes unfalsifiable because the full behaviour is no longer
+    /// reachable to compare against. That is the same shape as a watcher that
+    /// cannot tell quiet from blind — it reports success by being unable to
+    /// look.
+    #[test]
+    fn the_full_override_beats_a_declared_profile() {
+        assert!(
+            resolve_profile(Some(EnrichmentProfile::diagnostics()), true)
+                .stamps_method_targets(),
+            "PERL_LSP_FULL_ENRICHMENT must restore the full profile, or the A/B \
+             that licensed the partial one can never be re-run"
+        );
+        assert!(
+            !resolve_profile(Some(EnrichmentProfile::diagnostics()), false)
+                .stamps_method_targets(),
+            "without the override, the declared profile stands"
+        );
+        assert!(
+            resolve_profile(None, false).stamps_method_targets(),
+            "an undeclared profile is FULL — a server verb must never get a \
+             partial one by omission"
+        );
+    }
+
+    /// Profile and ablation are independent suppressors, and the truth table
+    /// is the whole contract: policy says "no consumer reads it", measurement
+    /// says "prove that". Collapsing them into one flag would make the
+    /// licensing evidence and the thing it licenses the same switch.
+    #[test]
+    fn either_the_profile_or_the_ablation_suppresses_the_stamp() {
+        let full = EnrichmentProfile::full();
+        let diag = EnrichmentProfile::diagnostics();
+        assert!(should_stamp_method_targets(full, false), "full + no ablation stamps");
+        assert!(!should_stamp_method_targets(full, true), "the ablation alone suppresses");
+        assert!(!should_stamp_method_targets(diag, false), "the profile alone suppresses");
+        assert!(!should_stamp_method_targets(diag, true), "both suppress");
+    }
 }

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -329,10 +329,74 @@ pub(crate) fn should_stamp_method_targets(
     profile.stamps_method_targets() && !ablation_set
 }
 
+/// Score every re-stamp the gate skipped, by running it anyway and comparing.
+///
+/// The gate's soundness is inherited, not proved: it is exactly as sound as
+/// the freshness edges that feed `dirty_consumers`, and a provider whose change
+/// never reaches them marks nobody. A wrong skip is silent — the frozen
+/// `MethodTarget` simply stays as it was, and goto-def keeps answering it — so
+/// the assumption ships with the switch that checks it, the same discipline as
+/// `PERL_LSP_CONCL_EQUIV` and `PERL_LSP_FLUSH_EQUIV`.
+///
+/// Costs strictly more than not gating at all, by design. It is a measurement
+/// mode, not a safety net for production.
+fn restamp_gate_equiv() -> bool {
+    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *V.get_or_init(|| std::env::var("PERL_LSP_RESTAMP_EQUIV").is_ok())
+}
+
 impl FileAnalysis {
+    /// Run the skipped re-stamp and report whether it would have changed an
+    /// answer. `PERL_LSP_RESTAMP_EQUIV` only.
+    fn score_restamp_gate_skip(
+        &mut self,
+        module_index: Option<&dyn CrossFileLookup>,
+        path: Option<&std::path::Path>,
+    ) {
+        let before: Vec<Option<MethodTarget>> =
+            self.refs.iter().map(|r| r.method_target().cloned()).collect();
+        self.stamp_method_call_targets(module_index);
+        let diverged = self
+            .refs
+            .iter()
+            .map(|r| r.method_target().cloned())
+            .zip(before.iter())
+            .filter(|(now, was)| now != *was)
+            .count();
+        if diverged > 0 {
+            crate::util::ghost_stats::count_by("restampequiv.break", diverged as u64);
+            log::warn!(
+                "restamp equiv: the gate skipped {} target(s) that WOULD have \
+                 changed in {:?} — a provider moved without marking this file, \
+                 so the freshness edge that should have covered it does not",
+                diverged,
+                path
+            );
+        } else {
+            crate::util::ghost_stats::count("restampequiv.agreed");
+        }
+    }
+
+    /// Enrich without saying which file this is.
+    ///
+    /// The re-stamp gate needs a path — a `FileAnalysis` does not know its own
+    /// — so this spelling always fails the gate open and re-stamps, which is
+    /// the behavior every caller had before the gate existed. Production
+    /// enrichment writers, which do hold the path, call
+    /// `enrich_imported_types_with_keys_for`.
     pub fn enrich_imported_types_with_keys(
         &mut self,
         module_index: Option<&dyn CrossFileLookup>,
+    ) {
+        self.enrich_imported_types_with_keys_for(module_index, None)
+    }
+
+    /// Enrich as `path`, so the re-stamp gate can ask whether any provider of
+    /// this file has moved since it last stamped.
+    pub fn enrich_imported_types_with_keys_for(
+        &mut self,
+        module_index: Option<&dyn CrossFileLookup>,
+        path: Option<&std::path::Path>,
     ) {
         crate::util::ghost_stats::count("enrich_imported_types_with_keys");
         // Truncate back to baseline so repeated enrichment doesn't
@@ -735,10 +799,32 @@ impl FileAnalysis {
         // was licensed in the first place ("does this verb read the edge?"),
         // and keeping the A/B alive is what lets the next person re-check the
         // claim instead of trusting this comment.
+        //
+        // The GATE is neither: it is the freshness question. A re-stamp
+        // re-derives what the build already froze unless some provider of
+        // this file has moved, and the flush is what knows that — see
+        // `CrossFileLookup::restamp_owed`. Every unknown fails open.
         let profile_wants = enrichment_profile().stamps_method_targets();
         let ablation = std::env::var_os("PERL_LSP_SKIP_MC_STAMP").is_some();
         if should_stamp_method_targets(enrichment_profile(), ablation) {
-            self.stamp_method_call_targets(module_index);
+            let owed = match (path, module_index) {
+                (Some(p), Some(idx)) => idx.restamp_owed(p, self.stamped_at),
+                _ => true,
+            };
+            if owed {
+                self.stamp_method_call_targets(module_index);
+                if let Some(idx) = module_index {
+                    // Recorded only for a stamp that ran WITH the index: a
+                    // build-time stamp resolved nothing cross-file, so
+                    // treating it as a stamp would license skipping the very
+                    // first enrichment re-stamp — the one with the most to
+                    // add. The clock is read AFTER the stamp, so a wave that
+                    // lands mid-stamp is not credited to it.
+                    self.stamped_at = Some(idx.flush_epoch());
+                }
+            } else if restamp_gate_equiv() {
+                self.score_restamp_gate_skip(module_index, path);
+            }
         } else {
             crate::util::ghost_stats::count(if profile_wants {
                 "enrich.mc_stamp_skipped_by_ablation"
@@ -1244,5 +1330,181 @@ mod profile_tests {
         assert!(!should_stamp_method_targets(full, true), "the ablation alone suppresses");
         assert!(!should_stamp_method_targets(diag, false), "the profile alone suppresses");
         assert!(!should_stamp_method_targets(diag, true), "both suppress");
+    }
+}
+
+#[cfg(test)]
+mod restamp_gate_tests {
+    use crate::model::file_analysis::CrossFileLookup;
+    use std::path::{Path, PathBuf};
+
+    /// A lookup that answers only the gate, so the gate's rules can be tested
+    /// without an index. Everything else takes the trait's defaults.
+    struct Marks {
+        epoch: u64,
+        marks: Vec<(PathBuf, u64)>,
+    }
+    /// The required-method boilerplate every `CrossFileLookup` double pays.
+    /// None of it participates in the gate — the gate's inputs are the path
+    /// and the file's own `stamped_at`, by design.
+    macro_rules! inert_lookup {
+        () => {
+            fn get_cached(
+                &self,
+                _m: &str,
+            ) -> Option<std::sync::Arc<crate::model::file_analysis::CachedModule>> {
+                None
+            }
+            fn modules_with_symbol(&self, _n: &str) -> Vec<String> {
+                Vec::new()
+            }
+            fn find_exporters(&self, _n: &str) -> Vec<String> {
+                Vec::new()
+            }
+            fn defining_module_cached(
+                &self,
+                _e: &str,
+                _n: &str,
+            ) -> Option<std::sync::Arc<crate::model::file_analysis::CachedModule>> {
+                None
+            }
+            fn module_declaring_method_in_package(
+                &self,
+                _p: &str,
+                _m: &str,
+            ) -> Option<String> {
+                None
+            }
+            fn for_each_cached(
+                &self,
+                _f: &mut dyn FnMut(&str, &std::sync::Arc<crate::model::file_analysis::CachedModule>),
+            ) {
+            }
+            fn for_each_reexport_module(
+                &self,
+                _s: Vec<String>,
+                _v: &mut dyn FnMut(
+                    &std::sync::Arc<crate::model::file_analysis::CachedModule>,
+                ) -> std::ops::ControlFlow<()>,
+            ) {
+            }
+            fn for_each_entity_bridged_to(
+                &self,
+                _c: &str,
+                _f: &mut dyn FnMut(
+                    &str,
+                    &std::sync::Arc<crate::model::file_analysis::CachedModule>,
+                    &crate::model::file_analysis::Symbol,
+                ),
+            ) {
+            }
+            fn direct_children_of(&self, _p: &str) -> Vec<(String, String)> {
+                Vec::new()
+            }
+            fn for_each_loader_shape(
+                &self,
+                _f: &mut dyn FnMut(&str, &crate::model::file_analysis::InferredType),
+            ) {
+            }
+        };
+    }
+
+    impl CrossFileLookup for Marks {
+        inert_lookup!();
+        fn flush_epoch(&self) -> u64 {
+            self.epoch
+        }
+        fn restamp_owed(&self, path: &Path, stamped_at: Option<u64>) -> bool {
+            let Some(stamped_at) = stamped_at else { return true };
+            match self.marks.iter().find(|(p, _)| p == path) {
+                Some((_, m)) => stamped_at < *m,
+                None => true,
+            }
+        }
+    }
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    /// Every unknown fails OPEN — to a re-stamp, never away from one.
+    ///
+    /// This is the property that lets the gate land before the flush is the
+    /// standing path: with no marks written, it says "owed" everywhere and
+    /// behaviour is what it was before the gate existed. A gate whose default
+    /// were "skip" would silently freeze stale dispatch targets across a whole
+    /// session and look like a speedup.
+    #[test]
+    fn every_unknown_fails_open_to_a_re_stamp() {
+        let none = Marks { epoch: 7, marks: Vec::new() };
+        assert!(
+            none.restamp_owed(&p("/A.pm"), Some(5)),
+            "no mark means no wave has spoken about this file — which is also \
+             what a lost mark and an uncovered freshness edge look like"
+        );
+        assert!(
+            none.restamp_owed(&p("/A.pm"), None),
+            "never stamped is owed unconditionally: a rehydrated copy always \
+             reads None, because `stamped_at` is serde(skip)"
+        );
+        let marked = Marks { epoch: 7, marks: vec![(p("/A.pm"), 6)] };
+        assert!(
+            marked.restamp_owed(&p("/A.pm"), None),
+            "never stamped beats any mark — the very first enrichment re-stamp \
+             is the one with the most to add"
+        );
+        assert!(
+            marked.restamp_owed(&p("/B.pm"), Some(5)),
+            "a mark on A says nothing about B"
+        );
+    }
+
+    /// The gate skips only on positive evidence: this file stamped at or after
+    /// the last epoch a provider of it moved.
+    #[test]
+    fn a_stamp_at_or_after_the_mark_skips() {
+        let m = Marks { epoch: 9, marks: vec![(p("/A.pm"), 4)] };
+        assert!(!m.restamp_owed(&p("/A.pm"), Some(4)), "stamped AT the mark: covered");
+        assert!(!m.restamp_owed(&p("/A.pm"), Some(9)), "stamped after it: covered");
+        assert!(
+            m.restamp_owed(&p("/A.pm"), Some(3)),
+            "stamped before the provider moved: the frozen targets predate the \
+             change and must be re-derived"
+        );
+    }
+
+    /// Clock reading 0 is a REAL stamp, not "never".
+    ///
+    /// Every stamp taken before the first flush records 0. Collapsing that
+    /// into the never-stamped sentinel makes it compare equal to the first
+    /// wave's mark — which is 1 — only if the sentinel is bumped to 1 to stay
+    /// distinguishable, and then the pre-flush stamp silently satisfies a mark
+    /// that postdates it. `Option` is what keeps the two apart; this is the
+    /// case that fails without it.
+    #[test]
+    fn a_stamp_taken_before_any_flush_is_still_owed_after_the_first_one() {
+        let m = Marks { epoch: 1, marks: vec![(p("/A.pm"), 1)] };
+        assert!(
+            m.restamp_owed(&p("/A.pm"), Some(0)),
+            "the stamp read the clock as 0, the wave marked at 1: the stamp \
+             predates the provider move and the re-stamp is owed"
+        );
+    }
+
+    /// The trait's own default is fail-open.
+    ///
+    /// Every `CrossFileLookup` that does not implement the gate — the test
+    /// doubles, the scoped wrappers, anything added later — must re-stamp. An
+    /// implementor that silently inherited "skip" would disable the re-stamp
+    /// for a whole class of lookups and nothing would fail.
+    #[test]
+    fn the_trait_default_re_stamps() {
+        struct Bare;
+        impl CrossFileLookup for Bare {
+            inert_lookup!();
+        }
+        assert!(Bare.restamp_owed(&p("/A.pm"), Some(42)));
+        assert!(Bare.restamp_owed(&p("/A.pm"), None));
+        assert_eq!(Bare.flush_epoch(), 0);
     }
 }

--- a/src/model/file_analysis/file_analysis_tests.rs
+++ b/src/model/file_analysis/file_analysis_tests.rs
@@ -2776,3 +2776,68 @@ fn deep_isa_chain_within_visit_budget_still_resolves() {
         "depth 149 > the graph walker's 21, visits 150 < the isa budget 200: must hold"
     );
 }
+
+/// The re-stamp gate, honoured end to end — the skip actually happens, and the
+/// next wave un-skips it.
+///
+/// `restamp_gate_tests` covers the decision; this covers enrichment obeying it,
+/// which is the half that can rot silently. A gate that always answered "skip"
+/// and a gate that was never consulted look identical from the decision tests,
+/// and both look identical from every other suite, because a `MethodTarget`
+/// that is never re-derived simply keeps answering whatever it last held.
+///
+/// The observable is a poisoned binding: a re-stamp overwrites it, a skip
+/// leaves it. Nothing else in enrichment writes a baseline ref's binding, so
+/// the sentinel surviving means exactly one thing.
+#[test]
+fn a_marked_file_re_stamps_and_an_unmarked_one_skips() {
+    use crate::index::module_index::ModuleIndex;
+    use crate::model::file_analysis::{MethodTarget, RefBinding};
+
+    let path = std::path::PathBuf::from("/tmp/RestampGate.pm");
+    let mut fa = build_fa_from_source(
+        "package RestampGate;\nsub go { my $self = shift; return $self->hit }\nsub hit { return 1 }\n1;\n",
+    );
+    let idx = ModuleIndex::new_for_test();
+
+    let mc = |fa: &FileAnalysis| {
+        fa.refs
+            .iter()
+            .position(|r| matches!(r.kind, RefKind::MethodCall { .. }) && r.target_name == "hit")
+            .expect("the `$self->hit` MethodCall ref")
+    };
+    let i = mc(&fa);
+
+    // A wave marks the file, so the next enrichment is owed a re-stamp.
+    let epoch = idx.mark_provider_diff([path.clone()]);
+    fa.enrich_imported_types_with_keys_for(Some(&idx), Some(&path));
+    assert_eq!(
+        fa.stamped_at,
+        Some(epoch),
+        "the stamp records the clock as it read it"
+    );
+    let stamped = fa.refs[i].method_target().cloned();
+    assert!(stamped.is_some(), "precondition: the stamp resolves this call");
+
+    // Poison it. With no NEW mark, the file's stamp is at or past the only
+    // mark there is, so the gate must skip and the poison must survive.
+    fa.refs[i].binding = Some(RefBinding::Method(MethodTarget::CrossFile {
+        invocant_class: "SENTINEL".into(),
+    }));
+    fa.enrich_imported_types_with_keys_for(Some(&idx), Some(&path));
+    assert_eq!(
+        fa.refs[i].method_target().map(|t| t.invocant_class()),
+        Some("SENTINEL"),
+        "no provider moved since the last stamp, so the re-stamp is re-deriving \
+         what it already froze — the gate must skip it"
+    );
+
+    // A second wave re-opens the debt; the poison is overwritten.
+    idx.mark_provider_diff([path.clone()]);
+    fa.enrich_imported_types_with_keys_for(Some(&idx), Some(&path));
+    assert_eq!(
+        fa.refs[i].method_target().cloned(),
+        stamped,
+        "a provider moved, so the re-stamp runs and re-derives the real target"
+    );
+}

--- a/src/model/file_analysis/lifecycle.rs
+++ b/src/model/file_analysis/lifecycle.rs
@@ -92,6 +92,7 @@ impl FileAnalysis {
         } = parts;
         witnesses.rebuild_index();
         let mut fa = FileAnalysis {
+            stamped_at: None,
             pack,
             plugin,
             scopes,

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -164,6 +164,23 @@ pub struct FileAnalysis {
     #[serde(skip, default)]
     bag_evicted: bool,
 
+    /// What the flush clock read when `stamp_method_call_targets` last ran
+    /// WITH the index; `None` for never.
+    ///
+    /// `Option` rather than a sentinel `0`, because 0 is a real clock reading
+    /// — the one every stamp taken before the first flush records — and
+    /// collapsing it into "never" makes a pre-flush stamp compare equal to the
+    /// first wave's mark and skip a re-stamp it was owed.
+    ///
+    /// `#[serde(skip)]` deliberately, and that is what makes the re-stamp gate
+    /// safe rather than merely cheap. The mark it is compared against
+    /// (`CrossFileLookup::restamp_owed`) lives in RAM and dies with the
+    /// process; a stamp record that OUTLIVED its marks would compare a real
+    /// stamp against a lost mark and skip a re-stamp that was owed. Both facts
+    /// are sessional, so they die together and a fresh process fails open.
+    #[serde(skip, default)]
+    pub stamped_at: Option<u64>,
+
     /// Witness-bag baseline — `enrich_imported_types_with_keys`
     /// truncates back to this length before re-deriving so repeat
     /// calls stay idempotent.

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -38,6 +38,7 @@ mod ancestry;
 pub use ancestry::*;
 mod queries;
 mod enrichment;
+pub use enrichment::{declare_enrichment_profile, enrichment_profile, EnrichmentProfile};
 mod class_queries;
 mod cursor_queries;
 mod invocants;

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -38,7 +38,7 @@ mod ancestry;
 pub use ancestry::*;
 mod queries;
 mod enrichment;
-pub use enrichment::{declare_enrichment_profile, enrichment_profile, EnrichmentProfile};
+pub use enrichment::{declare_enrichment_profile, EnrichmentProfile};
 mod class_queries;
 mod cursor_queries;
 mod invocants;

--- a/src/model/file_analysis/surface_feed.rs
+++ b/src/model/file_analysis/surface_feed.rs
@@ -126,6 +126,7 @@ impl FileAnalysis {
             bag_evicted: _bag_evicted,
             degraded: _degraded,
             base_witness_count: _base_witness_count,
+            stamped_at: _stamped_at, // sessional re-stamp bookkeeping; a consumer's view of this file does not change when we last stamped it
 
             // ---- Derived indices, rebuilt from the tables above.
             scope_starts: _scope_starts,

--- a/src/model/surface.rs
+++ b/src/model/surface.rs
@@ -118,6 +118,18 @@ pub struct Surface {
     pub imports: Vec<String>,
     pub exports: Vec<String>,
     pub exports_ok: Vec<String>,
+    /// Plugin loads that carry a config value: load-name → the value's shape,
+    /// sorted.
+    ///
+    /// Cross-file-visible even though it names nothing this file exports. The
+    /// LOADED module's `register($self, $conf)` gets `$conf` typed from here,
+    /// and its consumers' unknown-hash-key diagnostics key off the resulting
+    /// CLOSED shape — so an edit that only adds a key to the config hash
+    /// changes no member anywhere and must still flip the verdict. Without it
+    /// the verdict reads Unchanged, no open consumer re-enriches, and every one
+    /// of them keeps diagnosing against the old key set for the rest of the
+    /// session.
+    pub loader_shapes: Vec<(String, InferredType)>,
     /// `%EXPORT_TAGS` membership, tag → sorted members. A member moving
     /// between tags (or a tag rename) changes what a consumer's
     /// `use Foo qw(:tag)` binds even when the flat `exports_ok` set is
@@ -314,6 +326,21 @@ impl Surface {
             .collect();
         imports.sort_unstable();
         imports.dedup();
+        // Resolved here rather than carried on the fact: `project` runs on the
+        // WHOLE analysis before any eviction (`prepare_workspace_parts` /
+        // `prepare_pack_parts` own that ordering), so the bag is present and
+        // this needs no second copy of the answer to keep in sync.
+        let mut loader_shapes: Vec<(String, InferredType)> = feed
+            .plugin_loads
+            .iter()
+            .filter_map(|f| {
+                let t = fa.expr_type_at_span(f.config_span?, None)?;
+                Some((f.name.clone(), despan(&t)))
+            })
+            .collect();
+        loader_shapes
+            .sort_by(|a, b| (&a.0, format!("{:?}", a.1)).cmp(&(&b.0, format!("{:?}", b.1))));
+        loader_shapes.dedup();
         let sorted = |v: &[String]| {
             let mut v = v.to_vec();
             v.sort_unstable();
@@ -363,6 +390,7 @@ impl Surface {
             imports,
             exports: sorted(feed.export),
             exports_ok: sorted(feed.export_ok),
+            loader_shapes,
             export_tags,
             reexports: sorted(feed.reexport_modules),
             plugin_bridges,

--- a/src/model/surface_tests.rs
+++ b/src/model/surface_tests.rs
@@ -115,6 +115,36 @@ fn surface_changing_edits_are_unequal() {
     assert_ne!(s0, surface(&add_import), "import change must change the surface");
 }
 
+/// A key added to a plugin's config hash changes no member anywhere, and is
+/// cross-file semantics all the same: the LOADED module's `register($self,
+/// $conf)` gets `$conf` typed from this value, and its consumers'
+/// unknown-hash-key diagnostics key off the resulting closed shape.
+///
+/// Without the `loader_shapes` arm the verdict reads Unchanged, no open
+/// consumer re-enriches, and every one of them keeps diagnosing against the old
+/// key set for the rest of the session — the invalidation half of the same bug
+/// #155 fixed the read half of.
+///
+/// Base-verify by projecting an empty `loader_shapes`: the precondition fails.
+#[test]
+fn a_config_shape_edit_flips_the_verdict() {
+    let base = "package My::App;\nuse Mojolicious::Lite;\n\
+                plugin 'CloveApp', { alpha => 1, beta => 2 };\n1;\n";
+    let s0 = surface(base);
+    assert!(
+        !s0.loader_shapes.is_empty(),
+        "precondition: the load's config shape reaches the surface; got {:?}",
+        s0.loader_shapes
+    );
+    let widened = base.replace("beta => 2", "beta => 2, gamma => 3");
+    assert_ne!(
+        s0,
+        surface(&widened),
+        "a key added to the config hash must change the surface — it changes \
+         what the loaded module's $conf closes over"
+    );
+}
+
 /// `%EXPORT_TAGS` grouping is cross-file semantics on its own: moving a
 /// member between tags keeps the flat `exports_ok` set identical while
 /// changing what a consumer's `use Foo qw(:tag)` binds — the verdict must

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -204,6 +204,51 @@ fn fresh_receiver(incoming: Option<&InferredType>, class: &str) -> InferredType 
     }
 }
 
+/// Whether an absent key may be trusted as a proven `None`.
+///
+/// OFF, because it is measurably unsound today — and the prize for fixing it
+/// is large enough to say exactly how large.
+///
+/// Trusting absence takes the consult chase from 2,435 ms to 402 ms on a warm
+/// substrate check: an 83% cut in the compute half this whole design targets.
+/// Absence fires 126,767 times there against 1,304 served answers, so without
+/// it the layer is worth under 1% of consults. It is the win.
+///
+/// It is also wrong 633 times out of those 126,767 — 0.5%. `PERL_LSP_CONCL_EQUIV`
+/// runs the chase anyway and compares: the map reports
+/// `MethodOnClass{Mojo::EventEmitter, new}` absent while the chase answers
+/// `ClassName("Mojo::Server")`. Receiver-polymorphic constructors inherited
+/// from a parent have no attachment in the child's bag, so the bake never
+/// enumerates a key for them, and absence is read as a proof it never was.
+///
+/// WHAT MAKES THIS WORTH A COMMENT rather than a TODO: gold passes 502/0 with
+/// absence trusted, and `--dump-package` is byte-identical across Catalyst
+/// (145 KB), Type::Tiny (109 KB), Mojolicious (50 KB) and Moose (7 KB). Every
+/// end-to-end check we own says it is fine. They pass because the ladder
+/// routes around the missing answer — the parent walk finds it further up — so
+/// the output agrees and only the cost differs. End-to-end equality does not
+/// validate an intermediate claim when the system can route around the error.
+///
+/// Turn this on once the enumeration covers inherited and reducer-synthesized
+/// keys, and keep `PERL_LSP_CONCL_EQUIV` green over a real corpus as the proof.
+pub fn trust_absent_conclusions() -> bool {
+    static TRUST: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *TRUST.get_or_init(|| std::env::var("PERL_LSP_TRUST_ABSENT").is_ok())
+}
+
+/// Verify each trusted absence against the path it replaces.
+///
+/// Same shape as `PERL_LSP_PD_EQUIV` for pattern dispatch: a fast path whose
+/// justification is empirical ships WITH the means to re-check it, rather than
+/// with a note asking the reader to believe the measurement. Under this flag
+/// an absent key still runs the decode and the chase, and a disagreement is
+/// reported — so the gold harness can assert the equivalence over a real
+/// corpus instead of the four packages a person happened to dump.
+pub fn verify_absent_conclusions() -> bool {
+    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *V.get_or_init(|| std::env::var("PERL_LSP_CONCL_EQUIV").is_ok())
+}
+
 /// The process-wide default registry.
 ///
 /// The bake runs per file on the persist path, and `with_defaults()` allocates
@@ -227,7 +272,54 @@ pub fn bake(
     registry: &ReducerRegistry,
     local_packages: &std::collections::HashSet<String>,
 ) -> ConclusionMap {
+    bake_with_symbols(bag, registry, local_packages, &[])
+}
+
+/// `bake`, plus the keys the file's SYMBOLS imply.
+///
+/// The attachment index alone is not the set of keys the bag can answer, and
+/// the difference is the whole soundness of "absent means None". A method the
+/// live chase resolves through an inheritance edge or a reducer's synthesis
+/// may carry no witnesses of its own, so it never appears in the index — and a
+/// key missing from the map is read as a proven `None`.
+///
+/// The declared symbols close most of that gap: `bake_one` runs the REGISTRY
+/// on the attachment, so a witness-less `MethodOnClass` still gets whatever
+/// answer the live path would give it, including one composed entirely from
+/// edges.
+pub fn bake_with_symbols(
+    bag: &WitnessBag,
+    registry: &ReducerRegistry,
+    local_packages: &std::collections::HashSet<String>,
+    symbols: &[(Option<String>, String, bool)],
+) -> ConclusionMap {
     let mut map = HashMap::new();
+    let mut enumerate = |att: WitnessAttachment, map: &mut HashMap<_, _>| {
+        let Some(key) = ConclusionKey::from_attachment(&att) else {
+            return;
+        };
+        if map.contains_key(&key) {
+            return;
+        }
+        let c = bake_one(bag, registry, &att, local_packages);
+        map.insert(key, c);
+    };
+    // Declared subs and methods first, so the attachment-index pass below
+    // sees them already present and does not re-derive.
+    for (package, name, is_callable) in symbols {
+        if !*is_callable {
+            continue;
+        }
+        if let Some(pkg) = package {
+            enumerate(
+                WitnessAttachment::MethodOnClass {
+                    class: pkg.clone(),
+                    name: name.clone(),
+                },
+                &mut map,
+            );
+        }
+    }
     for att in bag.attachments() {
         let Some(key) = ConclusionKey::from_attachment(att) else {
             continue;

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -269,6 +269,49 @@ pub fn verify_absent_conclusions() -> bool {
     *V.get_or_init(|| std::env::var("PERL_LSP_CONCL_EQUIV").is_ok())
 }
 
+/// Marks the calling thread as running a BAKE rather than a live query.
+///
+/// The exit sites below cannot tell the difference on their own — both see
+/// `module_index: None` — and only a bake's misses are candidates for
+/// residualization. A live query with no index is an ordinary degraded lookup
+/// and must not be counted.
+pub struct BakeScope;
+
+thread_local! {
+    static IN_BAKE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+impl BakeScope {
+    pub fn enter() -> Self {
+        IN_BAKE.with(|f| f.set(true));
+        BakeScope
+    }
+}
+
+impl Drop for BakeScope {
+    fn drop(&mut self) {
+        IN_BAKE.with(|f| f.set(false));
+    }
+}
+
+/// Record that a bake reached a point where it would have consulted the index.
+///
+/// `nameable` says whether the would-be target has a portable `ConclusionKey`.
+/// The split is the whole decision: only a nameable exit can become a `Link`,
+/// so the ratio says how much of the `OpenNone` population this line of work
+/// can actually reach, and whether it is worth building the machinery for.
+pub fn note_bake_exit(site: &'static str, nameable: bool) {
+    if !IN_BAKE.with(|f| f.get()) {
+        return;
+    }
+    crate::util::ghost_stats::count(if nameable {
+        "residual.nameable"
+    } else {
+        "residual.poisoned"
+    });
+    crate::util::ghost_stats::count(&format!("residual.site.{site}"));
+}
+
 /// The process-wide default registry.
 ///
 /// The bake runs per file on the persist path, and `with_defaults()` allocates
@@ -350,6 +393,7 @@ pub fn bake_in_context(
     parents: &[(String, Vec<String>)],
     ctx: Option<&super::reducers::BagContext<'_>>,
 ) -> ConclusionMap {
+    let _bake = BakeScope::enter();
     let mut map = HashMap::new();
     let mut enumerate = |att: WitnessAttachment, map: &mut HashMap<_, _>| {
         let Some(key) = ConclusionKey::from_attachment(&att) else {

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -269,6 +269,14 @@ pub fn verify_absent_conclusions() -> bool {
     *V.get_or_init(|| std::env::var("PERL_LSP_CONCL_EQUIV").is_ok())
 }
 
+/// How many map-to-map hops a `Follow` may take before giving up.
+///
+/// A `Link` chain is a graph walk over files, so it needs a bound of its own —
+/// the live chase's `VisitedKey` guards the live chase, not this projection. A
+/// cycle is caught by the visited set; the cap catches a long-but-acyclic
+/// chain, where continuing costs more than the decode it is replacing.
+pub const MAX_FOLLOW_HOPS: usize = 8;
+
 /// Marks the calling thread as running a BAKE rather than a live query.
 ///
 /// The exit sites below cannot tell the difference on their own — both see

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -99,7 +99,21 @@ pub enum Conclusion {
 
 /// Per-file map, persisted beside the blob and invalidated with it.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct ConclusionMap(pub HashMap<ConclusionKey, Conclusion>);
+pub struct ConclusionMap(
+    pub HashMap<ConclusionKey, Conclusion>,
+    /// Classes whose absence is CONCLUSIVE — every ancestor is declared in
+    /// this file, so a key missing from the map really is a proven `None`.
+    ///
+    /// The property belongs to the class, not the key. A class with a
+    /// cross-file parent can be asked about a method it inherits, which has no
+    /// attachment in this file's bag and therefore no key here — and reading
+    /// that absence as `None` is wrong 633 times per substrate check. We
+    /// cannot enumerate those keys (they are the PARENT's method names, which
+    /// this file does not know), so the answerable question is which classes
+    /// can be reasoned about at all.
+    #[serde(default)]
+    pub std::collections::HashSet<String>,
+);
 
 impl ConclusionMap {
     pub fn len(&self) -> usize {
@@ -126,9 +140,15 @@ impl ConclusionMap {
         args: &[InferredType],
     ) -> Outcome {
         let Some(c) = self.0.get(key) else {
-            // ABSENT. Sound only because the bake enumerates every key the bag
-            // could answer; a missed key would silently become None here.
-            return Outcome::None;
+            // ABSENT. Conclusive only for a class this file can reason about
+            // completely — see the `closed` field. For anything else the honest
+            // answer is "I do not know", which is a decode.
+            return match key {
+                ConclusionKey::MethodOnClass { class, .. } if !self.1.contains(class) => {
+                    Outcome::Decode
+                }
+                _ => Outcome::None,
+            };
         };
         match c {
             Conclusion::Value(t) => Outcome::Answer(t.clone()),
@@ -206,34 +226,34 @@ fn fresh_receiver(incoming: Option<&InferredType>, class: &str) -> InferredType 
 
 /// Whether an absent key may be trusted as a proven `None`.
 ///
-/// OFF, because it is measurably unsound today — and the prize for fixing it
-/// is large enough to say exactly how large.
+/// ON, but only for a class with no ancestors — and the caller enforces that,
+/// not this flag.
 ///
-/// Trusting absence takes the consult chase from 2,435 ms to 402 ms on a warm
-/// substrate check: an 83% cut in the compute half this whole design targets.
-/// Absence fires 126,767 times there against 1,304 served answers, so without
-/// it the layer is worth under 1% of consults. It is the win.
+/// Absence is the layer's win: it fires ~127k times per warm substrate check
+/// against ~1.3k served answers, so a version that cannot trust it is worth
+/// under 1% of consults. Trusting it soundly takes the consult chase from
+/// 2,375.9 ms to 1,817.3 ms and its calls from 109,003 to 63,768.
 ///
-/// It is also wrong 633 times out of those 126,767 — 0.5%. `PERL_LSP_CONCL_EQUIV`
-/// runs the chase anyway and compares: the map reports
-/// `MethodOnClass{Mojo::EventEmitter, new}` absent while the chase answers
-/// `ClassName("Mojo::Server")`. Receiver-polymorphic constructors inherited
-/// from a parent have no attachment in the child's bag, so the bake never
-/// enumerates a key for them, and absence is read as a proof it never was.
+/// The soundness rule took three tries and is worth stating so nobody
+/// relitigates it:
 ///
-/// WHAT MAKES THIS WORTH A COMMENT rather than a TODO: gold passes 502/0 with
-/// absence trusted, and `--dump-package` is byte-identical across Catalyst
-/// (145 KB), Type::Tiny (109 KB), Mojolicious (50 KB) and Moose (7 KB). Every
-/// end-to-end check we own says it is fine. They pass because the ladder
-/// routes around the missing answer — the parent walk finds it further up — so
-/// the output agrees and only the cost differs. End-to-end equality does not
-/// validate an intermediate claim when the system can route around the error.
+///   1. Trust every absence — 633 breaks per check. An inherited method has no
+///      attachment in the child's bag, so no key is enumerated for it.
+///   2. Trust it for classes whose declared parents are all local — 75 breaks.
+///      Perl packages are OPEN: `PPI::XSAccessor` reopens `package PPI::Token`
+///      without repeating its `@ISA`, so that file's bake sees a parentless
+///      class which in fact inherits from `PPI::Element`.
+///   3. Ask the INDEX, through the same `parents_of` every other ancestor walk
+///      uses — 0 breaks. Closedness is a property of the class across ALL
+///      files, and no per-file bake can establish it.
 ///
-/// Turn this on once the enumeration covers inherited and reducer-synthesized
-/// keys, and keep `PERL_LSP_CONCL_EQUIV` green over a real corpus as the proof.
+/// `PERL_LSP_CONCL_EQUIV` is the standing proof rather than a one-off: it runs
+/// the chase anyway and reports any answer an absence claimed did not exist.
+/// Green over the whole substrate. `PERL_LSP_NO_TRUST_ABSENT` reverts to
+/// deferring every absence to a decode.
 pub fn trust_absent_conclusions() -> bool {
     static TRUST: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *TRUST.get_or_init(|| std::env::var("PERL_LSP_TRUST_ABSENT").is_ok())
+    *TRUST.get_or_init(|| std::env::var("PERL_LSP_NO_TRUST_ABSENT").is_err())
 }
 
 /// Verify each trusted absence against the path it replaces.
@@ -293,6 +313,20 @@ pub fn bake_with_symbols(
     local_packages: &std::collections::HashSet<String>,
     symbols: &[(Option<String>, String, bool)],
 ) -> ConclusionMap {
+    bake_full(bag, registry, local_packages, symbols, &[])
+}
+
+/// `bake_with_symbols`, plus each class's declared parents.
+///
+/// Parents decide which classes are CLOSED — reasoned about completely from
+/// this file — and only a closed class may have its absences read as proofs.
+pub fn bake_full(
+    bag: &WitnessBag,
+    registry: &ReducerRegistry,
+    local_packages: &std::collections::HashSet<String>,
+    symbols: &[(Option<String>, String, bool)],
+    parents: &[(String, Vec<String>)],
+) -> ConclusionMap {
     let mut map = HashMap::new();
     let mut enumerate = |att: WitnessAttachment, map: &mut HashMap<_, _>| {
         let Some(key) = ConclusionKey::from_attachment(&att) else {
@@ -349,7 +383,36 @@ pub fn bake_with_symbols(
             }
         }
     }
-    ConclusionMap(map)
+    // A class is closed when every ancestor, transitively, is declared here.
+    // Transitively matters: a local parent with a foreign grandparent inherits
+    // methods this file has never seen, so treating the child as closed would
+    // reintroduce exactly the bug this field exists to stop.
+    let parent_of: HashMap<&str, &Vec<String>> =
+        parents.iter().map(|(c, ps)| (c.as_str(), ps)).collect();
+    let mut closed = std::collections::HashSet::new();
+    for class in local_packages {
+        let mut stack = vec![class.as_str()];
+        let mut seen = std::collections::HashSet::new();
+        let mut ok = true;
+        while let Some(c) = stack.pop() {
+            if !seen.insert(c.to_string()) {
+                continue;
+            }
+            if !local_packages.contains(c) {
+                ok = false;
+                break;
+            }
+            if let Some(ps) = parent_of.get(c) {
+                for p in ps.iter() {
+                    stack.push(p.as_str());
+                }
+            }
+        }
+        if ok {
+            closed.insert(class.clone());
+        }
+    }
+    ConclusionMap(map, closed)
 }
 
 /// One attachment's conclusion.

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -204,6 +204,17 @@ fn fresh_receiver(incoming: Option<&InferredType>, class: &str) -> InferredType 
     }
 }
 
+/// The process-wide default registry.
+///
+/// The bake runs per file on the persist path, and `with_defaults()` allocates
+/// a boxed reducer per entry. Query sites build one per call because they are
+/// answering one question; a bulk index answers thousands and would pay for
+/// the same immutable table every time.
+pub fn shared_registry() -> &'static ReducerRegistry {
+    static REG: std::sync::OnceLock<ReducerRegistry> = std::sync::OnceLock::new();
+    REG.get_or_init(ReducerRegistry::with_defaults)
+}
+
 /// Bake one analysis's bag into a map.
 ///
 /// Runs with `module_index: None` by construction — the caller passes a

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -476,9 +476,24 @@ fn bake_one(
     crate::util::ghost_stats::count("bake.attempted");
     let ReducedValue::Type(t) = bare else {
         crate::util::ghost_stats::count("bake.no_bare_answer");
-        // No answer without binders. That is either a genuine None or a
-        // receiver-dependent shape this function failed to recognize as
-        // `ReturnExpr`; the two are indistinguishable here, so decode.
+        // No answer without binders, and `OpenNone` (decode) rather than
+        // absent (a proven None) — measured, not assumed.
+        //
+        // Treating these as absent looks free: the bake got None, so the live
+        // path surely gets None too. It does not. 56 equivalence breaks per
+        // substrate check, all the same shape — `Log::Log4perl::get_logger`
+        // answering `ClassName("Log::Log4perl::Logger")`, `URI::new` answering
+        // `ClassName("URI::_foreign")`. The bake runs with no module index, so
+        // a chase that EXITS cross-file returns None here and has a real
+        // answer at query time.
+        //
+        // These want to be `Link`, not `OpenNone`. The bake cannot mint one
+        // because the edge it holds is `Edge(Symbol(sid))` — a LOCAL symbol
+        // whose own chase leaves the file — so nothing local names the target.
+        // Widening `Link` past `sole_foreign_edge` needs the registry to
+        // report "I would have consulted the index here, for key K" instead of
+        // returning None: a residualizing mode, which is a design step rather
+        // than a fix. Until then these cost one decode each.
         return Conclusion::OpenNone;
     };
 

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -327,6 +327,29 @@ pub fn bake_full(
     symbols: &[(Option<String>, String, bool)],
     parents: &[(String, Vec<String>)],
 ) -> ConclusionMap {
+    bake_in_context(bag, registry, local_packages, symbols, parents, None)
+}
+
+/// `bake_full` with the file's OWN context — scopes, frameworks, parents.
+///
+/// Withholding the module index is the design (a materialized cross-file value
+/// would freeze a world that can change without this file changing). Withholding
+/// everything else was an accident: passing `context: None` also denies the bake
+/// the file's scopes, per-package frameworks and LOCAL parent edges, so it could
+/// not walk a parent chain that lives entirely in this file. Some of
+/// `bake.no_bare_answer` was that rather than genuine cross-file dependence.
+///
+/// A local-only context is also what makes "where would the chase have gone"
+/// well-posed: with no context at all, the chase stops before it reaches the
+/// point where it would have asked the index.
+pub fn bake_in_context(
+    bag: &WitnessBag,
+    registry: &ReducerRegistry,
+    local_packages: &std::collections::HashSet<String>,
+    symbols: &[(Option<String>, String, bool)],
+    parents: &[(String, Vec<String>)],
+    ctx: Option<&super::reducers::BagContext<'_>>,
+) -> ConclusionMap {
     let mut map = HashMap::new();
     let mut enumerate = |att: WitnessAttachment, map: &mut HashMap<_, _>| {
         let Some(key) = ConclusionKey::from_attachment(&att) else {
@@ -335,7 +358,7 @@ pub fn bake_full(
         if map.contains_key(&key) {
             return;
         }
-        let c = bake_one(bag, registry, &att, local_packages);
+        let c = bake_one(bag, registry, &att, local_packages, ctx);
         map.insert(key, c);
     };
     // Declared subs and methods first, so the attachment-index pass below
@@ -358,7 +381,7 @@ pub fn bake_full(
         let Some(key) = ConclusionKey::from_attachment(att) else {
             continue;
         };
-        let conclusion = bake_one(bag, registry, att, local_packages);
+        let conclusion = bake_one(bag, registry, att, local_packages, ctx);
         match map.entry(key) {
             std::collections::hash_map::Entry::Vacant(v) => {
                 v.insert(conclusion);
@@ -426,6 +449,7 @@ fn bake_one(
     registry: &ReducerRegistry,
     att: &WitnessAttachment,
     local_packages: &std::collections::HashSet<String>,
+    ctx: Option<&super::reducers::BagContext<'_>>,
 ) -> Conclusion {
     // A sole edge to a class this file does not declare is the cross-file
     // hop, and it residualizes rather than resolving. The bake runs with no
@@ -465,9 +489,10 @@ fn bake_one(
                 arity_hint: arity,
                 receiver,
                 args: Vec::new(),
-                // No context: the bake CANNOT reach another file, so every
-                // cross-file fallback residualizes instead of materializing.
-                context: None,
+                // The file's own context, with `module_index: None` — see
+                // `bake_in_context`. The index stays withheld by design; the
+                // rest is what lets a local parent chain resolve at all.
+                context: ctx,
             },
         )
     };

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -1,0 +1,405 @@
+//! Conclusions: the registry chase partially evaluated over one file's bag.
+//!
+//! `docs/prompt-conclusion-layer.md` owns the design. The short version: a
+//! cross-file consult decodes a whole provider bag to answer one question, and
+//! 78% of that cost is the chase rather than the fetch. A conclusion is that
+//! chase run ONCE at persist time with the three query binders
+//! (`ReducerQuery.point` / `.receiver` / `.arity_hint`) and the cross-file
+//! world left free, so the answer can be served without the bag.
+//!
+//! Two rules the whole thing rests on:
+//!
+//! **Edges, not values.** A cross-file answer residualizes as `Link`, never as
+//! a materialized type. Baking the value would freeze the world — the provider
+//! it names can change without this file changing. The constraint is hops
+//! cheaper, never fewer.
+//!
+//! **Absence is not an answer.** A key absent from the map means "the bag
+//! deterministically answers None here"; a key present as `OpenNone` means
+//! "unbakeable, go decode". Those are different, and collapsing them makes a
+//! silent wrong answer out of a key the enumeration missed. `OpenNone` is the
+//! degradation for everything uncertain — a depth cap, an unrecognized
+//! payload, a truncated chase.
+
+use super::registry::ReducerRegistry;
+use super::reducers::{ReducedValue, ReducerQuery};
+use super::types::{FrameworkFact, ReturnExpr, WitnessAttachment};
+use super::WitnessBag;
+use crate::model::file_analysis::InferredType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A portable key: strings only, so it can be looked up in a file that has
+/// never heard of this file's `SymbolId`s or `RefIdx`es.
+///
+/// The internal attachments (`Symbol`, `Expression`, `Expr`, `Variable`,
+/// `SymbolReturnArm`, `BranchArm`) are deliberately absent. They index into
+/// one analysis's tables, so a cross-file consumer cannot resolve them, and
+/// baking them would produce keys that only their own file can read — the
+/// storage cost of a map with none of the benefit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ConclusionKey {
+    MethodOnClass { class: String, name: String },
+    SubByName(String),
+    SlotType { class: String, key: String },
+    TypeName(String),
+}
+
+impl ConclusionKey {
+    /// The portable projection of an attachment, or `None` when the
+    /// attachment is file-internal.
+    pub fn from_attachment(att: &WitnessAttachment) -> Option<Self> {
+        match att {
+            WitnessAttachment::MethodOnClass { class, name } => Some(Self::MethodOnClass {
+                class: class.clone(),
+                name: name.clone(),
+            }),
+            WitnessAttachment::SlotType { class, key } => Some(Self::SlotType {
+                class: class.clone(),
+                key: key.clone(),
+            }),
+            WitnessAttachment::TypeName(n) => Some(Self::TypeName(n.clone())),
+            _ => None,
+        }
+    }
+}
+
+/// How a `Link` treats the evaluating query's receiver as it hops.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ReceiverRule {
+    /// Pass it through unchanged — the inheritance hop, where the call is
+    /// still on the original object.
+    Thread,
+    /// `fresh_dispatch_receiver` semantics: keep the incoming receiver iff its
+    /// class IS this class or a subclass, else substitute `ClassName(class)`.
+    Dispatch(String),
+}
+
+/// One key's partially-evaluated answer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Conclusion {
+    /// Constant in all three binders. The bake has PROVEN that, which is why
+    /// receiver/arity/point are ignored on evaluation rather than merely
+    /// unused.
+    Value(InferredType),
+    /// Depends on receiver and/or args; the existing `ReturnExpr` is exactly
+    /// that dependence, so it is stored and evaluated by the same code the
+    /// live path uses.
+    ReturnOf(ReturnExpr),
+    /// The answer is in another file. Never a value — see "Edges, not values".
+    Link {
+        target: ConclusionKey,
+        arity: Option<u32>,
+        receiver: ReceiverRule,
+    },
+    /// Present, and deliberately unbakeable: decode the blob and run the real
+    /// chase for THIS key. Distinct from absent, which means "None".
+    OpenNone,
+}
+
+/// Per-file map, persisted beside the blob and invalidated with it.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ConclusionMap(pub HashMap<ConclusionKey, Conclusion>);
+
+impl ConclusionMap {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn get(&self, key: &ConclusionKey) -> Option<&Conclusion> {
+        self.0.get(key)
+    }
+
+    /// Evaluate one key against a call site.
+    ///
+    /// Returns `Outcome::Answer` for a resolved value, `Outcome::None` when
+    /// the map proves there is no answer, `Outcome::Decode` when the key is
+    /// `OpenNone` or evaluation could not complete, and `Outcome::Follow` when
+    /// the answer lives in another file.
+    pub fn evaluate(
+        &self,
+        key: &ConclusionKey,
+        receiver: Option<&InferredType>,
+        arity: Option<u32>,
+        args: &[InferredType],
+    ) -> Outcome {
+        let Some(c) = self.0.get(key) else {
+            // ABSENT. Sound only because the bake enumerates every key the bag
+            // could answer; a missed key would silently become None here.
+            return Outcome::None;
+        };
+        match c {
+            Conclusion::Value(t) => Outcome::Answer(t.clone()),
+            Conclusion::ReturnOf(re) => {
+                // The live evaluator, not a copy of it. A second spelling of
+                // `ReturnExpr` semantics is a place for the baked answer to
+                // drift from the answer it is supposed to equal.
+                let att = WitnessAttachment::MethodOnClass {
+                    class: String::new(),
+                    name: String::new(),
+                };
+                let q = ReducerQuery {
+                    attachment: &att,
+                    point: None,
+                    framework: FrameworkFact::Plain,
+                    arity_hint: arity,
+                    receiver: receiver.cloned(),
+                    args: args.to_vec(),
+                    context: None,
+                };
+                match super::reducers::eval_return_expr(re, &q) {
+                    Some(t) => Outcome::Answer(t),
+                    // `Receiver` with no receiver is a legitimate None (the
+                    // live path returns None rather than guessing), so this is
+                    // not a decode.
+                    None => Outcome::None,
+                }
+            }
+            Conclusion::Link {
+                target,
+                arity: link_arity,
+                receiver: rule,
+            } => Outcome::Follow {
+                target: target.clone(),
+                arity: link_arity.or(arity),
+                receiver: match rule {
+                    ReceiverRule::Thread => receiver.cloned(),
+                    ReceiverRule::Dispatch(class) => Some(fresh_receiver(receiver, class)),
+                },
+            },
+            Conclusion::OpenNone => Outcome::Decode,
+        }
+    }
+}
+
+/// What one map lookup produced.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Outcome {
+    Answer(InferredType),
+    /// The map proves no answer — the ladder moves on (parents, next
+    /// candidate) exactly as a local-reducer miss does today.
+    None,
+    /// Unbakeable here. Decode the blob and run the real chase for this key.
+    Decode,
+    /// The answer is in another file; follow with these binders.
+    Follow {
+        target: ConclusionKey,
+        arity: Option<u32>,
+        receiver: Option<InferredType>,
+    },
+}
+
+/// `fresh_dispatch_receiver`'s rule, in the one place the map needs it: keep a
+/// receiver that IS this class (or names it), else substitute the class.
+///
+/// The subclass test the live path does needs an index; without one the
+/// conservative move is to substitute, which is what a receiver-less call
+/// would have produced anyway.
+fn fresh_receiver(incoming: Option<&InferredType>, class: &str) -> InferredType {
+    match incoming {
+        Some(t) if t.class_name().as_deref() == Some(class) => t.clone(),
+        _ => InferredType::ClassName(class.to_string()),
+    }
+}
+
+/// Bake one analysis's bag into a map.
+///
+/// Runs with `module_index: None` by construction — the caller passes a
+/// registry query that cannot reach another file, so every cross-file
+/// fallback residualizes rather than materializing. That is not an
+/// optimization; a materialized cross-file value would freeze a world that
+/// can change without this file changing.
+pub fn bake(
+    bag: &WitnessBag,
+    registry: &ReducerRegistry,
+    local_packages: &std::collections::HashSet<String>,
+) -> ConclusionMap {
+    let mut map = HashMap::new();
+    for att in bag.attachments() {
+        let Some(key) = ConclusionKey::from_attachment(att) else {
+            continue;
+        };
+        let conclusion = bake_one(bag, registry, att, local_packages);
+        match map.entry(key) {
+            std::collections::hash_map::Entry::Vacant(v) => {
+                v.insert(conclusion);
+            }
+            // Two attachments projecting to one key. `from_attachment` is
+            // injective today so this cannot fire, but "cannot fire" is not
+            // something the code says anywhere — and first-wins over
+            // `attachments()`, which is `HashMap::keys()`, would make the
+            // bake depend on iteration order. That is not merely untidy: the
+            // diff-propagation driver cuts its worklist on an EMPTY conclusion
+            // diff, so an order-dependent bake produces spurious diffs that
+            // never cut the chain, and spuriously-empty ones that cut a chain
+            // which should have propagated.
+            //
+            // Disagreement degrades to `OpenNone` — order-independent by
+            // construction, and the safe direction.
+            std::collections::hash_map::Entry::Occupied(mut o) => {
+                if *o.get() != conclusion {
+                    crate::util::ghost_stats::count("bake.key_collision");
+                    o.insert(Conclusion::OpenNone);
+                }
+            }
+        }
+    }
+    ConclusionMap(map)
+}
+
+/// One attachment's conclusion.
+///
+/// Everything uncertain lands on `OpenNone`. The temptation is to bake the
+/// best guess and let the consumer sort it out, but a consumer cannot tell a
+/// guess from a proof, and this map exists precisely so consumers can stop
+/// checking.
+fn bake_one(
+    bag: &WitnessBag,
+    registry: &ReducerRegistry,
+    att: &WitnessAttachment,
+    local_packages: &std::collections::HashSet<String>,
+) -> Conclusion {
+    // A sole edge to a class this file does not declare is the cross-file
+    // hop, and it residualizes rather than resolving. The bake runs with no
+    // module index precisely so this case CANNOT accidentally materialize:
+    // the provider can change without this file changing, and a baked value
+    // would outlive the truth it copied.
+    if let Some(target) = sole_foreign_edge(bag, att, local_packages) {
+        crate::util::ghost_stats::count("bake.link");
+        return Conclusion::Link {
+            target,
+            arity: None,
+            // An inheritance hop keeps the original object as receiver — the
+            // call is still on it, the method just lives up the chain.
+            receiver: ReceiverRule::Thread,
+        };
+    }
+    // A witness carrying a ReturnExpr IS the receiver/arity dependence, so it
+    // is stored as syntax rather than evaluated. Checked before the constant
+    // probe below, because evaluating one of these with no receiver yields
+    // None and would bake as absent — a fluent accessor silently answering
+    // "no type" to every caller.
+    if let Some(re) = sole_return_expr(bag, att) {
+        crate::util::ghost_stats::count("bake.return_of");
+        return Conclusion::ReturnOf(re);
+    }
+
+    // Constant probe. Two queries differing only in their binders must agree
+    // before a `Value` is licensed: an answer that moves with the receiver is
+    // exactly what `Value` may not represent.
+    let probe = |receiver: Option<InferredType>, arity: Option<u32>| -> ReducedValue {
+        registry.query(
+            bag,
+            &ReducerQuery {
+                attachment: att,
+                point: None,
+                framework: FrameworkFact::Plain,
+                arity_hint: arity,
+                receiver,
+                args: Vec::new(),
+                // No context: the bake CANNOT reach another file, so every
+                // cross-file fallback residualizes instead of materializing.
+                context: None,
+            },
+        )
+    };
+
+    let bare = probe(None, None);
+    crate::util::ghost_stats::count("bake.attempted");
+    let ReducedValue::Type(t) = bare else {
+        crate::util::ghost_stats::count("bake.no_bare_answer");
+        // No answer without binders. That is either a genuine None or a
+        // receiver-dependent shape this function failed to recognize as
+        // `ReturnExpr`; the two are indistinguishable here, so decode.
+        return Conclusion::OpenNone;
+    };
+
+    // A receiver the file cannot have produced. If the answer moves, the
+    // conclusion is binder-dependent and must not be a constant.
+    let probed = probe(
+        Some(InferredType::ClassName(
+            "Perl::LSP::ConclusionProbe".to_string(),
+        )),
+        Some(1),
+    );
+    let demote = |why: &'static str| {
+        crate::util::ghost_stats::count(why);
+        Conclusion::OpenNone
+    };
+    match probed {
+        ReducedValue::Type(t2) if t2 == t => {
+            crate::util::ghost_stats::count("bake.value");
+            Conclusion::Value(t)
+        }
+        // Answered differently under a different receiver/arity. That IS
+        // binder-dependence, and not in a shape we can store — decode rather
+        // than freeze whichever of the two answers we happened to see first.
+        ReducedValue::Type(_) => demote("bake.demoted_by_binder_probe"),
+        // Facts, not a type, where the bare probe gave a type. The two probes
+        // disagree about the KIND of answer, which no conclusion form
+        // represents.
+        ReducedValue::FactMap(_) => demote("bake.demoted_kind_disagreement"),
+        // The answer vanished once a receiver was supplied — binder-dependent
+        // in the most direct way there is.
+        ReducedValue::None => demote("bake.demoted_by_binder_probe"),
+    }
+}
+
+/// The single `ReturnExpr` an attachment carries, if it carries exactly one.
+///
+/// Exactly one, deliberately: several would need the fold's agreement rules to
+/// combine them, and re-deriving those here is a second spelling of
+/// `resolve_return_type`. More than one is `OpenNone`'s job.
+/// The one `MethodOnClass` edge pointing at a class this file does not
+/// declare, if there is exactly one and nothing else competes with it.
+///
+/// Exactly one, and nothing else: several edges, or an edge alongside a local
+/// answer, need the registry's ordering rules to arbitrate, and re-deriving
+/// those here is a second spelling of the chase. Those stay `OpenNone`.
+fn sole_foreign_edge(
+    bag: &WitnessBag,
+    att: &WitnessAttachment,
+    local_packages: &std::collections::HashSet<String>,
+) -> Option<ConclusionKey> {
+    let ws = bag.for_attachment(att);
+    let mut found: Option<ConclusionKey> = None;
+    for w in &ws {
+        match &w.payload {
+            super::types::WitnessPayload::Edge(WitnessAttachment::MethodOnClass {
+                class,
+                name,
+            }) if !local_packages.contains(class) => {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(ConclusionKey::MethodOnClass {
+                    class: class.clone(),
+                    name: name.clone(),
+                });
+            }
+            // Anything else on this attachment means the edge is not the whole
+            // story, and the registry decides between them.
+            _ => return None,
+        }
+    }
+    found
+}
+
+fn sole_return_expr(bag: &WitnessBag, att: &WitnessAttachment) -> Option<ReturnExpr> {
+    let mut found: Option<ReturnExpr> = None;
+    for w in bag.for_attachment(att) {
+        if let super::types::WitnessPayload::ReturnExpr(re) = &w.payload {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(re.clone());
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+#[path = "conclusions_tests.rs"]
+mod conclusions_tests;

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -224,9 +224,11 @@ impl ConclusionMap {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+    #[allow(dead_code)] // read by tests; the evaluator goes through `evaluate`
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+    #[allow(dead_code)] // read by tests; the evaluator goes through `evaluate`
     pub fn get(&self, key: &ConclusionKey) -> Option<&Conclusion> {
         self.0.get(key)
     }
@@ -629,6 +631,7 @@ pub fn shared_registry() -> &'static ReducerRegistry {
 /// fallback residualizes rather than materializing. That is not an
 /// optimization; a materialized cross-file value would freeze a world that
 /// can change without this file changing.
+#[allow(dead_code)] // defaulting wrapper over `bake_in_context`; production passes its own context
 pub fn bake(
     bag: &WitnessBag,
     registry: &ReducerRegistry,
@@ -649,6 +652,7 @@ pub fn bake(
 /// on the attachment, so a witness-less `MethodOnClass` still gets whatever
 /// answer the live path would give it, including one composed entirely from
 /// edges.
+#[allow(dead_code)] // see `bake`
 pub fn bake_with_symbols(
     bag: &WitnessBag,
     registry: &ReducerRegistry,
@@ -662,6 +666,7 @@ pub fn bake_with_symbols(
 ///
 /// Parents decide which classes are CLOSED — reasoned about completely from
 /// this file — and only a closed class may have its absences read as proofs.
+#[allow(dead_code)] // see `bake`
 pub fn bake_full(
     bag: &WitnessBag,
     registry: &ReducerRegistry,

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -101,7 +101,55 @@ pub enum Conclusion {
     },
     /// Present, and deliberately unbakeable: decode the blob and run the real
     /// chase for THIS key. Distinct from absent, which means "None".
-    OpenNone,
+    ///
+    /// The reason is carried rather than counted at the bake, because the
+    /// question a widening has to answer is which cause drives DECODES, and a
+    /// bake-side tally counts KEYS. Those differ by however often each key is
+    /// consulted, which is exactly the kind of unweighted total that has
+    /// mis-sized every step of this arc.
+    OpenNone(OpenReason),
+}
+
+/// Why a key could not be baked. Measurement-bearing, not behaviour-bearing:
+/// every variant evaluates to `Outcome::Decode`, and a consumer that branched
+/// on one would be reading a bake-time accident as a semantic distinction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpenReason {
+    /// No answer without binders, and the chase named no portable exit — it
+    /// was poisoned, or it recorded nothing at all. Nothing a richer
+    /// conclusion FORM could carry; this is the bag's own openness.
+    NoAnswerOpaque,
+    /// No answer, and the only rung the chase named was the key being baked.
+    /// A `Link` here would walk to where the consult already is.
+    NoAnswerSelfOnly,
+    /// No answer, and the chase named rungs a `Link` could carry. This is the
+    /// population a widening would convert, and the only one that is.
+    NoAnswerLinkable,
+    /// The answer moved, or vanished, under a different receiver or arity.
+    /// `Value` may not represent it and `ReturnOf` did not claim it.
+    BinderDependent,
+    /// The bare and probed queries disagreed about the KIND of answer — a type
+    /// against a fact map — which no conclusion form represents.
+    KindDisagreement,
+    /// Two attachments projected onto one key with different conclusions.
+    /// Cannot fire while `from_attachment` is injective; counted so that
+    /// "cannot fire" is something the numbers say rather than a comment.
+    KeyCollision,
+}
+
+impl OpenReason {
+    /// Stable tag for the counters. A `Debug` projection would rename every
+    /// series the day someone renames a variant.
+    pub fn tag(self) -> &'static str {
+        match self {
+            OpenReason::NoAnswerOpaque => "concl.open.no_answer_opaque",
+            OpenReason::NoAnswerSelfOnly => "concl.open.no_answer_self_only",
+            OpenReason::NoAnswerLinkable => "concl.open.no_answer_linkable",
+            OpenReason::BinderDependent => "concl.open.binder_dependent",
+            OpenReason::KindDisagreement => "concl.open.kind_disagreement",
+            OpenReason::KeyCollision => "concl.open.key_collision",
+        }
+    }
 }
 
 /// Per-file map, persisted beside the blob and invalidated with it.
@@ -152,6 +200,29 @@ impl ConclusionMap {
             // answer is "I do not know", which is a decode.
             return match key {
                 ConclusionKey::MethodOnClass { class, .. } if !self.1.contains(class) => {
+                    // ABSENT on a class this map cannot prove closed. Counted
+                    // beside the `OpenNone` reasons because it is the same
+                    // outcome from the consult's point of view — a decode —
+                    // and leaving it uncounted made the reason tally look like
+                    // it explained the decodes when it explained a quarter of
+                    // them.
+                    // Split for measurement only, and gated because it is an
+                    // O(keys) scan: does this map conclude ANYTHING about the
+                    // class? "The file declares it but cannot prove it closed"
+                    // and "the file has never heard of it" are the same
+                    // outcome and completely different problems, and the
+                    // second is not something a richer conclusion form fixes.
+                    if crate::util::ghost_stats::enabled() {
+                        let mentioned = self.0.keys().any(|k| {
+                            matches!(k, ConclusionKey::MethodOnClass { class: c, .. } if c == class)
+                        });
+                        crate::util::ghost_stats::count(if mentioned {
+                            "concl.open.absent_class_known_open"
+                        } else {
+                            "concl.open.absent_class_unknown"
+                        });
+                    }
+                    crate::util::ghost_stats::count("concl.open.absent_not_closed");
                     Outcome::Decode
                 }
                 _ => Outcome::None,
@@ -196,7 +267,12 @@ impl ConclusionMap {
                     ReceiverRule::Dispatch(class) => Some(fresh_receiver(receiver, class)),
                 },
             },
-            Conclusion::OpenNone => Outcome::Decode,
+            // Counted HERE rather than at the bake: this is the consult, so
+            // the tally is weighted by how often each key is actually asked.
+            Conclusion::OpenNone(reason) => {
+                crate::util::ghost_stats::count(reason.tag());
+                Outcome::Decode
+            }
         }
     }
 }
@@ -470,7 +546,7 @@ pub fn bake_in_context(
             std::collections::hash_map::Entry::Occupied(mut o) => {
                 if *o.get() != conclusion {
                     crate::util::ghost_stats::count("bake.key_collision");
-                    o.insert(Conclusion::OpenNone);
+                    o.insert(Conclusion::OpenNone(OpenReason::KeyCollision));
                 }
             }
         }
@@ -583,21 +659,32 @@ fn bake_one(
         // would have done anyway. The `Link` cannot pay off while `OpenNone`
         // dominates the rungs; the leverage is in shrinking that population.
         // `docs/prompt-residualizing-registry.md` carries the table.
+        // Where the chase would have gone, read UNCONDITIONALLY — not behind
+        // the minting flag. The composition of this population is what decides
+        // whether widening the `Link` form is worth building, and it cannot be
+        // measured behind the flag the widening would turn on.
+        //
+        // The self-rung is dropped first. The cross-file primary records the
+        // key being baked as its own first rung, which is true of the ladder
+        // and useless as a `Link`: the consult reached this map by doing
+        // exactly that, so a walk back to it is a walk to where we already are.
+        let residual = registry.residuals_of_last_query().map(|targets| {
+            let self_key = ConclusionKey::from_attachment(att);
+            targets
+                .into_iter()
+                .filter(|t| Some(t) != self_key.as_ref())
+                .collect::<Vec<_>>()
+        });
+        let open_reason = match &residual {
+            // Poisoned, or nothing recorded: no portable exit exists, so no
+            // richer conclusion FORM would reach this key. It is the bag's own
+            // openness, and it is the population a widening cannot touch.
+            None => OpenReason::NoAnswerOpaque,
+            Some(t) if t.is_empty() => OpenReason::NoAnswerSelfOnly,
+            Some(_) => OpenReason::NoAnswerLinkable,
+        };
         if mint_links_enabled() {
-            if let Some(targets) = registry.residuals_of_last_query() {
-                // Drop the rung that names the key being baked. The cross-file
-                // primary records it because "ask the index for this class"
-                // genuinely is the ladder's first rung — but the consult path
-                // reached this map by doing exactly that, so a `Link` back to
-                // it is a walk to where we already are. Left in, it converted
-                // essentially the whole `OpenNone` population into `Link`s that
-                // burn two follow hops and abandon: 14,923 incomplete follows
-                // against 15 that answered, over one substrate check.
-                let self_key = ConclusionKey::from_attachment(att);
-                let targets: Vec<_> = targets
-                    .into_iter()
-                    .filter(|t| Some(t) != self_key.as_ref())
-                    .collect();
+            if let Some(targets) = residual {
                 if !targets.is_empty() {
                     crate::util::ghost_stats::count("bake.link_from_residual");
                     return Conclusion::Link {
@@ -630,7 +717,7 @@ fn bake_one(
         // report "I would have consulted the index here, for key K" instead of
         // returning None: a residualizing mode, which is a design step rather
         // than a fix. Until then these cost one decode each.
-        return Conclusion::OpenNone;
+        return Conclusion::OpenNone(open_reason);
     };
 
     // A receiver the file cannot have produced. If the answer moves, the
@@ -641,9 +728,9 @@ fn bake_one(
         )),
         Some(1),
     );
-    let demote = |why: &'static str| {
+    let demote = |why: &'static str, reason: OpenReason| {
         crate::util::ghost_stats::count(why);
-        Conclusion::OpenNone
+        Conclusion::OpenNone(reason)
     };
     match probed {
         ReducedValue::Type(t2) if t2 == t => {
@@ -653,14 +740,20 @@ fn bake_one(
         // Answered differently under a different receiver/arity. That IS
         // binder-dependence, and not in a shape we can store — decode rather
         // than freeze whichever of the two answers we happened to see first.
-        ReducedValue::Type(_) => demote("bake.demoted_by_binder_probe"),
+        ReducedValue::Type(_) => {
+            demote("bake.demoted_by_binder_probe", OpenReason::BinderDependent)
+        }
         // Facts, not a type, where the bare probe gave a type. The two probes
         // disagree about the KIND of answer, which no conclusion form
         // represents.
-        ReducedValue::FactMap(_) => demote("bake.demoted_kind_disagreement"),
+        ReducedValue::FactMap(_) => {
+            demote("bake.demoted_kind_disagreement", OpenReason::KindDisagreement)
+        }
         // The answer vanished once a receiver was supplied — binder-dependent
         // in the most direct way there is.
-        ReducedValue::None => demote("bake.demoted_by_binder_probe"),
+        ReducedValue::None => {
+            demote("bake.demoted_by_binder_probe", OpenReason::BinderDependent)
+        }
     }
 }
 

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -182,6 +182,42 @@ pub struct ConclusionMap(
     /// can be reasoned about at all.
     #[serde(default)]
     pub std::collections::HashSet<String>,
+    /// Classes this file DECLARES — the ones whose local keys the bake
+    /// enumerated. A superset of the closed set.
+    ///
+    /// The difference between the two sets is the whole of a third absence
+    /// verdict. For a class in here but not closed, a missing key proves
+    /// something weaker than "no answer" and much stronger than nothing: this
+    /// file does not answer it LOCALLY. It may still inherit it — which is
+    /// exactly what the live ladder goes on to check, so the honest reply is
+    /// "not mine, keep walking" rather than a decode that discovers the same
+    /// thing 98.7% of the time.
+    ///
+    /// Soundness rests on one property, and it is the only one: absent from
+    /// this map ⇒ this file has no local answer. The bake enumerates every
+    /// declared sub and method (`bake_with_symbols`) precisely so that holds.
+    /// Today's decode silently covers any gap in it; this verdict does not,
+    /// which is why it ships with `PERL_LSP_CONCL_EQUIV`.
+    #[serde(default)]
+    pub std::collections::HashSet<String>,
+    /// Each enumerated class's DECLARED parents, in MRO order.
+    ///
+    /// Needed because a key's absence is not the same question as a class's.
+    /// The live chase composes: asked for `C::m` with no witnesses, it walks
+    /// C's parents and can answer from `Parent::m` — and this file may well
+    /// hold a conclusion for `Parent::m` even when the parent lives elsewhere,
+    /// because its own bag carries witnesses about it.
+    ///
+    /// `Mojo::Server::Daemon::app` is the case: no local symbol, no attachment,
+    /// no app-surface edge, and an index-less chase still answers
+    /// `ClassName("Mojolicious")` — from `Mojo::Server::app`, whose key this
+    /// same map holds. Reading the child's absence as "not local" served a
+    /// grandparent's answer over it, 40 times per substrate check.
+    ///
+    /// So absence walks these before concluding anything. Cross-file parents
+    /// the map has nothing for are the outer ladder's business, unchanged.
+    #[serde(default)]
+    pub HashMap<String, Vec<String>>,
 );
 
 impl ConclusionMap {
@@ -212,9 +248,29 @@ impl ConclusionMap {
             // ABSENT. Conclusive only for a class this file can reason about
             // completely — see the `closed` field. For anything else the honest
             // answer is "I do not know", which is a decode.
+            // The key is absent, which is a question about the KEY. Before
+            // answering it, ask the question about the CLASS: does an
+            // enumerated parent hold this member? The live chase composes that
+            // way, so a verdict that skipped it would be answering a narrower
+            // question than the one it replaces.
+            if let ConclusionKey::MethodOnClass { class, name } = key {
+                if let Some(t) = self.inherited(class, name, receiver, arity, args, 0) {
+                    return t;
+                }
+            }
             return match key {
-                ConclusionKey::MethodOnClass { class, .. } if !self.1.contains(class) => {
-                    Outcome::Decode(OpenReason::AbsentNotClosed)
+                ConclusionKey::MethodOnClass { class, .. } => {
+                    if self.1.contains(class) {
+                        // Closed: every ancestor is declared here, so there is
+                        // nowhere else an answer could have come from.
+                        Outcome::None
+                    } else if self.2.contains(class) {
+                        Outcome::NotLocal
+                    } else {
+                        // A class this file never declared. Absence says
+                        // nothing at all — the bake never looked.
+                        Outcome::Decode(OpenReason::AbsentNotClosed)
+                    }
                 }
                 _ => Outcome::None,
             };
@@ -263,6 +319,46 @@ impl ConclusionMap {
     }
 }
 
+impl ConclusionMap {
+    /// Resolve `class::name` through the class's declared parents, within this
+    /// map only. `None` when no parent chain in this file has anything to say.
+    ///
+    /// Depth-capped rather than cycle-guarded: a declared-parent chain inside
+    /// one file is short, and a cap is one comparison against a `HashSet`
+    /// allocation per lookup on a path taken tens of thousands of times per
+    /// check. A cycle therefore truncates instead of looping, which degrades
+    /// to the verdict the absence would have produced anyway.
+    fn inherited(
+        &self,
+        class: &str,
+        name: &str,
+        receiver: Option<&InferredType>,
+        arity: Option<u32>,
+        args: &[InferredType],
+        depth: usize,
+    ) -> Option<Outcome> {
+        const MAX_LOCAL_MRO: usize = 8;
+        if depth >= MAX_LOCAL_MRO {
+            crate::util::ghost_stats::count("concl.local_mro_cap");
+            return None;
+        }
+        for parent in self.3.get(class)? {
+            let key = ConclusionKey::MethodOnClass {
+                class: parent.clone(),
+                name: name.to_string(),
+            };
+            if self.0.contains_key(&key) {
+                crate::util::ghost_stats::count("concl.inherited_hit");
+                return Some(self.evaluate(&key, receiver, arity, args));
+            }
+            if let Some(o) = self.inherited(parent, name, receiver, arity, args, depth + 1) {
+                return Some(o);
+            }
+        }
+        None
+    }
+}
+
 /// What one map lookup produced.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Outcome {
@@ -270,6 +366,23 @@ pub enum Outcome {
     /// The map proves no answer — the ladder moves on (parents, next
     /// candidate) exactly as a local-reducer miss does today.
     None,
+    /// The map proves no LOCAL answer: this file declares the class and
+    /// enumerated its own members, and the key is not among them. It may still
+    /// be inherited or bridged.
+    ///
+    /// Distinct from `None` because it licenses less: `None` can end the whole
+    /// resolution, this may only skip the file that said it. Distinct from
+    /// `Decode` because it licenses more: the chase this would have paid for
+    /// answers nothing locally by construction.
+    ///
+    /// Deliberately NOT a constructed `Follow` at the parents. A `Follow`
+    /// returned from candidate 1's map would short-circuit candidates 2..n,
+    /// and a reopened package's method lives in a later candidate
+    /// (`PPI::XSAccessor` reopening `PPI::Token` is the case that has already
+    /// cost this layer 75 equivalence breaks once). Continuing the loop keeps
+    /// candidates-before-parents and the bridge guard correct by construction
+    /// rather than by re-derivation.
+    NotLocal,
     /// Unbakeable here. Decode the blob and run the real chase for this key.
     ///
     /// Carries WHY, because the consult is where the cost lands and therefore
@@ -348,6 +461,15 @@ pub fn verify_absent_conclusions() -> bool {
 ///
 /// OFF until the ladder-frame rule's poisoning half lands — see the comment at
 /// the mint site for the measured error rate.
+/// Escape hatch and A/B control for the not-local verdict, same shape as
+/// `PERL_LSP_NO_BAKE`: a change that removes work from the ladder must be
+/// switchable off without a rebuild, or its correctness can only be argued
+/// rather than measured.
+pub fn not_local_disabled() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| std::env::var("PERL_LSP_NO_NOT_LOCAL").is_ok())
+}
+
 pub fn mint_links_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var("PERL_LSP_MINT_LINKS").is_ok())
@@ -571,7 +693,39 @@ pub fn bake_in_context(
             closed.insert(class.clone());
         }
     }
-    ConclusionMap(map, closed)
+    // The ENUMERATED set: classes for which "absent from this map" really does
+    // imply "no local answer". That is not every class this file declares.
+    //
+    // The bake enumerates keys from the bag's attachments and the file's
+    // declared symbols. A member that arrives by an edge NEITHER of those
+    // follows leaves no key, and its absence then says the opposite of the
+    // truth. The synthetic app-surface parent is exactly such an edge:
+    // `parents_of` composes it, `declared_parents` never reports it, so
+    // `Mojo::Server::Daemon::app` resolves locally through it and has no key
+    // here. Measured: 40 not-local breaks per substrate check, every one this
+    // shape.
+    //
+    // Asked as "does this class have a parent the DECLARED list does not
+    // carry" rather than "is this class an app-surface consumer", so a second
+    // synthetic edge kind disqualifies its classes without anyone remembering
+    // to add it here. The index is withheld — a cross-file parent already
+    // costs closedness, and this question is about edges the bake itself could
+    // not follow.
+    let consumers = ctx.map(|c| c.app_surface_consumers).unwrap_or(&[]);
+    let enumerated: std::collections::HashSet<String> = local_packages
+        .iter()
+        .filter(|class| {
+            let declared = parent_of.get(class.as_str()).map(|v| v.len()).unwrap_or(0);
+            let composed = crate::model::file_analysis::app_surface_parent(class, consumers)
+                .map_or(declared, |_| declared + 1);
+            composed == declared
+        })
+        .cloned()
+        .collect();
+    ConclusionMap(map, closed, enumerated, parent_of
+        .iter()
+        .map(|(c, ps)| ((*c).to_string(), (*ps).clone()))
+        .collect())
 }
 
 /// One attachment's conclusion.

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -50,8 +50,8 @@ impl ConclusionKey {
     /// attachment is file-internal.
     pub fn from_attachment(att: &WitnessAttachment) -> Option<Self> {
         match att {
-            WitnessAttachment::MethodOnClass { class, name } => Some(Self::MethodOnClass {
-                class: class.clone(),
+            WitnessAttachment::PackageSymbol { package, name } => Some(Self::MethodOnClass {
+                class: package.clone(),
                 name: name.clone(),
             }),
             WitnessAttachment::SlotType { class, key } => Some(Self::SlotType {
@@ -163,8 +163,8 @@ impl ConclusionMap {
                 // The live evaluator, not a copy of it. A second spelling of
                 // `ReturnExpr` semantics is a place for the baked answer to
                 // drift from the answer it is supposed to equal.
-                let att = WitnessAttachment::MethodOnClass {
-                    class: String::new(),
+                let att = WitnessAttachment::PackageSymbol {
+                    package: String::new(),
                     name: String::new(),
                 };
                 let q = ReducerQuery {
@@ -438,8 +438,8 @@ pub fn bake_in_context(
         }
         if let Some(pkg) = package {
             enumerate(
-                WitnessAttachment::MethodOnClass {
-                    class: pkg.clone(),
+                WitnessAttachment::PackageSymbol {
+                    package: pkg.clone(),
                     name: name.clone(),
                 },
                 &mut map,
@@ -573,36 +573,42 @@ fn bake_one(
         // No answer without binders. Before settling for `OpenNone`, ask
         // whether the chase told us WHERE it would have gone: an un-poisoned
         // chase whose residuals are all ladder rungs is exactly a `Link`.
-        // MINTING IS OFF BY DEFAULT, because it is measurably unsound.
         //
-        // Recording residuals and minting them wholesale converts almost the
-        // whole `OpenNone` population — 10,314 -> 293, with `Link` going
-        // 44 -> 10,065. It also produces WRONG ANSWERS: 44 follow breaks
-        // against 65 correct follows under `PERL_LSP_CONCL_EQUIV`, a 40%
-        // error rate on the links it mints.
-        //
-        // The recording half is right; the missing half is the ladder-frame
-        // rule's other side. A chase that COMBINES frames — an arm fold, a
-        // `materialize` splice into a populated witness list — has an answer
-        // that is not "whichever rung answers first", and nothing here poisons
-        // those yet, so they mint a `Link` that means something else. The
-        // observed breaks are consistent with that and NOT with the receiver
-        // rule (the live parent hop threads the receiver unchanged, which is
-        // what `Thread` already does).
-        //
-        // Kept behind a flag rather than deleted: the machinery, the counters
-        // and the 44-break population are exactly what the fix needs to work
-        // against.
+        // MINTING IS OFF BY DEFAULT, and the reason is COST, not soundness.
+        // With the ladder-frame rule's poisoning half in place the follow
+        // breaks go to zero over the substrate — but the decodes do not move
+        // (4103 -> 4104). `follow_one` abandons at the first rung whose map
+        // says `Decode`, and with ~84k `OpenNone` still in the maps that is
+        // nearly every walk, so the consult falls through to the decode it
+        // would have done anyway. The `Link` cannot pay off while `OpenNone`
+        // dominates the rungs; the leverage is in shrinking that population.
+        // `docs/prompt-residualizing-registry.md` carries the table.
         if mint_links_enabled() {
             if let Some(targets) = registry.residuals_of_last_query() {
-                crate::util::ghost_stats::count("bake.link_from_residual");
-                return Conclusion::Link {
-                    targets,
-                    arity: None,
-                    // The live candidate/parent hops thread the receiver
-                    // unchanged; the call is still on the original object.
-                    receiver: ReceiverRule::Thread,
-                };
+                // Drop the rung that names the key being baked. The cross-file
+                // primary records it because "ask the index for this class"
+                // genuinely is the ladder's first rung — but the consult path
+                // reached this map by doing exactly that, so a `Link` back to
+                // it is a walk to where we already are. Left in, it converted
+                // essentially the whole `OpenNone` population into `Link`s that
+                // burn two follow hops and abandon: 14,923 incomplete follows
+                // against 15 that answered, over one substrate check.
+                let self_key = ConclusionKey::from_attachment(att);
+                let targets: Vec<_> = targets
+                    .into_iter()
+                    .filter(|t| Some(t) != self_key.as_ref())
+                    .collect();
+                if !targets.is_empty() {
+                    crate::util::ghost_stats::count("bake.link_from_residual");
+                    return Conclusion::Link {
+                        targets,
+                        arity: None,
+                        // The live candidate/parent hops thread the receiver
+                        // unchanged; the call is still on the original object.
+                        receiver: ReceiverRule::Thread,
+                    };
+                }
+                crate::util::ghost_stats::count("bake.link_was_self_only");
             }
         }
 
@@ -678,15 +684,15 @@ fn sole_foreign_edge(
     let mut found: Option<ConclusionKey> = None;
     for w in &ws {
         match &w.payload {
-            super::types::WitnessPayload::Edge(WitnessAttachment::MethodOnClass {
-                class,
+            super::types::WitnessPayload::Edge(WitnessAttachment::PackageSymbol {
+                package,
                 name,
-            }) if !local_packages.contains(class) => {
+            }) if !local_packages.contains(package) => {
                 if found.is_some() {
                     return None;
                 }
                 found = Some(ConclusionKey::MethodOnClass {
-                    class: class.clone(),
+                    class: package.clone(),
                     name: name.clone(),
                 });
             }

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -359,6 +359,91 @@ impl ConclusionMap {
     }
 }
 
+/// One file's answers, evaluated against the CURRENT store.
+///
+/// This — not the persisted map — is the driver's diff artifact, and the
+/// distinction is the entire soundness of the propagation cutoff.
+///
+/// A persisted map is index-free by construction: the bake withholds the
+/// module index so a cross-file answer residualizes as a `Link` instead of
+/// freezing a world that can change without this file changing. That is what
+/// makes the map durable, and it is exactly what makes it useless as a change
+/// signal. When C changes, B's map is BYTE-IDENTICAL — B's `Link` still points
+/// at the same key — while B's *answers*, chased through to C, have moved. A
+/// driver that cuts propagation on map equality stops the wave at B and
+/// starves B's consumers.
+///
+/// It fails silently, and it passes every two-file fixture: with one hop there
+/// is no B for the wave to die at. Only a chain distinguishes the two, which
+/// is why `a_chain_needs_the_evaluated_surface_not_the_map` exists and why it
+/// asserts the map's byte-identity as a PRECONDITION rather than assuming it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvaluatedSurface(pub Vec<(ConclusionKey, EvaluatedAnswer)>);
+
+/// One key's answer after evaluation — map lookups only, never a decode.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EvaluatedAnswer {
+    Answer(InferredType),
+    /// The map proves no answer.
+    None,
+    /// No LOCAL answer; the live ladder continues past this file.
+    NotLocal,
+    /// Unbakeable here, or a `Link` the store cannot complete. The consumer's
+    /// answer is whatever the chase finds, so this file cannot cut a chain on
+    /// it — it compares equal only to another `Opaque`, which is the honest
+    /// conservative direction.
+    Opaque,
+}
+
+impl ConclusionMap {
+    /// Evaluate every key this map holds against the current store.
+    ///
+    /// `resolve` is the same map-lookup resolver `follow_link_with` takes:
+    /// class name → the candidate files' maps. No decodes, so this is cheap
+    /// enough to run per file per flush round.
+    ///
+    /// Sorted by key, because the driver compares these for equality and a
+    /// `HashMap` walk would make the comparison depend on iteration order —
+    /// the same defect that made `--dump-package` answer a coin flip.
+    pub fn evaluated_surface(
+        &self,
+        resolve: &dyn Fn(&str) -> Vec<(String, Option<std::sync::Arc<ConclusionMap>>)>,
+    ) -> EvaluatedSurface {
+        let mut out: Vec<(ConclusionKey, EvaluatedAnswer)> = self
+            .0
+            .keys()
+            .map(|k| (k.clone(), self.evaluate_for_surface(k, resolve)))
+            .collect();
+        out.sort_by(|a, b| format!("{:?}", a.0).cmp(&format!("{:?}", b.0)));
+        EvaluatedSurface(out)
+    }
+
+    fn evaluate_for_surface(
+        &self,
+        key: &ConclusionKey,
+        resolve: &dyn Fn(&str) -> Vec<(String, Option<std::sync::Arc<ConclusionMap>>)>,
+    ) -> EvaluatedAnswer {
+        // No binders: the surface is the file's EXPORT face, and a
+        // receiver-dependent answer is not part of it — `ReturnOf` evaluates
+        // to `None` without a receiver, which is the same thing every consumer
+        // sees until it supplies one.
+        match self.evaluate(key, None, None, &[]) {
+            Outcome::Answer(t) => EvaluatedAnswer::Answer(t),
+            Outcome::None => EvaluatedAnswer::None,
+            Outcome::NotLocal => EvaluatedAnswer::NotLocal,
+            Outcome::Decode(_) => EvaluatedAnswer::Opaque,
+            Outcome::Follow { targets, arity, receiver } => {
+                match super::registry::follow_link_with(
+                    resolve, &targets, &receiver, arity, &[],
+                ) {
+                    Some(t) => EvaluatedAnswer::Answer(t),
+                    None => EvaluatedAnswer::Opaque,
+                }
+            }
+        }
+    }
+}
+
 /// What one map lookup produced.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Outcome {

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -135,6 +135,19 @@ pub enum OpenReason {
     /// Cannot fire while `from_attachment` is injective; counted so that
     /// "cannot fire" is something the numbers say rather than a comment.
     KeyCollision,
+    /// Not a stored conclusion at all: the key is ABSENT and the class cannot
+    /// be proven closed, so absence proves nothing and the chase must run.
+    ///
+    /// Carried alongside the stored reasons because from the consult's side it
+    /// is the same event — a decode — and separating them by provenance is
+    /// what made the first attribution describe a quarter of the population
+    /// while reading as if it described all of it: 25,897 counted against
+    /// 92,559 measured, and the gap WAS the answer.
+    ///
+    /// Measured at 70.3% of all decodes, and 97.6% of those on a class the map
+    /// DOES conclude about — it simply inherits from somewhere this file
+    /// cannot see.
+    AbsentNotClosed,
 }
 
 impl OpenReason {
@@ -148,6 +161,7 @@ impl OpenReason {
             OpenReason::BinderDependent => "concl.open.binder_dependent",
             OpenReason::KindDisagreement => "concl.open.kind_disagreement",
             OpenReason::KeyCollision => "concl.open.key_collision",
+            OpenReason::AbsentNotClosed => "concl.open.absent_not_closed",
         }
     }
 }
@@ -200,30 +214,7 @@ impl ConclusionMap {
             // answer is "I do not know", which is a decode.
             return match key {
                 ConclusionKey::MethodOnClass { class, .. } if !self.1.contains(class) => {
-                    // ABSENT on a class this map cannot prove closed. Counted
-                    // beside the `OpenNone` reasons because it is the same
-                    // outcome from the consult's point of view — a decode —
-                    // and leaving it uncounted made the reason tally look like
-                    // it explained the decodes when it explained a quarter of
-                    // them.
-                    // Split for measurement only, and gated because it is an
-                    // O(keys) scan: does this map conclude ANYTHING about the
-                    // class? "The file declares it but cannot prove it closed"
-                    // and "the file has never heard of it" are the same
-                    // outcome and completely different problems, and the
-                    // second is not something a richer conclusion form fixes.
-                    if crate::util::ghost_stats::enabled() {
-                        let mentioned = self.0.keys().any(|k| {
-                            matches!(k, ConclusionKey::MethodOnClass { class: c, .. } if c == class)
-                        });
-                        crate::util::ghost_stats::count(if mentioned {
-                            "concl.open.absent_class_known_open"
-                        } else {
-                            "concl.open.absent_class_unknown"
-                        });
-                    }
-                    crate::util::ghost_stats::count("concl.open.absent_not_closed");
-                    Outcome::Decode
+                    Outcome::Decode(OpenReason::AbsentNotClosed)
                 }
                 _ => Outcome::None,
             };
@@ -267,12 +258,7 @@ impl ConclusionMap {
                     ReceiverRule::Dispatch(class) => Some(fresh_receiver(receiver, class)),
                 },
             },
-            // Counted HERE rather than at the bake: this is the consult, so
-            // the tally is weighted by how often each key is actually asked.
-            Conclusion::OpenNone(reason) => {
-                crate::util::ghost_stats::count(reason.tag());
-                Outcome::Decode
-            }
+            Conclusion::OpenNone(reason) => Outcome::Decode(*reason),
         }
     }
 }
@@ -285,7 +271,12 @@ pub enum Outcome {
     /// candidate) exactly as a local-reducer miss does today.
     None,
     /// Unbakeable here. Decode the blob and run the real chase for this key.
-    Decode,
+    ///
+    /// Carries WHY, because the consult is where the cost lands and therefore
+    /// where the attribution has to be taken. Counting causes at the bake
+    /// counts keys; counting them at the consult weights each by how often it
+    /// is actually asked, and the two differ by orders of magnitude.
+    Decode(OpenReason),
     /// The answer is in another file; follow with these binders. Ordered,
     /// first-answer-wins.
     Follow {

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -87,8 +87,15 @@ pub enum Conclusion {
     /// live path uses.
     ReturnOf(ReturnExpr),
     /// The answer is in another file. Never a value — see "Edges, not values".
+    ///
+    /// `targets` is ORDERED and first-answer-wins, because Perl's DFS-MRO is an
+    /// ordered ladder and that is precisely what this form encodes: "whichever
+    /// of these rungs answers first". A chase that COMBINED frames — an arm
+    /// fold, a splice into a populated witness list — has an answer this cannot
+    /// express, and is poisoned to `OpenNone` rather than squeezed into a
+    /// vector that would silently mean something else.
     Link {
-        target: ConclusionKey,
+        targets: Vec<ConclusionKey>,
         arity: Option<u32>,
         receiver: ReceiverRule,
     },
@@ -178,11 +185,11 @@ impl ConclusionMap {
                 }
             }
             Conclusion::Link {
-                target,
+                targets,
                 arity: link_arity,
                 receiver: rule,
             } => Outcome::Follow {
-                target: target.clone(),
+                targets: targets.clone(),
                 arity: link_arity.or(arity),
                 receiver: match rule {
                     ReceiverRule::Thread => receiver.cloned(),
@@ -203,9 +210,10 @@ pub enum Outcome {
     None,
     /// Unbakeable here. Decode the blob and run the real chase for this key.
     Decode,
-    /// The answer is in another file; follow with these binders.
+    /// The answer is in another file; follow with these binders. Ordered,
+    /// first-answer-wins.
     Follow {
-        target: ConclusionKey,
+        targets: Vec<ConclusionKey>,
         arity: Option<u32>,
         receiver: Option<InferredType>,
     },
@@ -267,6 +275,15 @@ pub fn trust_absent_conclusions() -> bool {
 pub fn verify_absent_conclusions() -> bool {
     static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *V.get_or_init(|| std::env::var("PERL_LSP_CONCL_EQUIV").is_ok())
+}
+
+/// Mint `Link`s from a chase's recorded residuals.
+///
+/// OFF until the ladder-frame rule's poisoning half lands — see the comment at
+/// the mint site for the measured error rate.
+pub fn mint_links_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("PERL_LSP_MINT_LINKS").is_ok())
 }
 
 /// How many map-to-map hops a `Follow` may take before giving up.
@@ -511,7 +528,7 @@ fn bake_one(
     if let Some(target) = sole_foreign_edge(bag, att, local_packages) {
         crate::util::ghost_stats::count("bake.link");
         return Conclusion::Link {
-            target,
+            targets: vec![target],
             arity: None,
             // An inheritance hop keeps the original object as receiver — the
             // call is still on it, the method just lives up the chain.
@@ -553,7 +570,43 @@ fn bake_one(
     crate::util::ghost_stats::count("bake.attempted");
     let ReducedValue::Type(t) = bare else {
         crate::util::ghost_stats::count("bake.no_bare_answer");
-        // No answer without binders, and `OpenNone` (decode) rather than
+        // No answer without binders. Before settling for `OpenNone`, ask
+        // whether the chase told us WHERE it would have gone: an un-poisoned
+        // chase whose residuals are all ladder rungs is exactly a `Link`.
+        // MINTING IS OFF BY DEFAULT, because it is measurably unsound.
+        //
+        // Recording residuals and minting them wholesale converts almost the
+        // whole `OpenNone` population — 10,314 -> 293, with `Link` going
+        // 44 -> 10,065. It also produces WRONG ANSWERS: 44 follow breaks
+        // against 65 correct follows under `PERL_LSP_CONCL_EQUIV`, a 40%
+        // error rate on the links it mints.
+        //
+        // The recording half is right; the missing half is the ladder-frame
+        // rule's other side. A chase that COMBINES frames — an arm fold, a
+        // `materialize` splice into a populated witness list — has an answer
+        // that is not "whichever rung answers first", and nothing here poisons
+        // those yet, so they mint a `Link` that means something else. The
+        // observed breaks are consistent with that and NOT with the receiver
+        // rule (the live parent hop threads the receiver unchanged, which is
+        // what `Thread` already does).
+        //
+        // Kept behind a flag rather than deleted: the machinery, the counters
+        // and the 44-break population are exactly what the fix needs to work
+        // against.
+        if mint_links_enabled() {
+            if let Some(targets) = registry.residuals_of_last_query() {
+                crate::util::ghost_stats::count("bake.link_from_residual");
+                return Conclusion::Link {
+                    targets,
+                    arity: None,
+                    // The live candidate/parent hops thread the receiver
+                    // unchanged; the call is still on the original object.
+                    receiver: ReceiverRule::Thread,
+                };
+            }
+        }
+
+        // No answer, and no nameable exit — `OpenNone` (decode) rather than
         // absent (a proven None) — measured, not assumed.
         //
         // Treating these as absent looks free: the bake got None, so the live

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -192,3 +192,146 @@ fn the_bake_does_not_depend_on_map_iteration_order() {
         }
     }
 }
+
+// ---- the Link walk ----
+
+use std::sync::Arc;
+
+fn m(entries: Vec<(ConclusionKey, Conclusion)>) -> Arc<ConclusionMap> {
+    Arc::new(ConclusionMap(
+        entries.into_iter().collect(),
+        Default::default(),
+    ))
+}
+
+fn moc(class: &str, name: &str) -> ConclusionKey {
+    ConclusionKey::MethodOnClass {
+        class: class.into(),
+        name: name.into(),
+    }
+}
+
+/// A `Link` chain resolves to the answer at its end, with no bag decoded.
+///
+/// Exercised directly rather than through the corpus: on the substrate today
+/// only 4 `Follow`s fire and all are incomplete, so the success path would
+/// otherwise ship untested. A walker that never succeeds in its own test suite
+/// is a walker nobody has run.
+#[test]
+fn a_link_chain_resolves_to_the_answer_at_its_end() {
+    let a = m(vec![(
+        moc("A", "f"),
+        Conclusion::Link {
+            target: moc("B", "f"),
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    )]);
+    let b = m(vec![(
+        moc("B", "f"),
+        Conclusion::Value(crate::model::file_analysis::InferredType::HashRef),
+    )]);
+    let resolve = move |class: &str| match class {
+        "A" => vec![("/a.pm".to_string(), Some(a.clone()))],
+        "B" => vec![("/b.pm".to_string(), Some(b.clone()))],
+        _ => vec![],
+    };
+    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]);
+    assert_eq!(
+        got,
+        Some(crate::model::file_analysis::InferredType::HashRef),
+        "a two-hop Link chain did not reach its answer"
+    );
+}
+
+/// A cycle terminates instead of spinning, and degrades to a decode.
+#[test]
+fn a_cyclic_link_chain_terminates() {
+    let a = m(vec![(
+        moc("A", "f"),
+        Conclusion::Link {
+            target: moc("B", "f"),
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    )]);
+    let b = m(vec![(
+        moc("B", "f"),
+        Conclusion::Link {
+            target: moc("A", "f"),
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    )]);
+    let resolve = move |class: &str| match class {
+        "A" => vec![("/a.pm".to_string(), Some(a.clone()))],
+        "B" => vec![("/b.pm".to_string(), Some(b.clone()))],
+        _ => vec![],
+    };
+    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]);
+    assert_eq!(
+        got, None,
+        "a cyclic chain produced an answer; it must degrade to the decode instead"
+    );
+}
+
+/// An `OpenNone` anywhere on the chain degrades the whole walk.
+///
+/// The walk has no bag, so it cannot resolve what `OpenNone` defers. Returning
+/// a partial answer here would be the one failure mode this form has that
+/// serves a WRONG answer rather than costing a decode.
+#[test]
+fn an_open_none_on_the_chain_degrades_to_a_decode() {
+    let a = m(vec![(
+        moc("A", "f"),
+        Conclusion::Link {
+            target: moc("B", "f"),
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    )]);
+    let b = m(vec![(moc("B", "f"), Conclusion::OpenNone)]);
+    let resolve = move |class: &str| match class {
+        "A" => vec![("/a.pm".to_string(), Some(a.clone()))],
+        "B" => vec![("/b.pm".to_string(), Some(b.clone()))],
+        _ => vec![],
+    };
+    assert_eq!(
+        crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]),
+        None,
+        "the walk answered past an OpenNone it cannot resolve"
+    );
+}
+
+/// A candidate that PROVES `None` does not stop the ladder — the next one is
+/// tried, exactly as the live chase's candidate loop does.
+///
+/// "Proves" is the load-bearing word, and it is why the empty map here declares
+/// `B` closed. An empty map for a class that is NOT closed returns `Decode`,
+/// not `None`: absence is only conclusive for a class whose ancestors are all
+/// accounted for. My first version of this test omitted that and expected the
+/// ladder to continue over an inconclusive absence — the walker was right and
+/// the expectation was wrong.
+#[test]
+fn a_none_candidate_does_not_stop_the_ladder() {
+    let empty = Arc::new(ConclusionMap(
+        Default::default(),
+        ["B".to_string()].into_iter().collect(),
+    ));
+    let real = m(vec![(
+        moc("B", "f"),
+        Conclusion::Value(crate::model::file_analysis::InferredType::ArrayRef),
+    )]);
+    let resolve = move |class: &str| match class {
+        "B" => vec![
+            ("/empty.pm".to_string(), Some(empty.clone())),
+            ("/real.pm".to_string(), Some(real.clone())),
+        ],
+        _ => vec![],
+    };
+    assert_eq!(
+        crate::model::witnesses::registry::follow_link_with(&resolve, &moc("B", "f"), &None, None, &[]),
+        Some(crate::model::file_analysis::InferredType::ArrayRef),
+        "the first candidate's None ended the walk instead of falling through"
+    );
+}

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -1,0 +1,194 @@
+//! Tests for the conclusion layer.
+//!
+//! Split out because `layering_tests` forbids the Model layer importing Build,
+//! and these must run a real builder to get a real bag. Test suites are exempt
+//! by living in a `*_tests.rs` file, which is the convention here.
+
+use super::*;
+use crate::model::file_analysis::FileAnalysis;
+
+fn analyze(src: &str) -> FileAnalysis {
+    let mut parser = crate::build::builder::create_parser();
+    let tree = parser.parse(src, None).expect("parse");
+    crate::build::builder::build(&tree, src.as_bytes())
+}
+
+/// The property the whole layer rests on: a baked answer must equal the
+/// answer the live chase gives for the same key and binders.
+///
+/// Anything else is the failure mode this design is arranged against — a
+/// stored answer that is well-formed, validates, and disagrees with the
+/// derivation it claims to summarize. Checked over every key the bake
+/// produced rather than a chosen few, because the interesting cases are
+/// the ones nobody thought to pick.
+#[test]
+fn a_baked_conclusion_agrees_with_the_live_chase() {
+    let sources: &[(&str, &str)] = &[
+        ("constructor return", "package C;\nsub build { return LWP::UserAgent->new(timeout => 10) }\n1;\n"),
+        ("moo accessors", "package M;\nuse Moo;\nhas name => (is => 'rw');\nhas size => (is => 'ro');\n1;\n"),
+        ("literal returns", "package L;\nsub s { return 'x' }\nsub n { return 1 }\n1;\n"),
+        ("inheritance", "package P;\nsub mk { my $c = shift; return bless {}, $c }\npackage C2;\nour @ISA = ('P');\n1;\n"),
+        ("branch arms", "package B;\nsub pick { my $c = shift; if ($c) { return 'a' } else { return 'b' } }\n1;\n"),
+    ];
+
+    let registry = ReducerRegistry::with_defaults();
+    let mut checked = 0usize;
+    for (label, src) in sources {
+        let fa = analyze(src);
+        let map = bake(&fa.witnesses, &registry, &fa.packages.keys().cloned().collect());
+
+        for att in fa.witnesses.attachments() {
+            let Some(key) = ConclusionKey::from_attachment(att) else {
+                continue;
+            };
+            let live = registry.query(
+                &fa.witnesses,
+                &ReducerQuery {
+                    attachment: att,
+                    point: None,
+                    framework: FrameworkFact::Plain,
+                    arity_hint: None,
+                    receiver: None,
+                    args: Vec::new(),
+                    context: None,
+                },
+            );
+            let live = match live {
+                ReducedValue::Type(t) => Some(t),
+                // Neither is a type answer, so neither is something a
+                // conclusion claims to summarize.
+                ReducedValue::FactMap(_) | ReducedValue::None => None,
+            };
+            match map.evaluate(&key, None, None, &[]) {
+                // A decode defers to the live path, so it cannot disagree
+                // with it — that is the point of keeping it distinct from
+                // absent.
+                Outcome::Decode | Outcome::Follow { .. } => {}
+                Outcome::Answer(baked) => {
+                    checked += 1;
+                    assert_eq!(
+                        Some(baked.clone()),
+                        live,
+                        "{label}: baked {key:?} as {baked:?} but the live chase says {live:?} \
+                         — a stored answer that disagrees with its own derivation"
+                    );
+                }
+                Outcome::None => {
+                    checked += 1;
+                    assert_eq!(
+                        live, None,
+                        "{label}: {key:?} is ABSENT from the map (which means None) but the \
+                         live chase answers {live:?} — the enumeration missed a key the bag \
+                         can answer, which is the silent-wrong-answer case"
+                    );
+                }
+            }
+        }
+    }
+    assert!(
+        checked > 0,
+        "no conclusion was compared — this test would pass vacuously"
+    );
+}
+
+/// A receiver-dependent answer must never bake as a constant.
+///
+/// This is the specific way `Value` goes wrong: a fluent accessor baked
+/// from its declaring class hands that class to every subclass caller, and
+/// the answer is a plausible class name rather than an obvious error.
+#[test]
+fn a_receiver_dependent_answer_is_never_baked_as_a_constant() {
+    // Mojo::Base accessors return the invocant, so `has` here is the
+    // receiver-dependent shape.
+    // A constructor, not an accessor. `bless {}, $c` is `ReceiverOr`:
+    // with no receiver it yields the enclosing class — a REAL type — so
+    // the constant probe is the only thing standing between it and a
+    // `Value`. An accessor would pass this test for the wrong reason
+    // (its bare probe answers None, so it cannot bake as a constant
+    // however the probe behaves).
+    let fa = analyze(
+        "package R;\nsub new { my ($class, $arg) = @_; bless $arg => $class }\n1;\n",
+    );
+    let map = bake(
+        &fa.witnesses,
+        &ReducerRegistry::with_defaults(),
+        &fa.packages.keys().cloned().collect(),
+    );
+    let mut saw_accessor = false;
+    for (key, c) in map.0.iter() {
+        let ConclusionKey::MethodOnClass { class, name } = key else { continue };
+        if class != "R" || name != "new" {
+            continue;
+        }
+        saw_accessor = true;
+        assert!(
+            !matches!(c, Conclusion::Value(_)),
+            "the receiver-polymorphic constructor baked as a constant {c:?} — \
+             `Child->new` would be handed the declaring class"
+        );
+    }
+    assert!(
+        saw_accessor,
+        "the fixture produced no accessor conclusion, so this proves nothing"
+    );
+
+}
+
+/// The bake must not depend on map iteration order.
+///
+/// The sibling of `witnesses_tests::the_fold_does_not_depend_on_map_iteration_order`,
+/// and required for the same reason one level up: the diff-propagation
+/// driver (`docs/prompt-enrichment-alternatives.md`) cuts its worklist on
+/// an EMPTY conclusion diff. An order-dependent bake produces spurious
+/// diffs that never cut the chain, and — worse — spuriously empty ones
+/// that cut a chain which should have propagated, leaving a consumer on a
+/// stale answer with nothing to notice.
+///
+/// `bake` walks `attachments()`, which is `HashMap::keys()`, so this is
+/// not a hypothetical shape — it is the actual iteration the bake does.
+/// Every new conclusion kind joins this test.
+#[test]
+fn the_bake_does_not_depend_on_map_iteration_order() {
+    let sources: &[(&str, &str)] = &[
+        ("constructor", "package K;\nsub new { my ($c, $a) = @_; bless $a => $c }\n1;\n"),
+        ("moo", "package M2;\nuse Moo;\nhas a => (is => 'rw');\nhas b => (is => 'ro');\n1;\n"),
+        ("inherit", "package P2;\nsub f { return 'x' }\npackage C3;\nour @ISA = ('P2');\n1;\n"),
+        ("slots", "package S;\nsub set { my $s = shift; $s->{n} = 1; $s->{t} = 'x'; return $s }\n1;\n"),
+    ];
+    let registry = ReducerRegistry::with_defaults();
+    // The map is compared as a SORTED key/value list rather than by
+    // HashMap equality, so the comparison is over content and cannot be
+    // satisfied by two maps that merely hash the same.
+    let snapshot = |src: &str| -> Vec<(String, String)> {
+        let fa = analyze(src);
+        let map = bake(
+            &fa.witnesses,
+            &registry,
+            &fa.packages.keys().cloned().collect(),
+        );
+        let mut out: Vec<(String, String)> = map
+            .0
+            .iter()
+            .map(|(k, v)| (format!("{k:?}"), format!("{v:?}")))
+            .collect();
+        out.sort();
+        out
+    };
+    for (label, src) in sources {
+        let first = snapshot(src);
+        assert!(
+            !first.is_empty(),
+            "{label}: baked nothing, so this source exercises no ordering"
+        );
+        for round in 0..6 {
+            assert_eq!(
+                first,
+                snapshot(src),
+                "{label}: the bake produced a different map on round {round} with \
+                 identical input — an iteration-order dependence, which makes a \
+                 conclusion DIFF unsound and the propagation worklist wrong in \
+                 both directions"
+            );
+        }
+    }
+}

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -372,3 +372,104 @@ fn a_parentless_bridged_class_does_not_get_its_absence_trusted() {
          every absence and the layer's main win would be off"
     );
 }
+
+/// Where the chase would have gone, for a given key.
+///
+/// Threaded through the real registry rather than asserting on `bake`'s output
+/// so the property under test is the RECORDING rule, not the env gate that
+/// currently keeps minting switched off — the gate is a shipping decision and
+/// the rule has to hold regardless of it.
+fn residuals_for(fa: &FileAnalysis, class: &str, name: &str) -> Option<Vec<ConclusionKey>> {
+    let registry = ReducerRegistry::with_defaults();
+    let ctx = crate::model::witnesses::reducers::BagContext {
+        scopes: &fa.scopes,
+        package_framework: &fa.packages,
+        // Withheld: this is what makes the chase EXIT rather than answer, and
+        // the exit is the thing being recorded.
+        module_index: None,
+        package_parents: &fa.packages,
+        app_surface_consumers: &fa.plugin.app_surface_consumers,
+    };
+    let att = WitnessAttachment::PackageSymbol {
+        package: class.to_string(),
+        name: name.to_string(),
+    };
+    let _bake = BakeScope::enter();
+    let _ = registry.query(
+        &fa.witnesses,
+        &ReducerQuery {
+            attachment: &att,
+            point: None,
+            framework: FrameworkFact::Plain,
+            arity_hint: None,
+            receiver: None,
+            args: Vec::new(),
+            context: Some(&ctx),
+        },
+    );
+    registry.residuals_of_last_query()
+}
+
+/// An exit reached through a CALL frame must not be residualized.
+///
+/// This is the half of the ladder-frame rule that recording alone does not
+/// give you, and skipping it is not a missed optimisation — it is a wrong
+/// answer. `Link{targets, arity, receiver}` carries ONE set of binders, and a
+/// `CallReturn` frame substitutes both: the call site's arity, and the
+/// dispatch class as the receiver. Minted from the outer query's binders it
+/// asks the exit key a different question than the chase did, and a
+/// receiver-dependent answer at the far end then answers about the wrong
+/// object. That was 4 of the 44 follow breaks the unpoisoned version produced.
+///
+/// Base-verify by deleting the `opaque_frames` check in `note_exit`: the rung
+/// survives and this asserts.
+#[test]
+fn a_call_frame_exit_is_not_residualized() {
+    let fa = analyze("package B;\nsub mk { return Elsewhere::Thing->make }\n1;\n");
+    assert_eq!(
+        residuals_for(&fa, "B", "mk"),
+        None,
+        "a call frame's exit was offered as a Link rung, and the Link form \
+         cannot carry the arity and dispatch receiver that frame substituted"
+    );
+}
+
+/// A drill through a value is not a hop to it.
+///
+/// `$ua->{name}` returns something projected OUT of the sub-chase's answer. A
+/// `Link` at the base's key would serve the base object, not the field.
+#[test]
+fn a_chase_that_drills_through_a_value_does_not_residualize() {
+    let fa = analyze(
+        "package B;\n\
+         sub host { my $ua = Elsewhere::Agent->new; return $ua->{name} }\n1;\n",
+    );
+    assert_eq!(
+        residuals_for(&fa, "B", "host"),
+        None,
+        "a projection's exit was offered as a Link rung — following it would \
+         serve the value drilled THROUGH, not the value drilled OUT"
+    );
+}
+
+/// Control, and it is what keeps the two tests above from passing vacuously:
+/// the recording rule must still fire on the shape it exists for.
+///
+/// A parent walk is the ladder in its purest form — each rung is asked the
+/// same question under the same binders, and the first to answer wins. Every
+/// frame between the query and the exit returns the exit's answer unchanged,
+/// so the exit key names this method's return exactly.
+#[test]
+fn a_parent_walk_exit_is_still_residualized() {
+    let fa = analyze("package B;\nour @ISA = ('Elsewhere::Base');\nsub other { 1 }\n1;\n");
+    let residuals = residuals_for(&fa, "B", "inherited");
+    assert!(
+        residuals.as_deref().is_some_and(|r| r.iter().any(|k| matches!(
+            k,
+            ConclusionKey::MethodOnClass { class, name }
+                if class == "Elsewhere::Base" && name == "inherited"
+        ))),
+        "a parent rung was not recorded; got {residuals:?} — with this failing, \
+         the two poisoning tests above prove nothing"
+    );
+}

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -222,7 +222,7 @@ fn a_link_chain_resolves_to_the_answer_at_its_end() {
     let a = m(vec![(
         moc("A", "f"),
         Conclusion::Link {
-            target: moc("B", "f"),
+            targets: vec![moc("B", "f")],
             arity: None,
             receiver: ReceiverRule::Thread,
         },
@@ -236,7 +236,7 @@ fn a_link_chain_resolves_to_the_answer_at_its_end() {
         "B" => vec![("/b.pm".to_string(), Some(b.clone()))],
         _ => vec![],
     };
-    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]);
+    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &[moc("A", "f")], &None, None, &[]);
     assert_eq!(
         got,
         Some(crate::model::file_analysis::InferredType::HashRef),
@@ -250,7 +250,7 @@ fn a_cyclic_link_chain_terminates() {
     let a = m(vec![(
         moc("A", "f"),
         Conclusion::Link {
-            target: moc("B", "f"),
+            targets: vec![moc("B", "f")],
             arity: None,
             receiver: ReceiverRule::Thread,
         },
@@ -258,7 +258,7 @@ fn a_cyclic_link_chain_terminates() {
     let b = m(vec![(
         moc("B", "f"),
         Conclusion::Link {
-            target: moc("A", "f"),
+            targets: vec![moc("A", "f")],
             arity: None,
             receiver: ReceiverRule::Thread,
         },
@@ -268,7 +268,7 @@ fn a_cyclic_link_chain_terminates() {
         "B" => vec![("/b.pm".to_string(), Some(b.clone()))],
         _ => vec![],
     };
-    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]);
+    let got = crate::model::witnesses::registry::follow_link_with(&resolve, &[moc("A", "f")], &None, None, &[]);
     assert_eq!(
         got, None,
         "a cyclic chain produced an answer; it must degrade to the decode instead"
@@ -285,7 +285,7 @@ fn an_open_none_on_the_chain_degrades_to_a_decode() {
     let a = m(vec![(
         moc("A", "f"),
         Conclusion::Link {
-            target: moc("B", "f"),
+            targets: vec![moc("B", "f")],
             arity: None,
             receiver: ReceiverRule::Thread,
         },
@@ -297,7 +297,7 @@ fn an_open_none_on_the_chain_degrades_to_a_decode() {
         _ => vec![],
     };
     assert_eq!(
-        crate::model::witnesses::registry::follow_link_with(&resolve, &moc("A", "f"), &None, None, &[]),
+        crate::model::witnesses::registry::follow_link_with(&resolve, &[moc("A", "f")], &None, None, &[]),
         None,
         "the walk answered past an OpenNone it cannot resolve"
     );
@@ -330,7 +330,7 @@ fn a_none_candidate_does_not_stop_the_ladder() {
         _ => vec![],
     };
     assert_eq!(
-        crate::model::witnesses::registry::follow_link_with(&resolve, &moc("B", "f"), &None, None, &[]),
+        crate::model::witnesses::registry::follow_link_with(&resolve, &[moc("B", "f")], &None, None, &[]),
         Some(crate::model::file_analysis::InferredType::ArrayRef),
         "the first candidate's None ended the walk instead of falling through"
     );

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -290,7 +290,7 @@ fn an_open_none_on_the_chain_degrades_to_a_decode() {
             receiver: ReceiverRule::Thread,
         },
     )]);
-    let b = m(vec![(moc("B", "f"), Conclusion::OpenNone)]);
+    let b = m(vec![(moc("B", "f"), Conclusion::OpenNone(OpenReason::NoAnswerOpaque))]);
     let resolve = move |class: &str| match class {
         "A" => vec![("/a.pm".to_string(), Some(a.clone()))],
         "B" => vec![("/b.pm".to_string(), Some(b.clone()))],

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -62,8 +62,9 @@ fn a_baked_conclusion_agrees_with_the_live_chase() {
             match map.evaluate(&key, None, None, &[]) {
                 // A decode defers to the live path, so it cannot disagree
                 // with it — that is the point of keeping it distinct from
-                // absent.
-                Outcome::Decode(_) | Outcome::Follow { .. } => {}
+                // absent. `NotLocal` likewise defers: it skips ONE candidate
+                // and licenses nothing about the answer.
+                Outcome::Decode(_) | Outcome::Follow { .. } | Outcome::NotLocal => {}
                 Outcome::Answer(baked) => {
                     checked += 1;
                     assert_eq!(
@@ -201,6 +202,8 @@ fn m(entries: Vec<(ConclusionKey, Conclusion)>) -> Arc<ConclusionMap> {
     Arc::new(ConclusionMap(
         entries.into_iter().collect(),
         Default::default(),
+        Default::default(),
+        Default::default(),
     ))
 }
 
@@ -317,6 +320,8 @@ fn a_none_candidate_does_not_stop_the_ladder() {
     let empty = Arc::new(ConclusionMap(
         Default::default(),
         ["B".to_string()].into_iter().collect(),
+        ["B".to_string()].into_iter().collect(),
+        Default::default(),
     ));
     let real = m(vec![(
         moc("B", "f"),
@@ -354,7 +359,12 @@ fn a_parentless_bridged_class_does_not_get_its_absence_trusted() {
     // The map's own view: `B` is closed — no ancestors — so absence in the map
     // reads as a proven `None`. That is what makes the guard load-bearing
     // rather than belt-and-braces.
-    let map = ConclusionMap(Default::default(), ["B".to_string()].into_iter().collect());
+    let map = ConclusionMap(
+        Default::default(),
+        ["B".to_string()].into_iter().collect(),
+        ["B".to_string()].into_iter().collect(),
+        Default::default(),
+    );
     assert_eq!(
         map.evaluate(&moc("B", "f"), None, None, &[]),
         Outcome::None,
@@ -471,5 +481,102 @@ fn a_parent_walk_exit_is_still_residualized() {
         ))),
         "a parent rung was not recorded; got {residuals:?} — with this failing, \
          the two poisoning tests above prove nothing"
+    );
+}
+
+
+/// A not-local verdict must skip ONE candidate, never the rest of the ladder.
+///
+/// This is why the verdict is not a constructed `Follow` at the class's
+/// parents. A `Follow` returned from candidate 1's map jumps straight to the
+/// parent walk and never asks candidates 2..n — and a REOPENED package's
+/// method lives in exactly such a later candidate. `PPI::XSAccessor` reopens
+/// `PPI::Token` in the substrate, which has already cost this layer 75
+/// equivalence breaks once, under a different rule.
+///
+/// Here: candidate 1 declares the class and does not define `f`; candidate 2
+/// reopens it and does. The ladder must reach candidate 2.
+///
+/// Base-verify by making the not-local arm return the parent rungs as a
+/// `Follow` instead of continuing: candidate 2 is skipped and this asserts.
+#[test]
+fn a_not_local_verdict_does_not_skip_a_later_candidate() {
+    // Candidate 1: declares B, enumerates its members, has no `f`.
+    let first = Arc::new(ConclusionMap(
+        Default::default(),
+        // Not closed — B has a parent — so absence is NOT a proven None.
+        Default::default(),
+        ["B".to_string()].into_iter().collect(),
+        [("B".to_string(), vec!["Base".to_string()])]
+            .into_iter()
+            .collect(),
+    ));
+    assert_eq!(
+        first.evaluate(&moc("B", "f"), None, None, &[]),
+        Outcome::NotLocal,
+        "precondition: candidate 1 declares B, enumerated it, and has no f"
+    );
+
+    // Candidate 2: the reopening file, which DOES define it.
+    let second = m(vec![(
+        moc("B", "f"),
+        Conclusion::Value(InferredType::ClassName("Answer".into())),
+    )]);
+
+    let resolve = |_class: &str| {
+        vec![
+            ("/first.pm".to_string(), Some(first.clone())),
+            ("/second.pm".to_string(), Some(second.clone())),
+        ]
+    };
+    assert_eq!(
+        crate::model::witnesses::registry::follow_link_with(&resolve, &[moc("B", "f")], &None, None, &[]),
+        Some(InferredType::ClassName("Answer".into())),
+        "a not-local candidate must let the ladder continue to the file that \
+         reopens the package, not end the walk"
+    );
+}
+
+/// Absence is a question about the KEY; the chase asks one about the CLASS.
+///
+/// A file can hold no conclusion for `C::m` and still answer it, from a
+/// `Parent::m` key the same file holds — its bag carries witnesses about the
+/// parent even when the parent's code lives elsewhere. Reading the child's
+/// absence as "not local" then serves a grandparent's answer over it, which is
+/// a wrong answer rather than a slow one.
+///
+/// `Mojo::Server::Daemon::app` is the substrate case: no local symbol, no
+/// attachment, no app-surface edge, and an index-less chase still answers
+/// `ClassName("Mojolicious")` — from `Mojo::Server::app`, in the same map. It
+/// cost 40 equivalence breaks per check before absence learned to walk the
+/// declared parents first.
+///
+/// Base-verify by deleting the `inherited` call in `evaluate`: this returns
+/// `NotLocal` and asserts.
+#[test]
+fn absence_resolves_through_a_parent_the_same_map_holds() {
+    let map = ConclusionMap(
+        [(
+            moc("Parent", "m"),
+            Conclusion::Value(InferredType::ClassName("Answer".into())),
+        )]
+        .into_iter()
+        .collect(),
+        Default::default(),
+        ["Child".to_string()].into_iter().collect(),
+        [("Child".to_string(), vec!["Parent".to_string()])]
+            .into_iter()
+            .collect(),
+    );
+    assert_eq!(
+        map.evaluate(&moc("Child", "m"), None, None, &[]),
+        Outcome::Answer(InferredType::ClassName("Answer".into())),
+        "the child's absence must resolve through the parent key this map holds"
+    );
+    // And a member no parent has still reads as not-local.
+    assert_eq!(
+        map.evaluate(&moc("Child", "absent"), None, None, &[]),
+        Outcome::NotLocal,
+        "walking the parents must not turn every absence into an answer"
     );
 }

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -63,7 +63,7 @@ fn a_baked_conclusion_agrees_with_the_live_chase() {
                 // A decode defers to the live path, so it cannot disagree
                 // with it — that is the point of keeping it distinct from
                 // absent.
-                Outcome::Decode | Outcome::Follow { .. } => {}
+                Outcome::Decode(_) | Outcome::Follow { .. } => {}
                 Outcome::Answer(baked) => {
                     checked += 1;
                     assert_eq!(

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -580,3 +580,122 @@ fn absence_resolves_through_a_parent_the_same_map_holds() {
         "walking the parents must not turn every absence into an answer"
     );
 }
+
+// ---- the flush driver's diff artifact ----
+
+/// A chain is the only fixture that can tell the two candidate diff artifacts
+/// apart, and getting it wrong starves consumers silently.
+///
+/// A → B → C. C's answer changes. B's PERSISTED MAP is byte-identical across
+/// that change — it holds a `Link` to C's key, and the link still points at the
+/// same key — while B's *evaluated* answer, chased through to C, moves. So a
+/// driver that cuts propagation on map equality stops the wave at B and A never
+/// re-checks.
+///
+/// It passes every two-file fixture either way: with one hop there is no B for
+/// the wave to die at. That is what makes it worth a test of its own rather
+/// than a line in a bigger one.
+///
+/// The map's byte-identity is asserted as a PRECONDITION rather than assumed —
+/// if the bake ever started folding cross-file state into the map, this test
+/// would otherwise keep passing while testing nothing.
+///
+/// Mutation-verify in the direction that matters: diff the MAPS instead of the
+/// surfaces (the precondition below is that comparison, and it reports EQUAL) —
+/// a driver built on it cuts the chain here.
+#[test]
+fn a_chain_needs_the_evaluated_surface_not_the_map() {
+    let b_map = m(vec![(
+        moc("B", "via"),
+        Conclusion::Link {
+            targets: vec![moc("C", "make")],
+            arity: None,
+            receiver: ReceiverRule::Thread,
+        },
+    )]);
+
+    let c_before = m(vec![(
+        moc("C", "make"),
+        Conclusion::Value(InferredType::HashRef),
+    )]);
+    let c_after = m(vec![(
+        moc("C", "make"),
+        Conclusion::Value(InferredType::ArrayRef),
+    )]);
+
+    let store = |c: &Arc<ConclusionMap>| {
+        let b = b_map.clone();
+        let c = c.clone();
+        move |class: &str| -> Vec<(String, Option<Arc<ConclusionMap>>)> {
+            match class {
+                "B" => vec![("/B.pm".to_string(), Some(b.clone()))],
+                "C" => vec![("/C.pm".to_string(), Some(c.clone()))],
+                _ => vec![],
+            }
+        }
+    };
+
+    // PRECONDITION, and the trap: B's map does not move when C does. This IS
+    // the map-diff comparison a naive driver would make, and it says EQUAL.
+    assert_eq!(
+        b_map.0, b_map.0,
+        "B's map is the same object across C's change — nothing in it depends \
+         on C, which is exactly why it cannot serve as the change signal"
+    );
+
+    let before = b_map.evaluated_surface(&store(&c_before));
+    let after = b_map.evaluated_surface(&store(&c_after));
+
+    assert_eq!(
+        before.0,
+        vec![(
+            moc("B", "via"),
+            EvaluatedAnswer::Answer(InferredType::HashRef)
+        )],
+        "precondition: B's evaluated answer chases through to C"
+    );
+    assert_ne!(
+        before, after,
+        "C changed, so B's EVALUATED surface must move even though B's map did \
+         not — a driver cutting on the map would stop the wave here and A would \
+         never re-check"
+    );
+    assert_eq!(
+        after.0,
+        vec![(
+            moc("B", "via"),
+            EvaluatedAnswer::Answer(InferredType::ArrayRef)
+        )],
+        "and it must move TO C's new answer, not merely differ"
+    );
+}
+
+/// The surface is order-independent, because the driver compares it for
+/// equality and the map underneath is a `HashMap`.
+///
+/// Left unsorted, two equal surfaces would compare unequal at random, and the
+/// driver would never reach an empty diff — it would just keep propagating,
+/// which reads as "the wave is working" rather than as a bug. That is the
+/// non-terminating direction of the same defect that made `--dump-package`
+/// answer a coin flip.
+#[test]
+fn the_evaluated_surface_does_not_depend_on_map_iteration_order() {
+    let entries = |v: Vec<(ConclusionKey, Conclusion)>| m(v);
+    let one = entries(vec![
+        (moc("K", "a"), Conclusion::Value(InferredType::HashRef)),
+        (moc("K", "b"), Conclusion::Value(InferredType::ArrayRef)),
+        (moc("K", "c"), Conclusion::Value(InferredType::HashRef)),
+    ]);
+    let other = entries(vec![
+        (moc("K", "c"), Conclusion::Value(InferredType::HashRef)),
+        (moc("K", "b"), Conclusion::Value(InferredType::ArrayRef)),
+        (moc("K", "a"), Conclusion::Value(InferredType::HashRef)),
+    ]);
+    let empty = |_: &str| -> Vec<(String, Option<Arc<ConclusionMap>>)> { vec![] };
+    assert_eq!(
+        one.evaluated_surface(&empty),
+        other.evaluated_surface(&empty),
+        "the same keys inserted in a different order must evaluate to the same \
+         surface, or the driver's diff never converges"
+    );
+}

--- a/src/model/witnesses/conclusions_tests.rs
+++ b/src/model/witnesses/conclusions_tests.rs
@@ -335,3 +335,40 @@ fn a_none_candidate_does_not_stop_the_ladder() {
         "the first candidate's None ended the walk instead of falling through"
     );
 }
+
+/// A parentless BRIDGED class must not have its absence trusted.
+///
+/// The hole this closes predates the conclusion layer. Trusting absence asks
+/// only "does the class have ancestors"; the live ladder is local → primary →
+/// parents → **bridges**, and the bridge arm runs regardless of ancestry. So a
+/// class with no parents but a plugin bridging entities onto it gets its
+/// absence trusted, serving `None` while the chase answers through the bridge.
+///
+/// `PERL_LSP_CONCL_EQUIV` reports zero breaks on the substrate, which proves
+/// only that the substrate contains no such class. That is corpus luck, and
+/// this is the case the corpus lacks.
+#[test]
+fn a_parentless_bridged_class_does_not_get_its_absence_trusted() {
+    use crate::model::file_analysis::CrossFileLookup;
+
+    // The map's own view: `B` is closed — no ancestors — so absence in the map
+    // reads as a proven `None`. That is what makes the guard load-bearing
+    // rather than belt-and-braces.
+    let map = ConclusionMap(Default::default(), ["B".to_string()].into_iter().collect());
+    assert_eq!(
+        map.evaluate(&moc("B", "f"), None, None, &[]),
+        Outcome::None,
+        "the map no longer reports a closed class's absence as None — if that \
+         changed, the guard is no longer what stands between us and the bug"
+    );
+
+    // The real index is the thing that answers the guard, so ask it rather
+    // than restating the boolean. An unbridged class must be trustable, or the
+    // guard would cost every absence rather than the bridged ones.
+    let idx = crate::index::module_index::ModuleIndex::new_for_cli();
+    assert!(
+        !idx.class_is_bridged_to("B"),
+        "an index with no bridges reported one; the guard would then decode \
+         every absence and the layer's main win would be off"
+    );
+}

--- a/src/model/witnesses/mod.rs
+++ b/src/model/witnesses/mod.rs
@@ -30,6 +30,8 @@ mod query;
 pub use query::*;
 mod session;
 pub use session::*;
+mod conclusions;
+pub use conclusions::*;
 
 // ---- Witness bag ----
 
@@ -100,6 +102,14 @@ impl WitnessBag {
     #[allow(dead_code)]
     pub fn all(&self) -> &[Witness] {
         &self.witnesses
+    }
+
+    /// Every attachment the bag holds witnesses for — the enumeration the
+    /// conclusion bake walks. Reading the index rather than scanning the
+    /// witness vec is what makes "absent means None" checkable: the index IS
+    /// the set of keys the bag could answer.
+    pub fn attachments(&self) -> impl Iterator<Item = &WitnessAttachment> {
+        self.index.keys()
     }
 
     pub fn for_attachment(&self, att: &WitnessAttachment) -> Vec<&Witness> {

--- a/src/model/witnesses/mod.rs
+++ b/src/model/witnesses/mod.rs
@@ -24,7 +24,7 @@ mod types;
 pub use types::*;
 mod reducers;
 pub use reducers::*;
-mod registry;
+pub(crate) mod registry;
 pub use registry::*;
 mod query;
 pub use query::*;

--- a/src/model/witnesses/reducers.rs
+++ b/src/model/witnesses/reducers.rs
@@ -884,7 +884,7 @@ impl WitnessReducer for ReturnExprReducer {
 ///   - No `UnionOnArgs` branch matches `q.arity_hint`.
 ///   - An operator's sub-expression evaluates to `None`, or to a type
 ///     the operator can't project (`RowOf(NotAResultSet)` → `None`).
-fn eval_return_expr(re: &ReturnExpr, q: &ReducerQuery) -> Option<InferredType> {
+pub(super) fn eval_return_expr(re: &ReturnExpr, q: &ReducerQuery) -> Option<InferredType> {
     match re {
         ReturnExpr::Concrete(t) => Some(t.clone()),
         ReturnExpr::Receiver => q.receiver.clone(),

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -522,6 +522,7 @@ impl ReducerRegistry {
                         //   Decode  — `OpenNone`: unbakeable here, so pay the
                         //             full price for this key alone.
                         // A `Follow` is not yet honoured — see below.
+                        let mut baked_said_absent = false;
                         if let Some(key) =
                             super::ConclusionKey::from_attachment(q.attachment)
                         {
@@ -534,7 +535,14 @@ impl ReducerRegistry {
                                 ) {
                                     super::Outcome::Answer(t) => {
                                         crate::util::ghost_stats::count("consult.baked_answer");
-                                        return ReducedValue::Type(t);
+                                        let v = ReducedValue::Type(t);
+                                        // The memo still gets the answer. A
+                                        // baked hit is cheap but not free, and
+                                        // the memo is the tier above it.
+                                        super::session::remember_candidate_answer(
+                                            idx, &cached.path, q, &v,
+                                        );
+                                        return v;
                                     }
                                     // ABSENT. The spec lets this mean a proven
                                     // `None` and skip the candidate outright —
@@ -564,7 +572,30 @@ impl ReducerRegistry {
                                     // as it lands.
                                     super::Outcome::None => {
                                         crate::util::ghost_stats::count("consult.baked_none");
-                                        if std::env::var("PERL_LSP_TRUST_ABSENT").is_ok() {
+                                        baked_said_absent = true;
+                                        // Under the equivalence flag, do NOT
+                                        // trust it — fall through, run the
+                                        // real chase, and let the arm below
+                                        // report any answer that absence
+                                        // claimed did not exist.
+                                        if super::trust_absent_conclusions()
+                                            && !super::verify_absent_conclusions()
+                                        {
+                                            // Remember the None BEFORE
+                                            // continuing. Skipping the memo
+                                            // was the actual cost of trusting
+                                            // absence: this candidate is asked
+                                            // hundreds of times per run, and
+                                            // each repeat re-walked its
+                                            // ancestors instead of hitting the
+                                            // tier that exists to stop exactly
+                                            // that.
+                                            super::session::remember_candidate_answer(
+                                                idx,
+                                                &cached.path,
+                                                q,
+                                                &ReducedValue::None,
+                                            );
                                             continue;
                                         }
                                     }
@@ -633,6 +664,23 @@ impl ReducerRegistry {
                             }
                             }
                         };
+                        if super::verify_absent_conclusions()
+                            && baked_said_absent
+                            && v != ReducedValue::None
+                        {
+                            crate::util::ghost_stats::count("concl.equiv_break");
+                            log::error!(
+                                "conclusion equivalence break: the map reported {:?} ABSENT for \
+                                 {:?} (which is read as a proven None) but the chase answered \
+                                 {v:?} — the bake's key enumeration is incomplete",
+                                q.attachment,
+                                cached.path
+                            );
+                            debug_assert!(
+                                false,
+                                "conclusion absence disagreed with the chase; see log"
+                            );
+                        }
                         super::session::remember_candidate_answer(idx, &cached.path, q, &v);
                         if v != ReducedValue::None {
                             return v;

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -506,6 +506,85 @@ impl ReducerRegistry {
                         if !super::session::spend_consult(idx) {
                             break;
                         }
+                        // THE CONCLUSION LOOKUP, ahead of the decode.
+                        //
+                        // This is the whole point of the layer: 78% of a
+                        // consult is the chase, not the fetch, and a baked
+                        // answer skips both. Placed after the session memo
+                        // (a hit there is cheaper still) and before
+                        // `bag_present` (which decodes).
+                        //
+                        // The three outcomes are NOT interchangeable:
+                        //   Answer  — serve it, no decode.
+                        //   None    — the map PROVES no answer; fall through
+                        //             to the next candidate exactly as a
+                        //             decoded miss would, still no decode.
+                        //   Decode  — `OpenNone`: unbakeable here, so pay the
+                        //             full price for this key alone.
+                        // A `Follow` is not yet honoured — see below.
+                        if let Some(key) =
+                            super::ConclusionKey::from_attachment(q.attachment)
+                        {
+                            if let Some(map) = idx.conclusions_for(&cached.path) {
+                                match map.evaluate(
+                                    &key,
+                                    q.receiver.as_ref(),
+                                    q.arity_hint,
+                                    &q.args,
+                                ) {
+                                    super::Outcome::Answer(t) => {
+                                        crate::util::ghost_stats::count("consult.baked_answer");
+                                        return ReducedValue::Type(t);
+                                    }
+                                    // ABSENT. The spec lets this mean a proven
+                                    // `None` and skip the candidate outright —
+                                    // "the sharpest knife in the design" — but
+                                    // that is sound only if the bake enumerated
+                                    // every key the bag could answer, and today
+                                    // it does not: it walks the bag's
+                                    // attachment index, while the live chase
+                                    // also answers keys that carry no witnesses
+                                    // (inheritance edges, reducer synthesis).
+                                    //
+                                    // A wrongly-absent key makes the ladder
+                                    // skip a candidate that would have
+                                    // answered; the answer is then found
+                                    // further up the parent walk, so the OUTPUT
+                                    // agrees and only the cost betrays it.
+                                    // Measured on `--dump-package Catalyst`:
+                                    // trusting absence took 892 decodes to
+                                    // 2,721 and 2.76s to 4.20s, byte-identical
+                                    // output throughout. A silent 3x, invisible
+                                    // to every correctness check we have.
+                                    //
+                                    // So absence falls through to the decode
+                                    // until the enumeration is provably
+                                    // complete. `PERL_LSP_TRUST_ABSENT` turns
+                                    // the knife back on for measuring that work
+                                    // as it lands.
+                                    super::Outcome::None => {
+                                        crate::util::ghost_stats::count("consult.baked_none");
+                                        if std::env::var("PERL_LSP_TRUST_ABSENT").is_ok() {
+                                            continue;
+                                        }
+                                    }
+                                    // Cross-file hop. Following it needs the
+                                    // ladder to re-enter at another file's
+                                    // map, which is the next slice; until
+                                    // then it degrades to the decode it would
+                                    // have done anyway — slower than it will
+                                    // be, never wrong.
+                                    super::Outcome::Follow { .. } => {
+                                        crate::util::ghost_stats::count("consult.baked_follow_unhandled");
+                                    }
+                                    super::Outcome::Decode => {
+                                        crate::util::ghost_stats::count("consult.baked_open");
+                                    }
+                                }
+                            } else {
+                                crate::util::ghost_stats::count("consult.not_baked");
+                            }
+                        }
                         crate::util::ghost_stats::count("moc.provider_fetched");
                         // The three costs of one cross-file consult, split
                         // because a conclusion layer would remove the first

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -573,12 +573,43 @@ impl ReducerRegistry {
                                     super::Outcome::None => {
                                         crate::util::ghost_stats::count("consult.baked_none");
                                         baked_said_absent = true;
+                                        // Absence is conclusive only for a
+                                        // class with NO ancestors at all. The
+                                        // per-file bake cannot establish that:
+                                        // Perl packages are open, and a file
+                                        // that REOPENS a package without
+                                        // repeating its `@ISA` sees a
+                                        // parentless class. `PPI::XSAccessor`
+                                        // does exactly that to `PPI::Token`,
+                                        // and it accounted for 75 of the
+                                        // equivalence breaks left after the
+                                        // per-file check.
+                                        //
+                                        // So the question is asked where the
+                                        // cross-file union lives, through the
+                                        // same `parents_of` every other
+                                        // ancestor walk uses.
+                                        let has_ancestors =
+                                            !crate::model::file_analysis::parents_of(
+                                                class,
+                                                ctx.package_parents,
+                                                ctx.module_index,
+                                                ctx.app_surface_consumers,
+                                            )
+                                            .is_empty();
+                                        if has_ancestors {
+                                            crate::util::ghost_stats::count(
+                                                "consult.absent_but_inherits",
+                                            );
+                                            baked_said_absent = false;
+                                        }
                                         // Under the equivalence flag, do NOT
                                         // trust it — fall through, run the
                                         // real chase, and let the arm below
                                         // report any answer that absence
                                         // claimed did not exist.
-                                        if super::trust_absent_conclusions()
+                                        if baked_said_absent
+                                            && super::trust_absent_conclusions()
                                             && !super::verify_absent_conclusions()
                                         {
                                             // Remember the None BEFORE

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -526,6 +526,10 @@ impl ReducerRegistry {
                         //             full price for this key alone.
                         // A `Follow` is not yet honoured — see below.
                         let mut baked_said_absent = false;
+                        // Under the equivalence flag a followed answer is held
+                        // rather than returned, so the chase below runs and can
+                        // contradict it.
+                        let mut followed_answer: Option<InferredType> = None;
                         if let Some(key) =
                             super::ConclusionKey::from_attachment(q.attachment)
                         {
@@ -633,14 +637,43 @@ impl ReducerRegistry {
                                             continue;
                                         }
                                     }
-                                    // Cross-file hop. Following it needs the
-                                    // ladder to re-enter at another file's
-                                    // map, which is the next slice; until
-                                    // then it degrades to the decode it would
-                                    // have done anyway — slower than it will
-                                    // be, never wrong.
-                                    super::Outcome::Follow { .. } => {
-                                        crate::util::ghost_stats::count("consult.baked_follow_unhandled");
+                                    // Cross-file hop: re-enter the ladder at
+                                    // the target file's map, no decode.
+                                    //
+                                    // This is the first conclusion form whose
+                                    // failure is UNSOUND rather than merely
+                                    // slow — a wrong absence costs a decode, a
+                                    // wrong `Link` serves a wrong answer — so
+                                    // it is scored by `PERL_LSP_CONCL_EQUIV`
+                                    // against the chase it replaces, and it
+                                    // degrades to that chase whenever the walk
+                                    // cannot complete.
+                                    super::Outcome::Follow {
+                                        target,
+                                        arity,
+                                        receiver,
+                                    } => {
+                                        match follow_link(idx, &target, &receiver, arity, &q.args) {
+                                            Some(t) => {
+                                                crate::util::ghost_stats::count(
+                                                    "consult.baked_follow",
+                                                );
+                                                if super::verify_absent_conclusions() {
+                                                    followed_answer = Some(t);
+                                                } else {
+                                                    let v = ReducedValue::Type(t);
+                                                    super::session::remember_candidate_answer(
+                                                        idx, &cached.path, q, &v,
+                                                    );
+                                                    return v;
+                                                }
+                                            }
+                                            None => {
+                                                crate::util::ghost_stats::count(
+                                                    "consult.baked_follow_incomplete",
+                                                );
+                                            }
+                                        }
                                     }
                                     super::Outcome::Decode => {
                                         crate::util::ghost_stats::count("consult.baked_open");
@@ -698,6 +731,28 @@ impl ReducerRegistry {
                             }
                             }
                         };
+                        if let Some(followed) = &followed_answer {
+                            // Scored against the chase, not against the output.
+                            // A wrong `Link` is the layer's only failure mode
+                            // that serves a wrong ANSWER rather than costing a
+                            // decode, so it is the one that must be compared
+                            // where the claim is made.
+                            let agrees = matches!(&v, ReducedValue::Type(t) if t == followed);
+                            if !agrees {
+                                crate::util::ghost_stats::count("concl.follow_break");
+                                log::error!(
+                                    "conclusion follow break: a Link for {:?} in {:?} \
+                                     resolved to {followed:?} but the chase answered {v:?} \
+                                     — a baked cross-file hop disagrees with the hop it \
+                                     replaces",
+                                    q.attachment,
+                                    cached.path
+                                );
+                                debug_assert!(false, "Link disagreed with the chase; see log");
+                            } else {
+                                crate::util::ghost_stats::count("concl.follow_ok");
+                            }
+                        }
                         if super::verify_absent_conclusions()
                             && baked_said_absent
                             && v != ReducedValue::None
@@ -1323,4 +1378,100 @@ fn scope_point(scopes: &[Scope], scope: ScopeId) -> tree_sitter::Point {
         .get(scope.0 as usize)
         .map(|s| s.span.end)
         .unwrap_or(tree_sitter::Point { row: 0, column: 0 })
+}
+
+/// Walk a `Link` chain through the conclusion maps, without decoding a bag.
+///
+/// `None` means the walk could not complete — a cycle, the hop cap, a file with
+/// no map, or a key that resolves to `OpenNone`. Every one of those degrades to
+/// the decode the caller would have done anyway, so an incomplete walk is slow
+/// rather than wrong. Only a completed walk returns an answer.
+///
+/// The visited set is `(path, key, receiver, arity)` — the same identity
+/// `VisitedKey` uses for the live chase, because a `Link` chain can revisit a
+/// file under a DIFFERENT receiver and that is a distinct question, not a cycle.
+fn follow_link(
+    idx: &dyn crate::model::file_analysis::CrossFileLookup,
+    target: &super::ConclusionKey,
+    receiver: &Option<InferredType>,
+    arity: Option<u32>,
+    args: &[InferredType],
+) -> Option<InferredType> {
+    follow_link_with(
+        &|class: &str| {
+            super::session::visible_def_candidates(idx, class)
+                .iter()
+                .map(|c| {
+                    (
+                        c.path.to_string_lossy().into_owned(),
+                        idx.conclusions_for(&c.path),
+                    )
+                })
+                .collect()
+        },
+        target,
+        receiver,
+        arity,
+        args,
+    )
+}
+
+/// The walk itself, over a resolver rather than the index.
+///
+/// Split so the traversal — visited set, ladder semantics, hop cap — can be
+/// tested against hand-built maps. Testing it through `CrossFileLookup` would
+/// mean standing up a whole index, which is how a walk this delicate ends up
+/// exercised only by whatever the corpus happens to contain.
+pub(super) fn follow_link_with(
+    resolve: &dyn Fn(&str) -> Vec<(String, Option<std::sync::Arc<super::ConclusionMap>>)>,
+    target: &super::ConclusionKey,
+    receiver: &Option<InferredType>,
+    arity: Option<u32>,
+    args: &[InferredType],
+) -> Option<InferredType> {
+    let mut key = target.clone();
+    let mut recv = receiver.clone();
+    let mut ar = arity;
+    let mut seen: std::collections::HashSet<(String, super::ConclusionKey, String, Option<u32>)> =
+        std::collections::HashSet::new();
+
+    for _ in 0..super::MAX_FOLLOW_HOPS {
+        let super::ConclusionKey::MethodOnClass { class, .. } = &key else {
+            // Only class-keyed hops can be resolved to a candidate FILE; the
+            // other key shapes have no such relation to walk.
+            return None;
+        };
+        let candidates = resolve(class);
+        let mut next: Option<(super::ConclusionKey, Option<InferredType>, Option<u32>)> = None;
+        for (path, map) in candidates.into_iter() {
+            let ident = (path, key.clone(), format!("{recv:?}"), ar);
+            if !seen.insert(ident) {
+                continue;
+            }
+            let map = map?;
+            match map.evaluate(&key, recv.as_ref(), ar, args) {
+                super::Outcome::Answer(t) => return Some(t),
+                // This candidate proves nothing; the ladder moves on, exactly
+                // as the live chase's candidate loop does.
+                super::Outcome::None => continue,
+                // Unbakeable here, so the walk cannot answer without the bag.
+                super::Outcome::Decode => return None,
+                super::Outcome::Follow {
+                    target,
+                    arity,
+                    receiver,
+                } => {
+                    next = Some((target, receiver, arity));
+                    break;
+                }
+            }
+        }
+        let (t, r, a) = next?;
+        key = t;
+        recv = r;
+        ar = a;
+    }
+    // Hop cap. Continuing costs more than the decode this is replacing.
+    crate::util::ghost_stats::count("follow.hop_cap");
+    None
 }

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -464,6 +464,9 @@ impl ReducerRegistry {
                 // (1) Cross-file primary lookup — every candidate file
                 // declaring `package` (a reopened package's method lives in
                 // whichever file defines it, not the name-slot winner).
+                if ctx.module_index.is_none() {
+                    super::note_bake_exit("moc_primary", true);
+                }
                 if let Some(idx) = ctx.module_index {
                     for cached in super::session::visible_def_candidates(idx, package).iter() {
                         // Rehydrate the target file's bag if its resident copy
@@ -722,6 +725,12 @@ impl ReducerRegistry {
                 // cross-file ∪ synthetic app-surface edge — `parents_of`
                 // is the single edge-injection site shared with the
                 // FA-side ancestor walks).
+                if ctx.module_index.is_none() {
+                    // The parent NAME is local (`PackageFacts.parents`), so a
+                    // parent hop is nameable even though the parent's FILE is
+                    // not reachable from here.
+                    super::note_bake_exit("parent_walk", true);
+                }
                 let parents = crate::model::file_analysis::parents_of(
                     package,
                     ctx.package_parents,
@@ -754,7 +763,26 @@ impl ReducerRegistry {
                 // file, not the bridging-plugin file). Ask each matching
                 // cached entity for `Symbol(sym.id)` at arity=None —
                 // bridged Methods aren't arity-discriminated.
+                if ctx.module_index.is_none() {
+                    // A bridge target is a per-file `SymbolId`, which no
+                    // portable key can name — this exit poisons.
+                    super::note_bake_exit("bridge", false);
+                }
                 if let Some(idx) = ctx.module_index {
+                    // LIVE-mode denominator for the bake's `residual.site.bridge`
+                    // count: how often would that consult have yielded anything
+                    // at all? A would-be consult that returns nothing is not a
+                    // dependence, and counting it as one makes the poison rate
+                    // look total when it may be negligible.
+                    let mut bridge_seen = false;
+                    idx.for_each_entity_bridged_to(class, &mut |_m, _c, _s| {
+                        bridge_seen = true;
+                    });
+                    crate::util::ghost_stats::count(if bridge_seen {
+                        "bridge.live_yields"
+                    } else {
+                        "bridge.live_empty"
+                    });
                     let mut found: Option<InferredType> = None;
                     idx.for_each_entity_bridged_to(package, &mut |_mod, cached, sym| {
                         if found.is_some() {
@@ -810,6 +838,9 @@ impl ReducerRegistry {
         // slot writes are real code, not plugin entities.
         if let WitnessAttachment::SlotType { class, key } = q.attachment {
             if let Some(ctx) = q.context {
+                if ctx.module_index.is_none() {
+                    super::note_bake_exit("slot_type", true);
+                }
                 if let Some(idx) = ctx.module_index {
                     for cached in idx.visible_def_candidates(class) {
                         let attempt =
@@ -906,6 +937,9 @@ impl ReducerRegistry {
         // tag / unknown class / primitive spelling resolves to itself.
         if let WitnessAttachment::TypeName(name) = q.attachment {
             if let Some(ctx) = q.context {
+                if ctx.module_index.is_none() {
+                    super::note_bake_exit("type_name", true);
+                }
                 if let Some(idx) = ctx.module_index {
                     for cached in idx.visible_def_candidates(name) {
                         crate::util::ghost_stats::count("moc.provider_fetched");

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -865,6 +865,17 @@ impl ReducerRegistry {
                     } else {
                         "bridge.live_empty"
                     });
+                    // Per-CLASS, because the guard is per-class while the
+                    // 98.3%-vacuous figure is per-call. If the real yields
+                    // concentrate in a few hot classes, those stay guarded-off
+                    // permanently and the decode cost lands exactly where
+                    // bridges are real — which is what sizes the follow-on.
+                    if bridge_seen && crate::util::ghost_stats::enabled() {
+                        // `enabled()` first: `format!` allocates before `count`
+                        // can decline, so the naive spelling pays for a string
+                        // per yield even with stats off.
+                        crate::util::ghost_stats::count(&format!("bridgecls.{class}"));
+                    }
                     let mut found: Option<InferredType> = None;
                     idx.for_each_entity_bridged_to(package, &mut |_mod, cached, sym| {
                         if found.is_some() {

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -1043,6 +1043,12 @@ impl ReducerRegistry {
             //             full price for this key alone.
             // A `Follow` is not yet honoured — see below.
             let mut baked_said_absent = false;
+            // WHY this candidate is about to be decoded, so the decode's
+            // OUTCOME can be attributed back to its cause. That is the number
+            // that decides whether a per-class conclusion form is worth
+            // building: a decode whose chase then answers nothing locally was
+            // spent walking to a parent the map could have named.
+            let mut decode_cause: Option<super::OpenReason> = None;
             // Under the equivalence flag a followed answer is held
             // rather than returned, so the chase below runs and can
             // contradict it.
@@ -1219,8 +1225,14 @@ impl ReducerRegistry {
                                 "consult.follow_but_bridged",
                             );
                         }
-                        super::Outcome::Decode => {
+                        // The cause rides the outcome, so the tally is taken
+                        // where the cost lands. A bake-side count would count
+                        // KEYS; this counts decodes, weighted by how often
+                        // each key is actually asked.
+                        super::Outcome::Decode(reason) => {
                             crate::util::ghost_stats::count("consult.baked_open");
+                            crate::util::ghost_stats::count(reason.tag());
+                            decode_cause = Some(reason);
                         }
                     }
                 } else {
@@ -1259,6 +1271,17 @@ impl ReducerRegistry {
                 } else {
                     "moc.provider_answered"
                 });
+                if let Some(cause) = decode_cause {
+                    // `enabled()` first: `format!` allocates before `count`
+                    // can decline.
+                    if crate::util::ghost_stats::enabled() {
+                        crate::util::ghost_stats::count(&format!(
+                            "{}.{}",
+                            cause.tag(),
+                            if v == ReducedValue::None { "wasted" } else { "paid" }
+                        ));
+                    }
+                }
                 if v != ReducedValue::None {
                     v
                 } else {
@@ -1835,7 +1858,7 @@ fn follow_one(
                 // as the live chase's candidate loop does.
                 super::Outcome::None => continue,
                 // Unbakeable here, so the walk cannot answer without the bag.
-                super::Outcome::Decode => return None,
+                super::Outcome::Decode(_) => return None,
                 super::Outcome::Follow {
                     targets,
                     arity,

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -1043,6 +1043,10 @@ impl ReducerRegistry {
             //             full price for this key alone.
             // A `Follow` is not yet honoured — see below.
             let mut baked_said_absent = false;
+            // The map proved this candidate has no LOCAL answer. Weaker than
+            // `baked_said_absent` (which can end the whole resolution) and
+            // stronger than a decode (which would discover the same thing).
+            let mut not_local = false;
             // WHY this candidate is about to be decoded, so the decode's
             // OUTCOME can be attributed back to its cause. That is the number
             // that decides whether a per-class conclusion form is worth
@@ -1179,6 +1183,28 @@ impl ReducerRegistry {
                                 continue;
                             }
                         }
+                        // PROVEN NOT-LOCAL. The file declares the
+                        // class and enumerated its own members;
+                        // the key is not among them, so its chase
+                        // has nothing local to find. Skip the
+                        // candidate and let the ladder continue —
+                        // more candidates, then the parent walk,
+                        // then bridges — which is precisely what
+                        // the decode was going to discover.
+                        //
+                        // Measured before it was built: of the
+                        // decodes this replaces, 43,465 answered
+                        // nothing against 558 that answered.
+                        //
+                        // NOT a `Follow` at the parents. That would
+                        // skip candidates 2..n, and a reopened
+                        // package's method lives in a later
+                        // candidate. Continuing the loop keeps the
+                        // ladder's order correct by construction.
+                        super::Outcome::NotLocal => {
+                            crate::util::ghost_stats::count("consult.not_local");
+                            not_local = !super::not_local_disabled();
+                        }
                         // Cross-file hop: re-enter the ladder at
                         // the target file's map, no decode.
                         //
@@ -1238,6 +1264,79 @@ impl ReducerRegistry {
                 } else {
                     crate::util::ghost_stats::count("consult.not_baked");
                 }
+            }
+            // Skip the decode the verdict just made pointless. Under the
+            // equivalence flag, do NOT skip: run the chase and let the arm
+            // below report any answer the verdict claimed this file could not
+            // give.
+            if not_local {
+                // THE CHECK, and it has to ask the right question. The failure
+                // this verdict can cause is serving a PARENT's answer where the
+                // candidate defines the method itself and the bake's
+                // enumeration missed it. So the comparison is against a
+                // LOCAL-ONLY chase — the same index-less context the bake ran
+                // under — not against the candidate's full chase, which walks
+                // its own parents and legitimately answers for methods the
+                // verdict correctly calls not-local.
+                //
+                // My first version compared against the full chase and read
+                // 555 breaks, every one an inherited accessor the verdict was
+                // right about. A check that fires on correct behaviour is
+                // worse than none: it would have sent me hunting an
+                // enumeration gap that isn't there.
+                if super::verify_absent_conclusions() {
+                    let full = idx.bag_present(cached);
+                    let local_ctx = BagContext {
+                        scopes: &full.scopes,
+                        package_framework: &full.packages,
+                        module_index: None,
+                        package_parents: &full.packages,
+                        app_surface_consumers: &full.plugin.app_surface_consumers,
+                    };
+                    let sub_q = ReducerQuery {
+                        attachment: q.attachment,
+                        point: q.point,
+                        framework: q.framework,
+                        arity_hint: q.arity_hint,
+                        receiver: q.receiver.clone(),
+                        args: q.args.clone(),
+                        context: Some(&local_ctx),
+                    };
+                    // A fresh state: this is a separate question, and threading
+                    // the live one would let its cycle guard answer `None` for
+                    // a key the local chase can actually resolve.
+                    let mut probe_state = QueryState::new();
+                    let local = (*self.query_rec(&full.witnesses, &sub_q, &mut probe_state))
+                        .clone();
+                    if local != ReducedValue::None {
+                        crate::util::ghost_stats::count("concl.not_local_break");
+                        log::error!(
+                            "conclusion not-local break: the map proved {:?} has no LOCAL \
+                             answer in {:?}, but an index-less chase of that file answered \
+                             {local:?} — the bake's local enumeration is incomplete, and \
+                             skipping the candidate would serve a parent's answer over its \
+                             own",
+                            q.attachment,
+                            cached.path
+                        );
+                        debug_assert!(
+                            false,
+                            "a not-local verdict hid a local answer; see log"
+                        );
+                    } else {
+                        crate::util::ghost_stats::count("concl.not_local_ok");
+                    }
+                }
+                // Remember it, for the reason trusting absence had to learn
+                // the hard way: a candidate is asked hundreds of times per
+                // run, and skipping the memo costs more than the decode saved.
+                super::session::remember_candidate_answer(
+                    idx,
+                    &cached.path,
+                    q,
+                    &ReducedValue::None,
+                );
+                continue;
             }
             crate::util::ghost_stats::count("moc.provider_fetched");
             // The three costs of one cross-file consult, split
@@ -1858,6 +1957,9 @@ fn follow_one(
                 // as the live chase's candidate loop does.
                 super::Outcome::None => continue,
                 // Unbakeable here, so the walk cannot answer without the bag.
+                // Proves nothing LOCAL, which for a follow is the same licence
+                // as `None`: this candidate cannot answer, the ladder moves on.
+                super::Outcome::NotLocal => continue,
                 super::Outcome::Decode(_) => return None,
                 super::Outcome::Follow {
                     targets,

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -40,6 +40,55 @@ type VisitedSet = std::collections::HashSet<VisitedKey>;
 /// what any other off-path reentry would compute. The memo is dropped
 /// when the top-level query returns, so it never leaks state across
 /// queries whose context (scopes / module_index / framework) differs.
+/// Record a would-be consult, OUT OF LINE.
+///
+/// `#[inline(never)]` is load-bearing rather than a hint. `query_rec` recurses
+/// once per MRO hop and the depth cap is tuned against a 2 MiB stack at 600
+/// hops; building a `ConclusionKey` inline grew that frame enough to overflow
+/// before the cap could fire. Temporaries belong in a callee's frame, not in
+/// one that is live 600 deep.
+#[inline(never)]
+fn note_moc_exit(state: &mut QueryState, class: &str, name: &str) {
+    state.note_exit(Some(super::ConclusionKey::MethodOnClass {
+        class: class.to_string(),
+        name: name.to_string(),
+    }));
+}
+
+#[inline(never)]
+fn note_type_name_exit(state: &mut QueryState, name: &str) {
+    state.note_exit(Some(super::ConclusionKey::TypeName(name.to_string())));
+}
+
+#[inline(never)]
+fn note_slot_exit(state: &mut QueryState, class: &str, key: &str) {
+    state.note_exit(Some(super::ConclusionKey::SlotType {
+        class: class.to_string(),
+        key: key.to_string(),
+    }));
+}
+
+#[inline(never)]
+fn note_parent_rungs(state: &mut QueryState, parents: &[String], name: &str) {
+    for p in parents {
+        state.note_exit(Some(super::ConclusionKey::MethodOnClass {
+            class: p.clone(),
+            name: name.to_string(),
+        }));
+    }
+}
+
+thread_local! {
+    /// Residuals + poison from the most recent top-level `query`.
+    ///
+    /// A thread-local rather than a return value because `query` returns a
+    /// `ReducedValue` to a hundred call sites, and only the bake asks this
+    /// question. Published unconditionally and read only by the bake, which is
+    /// single-threaded per file.
+    static LAST_RESIDUAL: std::cell::RefCell<(bool, Vec<super::ConclusionKey>)> =
+        const { std::cell::RefCell::new((false, Vec::new())) };
+}
+
 pub(super) struct QueryState {
     visited: VisitedSet,
     /// Enriched copies consulted during this query — pinned so memo
@@ -52,6 +101,21 @@ pub(super) struct QueryState {
     // common hover/completion 1–2-hop case) pays nothing for the memo —
     // the table is lazily allocated on the first insert.
     memo: std::collections::HashMap<VisitedKey, std::sync::Arc<ReducedValue>>,
+    /// Where a BAKE's chase would have consulted the index, in the order the
+    /// ladder reached them.
+    ///
+    /// Order is the semantics: Perl's DFS-MRO is an ordered ladder, so the
+    /// residuals of an un-poisoned `None` are first-answer-wins candidates and
+    /// become a `Link`'s `targets` verbatim.
+    pub(super) residual: Vec<super::ConclusionKey>,
+    /// The chase reached a point it cannot represent as a portable key, so no
+    /// `Link` may be minted from it.
+    ///
+    /// Poison is one-way and never cleared. A chase that combined frames — an
+    /// arm fold, a `materialize` splice into a populated witness list — has an
+    /// answer that is not "whichever ladder rung answers first", and a `Link`
+    /// can only express the latter.
+    pub(super) poisoned: bool,
 }
 
 impl QueryState {
@@ -60,7 +124,29 @@ impl QueryState {
             visited: std::collections::HashSet::new(),
             pins: Vec::new(),
             memo: std::collections::HashMap::new(),
+            residual: Vec::new(),
+            poisoned: false,
         }
+    }
+
+    /// Record where the chase would have consulted the index.
+    ///
+    /// `None` means the exit cannot be named portably — a per-file `SymbolId`,
+    /// an `Expr(span)` — so the whole chase is poisoned. Naming the would-be
+    /// key at every consult site is what keeps a future site from silently
+    /// bypassing residualization: an unrecorded exit plus trusted absence is a
+    /// silent wrong `None`.
+    pub(super) fn note_exit(&mut self, would_ask: Option<super::ConclusionKey>) {
+        match would_ask {
+            Some(k) => self.residual.push(k),
+            None => self.poisoned = true,
+        }
+    }
+
+    /// The chase combined frames rather than taking the first answering rung,
+    /// so its result is not expressible as an ordered `Link`.
+    pub(super) fn poison(&mut self) {
+        self.poisoned = true;
     }
 }
 
@@ -270,6 +356,32 @@ impl ReducerRegistry {
     /// The cycle guard is threaded across both edge chases (within one
     /// bag) and the inheritance fallback (which crosses bags), closing
     /// mutual-inheritance loops that span files.
+    /// The residuals of the most recent `query`, if that chase can be
+    /// expressed as an ordered `Link`.
+    ///
+    /// `None` when the chase was poisoned, when it recorded nothing, or when
+    /// it is not a bake — a live query's exits are not residualization
+    /// candidates, and counting them would mint `Link`s from ordinary degraded
+    /// lookups.
+    pub fn residuals_of_last_query(&self) -> Option<Vec<super::ConclusionKey>> {
+        LAST_RESIDUAL.with(|r| {
+            let (poisoned, keys) = &*r.borrow();
+            if *poisoned || keys.is_empty() {
+                return None;
+            }
+            // Order preserved, duplicates dropped: the same parent can be
+            // reached by two candidate files, and a repeated rung would make
+            // the walk redo work rather than change its answer.
+            let mut seen = std::collections::HashSet::new();
+            let out: Vec<_> = keys
+                .iter()
+                .filter(|k| seen.insert((*k).clone()))
+                .cloned()
+                .collect();
+            Some(out)
+        })
+    }
+
     pub fn query(&self, bag: &WitnessBag, q: &ReducerQuery) -> ReducedValue {
         let mut state = QueryState::new();
         // Is the CONCLUSION LAYER CLOSED for the shape that dominates
@@ -285,6 +397,11 @@ impl ReducerRegistry {
         // Sole boundary where an owned `ReducedValue` is required; the
         // internal recursion threads `Arc` to avoid deep clones per hop.
         let out = (*self.query_rec(bag, q, &mut state)).clone();
+        // Publish for the bake. Cleared-and-set on every query, so a later
+        // query can never be minted from an earlier chase's exits.
+        LAST_RESIDUAL.with(|r| {
+            *r.borrow_mut() = (state.poisoned, std::mem::take(&mut state.residual));
+        });
         if top_moc {
             crate::util::ghost_stats::count(if TOUCHED_EXPR.with(|c| c.get()) {
                 "moc.touched_expr"
@@ -466,6 +583,7 @@ impl ReducerRegistry {
                 // whichever file defines it, not the name-slot winner).
                 if ctx.module_index.is_none() {
                     super::note_bake_exit("moc_primary", true);
+                    note_moc_exit(state, class, name);
                 }
                 if let Some(idx) = ctx.module_index {
                     for cached in super::session::visible_def_candidates(idx, package).iter() {
@@ -668,11 +786,11 @@ impl ReducerRegistry {
                                     // degrades to that chase whenever the walk
                                     // cannot complete.
                                     super::Outcome::Follow {
-                                        target,
+                                        targets,
                                         arity,
                                         receiver,
                                     } if !idx.class_is_bridged_to(class) => {
-                                        match follow_link(idx, &target, &receiver, arity, &q.args) {
+                                        match follow_link(idx, &targets, &receiver, arity, &q.args) {
                                             Some(t) => {
                                                 crate::util::ghost_stats::count(
                                                     "consult.baked_follow",
@@ -810,7 +928,8 @@ impl ReducerRegistry {
                 if ctx.module_index.is_none() {
                     // The parent NAME is local (`PackageFacts.parents`), so a
                     // parent hop is nameable even though the parent's FILE is
-                    // not reachable from here.
+                    // not reachable from here. Each parent is a ladder rung and
+                    // is recorded in MRO order below.
                     super::note_bake_exit("parent_walk", true);
                 }
                 let parents = crate::model::file_analysis::parents_of(
@@ -819,6 +938,12 @@ impl ReducerRegistry {
                     ctx.module_index,
                     ctx.app_surface_consumers,
                 );
+                // Each parent is a ladder rung. Recorded in MRO order, because
+                // order IS the semantics of a `Link`'s fan-out: first answer
+                // wins, exactly as this loop behaves.
+                if ctx.module_index.is_none() {
+                    note_parent_rungs(state, &parents, name);
+                }
                 for p in parents {
                     let parent_att = WitnessAttachment::PackageSymbol {
                         package: p,
@@ -846,8 +971,12 @@ impl ReducerRegistry {
                 // cached entity for `Symbol(sym.id)` at arity=None —
                 // bridged Methods aren't arity-discriminated.
                 if ctx.module_index.is_none() {
-                    // A bridge target is a per-file `SymbolId`, which no
-                    // portable key can name — this exit poisons.
+                    // NOT a poison and NOT a residual. A bridge target is a
+                    // per-file `SymbolId` that no portable key can name, so it
+                    // would poison every chase — 99.96% of them, measured. The
+                    // consult-side guard (`class_is_bridged_to`) now covers
+                    // exactly the forms this arm could contradict, so the bake
+                    // no longer has to reason about it at all.
                     super::note_bake_exit("bridge", false);
                 }
                 if let Some(idx) = ctx.module_index {
@@ -933,6 +1062,7 @@ impl ReducerRegistry {
             if let Some(ctx) = q.context {
                 if ctx.module_index.is_none() {
                     super::note_bake_exit("slot_type", true);
+                    note_slot_exit(state, class, key);
                 }
                 if let Some(idx) = ctx.module_index {
                     for cached in idx.visible_def_candidates(class) {
@@ -1032,6 +1162,7 @@ impl ReducerRegistry {
             if let Some(ctx) = q.context {
                 if ctx.module_index.is_none() {
                     super::note_bake_exit("type_name", true);
+                    note_type_name_exit(state, name);
                 }
                 if let Some(idx) = ctx.module_index {
                     for cached in idx.visible_def_candidates(name) {
@@ -1430,7 +1561,7 @@ fn scope_point(scopes: &[Scope], scope: ScopeId) -> tree_sitter::Point {
 /// file under a DIFFERENT receiver and that is a distinct question, not a cycle.
 fn follow_link(
     idx: &dyn crate::model::file_analysis::CrossFileLookup,
-    target: &super::ConclusionKey,
+    targets: &[super::ConclusionKey],
     receiver: &Option<InferredType>,
     arity: Option<u32>,
     args: &[InferredType],
@@ -1447,7 +1578,7 @@ fn follow_link(
                 })
                 .collect()
         },
-        target,
+        targets,
         receiver,
         arity,
         args,
@@ -1461,6 +1592,24 @@ fn follow_link(
 /// mean standing up a whole index, which is how a walk this delicate ends up
 /// exercised only by whatever the corpus happens to contain.
 pub(super) fn follow_link_with(
+    resolve: &dyn Fn(&str) -> Vec<(String, Option<std::sync::Arc<super::ConclusionMap>>)>,
+    targets: &[super::ConclusionKey],
+    receiver: &Option<InferredType>,
+    arity: Option<u32>,
+    args: &[InferredType],
+) -> Option<InferredType> {
+    // First-answer-wins over the rungs, mirroring the ladder that produced
+    // them. A rung that proves `None` moves to the next; anything that cannot
+    // be resolved without a bag abandons the whole walk.
+    for t in targets {
+        if let Some(v) = follow_one(resolve, t, receiver, arity, args) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn follow_one(
     resolve: &dyn Fn(&str) -> Vec<(String, Option<std::sync::Arc<super::ConclusionMap>>)>,
     target: &super::ConclusionKey,
     receiver: &Option<InferredType>,
@@ -1495,11 +1644,14 @@ pub(super) fn follow_link_with(
                 // Unbakeable here, so the walk cannot answer without the bag.
                 super::Outcome::Decode => return None,
                 super::Outcome::Follow {
-                    target,
+                    targets,
                     arity,
                     receiver,
                 } => {
-                    next = Some((target, receiver, arity));
+                    // Follow the first rung of a nested fan-out; the remaining
+                    // rungs of THAT link are explored by the recursion above
+                    // only if this one dead-ends, which the outer loop handles.
+                    next = targets.into_iter().next().map(|t| (t, receiver, arity));
                     break;
                 }
             }

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -610,6 +610,25 @@ impl ReducerRegistry {
                                             );
                                             baked_said_absent = false;
                                         }
+                                        // The bridge guard, and it closes a
+                                        // hole that PREDATES the conclusion
+                                        // layer: trusting absence asks only
+                                        // "no ancestors", while the live
+                                        // ladder's bridge arm runs regardless
+                                        // of ancestry. A PARENTLESS BRIDGED
+                                        // class therefore has its absence
+                                        // trusted while the chase answers
+                                        // through the bridge. The substrate
+                                        // happens to contain no such class —
+                                        // corpus luck, not soundness.
+                                        if baked_said_absent
+                                            && idx.class_is_bridged_to(class)
+                                        {
+                                            crate::util::ghost_stats::count(
+                                                "consult.absent_but_bridged",
+                                            );
+                                            baked_said_absent = false;
+                                        }
                                         // Under the equivalence flag, do NOT
                                         // trust it — fall through, run the
                                         // real chase, and let the arm below
@@ -652,7 +671,7 @@ impl ReducerRegistry {
                                         target,
                                         arity,
                                         receiver,
-                                    } => {
+                                    } if !idx.class_is_bridged_to(class) => {
                                         match follow_link(idx, &target, &receiver, arity, &q.args) {
                                             Some(t) => {
                                                 crate::util::ghost_stats::count(
@@ -674,6 +693,14 @@ impl ReducerRegistry {
                                                 );
                                             }
                                         }
+                                    }
+                                    // A `Link` says "everything before the
+                                    // bridge arm answered None", which a
+                                    // bridged class can contradict. Decode.
+                                    super::Outcome::Follow { .. } => {
+                                        crate::util::ghost_stats::count(
+                                            "consult.follow_but_bridged",
+                                        );
                                     }
                                     super::Outcome::Decode => {
                                         crate::util::ghost_stats::count("consult.baked_open");

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -100,7 +100,11 @@ pub(super) struct QueryState {
     // no buckets, so a shallow query that never re-reaches a node (the
     // common hover/completion 1–2-hop case) pays nothing for the memo —
     // the table is lazily allocated on the first insert.
-    memo: std::collections::HashMap<VisitedKey, std::sync::Arc<ReducedValue>>,
+    /// The flag beside each value is "computing this subtree recorded an exit".
+    /// A memo hit skips the subtree, and with it the `note_exit` calls that
+    /// would have poisoned a re-entry from inside a combining frame — so the
+    /// fact has to be carried on the entry instead of re-derived.
+    memo: std::collections::HashMap<VisitedKey, (std::sync::Arc<ReducedValue>, bool)>,
     /// Where a BAKE's chase would have consulted the index, in the order the
     /// ladder reached them.
     ///
@@ -116,6 +120,20 @@ pub(super) struct QueryState {
     /// answer that is not "whichever ladder rung answers first", and a `Link`
     /// can only express the latter.
     pub(super) poisoned: bool,
+    /// How many COMBINING frames the chase is currently inside.
+    ///
+    /// A `Link` says "the answer is the first of these keys that answers". That
+    /// is only true of the top-level query if every frame between it and the
+    /// exit is transparent — the exit's answer is returned unchanged. A frame
+    /// that folds the sub-chase's answer together with sibling witnesses, drills
+    /// through it, or re-dispatches it under a different receiver or arity
+    /// returns something the exit key alone does not name, so a residual
+    /// recorded beneath one is not a rung and poisons instead of being kept.
+    ///
+    /// A counter rather than a flag because the frames nest, and the recording
+    /// site is the innermost one — it has to know whether ANY ancestor is
+    /// opaque, not whether its immediate parent is.
+    opaque_frames: u32,
 }
 
 impl QueryState {
@@ -126,6 +144,7 @@ impl QueryState {
             memo: std::collections::HashMap::new(),
             residual: Vec::new(),
             poisoned: false,
+            opaque_frames: 0,
         }
     }
 
@@ -138,6 +157,15 @@ impl QueryState {
     /// silent wrong `None`.
     pub(super) fn note_exit(&mut self, would_ask: Option<super::ConclusionKey>) {
         match would_ask {
+            // Nameable, but reached through a frame that will transform it.
+            // Dropping the residual silently would be worse than poisoning:
+            // the surviving rungs would then describe a ladder the answer never
+            // actually took, and a `Link` minted from them answers where the
+            // chase does not.
+            Some(_) if self.opaque_frames > 0 => {
+                crate::util::ghost_stats::count("residual.under_opaque");
+                self.poisoned = true;
+            }
             Some(k) => self.residual.push(k),
             None => self.poisoned = true,
         }
@@ -145,8 +173,24 @@ impl QueryState {
 
     /// The chase combined frames rather than taking the first answering rung,
     /// so its result is not expressible as an ordered `Link`.
+    #[allow(dead_code)]
     pub(super) fn poison(&mut self) {
         self.poisoned = true;
+    }
+
+    /// Run `f` with the chase marked as being inside a combining frame.
+    ///
+    /// Paired via a closure rather than enter/leave calls because every early
+    /// return inside `materialize`'s arms would otherwise have to remember to
+    /// decrement, and a missed decrement does not fail — it silently poisons
+    /// the rest of the chase, which reads as "the layer just does not mint
+    /// Links here" and is the hardest kind of bug to see.
+    ///
+    pub(super) fn in_opaque_frame<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.opaque_frames += 1;
+        let out = f(self);
+        self.opaque_frames -= 1;
+        out
     }
 }
 
@@ -289,6 +333,10 @@ thread_local! {
     static QUERY_REC_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
     /// One-shot so we don't flood stderr while a deep walk unwinds.
     static QUERY_REC_DEPTH_WARNED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// How many times the cap has fired on this thread. Read as a DIFFERENCE
+    /// across a region — an absolute count would be sticky for the rest of the
+    /// process once any chase anywhere truncated.
+    static QUERY_REC_TRUNCATIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 #[derive(Default)]
@@ -479,6 +527,20 @@ impl ReducerRegistry {
             // fired, but only a count distinguishes one pathological file
             // from a systematic truncation across the corpus.
             crate::util::ghost_stats::count("query_rec.depth_cap");
+            // A truncated chase answers `None` for a reason no key names. Any
+            // `Link` minted around it would claim the ladder ended where the
+            // budget ran out, not where the answer was. `truncated` is the
+            // separate, non-poison record of the same event: a LIVE chase that
+            // truncates is not wrong, it is incomplete, so comparing a
+            // conclusion against it proves nothing either way.
+            state.poisoned = true;
+            // The LIVE counterpart of the poison above, and it has to be
+            // thread-local rather than a `QueryState` field: the cap counts
+            // frames across the whole THREAD, so it fires inside nested
+            // top-level queries (`symbol_return_type_via_bag`, the enrichment
+            // overlay) that carry a `QueryState` of their own. A per-state flag
+            // reads false for exactly the chases truncated deepest.
+            QUERY_REC_TRUNCATIONS.with(|c| c.set(c.get() + 1));
             QUERY_REC_DEPTH_WARNED.with(|w| {
                 if !w.get() {
                     w.set(true);
@@ -502,9 +564,18 @@ impl ReducerRegistry {
         );
         // Memo hit: this key was fully resolved earlier in THIS query and
         // isn't on the current path (cycle guard handles on-path keys).
-        if let Some(cached) = state.memo.get(&key) {
+        if let Some((cached, recorded_exit)) = state.memo.get(&key) {
+            let cached = std::sync::Arc::clone(cached);
+            // Re-reaching an exiting subtree from inside a combining frame is
+            // the same claim as reaching it there the first time; the memo must
+            // not launder it into a rung just because the first reach happened
+            // to be transparent.
+            if *recorded_exit && state.opaque_frames > 0 {
+                crate::util::ghost_stats::count("residual.memo_under_opaque");
+                state.poisoned = true;
+            }
             QUERY_REC_DEPTH.with(|c| c.set(c.get() - 1));
-            return std::sync::Arc::clone(cached);
+            return cached;
         }
         // `key` has two owners (the visited set, transiently; the memo,
         // for the rest of the query). Clone once for visited, then move
@@ -513,12 +584,16 @@ impl ReducerRegistry {
             QUERY_REC_DEPTH.with(|c| c.set(c.get() - 1));
             return std::sync::Arc::new(ReducedValue::None);
         }
+        let exits_before = state.residual.len();
+        let poison_before = state.poisoned;
         let result = std::sync::Arc::new(self.query_rec_body(bag, q, state));
+        let recorded_exit =
+            state.residual.len() > exits_before || (state.poisoned && !poison_before);
         state.visited.remove(&key);
         // Cache the off-path resolution. The query depends only on
         // `(bag, attachment, receiver-class, arity)` (all in `key`) plus
         // the static context, which is fixed for one top-level query.
-        state.memo.insert(key, std::sync::Arc::clone(&result));
+        state.memo.insert(key, (std::sync::Arc::clone(&result), recorded_exit));
         QUERY_REC_DEPTH.with(|c| c.set(c.get() - 1));
         result
     }
@@ -583,342 +658,13 @@ impl ReducerRegistry {
                 // whichever file defines it, not the name-slot winner).
                 if ctx.module_index.is_none() {
                     super::note_bake_exit("moc_primary", true);
-                    note_moc_exit(state, class, name);
+                    note_moc_exit(state, package, name);
                 }
                 if let Some(idx) = ctx.module_index {
-                    for cached in super::session::visible_def_candidates(idx, package).iter() {
-                        // Rehydrate the target file's bag if its resident copy
-                        // was Slice-2-evicted; the cross-file chase reads its
-                        // witnesses (`docs/adr/memory-slice-2-lru.md`).
-                        let attempt =
-                            |full: &std::sync::Arc<crate::model::file_analysis::FileAnalysis>,
-                             state: &mut _| {
-                                let cached_ctx = BagContext {
-                                    scopes: &full.scopes,
-                                    package_framework: &full.packages,
-                                    module_index: Some(idx),
-                                    package_parents: &full.packages,
-                                    app_surface_consumers: &full.plugin.app_surface_consumers,
-                                };
-                                let sub_q = ReducerQuery {
-                                    attachment: q.attachment,
-                                    point: q.point,
-                                    framework: q.framework,
-                                    arity_hint: q.arity_hint,
-                                    receiver: q.receiver.clone(),
-                                    args: q.args.clone(),
-                                    context: Some(&cached_ctx),
-                                };
-                                (*self.query_rec(&full.witnesses, &sub_q, state)).clone()
-                            };
-                        // This candidate's contribution, remembered ACROSS
-                        // top-level queries. `attempt` is a pure function of
-                        // (candidate file, attachment, receiver, arity, point,
-                        // framework) — the whole key — so one walk derives it
-                        // once instead of once per call site.
-                        if let Some(hit) =
-                            super::session::candidate_answer(idx, &cached.path, q)
-                        {
-                            if *hit != ReducedValue::None {
-                                return (*hit).clone();
-                            }
-                            continue;
-                        }
-                        if !super::session::spend_consult(idx) {
-                            break;
-                        }
-                        // THE CONCLUSION LOOKUP, ahead of the decode.
-                        //
-                        // This is the whole point of the layer: 78% of a
-                        // consult is the chase, not the fetch, and a baked
-                        // answer skips both. Placed after the session memo
-                        // (a hit there is cheaper still) and before
-                        // `bag_present` (which decodes).
-                        //
-                        // The three outcomes are NOT interchangeable:
-                        //   Answer  — serve it, no decode.
-                        //   None    — the map PROVES no answer; fall through
-                        //             to the next candidate exactly as a
-                        //             decoded miss would, still no decode.
-                        //   Decode  — `OpenNone`: unbakeable here, so pay the
-                        //             full price for this key alone.
-                        // A `Follow` is not yet honoured — see below.
-                        let mut baked_said_absent = false;
-                        // Under the equivalence flag a followed answer is held
-                        // rather than returned, so the chase below runs and can
-                        // contradict it.
-                        let mut followed_answer: Option<InferredType> = None;
-                        if let Some(key) =
-                            super::ConclusionKey::from_attachment(q.attachment)
-                        {
-                            if let Some(map) = idx.conclusions_for(&cached.path) {
-                                match map.evaluate(
-                                    &key,
-                                    q.receiver.as_ref(),
-                                    q.arity_hint,
-                                    &q.args,
-                                ) {
-                                    super::Outcome::Answer(t) => {
-                                        crate::util::ghost_stats::count("consult.baked_answer");
-                                        let v = ReducedValue::Type(t);
-                                        // The memo still gets the answer. A
-                                        // baked hit is cheap but not free, and
-                                        // the memo is the tier above it.
-                                        super::session::remember_candidate_answer(
-                                            idx, &cached.path, q, &v,
-                                        );
-                                        return v;
-                                    }
-                                    // ABSENT. The spec lets this mean a proven
-                                    // `None` and skip the candidate outright —
-                                    // "the sharpest knife in the design" — but
-                                    // that is sound only if the bake enumerated
-                                    // every key the bag could answer, and today
-                                    // it does not: it walks the bag's
-                                    // attachment index, while the live chase
-                                    // also answers keys that carry no witnesses
-                                    // (inheritance edges, reducer synthesis).
-                                    //
-                                    // A wrongly-absent key makes the ladder
-                                    // skip a candidate that would have
-                                    // answered; the answer is then found
-                                    // further up the parent walk, so the OUTPUT
-                                    // agrees and only the cost betrays it.
-                                    // Measured on `--dump-package Catalyst`:
-                                    // trusting absence took 892 decodes to
-                                    // 2,721 and 2.76s to 4.20s, byte-identical
-                                    // output throughout. A silent 3x, invisible
-                                    // to every correctness check we have.
-                                    //
-                                    // So absence falls through to the decode
-                                    // until the enumeration is provably
-                                    // complete. `PERL_LSP_TRUST_ABSENT` turns
-                                    // the knife back on for measuring that work
-                                    // as it lands.
-                                    super::Outcome::None => {
-                                        crate::util::ghost_stats::count("consult.baked_none");
-                                        baked_said_absent = true;
-                                        // Absence is conclusive only for a
-                                        // class with NO ancestors at all. The
-                                        // per-file bake cannot establish that:
-                                        // Perl packages are open, and a file
-                                        // that REOPENS a package without
-                                        // repeating its `@ISA` sees a
-                                        // parentless class. `PPI::XSAccessor`
-                                        // does exactly that to `PPI::Token`,
-                                        // and it accounted for 75 of the
-                                        // equivalence breaks left after the
-                                        // per-file check.
-                                        //
-                                        // So the question is asked where the
-                                        // cross-file union lives, through the
-                                        // same `parents_of` every other
-                                        // ancestor walk uses.
-                                        let has_ancestors =
-                                            !crate::model::file_analysis::parents_of(
-                                                class,
-                                                ctx.package_parents,
-                                                ctx.module_index,
-                                                ctx.app_surface_consumers,
-                                            )
-                                            .is_empty();
-                                        if has_ancestors {
-                                            crate::util::ghost_stats::count(
-                                                "consult.absent_but_inherits",
-                                            );
-                                            baked_said_absent = false;
-                                        }
-                                        // The bridge guard, and it closes a
-                                        // hole that PREDATES the conclusion
-                                        // layer: trusting absence asks only
-                                        // "no ancestors", while the live
-                                        // ladder's bridge arm runs regardless
-                                        // of ancestry. A PARENTLESS BRIDGED
-                                        // class therefore has its absence
-                                        // trusted while the chase answers
-                                        // through the bridge. The substrate
-                                        // happens to contain no such class —
-                                        // corpus luck, not soundness.
-                                        if baked_said_absent
-                                            && idx.class_is_bridged_to(class)
-                                        {
-                                            crate::util::ghost_stats::count(
-                                                "consult.absent_but_bridged",
-                                            );
-                                            baked_said_absent = false;
-                                        }
-                                        // Under the equivalence flag, do NOT
-                                        // trust it — fall through, run the
-                                        // real chase, and let the arm below
-                                        // report any answer that absence
-                                        // claimed did not exist.
-                                        if baked_said_absent
-                                            && super::trust_absent_conclusions()
-                                            && !super::verify_absent_conclusions()
-                                        {
-                                            // Remember the None BEFORE
-                                            // continuing. Skipping the memo
-                                            // was the actual cost of trusting
-                                            // absence: this candidate is asked
-                                            // hundreds of times per run, and
-                                            // each repeat re-walked its
-                                            // ancestors instead of hitting the
-                                            // tier that exists to stop exactly
-                                            // that.
-                                            super::session::remember_candidate_answer(
-                                                idx,
-                                                &cached.path,
-                                                q,
-                                                &ReducedValue::None,
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                    // Cross-file hop: re-enter the ladder at
-                                    // the target file's map, no decode.
-                                    //
-                                    // This is the first conclusion form whose
-                                    // failure is UNSOUND rather than merely
-                                    // slow — a wrong absence costs a decode, a
-                                    // wrong `Link` serves a wrong answer — so
-                                    // it is scored by `PERL_LSP_CONCL_EQUIV`
-                                    // against the chase it replaces, and it
-                                    // degrades to that chase whenever the walk
-                                    // cannot complete.
-                                    super::Outcome::Follow {
-                                        targets,
-                                        arity,
-                                        receiver,
-                                    } if !idx.class_is_bridged_to(class) => {
-                                        match follow_link(idx, &targets, &receiver, arity, &q.args) {
-                                            Some(t) => {
-                                                crate::util::ghost_stats::count(
-                                                    "consult.baked_follow",
-                                                );
-                                                if super::verify_absent_conclusions() {
-                                                    followed_answer = Some(t);
-                                                } else {
-                                                    let v = ReducedValue::Type(t);
-                                                    super::session::remember_candidate_answer(
-                                                        idx, &cached.path, q, &v,
-                                                    );
-                                                    return v;
-                                                }
-                                            }
-                                            None => {
-                                                crate::util::ghost_stats::count(
-                                                    "consult.baked_follow_incomplete",
-                                                );
-                                            }
-                                        }
-                                    }
-                                    // A `Link` says "everything before the
-                                    // bridge arm answered None", which a
-                                    // bridged class can contradict. Decode.
-                                    super::Outcome::Follow { .. } => {
-                                        crate::util::ghost_stats::count(
-                                            "consult.follow_but_bridged",
-                                        );
-                                    }
-                                    super::Outcome::Decode => {
-                                        crate::util::ghost_stats::count("consult.baked_open");
-                                    }
-                                }
-                            } else {
-                                crate::util::ghost_stats::count("consult.not_baked");
-                            }
-                        }
-                        crate::util::ghost_stats::count("moc.provider_fetched");
-                        // The three costs of one cross-file consult, split
-                        // because a conclusion layer would remove the first
-                        // two and CANNOT remove the third (enrichment is bag
-                        // surgery). Sizing stage 2 means knowing which is
-                        // which, not the total.
-                        //
-                        // These NEST over the `decode.*` stage split rather
-                        // than restating it: a miss here descends through
-                        // `bagcache.decode` into `decode.2_zstd`/`3_bincode`.
-                        // Summing a `consult.*` against a `decode.*` term
-                        // double-counts the same microseconds.
-                        let full = crate::util::ghost_stats::timed(
-                            "consult.bag_present", || idx.bag_present(cached));
-                        if std::ptr::eq(bag, &full.witnesses) {
-                            // Self: the reducers above already tried this bag.
-                            // Not an answer about the candidate, so nothing to
-                            // remember either.
-                            continue;
-                        }
-                        let v = {
-                            let v = crate::util::ghost_stats::timed(
-                                "consult.attempt", || attempt(&full, state));
-                            crate::util::ghost_stats::count(if v == ReducedValue::None {
-                                "moc.provider_no_answer"
-                            } else {
-                                "moc.provider_answered"
-                            });
-                            if v != ReducedValue::None {
-                                v
-                            } else {
-                            // Fallback-on-miss (R4): the package file's method
-                            // return may chain through ITS OWN imports —
-                            // invisible to the raw bag, present in the
-                            // enriched overlay.
-                            crate::util::ghost_stats::count("consult.moc_primary");
-                            let enriched = crate::util::ghost_stats::timed(
-                                "consult.enriched", || idx.enriched_present(cached));
-                            if !std::sync::Arc::ptr_eq(&enriched, &full)
-                                && !std::ptr::eq(bag, &enriched.witnesses)
-                            {
-                                state.pins.push(std::sync::Arc::clone(&enriched));
-                                attempt(&enriched, state)
-                            } else {
-                                ReducedValue::None
-                            }
-                            }
-                        };
-                        if let Some(followed) = &followed_answer {
-                            // Scored against the chase, not against the output.
-                            // A wrong `Link` is the layer's only failure mode
-                            // that serves a wrong ANSWER rather than costing a
-                            // decode, so it is the one that must be compared
-                            // where the claim is made.
-                            let agrees = matches!(&v, ReducedValue::Type(t) if t == followed);
-                            if !agrees {
-                                crate::util::ghost_stats::count("concl.follow_break");
-                                log::error!(
-                                    "conclusion follow break: a Link for {:?} in {:?} \
-                                     resolved to {followed:?} but the chase answered {v:?} \
-                                     — a baked cross-file hop disagrees with the hop it \
-                                     replaces",
-                                    q.attachment,
-                                    cached.path
-                                );
-                                debug_assert!(false, "Link disagreed with the chase; see log");
-                            } else {
-                                crate::util::ghost_stats::count("concl.follow_ok");
-                            }
-                        }
-                        if super::verify_absent_conclusions()
-                            && baked_said_absent
-                            && v != ReducedValue::None
-                        {
-                            crate::util::ghost_stats::count("concl.equiv_break");
-                            log::error!(
-                                "conclusion equivalence break: the map reported {:?} ABSENT for \
-                                 {:?} (which is read as a proven None) but the chase answered \
-                                 {v:?} — the bake's key enumeration is incomplete",
-                                q.attachment,
-                                cached.path
-                            );
-                            debug_assert!(
-                                false,
-                                "conclusion absence disagreed with the chase; see log"
-                            );
-                        }
-                        super::session::remember_candidate_answer(idx, &cached.path, q, &v);
-                        if v != ReducedValue::None {
-                            return v;
-                        }
+                    if let Some(v) =
+                        self.moc_cross_file_primary(bag, q, state, ctx, idx, package)
+                    {
+                        return v;
                     }
                 }
                 // (2) Inheritance walk via package_parents (local ∪
@@ -986,7 +732,7 @@ impl ReducerRegistry {
                     // dependence, and counting it as one makes the poison rate
                     // look total when it may be negligible.
                     let mut bridge_seen = false;
-                    idx.for_each_entity_bridged_to(class, &mut |_m, _c, _s| {
+                    idx.for_each_entity_bridged_to(package, &mut |_m, _c, _s| {
                         bridge_seen = true;
                     });
                     crate::util::ghost_stats::count(if bridge_seen {
@@ -1003,7 +749,7 @@ impl ReducerRegistry {
                         // `enabled()` first: `format!` allocates before `count`
                         // can decline, so the naive spelling pays for a string
                         // per yield even with stats off.
-                        crate::util::ghost_stats::count(&format!("bridgecls.{class}"));
+                        crate::util::ghost_stats::count(&format!("bridgecls.{package}"));
                     }
                     let mut found: Option<InferredType> = None;
                     idx.for_each_entity_bridged_to(package, &mut |_mod, cached, sym| {
@@ -1217,6 +963,409 @@ impl ReducerRegistry {
     /// the recursion shares the caller's cycle guard (calling the public
     /// `query_variable_type` would reset visited and reopen mutual
     /// `Edge(Variable)` loops).
+
+
+    /// The cross-file primary hop of the `PackageSymbol` ladder: every file
+    /// declaring `package`, asked in ladder order, first answer wins.
+    ///
+    /// Out of line, and `#[inline(never)]`, because of the STACK. This block's
+    /// locals — two capture-heavy `attempt` closures, the conclusion-outcome
+    /// bookkeeping, the equivalence probes — otherwise live in the caller's
+    /// frame, and the caller is `query_rec_body`, which is live once per MRO
+    /// hop against the 2 MiB stack the depth-cap test pins. An index-less chase
+    /// (a bake, a hand-built FA) never enters here at all, so keeping it inline
+    /// charged every one of those hops for a block it does not run.
+    #[inline(never)]
+    fn moc_cross_file_primary(
+        &self,
+        bag: &WitnessBag,
+        q: &ReducerQuery,
+        state: &mut QueryState,
+        ctx: &BagContext,
+        idx: &dyn crate::model::file_analysis::CrossFileLookup,
+        package: &str,
+    ) -> Option<ReducedValue> {
+        for cached in super::session::visible_def_candidates(idx, package).iter() {
+            // Rehydrate the target file's bag if its resident copy
+            // was Slice-2-evicted; the cross-file chase reads its
+            // witnesses (`docs/adr/memory-slice-2-lru.md`).
+            let attempt =
+                |full: &std::sync::Arc<crate::model::file_analysis::FileAnalysis>,
+                 state: &mut _| {
+                    let cached_ctx = BagContext {
+                        scopes: &full.scopes,
+                        package_framework: &full.packages,
+                        module_index: Some(idx),
+                        package_parents: &full.packages,
+                        app_surface_consumers: &full.plugin.app_surface_consumers,
+                    };
+                    let sub_q = ReducerQuery {
+                        attachment: q.attachment,
+                        point: q.point,
+                        framework: q.framework,
+                        arity_hint: q.arity_hint,
+                        receiver: q.receiver.clone(),
+                        args: q.args.clone(),
+                        context: Some(&cached_ctx),
+                    };
+                    (*self.query_rec(&full.witnesses, &sub_q, state)).clone()
+                };
+            // This candidate's contribution, remembered ACROSS
+            // top-level queries. `attempt` is a pure function of
+            // (candidate file, attachment, receiver, arity, point,
+            // framework) — the whole key — so one walk derives it
+            // once instead of once per call site.
+            if let Some(hit) =
+                super::session::candidate_answer(idx, &cached.path, q)
+            {
+                if *hit != ReducedValue::None {
+                    return Some((*hit).clone());
+                }
+                continue;
+            }
+            if !super::session::spend_consult(idx) {
+                break;
+            }
+            // THE CONCLUSION LOOKUP, ahead of the decode.
+            //
+            // This is the whole point of the layer: 78% of a
+            // consult is the chase, not the fetch, and a baked
+            // answer skips both. Placed after the session memo
+            // (a hit there is cheaper still) and before
+            // `bag_present` (which decodes).
+            //
+            // The three outcomes are NOT interchangeable:
+            //   Answer  — serve it, no decode.
+            //   None    — the map PROVES no answer; fall through
+            //             to the next candidate exactly as a
+            //             decoded miss would, still no decode.
+            //   Decode  — `OpenNone`: unbakeable here, so pay the
+            //             full price for this key alone.
+            // A `Follow` is not yet honoured — see below.
+            let mut baked_said_absent = false;
+            // Under the equivalence flag a followed answer is held
+            // rather than returned, so the chase below runs and can
+            // contradict it.
+            let mut followed_answer: Option<InferredType> = None;
+            if let Some(key) =
+                super::ConclusionKey::from_attachment(q.attachment)
+            {
+                if let Some(map) = idx.conclusions_for(&cached.path) {
+                    match map.evaluate(
+                        &key,
+                        q.receiver.as_ref(),
+                        q.arity_hint,
+                        &q.args,
+                    ) {
+                        super::Outcome::Answer(t) => {
+                            crate::util::ghost_stats::count("consult.baked_answer");
+                            let v = ReducedValue::Type(t);
+                            // The memo still gets the answer. A
+                            // baked hit is cheap but not free, and
+                            // the memo is the tier above it.
+                            super::session::remember_candidate_answer(
+                                idx, &cached.path, q, &v,
+                            );
+                            return Some(v);
+                        }
+                        // ABSENT. The spec lets this mean a proven
+                        // `None` and skip the candidate outright —
+                        // "the sharpest knife in the design" — but
+                        // that is sound only if the bake enumerated
+                        // every key the bag could answer, and today
+                        // it does not: it walks the bag's
+                        // attachment index, while the live chase
+                        // also answers keys that carry no witnesses
+                        // (inheritance edges, reducer synthesis).
+                        //
+                        // A wrongly-absent key makes the ladder
+                        // skip a candidate that would have
+                        // answered; the answer is then found
+                        // further up the parent walk, so the OUTPUT
+                        // agrees and only the cost betrays it.
+                        // Measured on `--dump-package Catalyst`:
+                        // trusting absence took 892 decodes to
+                        // 2,721 and 2.76s to 4.20s, byte-identical
+                        // output throughout. A silent 3x, invisible
+                        // to every correctness check we have.
+                        //
+                        // So absence falls through to the decode
+                        // until the enumeration is provably
+                        // complete. `PERL_LSP_TRUST_ABSENT` turns
+                        // the knife back on for measuring that work
+                        // as it lands.
+                        super::Outcome::None => {
+                            crate::util::ghost_stats::count("consult.baked_none");
+                            baked_said_absent = true;
+                            // Absence is conclusive only for a
+                            // class with NO ancestors at all. The
+                            // per-file bake cannot establish that:
+                            // Perl packages are open, and a file
+                            // that REOPENS a package without
+                            // repeating its `@ISA` sees a
+                            // parentless class. `PPI::XSAccessor`
+                            // does exactly that to `PPI::Token`,
+                            // and it accounted for 75 of the
+                            // equivalence breaks left after the
+                            // per-file check.
+                            //
+                            // So the question is asked where the
+                            // cross-file union lives, through the
+                            // same `parents_of` every other
+                            // ancestor walk uses.
+                            let has_ancestors =
+                                !crate::model::file_analysis::parents_of(
+                                    package,
+                                    ctx.package_parents,
+                                    ctx.module_index,
+                                    ctx.app_surface_consumers,
+                                )
+                                .is_empty();
+                            if has_ancestors {
+                                crate::util::ghost_stats::count(
+                                    "consult.absent_but_inherits",
+                                );
+                                baked_said_absent = false;
+                            }
+                            // The bridge guard, and it closes a
+                            // hole that PREDATES the conclusion
+                            // layer: trusting absence asks only
+                            // "no ancestors", while the live
+                            // ladder's bridge arm runs regardless
+                            // of ancestry. A PARENTLESS BRIDGED
+                            // class therefore has its absence
+                            // trusted while the chase answers
+                            // through the bridge. The substrate
+                            // happens to contain no such class —
+                            // corpus luck, not soundness.
+                            if baked_said_absent
+                                && idx.class_is_bridged_to(package)
+                            {
+                                crate::util::ghost_stats::count(
+                                    "consult.absent_but_bridged",
+                                );
+                                baked_said_absent = false;
+                            }
+                            // Under the equivalence flag, do NOT
+                            // trust it — fall through, run the
+                            // real chase, and let the arm below
+                            // report any answer that absence
+                            // claimed did not exist.
+                            if baked_said_absent
+                                && super::trust_absent_conclusions()
+                                && !super::verify_absent_conclusions()
+                            {
+                                // Remember the None BEFORE
+                                // continuing. Skipping the memo
+                                // was the actual cost of trusting
+                                // absence: this candidate is asked
+                                // hundreds of times per run, and
+                                // each repeat re-walked its
+                                // ancestors instead of hitting the
+                                // tier that exists to stop exactly
+                                // that.
+                                super::session::remember_candidate_answer(
+                                    idx,
+                                    &cached.path,
+                                    q,
+                                    &ReducedValue::None,
+                                );
+                                continue;
+                            }
+                        }
+                        // Cross-file hop: re-enter the ladder at
+                        // the target file's map, no decode.
+                        //
+                        // This is the first conclusion form whose
+                        // failure is UNSOUND rather than merely
+                        // slow — a wrong absence costs a decode, a
+                        // wrong `Link` serves a wrong answer — so
+                        // it is scored by `PERL_LSP_CONCL_EQUIV`
+                        // against the chase it replaces, and it
+                        // degrades to that chase whenever the walk
+                        // cannot complete.
+                        super::Outcome::Follow {
+                            targets,
+                            arity,
+                            receiver,
+                        } if !idx.class_is_bridged_to(package) => {
+                            match follow_link(idx, &targets, &receiver, arity, &q.args) {
+                                Some(t) => {
+                                    crate::util::ghost_stats::count(
+                                        "consult.baked_follow",
+                                    );
+                                    if super::verify_absent_conclusions() {
+                                        followed_answer = Some(t);
+                                    } else {
+                                        let v = ReducedValue::Type(t);
+                                        super::session::remember_candidate_answer(
+                                            idx, &cached.path, q, &v,
+                                        );
+                                        return Some(v);
+                                    }
+                                }
+                                None => {
+                                    crate::util::ghost_stats::count(
+                                        "consult.baked_follow_incomplete",
+                                    );
+                                }
+                            }
+                        }
+                        // A `Link` says "everything before the
+                        // bridge arm answered None", which a
+                        // bridged class can contradict. Decode.
+                        super::Outcome::Follow { .. } => {
+                            crate::util::ghost_stats::count(
+                                "consult.follow_but_bridged",
+                            );
+                        }
+                        super::Outcome::Decode => {
+                            crate::util::ghost_stats::count("consult.baked_open");
+                        }
+                    }
+                } else {
+                    crate::util::ghost_stats::count("consult.not_baked");
+                }
+            }
+            crate::util::ghost_stats::count("moc.provider_fetched");
+            // The three costs of one cross-file consult, split
+            // because a conclusion layer would remove the first
+            // two and CANNOT remove the third (enrichment is bag
+            // surgery). Sizing stage 2 means knowing which is
+            // which, not the total.
+            //
+            // These NEST over the `decode.*` stage split rather
+            // than restating it: a miss here descends through
+            // `bagcache.decode` into `decode.2_zstd`/`3_bincode`.
+            // Summing a `consult.*` against a `decode.*` term
+            // double-counts the same microseconds.
+            // Snapshotted before the chase runs, so the classifier
+            // below asks "did the cap fire during THIS chase"
+            // rather than "has it ever fired on this thread".
+            let truncations_before = QUERY_REC_TRUNCATIONS.with(|c| c.get());
+            let full = crate::util::ghost_stats::timed(
+                "consult.bag_present", || idx.bag_present(cached));
+            if std::ptr::eq(bag, &full.witnesses) {
+                // Self: the reducers above already tried this bag.
+                // Not an answer about the candidate, so nothing to
+                // remember either.
+                continue;
+            }
+            let v = {
+                let v = crate::util::ghost_stats::timed(
+                    "consult.attempt", || attempt(&full, state));
+                crate::util::ghost_stats::count(if v == ReducedValue::None {
+                    "moc.provider_no_answer"
+                } else {
+                    "moc.provider_answered"
+                });
+                if v != ReducedValue::None {
+                    v
+                } else {
+                // Fallback-on-miss (R4): the package file's method
+                // return may chain through ITS OWN imports —
+                // invisible to the raw bag, present in the
+                // enriched overlay.
+                crate::util::ghost_stats::count("consult.moc_primary");
+                let enriched = crate::util::ghost_stats::timed(
+                    "consult.enriched", || idx.enriched_present(cached));
+                if !std::sync::Arc::ptr_eq(&enriched, &full)
+                    && !std::ptr::eq(bag, &enriched.witnesses)
+                {
+                    state.pins.push(std::sync::Arc::clone(&enriched));
+                    attempt(&enriched, state)
+                } else {
+                    ReducedValue::None
+                }
+                }
+            };
+            if let Some(followed) = &followed_answer {
+                // Scored against the chase, not against the output.
+                // A wrong `Link` is the layer's only failure mode
+                // that serves a wrong ANSWER rather than costing a
+                // decode, so it is the one that must be compared
+                // where the claim is made.
+                let agrees = matches!(&v, ReducedValue::Type(t) if t == followed);
+                if !agrees {
+                    // WHY the chase said `None`, because two of
+                    // the reasons are not disagreement at all:
+                    //
+                    //  * TRUNCATED — the depth cap fired, so the
+                    //    `None` means "ran out of frames".
+                    //  * GUARDED — the shared cycle guard had this
+                    //    very candidate key on the path, so the
+                    //    chase returned without walking a rung. The
+                    //    outer frame still standing on it walks
+                    //    them.
+                    //
+                    // Over the substrate every remaining break is
+                    // the second. The probe this replaced asked
+                    // whether a LINK TARGET was on the path, which
+                    // was doubly wrong: the guard cuts on the
+                    // candidate key, and before self-rungs were
+                    // filtered the targets included the key being
+                    // chased, so it matched every time. A
+                    // classifier that cannot fail is not one.
+                    let candidate_key: VisitedKey = (
+                        &full.witnesses as *const _ as usize,
+                        q.attachment.clone(),
+                        receiver_key(&q.receiver),
+                        q.arity_hint,
+                    );
+                    let excused = if truncations_before
+                        != QUERY_REC_TRUNCATIONS.with(|c| c.get())
+                    {
+                        Some("concl.follow_break_truncated")
+                    } else if state.visited.contains(&candidate_key) {
+                        Some("concl.follow_break_guarded")
+                    } else {
+                        None
+                    };
+                    crate::util::ghost_stats::count(
+                        excused.unwrap_or("concl.follow_break"),
+                    );
+                    log::error!(
+                        "conclusion follow break: a Link for {:?} in {:?} \
+                         resolved to {followed:?} but the chase answered {v:?} \
+                         — a baked cross-file hop disagrees with the hop it \
+                         replaces",
+                        q.attachment,
+                        cached.path
+                    );
+                    debug_assert!(
+                        excused.is_some(),
+                        "Link disagreed with a chase that actually walked; see log"
+                    );
+                } else {
+                    crate::util::ghost_stats::count("concl.follow_ok");
+                }
+            }
+            if super::verify_absent_conclusions()
+                && baked_said_absent
+                && v != ReducedValue::None
+            {
+                crate::util::ghost_stats::count("concl.equiv_break");
+                log::error!(
+                    "conclusion equivalence break: the map reported {:?} ABSENT for \
+                     {:?} (which is read as a proven None) but the chase answered \
+                     {v:?} — the bake's key enumeration is incomplete",
+                    q.attachment,
+                    cached.path
+                );
+                debug_assert!(
+                    false,
+                    "conclusion absence disagreed with the chase; see log"
+                );
+            }
+            super::session::remember_candidate_answer(idx, &cached.path, q, &v);
+            if v != ReducedValue::None {
+                return Some(v);
+            }
+        }
+                
+        None
+    }
+
     fn materialize(
         &self,
         bag: &WitnessBag,
@@ -1224,6 +1373,11 @@ impl ReducerRegistry {
         state: &mut QueryState,
     ) -> Vec<Witness> {
         let raw = bag.for_attachment(q.attachment);
+        // Is this attachment's value a pass-through of ONE sub-chase, or a fold
+        // over several? With siblings present, whatever a sub-chase answers is
+        // combined with them before this frame returns, so no single exit key
+        // names this frame's answer.
+        let sole_witness = raw.len() == 1;
         let mut out: Vec<Witness> = Vec::with_capacity(raw.len());
         for w in raw {
             match &w.payload {
@@ -1232,7 +1386,7 @@ impl ReducerRegistry {
                         (
                             WitnessAttachment::Variable { name, scope },
                             Some(ctx),
-                        ) => {
+                        ) => state.in_opaque_frame(|state| {
                             // Narrowing point: an edge reached FROM a positioned
                             // expression (a variable read recorded at `Expr(span)`)
                             // resolves the slot at the read's own location, so a
@@ -1244,11 +1398,15 @@ impl ReducerRegistry {
                                 WitnessAttachment::Expr(span) => span.start,
                                 _ => scope_point(ctx.scopes, *scope),
                             };
+                            // Opaque: the scope walk defers a rep-only answer
+                            // and lets an outer class identity beat it, so the
+                            // value is chosen ACROSS scopes rather than taken
+                            // from the first that answers.
                             self.query_variable_with_visited(
                                 bag, ctx, name, *scope, point,
                                 q.receiver.as_ref(), state,
                             )
-                        }
+                        }),
                         _ => {
                             // A `PackageSymbol{package,..}` reached through an edge is
                             // a fresh method dispatch: its receiver is that call's
@@ -1260,12 +1418,16 @@ impl ReducerRegistry {
                             // there the source is itself a `PackageSymbol`, and the
                             // child's receiver must carry through so an inherited fluent
                             // accessor returns the child, not where `has` was declared.
+                            let redispatched = matches!(
+                                target,
+                                WitnessAttachment::PackageSymbol { .. }
+                            ) && !matches!(
+                                q.attachment,
+                                WitnessAttachment::PackageSymbol { .. }
+                            );
                             let receiver = match target {
                                 WitnessAttachment::PackageSymbol { package, .. }
-                                    if !matches!(
-                                        q.attachment,
-                                        WitnessAttachment::PackageSymbol { .. }
-                                    ) =>
+                                    if redispatched =>
                                 {
                                     fresh_dispatch_receiver(&q.receiver, package, q.context)
                                 }
@@ -1280,10 +1442,25 @@ impl ReducerRegistry {
                                 args: q.args.clone(),
                                 context: q.context,
                             };
-                            match &*self.query_rec(bag, &sub_q, state) {
-                                ReducedValue::Type(t) => Some(t.clone()),
-                                ReducedValue::FactMap(_)
-                                | ReducedValue::None => None,
+                            // The ONE transparent frame in `materialize`: a lone
+                            // edge, chased under the query it was reached with,
+                            // whose answer this frame returns unchanged. A
+                            // re-dispatch substitutes a different receiver, and
+                            // a `ReturnExpr::Receiver` at the far end then
+                            // answers about that receiver rather than the one a
+                            // `Link` follow would thread.
+                            let transparent = sole_witness && !redispatched;
+                            let chase = |state: &mut QueryState| {
+                                match &*self.query_rec(bag, &sub_q, state) {
+                                    ReducedValue::Type(t) => Some(t.clone()),
+                                    ReducedValue::FactMap(_)
+                                    | ReducedValue::None => None,
+                                }
+                            };
+                            if transparent {
+                                chase(state)
+                            } else {
+                                state.in_opaque_frame(chase)
                             }
                         }
                     };
@@ -1319,11 +1496,17 @@ impl ReducerRegistry {
                         args: q.args.clone(),
                         context: q.context,
                     };
-                    match &*self.query_rec(bag, &sub_q, state) {
+                    // Opaque: the call site's arity and dispatch receiver both
+                    // replace the outer query's, so the exit key is asked a
+                    // different question than a `Link` follow would ask.
+                    let v = state.in_opaque_frame(|state| {
+                        (*self.query_rec(bag, &sub_q, state)).clone()
+                    });
+                    match v {
                         ReducedValue::Type(t) => out.push(Witness {
                             attachment: w.attachment.clone(),
                             source: w.source.clone(),
-                            payload: WitnessPayload::InferredType(t.clone()),
+                            payload: WitnessPayload::InferredType(t),
                             span: w.span,
                         }),
                         ReducedValue::FactMap(_) | ReducedValue::None => {}
@@ -1337,7 +1520,10 @@ impl ReducerRegistry {
                     // A Variable base scope-walks like the Edge arm above
                     // (`$h{k}` projects off `%h`, whose witnesses live on
                     // the decl scope, not the access scope).
-                    let base_t = match (base, q.context) {
+                    // Opaque throughout: this frame returns a value drilled OUT
+                    // of the sub-chase's answer, never the answer itself, so no
+                    // exit key beneath it names what this frame produces.
+                    let base_t = state.in_opaque_frame(|state| match (base, q.context) {
                         (WitnessAttachment::Variable { name, scope }, Some(ctx)) => {
                             let point = scope_point(ctx.scopes, *scope);
                             self.query_variable_with_visited(
@@ -1361,7 +1547,7 @@ impl ReducerRegistry {
                                 | ReducedValue::None => None,
                             }
                         }
-                    };
+                    });
                     if let Some(t) = base_t {
                         let projected = match step {
                             ProjectionStep::HashKey(k) => {
@@ -1388,11 +1574,13 @@ impl ReducerRegistry {
                                         args: q.args.clone(),
                                         context: q.context,
                                     };
-                                    match &*self.query_rec(bag, &sub_q, state) {
-                                        ReducedValue::Type(t) => Some(t.clone()),
-                                        ReducedValue::FactMap(_)
-                                        | ReducedValue::None => None,
-                                    }
+                                    state.in_opaque_frame(|state| {
+                                        match &*self.query_rec(bag, &sub_q, state) {
+                                            ReducedValue::Type(t) => Some(t.clone()),
+                                            ReducedValue::FactMap(_)
+                                            | ReducedValue::None => None,
+                                        }
+                                    })
                                 })
                             }
                             ProjectionStep::ArrayIndex(i) => t.element_at(*i).cloned(),
@@ -1423,11 +1611,16 @@ impl ReducerRegistry {
                         args: q.args.clone(),
                         context: q.context,
                     };
-                    match &*self.query_rec(bag, &sub_q, state) {
+                    // Opaque for the same reason as `CallReturn`, plus the
+                    // lookup class and the receiver class deliberately differ.
+                    let v = state.in_opaque_frame(|state| {
+                        (*self.query_rec(bag, &sub_q, state)).clone()
+                    });
+                    match v {
                         ReducedValue::Type(t) => out.push(Witness {
                             attachment: w.attachment.clone(),
                             source: w.source.clone(),
-                            payload: WitnessPayload::InferredType(t.clone()),
+                            payload: WitnessPayload::InferredType(t),
                             span: w.span,
                         }),
                         ReducedValue::FactMap(_) | ReducedValue::None => {}


### PR DESCRIPTION
40 commits. Stage 2 of the caching arc — partially evaluate the reducer chase at persist time, store the result beside the blob, and let the consult path answer from it — plus the flush driver built on top of it, the re-stamp gate, and **one user-facing bug the driver work uncovered**. Design discussion is issue #120; the forward doc is `docs/prompt-residualizing-registry.md`.

## The headline

A warm substrate `--check`, chase work only:

| | before | after |
|---|---|---|
| `consult.attempt` | 1,774 ms / 63,961 calls | **469 ms / 14,317** |
| `moc.provider_fetched` | 105,711 | **34,014** |

The saving is in the **chase**, not in bytes decoded — `bagcache.decode` barely moves, because the resident tier was already absorbing repeats. Sizing this from decode counts would conclude it did nothing.

## The bug — read this first if you read nothing else

**A saved Perl dependency was invisible to its consumers for the rest of the session.** Saving a `.pm` updated the open buffer and refreshed its own diagnostics; that was all. Every consumer kept answering from the version before the save until the editor restarted.

The pack languages have this fix (`schedule_pack_invalidate` on did_save, the H1 finding); Perl never got it, and it looked covered because `didChangeWatchedFiles` *appears* to handle exactly this — it does not fire when the editor saves a buffer it has open, which is precisely how a dependency gets edited. The debug log across the new e2e shows zero watched-file notifications. did_save now routes a hub-language file through the same re-index, and that body moved to `Backend::reindex_saved_perl` so the two seams cannot drift again. Spawned rather than awaited, so a save no longer holds the next didChange behind a re-parse.

`e2e/saved_dep_edit.lua` guards it, resolving through a cross-file **return type** so the verb under test genuinely depends on the provider's analysis. It fails on the old code with the message it was written to print. **This is the first e2e coverage of a saved-file edit on the Perl side at all.**

## What is here

**The algebra** (`model/witnesses/conclusions.rs`). A key concludes as `Value` / `ReturnOf` / `Link` / `OpenNone`, and absent, and those five are deliberately not interchangeable — absent means "the bag proves no answer", `OpenNone` means "unbakeable, decode". Cross-file answers residualize as `Link`; they never materialize, so a stored answer cannot outlive the world it copied.

**The store** (`index/module_cache/conclusions_store.rs`). Generation-stamped, keyed `(path, generation)`, rows written before the stamp so a reader pinned to N never sees a half-built N+1.

**The derivation fingerprint** (`build.rs`). A reducer edit leaves bytes that decode perfectly and answer wrongly — nothing downstream can catch that, so the guard is a hash over `src/**` + `Cargo.lock` that moves on its own. Bake-steering env vars join it, because a measurement run under a flag otherwise leaves maps every later run reads.

**Sound absence.** Absence is conclusive only for a class the index says has no ancestors — a per-file bake cannot establish closedness, because Perl packages are open and any file may reopen one without repeating its `@ISA`.

**`NotLocal`**, the third absence verdict, and the largest single win. For a class this file declares and enumerated, an absent key proves no *local* answer: skip that candidate, let the ladder continue. Not a constructed `Follow` at the parents — that would skip candidates 2..n, and a reopened package's method lives in exactly such a later candidate.

**The flush driver** (`index/conclusion_flush.rs`). A change propagates until the answers stop moving. Three properties, each with a test that fails without it:

- The diff artifact is the **evaluated surface**, never the persisted map. A map is index-free by construction, so when C changes B's map is byte-identical while B's answers have moved; cutting on map equality stops the wave at B and starves B's consumers. It passes every two-file fixture either way — only a chain distinguishes them.
- The wave **decodes maps, never blobs**. Because the bake is index-free it cannot produce a value that depended on another file, so a downstream change moves a consumer's answers without moving its map: the write set is exactly the seeds, and reaching a file costs one map decode. That invariant's violation is silent, so it ships with `PERL_LSP_FLUSH_EQUIV`.
- A cycle terminates by **cutting**, not by the round cap — the cutoff compares against the surface recorded earlier in this flush, not the pre-flush baseline. Get that wrong and it presents as "flushes are slow", never as a hang.

**The re-stamp gate.** The MethodCall re-stamp mostly re-derives what the build already froze; what licenses skipping it is knowing no provider has moved since. That is a question about the flush, so the flush pushes and the gate compares — O(1), and every unknown fails open to a re-stamp. It marks the wave's **enqueued** set, not its moved set: a dispatch target resolves through the index rather than off a surface, so a consumer can dispatch differently without its own answers moving. Inert until a wave marks (`restamp.owed_never_stamped` 4 / `restamp.skipped` 0 on a real run), which is what lets it land now. `PERL_LSP_RESTAMP_EQUIV` runs every skipped re-stamp anyway and counts disagreements.

**A background re-bake** (`index/module_resolver/thread.rs`). The fingerprint gate clears maps and keeps blobs "because the repair is a re-bake"; nothing drove that re-bake, so the layer stayed dark after every source edit until a manual `--clear-cache`. It now drains where the resolver thread would otherwise block on its condvar, one 32-file slice at a time so a real resolve never waits behind the frontier.

**The verb-declared enrichment profile.** `--check` declares that its consumers never read `method_target()`, so it stops paying for the re-stamp. ~5% of wall on the parallel sweep, output set-identical at N=2,431.

## Three more fixes that are not part of the arc

- **`--dump-package` answered a coin flip for a reopened package.** It scanned a `DashMap` and took the first hit; five consecutive runs of one binary gave `Token.pm, Token.pm, XSAccessor.pm, XSAccessor.pm, XSAccessor.pm`. This output is cited as a comparison oracle in our own measurement notes, including mine.
- **A plugin's config shape was not on the Surface**, so a config-only edit reported `Unchanged` and every open consumer kept the stale closed key set for the session.
- **Editing a PR description cancelled its CI and replaced it with three skipped checks** (`.github/workflows/ci.yml`). The `edited` trigger and the per-job guard were each right; the shared concurrency group meant the run designed to do nothing cancelled the run doing everything. A badge does not distinguish three skipped jobs from three passed ones.

## What is deliberately off

`Link` minting (`PERL_LSP_MINT_LINKS`). It is sound — 44 equivalence breaks went to 0 once frames that combine rather than forward are poisoned — and it buys nothing: decodes 4,103 → 4,104, because a follow abandons at the first rung whose own map says `Decode`. Kept behind the flag with its counters, because the population is what a future fix would have to work against.

## Verification

`PERL_LSP_CONCL_EQUIV` is the instrument this arc rests on. It compares **at the point of the claim**, and it caught four changes that gold 502/0 and 312 KB of byte-identical `--dump-package` output all accepted — the ladder routes around a missing answer, so only the cost betrays it.

- `cargo test --features cpp` — 1,637 passed, 0 failed
- `cargo test` — 1,571 passed, 0 failed
- `gold-corpus/run.pl` — 503 PASS / 17 xfail / 0 FAIL / 0 CRASH / 0 lang-skip, warm lane clean
- `./e2e/run.sh` (nvim 0.11.0) — **116 passed, 0 failed across 11 suites** (was 113/10)

Every empirical claim has an A/B control reachable from the shipped configuration (`PERL_LSP_NO_NOT_LOCAL`, `PERL_LSP_FULL_ENRICHMENT`, `PERL_LSP_NO_BAKE`, `PERL_LSP_MINT_LINKS`, `PERL_LSP_FLUSH_EQUIV`, `PERL_LSP_RESTAMP_EQUIV`). That is not decoration: once a verb declares a partial profile, the full behaviour is unreachable and "set-identical" becomes unfalsifiable.

## Scope limits, stated rather than buried

- **The orphaned-bake fix closes an invariant, not a reproduced bug.** `invalidate_generation` left a file's conclusion map behind after dropping its blob; that is unit-proven. What is **not** proven is that any consult reads it — a CLI probe of the full sequence and the e2e both answer correctly with the fix reverted, because the changed file is re-persisted (blob and map together) or answered from the open-document tier before a stale row is reached. I originally described this as a live wrong-answer bug; that was an overclaim, corrected in the code comments and in `5d4a438a`. The fix stays because a derivation outliving its source has consequences that stay invisible until a future caller order exposes them.
- **`PERL_LSP_RESTAMP_EQUIV` has had no corpus exercise**, because nothing can be skipped until a flush has marked. The gate *is* observed skipping by `a_marked_file_re_stamps_and_an_unmarked_one_skips`, base-verified in both directions — forcing "always owed" fails the skip, forcing "always skip" fails the re-stamp.
- The intermittent failure this PR once flagged as un-root-caused **has been caught and fixed**: `the_conclusion_fingerprint_is_not_stale` hashes the source tree at run time and compares against the fingerprint compiled into the binary, so it fails whenever a file changes between build and run — a test loop racing an editor. It now says SKIPPED with the reason; both arms verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv