### PR TITLE
Close the Surface projection drift between the cold and warm conclusion producers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -55,6 +55,36 @@ fn main() {
     // build), an unspecified hash is a poor thing to hang a cache invariant
     // on when the specified one is four lines.
     println!("cargo:rustc-env=PERL_LSP_CONCLUSION_FINGERPRINT={acc:016x}");
+
+    // The SURFACE lane's own gate, narrower on purpose.
+    //
+    // A persisted `Surface` outlives the `Surface::project` that wrote it, so
+    // it needs a version that moves when the projection does — the same class
+    // as a derivation outliving its source, and the same reason a
+    // hand-bumped constant is the wrong instrument. Scoped to `src/model/`
+    // because that is what determines a projection's OUTPUT, and because the
+    // whole-tree fingerprint above would invalidate every persisted surface on
+    // an edit to an LSP handler, paying a corpus-wide re-projection for a
+    // change that cannot alter one.
+    //
+    // Cargo.lock rides along: a grammar bump reshapes the CST, which reshapes
+    // the analysis a surface is projected from.
+    let mut model = Vec::new();
+    collect(Path::new("src/model"), &mut model);
+    if Path::new("Cargo.lock").is_file() {
+        model.push(PathBuf::from("Cargo.lock"));
+    }
+    model.sort();
+    let mut sacc: u64 = 0xcbf2_9ce4_8422_2325;
+    for path in &model {
+        println!("cargo:rerun-if-changed={}", path.display());
+        let Ok(bytes) = std::fs::read(path) else { continue };
+        fnv(&mut sacc, path.to_string_lossy().as_bytes());
+        fnv(&mut sacc, b"\0");
+        fnv(&mut sacc, &bytes);
+        fnv(&mut sacc, b"\0");
+    }
+    println!("cargo:rustc-env=PERL_LSP_SURFACE_FINGERPRINT={sacc:016x}");
 }
 
 fn collect(dir: &Path, out: &mut Vec<PathBuf>) {

--- a/docs/prompt-surface-projection-drift.md
+++ b/docs/prompt-surface-projection-drift.md
@@ -1,0 +1,93 @@
+# The warm lane records a different Surface than the cold lane
+
+`Surface::project` reads the witness bag. The warm lane projects from
+bag-EVICTED copies. So the same unchanged file fingerprints differently
+depending on whether the process that recorded it built the analysis or
+decoded it, and nothing about the degraded projection says it is partial.
+
+Reproduced as a unit property in
+`surface_tests::a_bag_evicted_analysis_projects_a_different_surface`: build an
+analysis, project + fingerprint; `evict_witness_bag()`, project + fingerprint;
+the two differ. Refs eviction adds nothing further — the bag is the whole
+difference.
+
+Observed end to end on the substrate (3,515 files), same bytes both runs:
+
+```
+cold:  record .../PPI/Statement.pm fp=2ee5dacc900de432   <- also the stamp written to the row
+warm:  record .../PPI/Statement.pm fp=8736e9cbba9a1885
+```
+
+## Why nobody noticed
+
+`FreshnessIndex` is in-memory and per-process. Within one process every record
+comes from the same lane, so the index is self-consistent and every file is
+`FirstSeen` on a fresh start. Nothing compared a recorded fingerprint against
+one written by an earlier process until the self-validating conclusions row
+(`docs/prompt-enrichment-alternatives.md` §6b) did.
+
+The class was already known in the narrow: `index_perl.rs` rehydrates the bag
+before recording for files with `plugin.loads`, with a comment explaining that
+a bag-evicted projection "records NO shape" and every diagnostic downstream
+goes quiet. That mitigation covers loader shapes. The `despan`ed
+`InferredType`s on methods and values have the same dependency and are not
+covered.
+
+## What it costs
+
+Measured on the substrate, same binary, the consult-time stamp compare
+bypassed vs active (per-arm caches, three warm runs each, byte-identical
+counters within an arm):
+
+| | stamp active | stamp bypassed |
+|---|---:|---:|
+| `moc.provider_fetched` | 57,481 | **17,419** |
+| `consult.baked_open` | 2,084 | 11,934 |
+| `conclrow.valid` | 14,578 | — |
+| `conclrow.stale` | 47,967 | — |
+
+76.7% of rows are rejected as stale against rows that are in fact CORRECT —
+the files did not change, the two projections disagree. The chase that
+replaces them costs 3.3x the provider fetches. Wall does not separate at this
+scale (4.45-5.17 s vs 4.10-4.84 s), which is the substrate being the wrong
+corpus for this layer rather than the work being free.
+
+The soundness the stamp buys is real and independent of this; the cost is not
+inherent to it and disappears entirely once the two producers agree.
+
+## Wider consequence, beyond the conclusions row
+
+A warm-start freshness verdict is computed over a degraded Surface. An edit
+that changes only bag-derived content therefore compares equal to the
+degraded baseline and reads `Unchanged`, so no consumer re-enriches and every
+one of them keeps answering against the pre-edit state. That is the failure
+`loader_shapes` was added to the Surface to prevent, arriving through the
+residency door instead of the projection door.
+
+## The fork
+
+Three shapes, none of them obviously dominant:
+
+1. **Persist the Surface** and have the warm lane `record_surface_value` the
+   decoded projection instead of re-projecting from a stripped copy. Cold and
+   warm then record identical Surfaces by construction, and this fixes the
+   freshness verdict as well as the stamp. Precedent exists: the pack warm
+   lane already reads a persisted Surface out of the `stubs` table. Cost: a
+   `SCHEMA_VERSION` bump (a cache-wide rebuild) or a second stub-like store,
+   plus the bytes.
+
+2. **Stamp on something both producers compute identically** — the encoded
+   analysis bytes, or the `modules` row's own `(mtime, size, extract_version)`
+   — instead of the Surface fingerprint. Cheaper, and it answers the actual
+   question ("did this row outlive the blob it was baked from"), but it drops
+   the property that makes the Surface fingerprint attractive: it is
+   content-keyed, so it catches a file that changed and changed back to a
+   DIFFERENT surface-equal state, and it is the value the freshness index
+   already holds, so the consult needs no extra read.
+
+3. **Make the projection bag-independent** by baking the bag-derived parts of
+   the Surface into the analysis at build time. Largest change, and the only
+   one that makes the degraded projection impossible rather than avoided.
+
+Whichever is taken, the tripwire test asserts the drift as it stands today, so
+a fix flips it rather than passing unnoticed.

--- a/docs/prompt-surface-projection-drift.md
+++ b/docs/prompt-surface-projection-drift.md
@@ -64,9 +64,58 @@ one of them keeps answering against the pre-edit state. That is the failure
 `loader_shapes` was added to the Surface to prevent, arriving through the
 residency door instead of the projection door.
 
-## The fork
+## Resolution: option (1), persisted surfaces
 
-Three shapes, none of them obviously dominant:
+Ruled by the coordinator and landed. `Surface::project`'s output is stored
+beside the blob it was projected from, in a `surfaces` table created with
+`CREATE TABLE IF NOT EXISTS` in the always-run batch — no `SCHEMA_VERSION`
+bump, no cache-wide rebuild. The warm lane adopts the persisted projection
+instead of re-deriving a degraded twin, so cold and warm record the same
+surface for the same bytes by construction.
+
+Option (2) — stamping on something both producers compute identically — was
+disqualified on scope, not cost: it removes the 3.3x that made the wrong-answer
+bug visible while leaving the bug. **Agreement between the lanes is the
+property; the stamp is not.**
+
+Option (3) remains the right END STATE and deliberately did not gate this: it
+is the only shape that makes the degraded projection impossible rather than
+avoided, which is rule #10's "encode the property on the value so consumers
+cannot ask the wrong question". A live wrong-answer bug should not wait behind
+a refactor of the analysis shape.
+
+### Version gate
+
+Per ROW, not per database, and independent of `SCHEMA_VERSION`:
+`PERL_LSP_SURFACE_FINGERPRINT` is derived at compile time over `src/model/` +
+`Cargo.lock`. Narrower than the conclusion fingerprint on purpose — the
+whole-tree hash would invalidate every persisted surface on an edit to an LSP
+handler, paying a corpus-wide re-projection for a change that cannot alter one.
+
+A persisted projection outliving its projector is the same class as a
+derivation outliving its source: the bytes deserialize cleanly and describe a
+shape this build no longer produces. A mismatch reads ABSENT, so the caller
+re-projects — exactly what it did before the store existed — and the file goes
+back on the repair frontier, which shares the conclusion repair's with-bag
+decode and rewrites both products of the one projection.
+
+### Measured, substrate, warm
+
+| | before | after |
+|---|---:|---:|
+| `moc.provider_fetched` | 57,481 | **18,924** |
+| `consult.baked_open` | 2,084 | 11,804 |
+| `conclrow.valid` / `.stale` | 14,578 / 47,967 | 36,143 / **0** |
+| `surface.adopted_persisted` | — | 3,336 |
+
+Stale rejections go to zero. The stamp now costs 8.6% more fetches than
+bypassing it entirely (18,924 vs 17,419) rather than 230%, and that residue is
+the 1,635 `conclrow.unrecorded` — paths the freshness index has no record for
+at all, which is the fail-open direction working as designed.
+
+## The fork, as it stood
+
+Three shapes, none of them obviously dominant at the time:
 
 1. **Persist the Surface** and have the warm lane `record_surface_value` the
    decoded projection instead of re-projecting from a stripped copy. Cold and

--- a/src/index/conclusion_cache.rs
+++ b/src/index/conclusion_cache.rs
@@ -18,6 +18,7 @@
 //! `None`. Collapsing the two would turn every unbaked file into a file that
 //! concludes nothing.
 
+use crate::index::module_cache::RowStamp;
 use crate::model::witnesses::ConclusionMap;
 use dashmap::DashMap;
 use std::path::{Path, PathBuf};
@@ -27,17 +28,19 @@ use std::sync::Arc;
 /// What a lookup found, kept distinct so a caller cannot accidentally read
 /// "nothing stored" as "nothing concluded".
 pub enum Cached {
-    /// The store has a map for this path.
-    Map(Arc<ConclusionMap>),
+    /// The store has a map for this path, with the stamps it asserts about
+    /// itself. The map is NOT judged here — validity is the caller's compare
+    /// against what the freshness index currently records.
+    Map(Arc<ConclusionMap>, RowStamp),
     /// The store has no map for this path — it was never baked, or its bake
     /// was cleared. Decode.
     NotBaked,
 }
 
-type Loader = Box<dyn Fn(&Path) -> Option<ConclusionMap> + Send + Sync>;
+type Loader = Box<dyn Fn(&Path) -> Option<(ConclusionMap, RowStamp)> + Send + Sync>;
 
 pub struct ConclusionCache {
-    entries: DashMap<PathBuf, (Arc<ConclusionMap>, usize)>,
+    entries: DashMap<PathBuf, (Arc<ConclusionMap>, RowStamp, usize)>,
     /// Paths the loader has already reported absent. Without this, every
     /// consult against an unbaked file re-queries SQLite forever — the
     /// negative answer is the one a hot loop hits most while a workspace is
@@ -51,7 +54,7 @@ pub struct ConclusionCache {
 impl ConclusionCache {
     pub fn new(
         cap_bytes: usize,
-        loader: impl Fn(&Path) -> Option<ConclusionMap> + Send + Sync + 'static,
+        loader: impl Fn(&Path) -> Option<(ConclusionMap, RowStamp)> + Send + Sync + 'static,
     ) -> Self {
         Self {
             entries: DashMap::new(),
@@ -65,14 +68,15 @@ impl ConclusionCache {
     pub fn get(&self, path: &Path) -> Cached {
         if let Some(hit) = self.entries.get(path) {
             crate::util::ghost_stats::count("conclcache.hit");
-            return Cached::Map(hit.value().0.clone());
+            let e = hit.value();
+            return Cached::Map(e.0.clone(), e.1);
         }
         if self.absent.contains_key(path) {
             crate::util::ghost_stats::count("conclcache.known_absent");
             return Cached::NotBaked;
         }
         crate::util::ghost_stats::count("conclcache.miss");
-        let Some(map) = crate::util::ghost_stats::timed("conclcache.load", || {
+        let Some((map, stamp)) = crate::util::ghost_stats::timed("conclcache.load", || {
             (self.loader)(path)
         }) else {
             self.absent.insert(path.to_path_buf(), ());
@@ -82,17 +86,19 @@ impl ConclusionCache {
         let arc = Arc::new(map);
         if self.cap_bytes > 0 {
             self.bytes.fetch_add(sz, Ordering::Relaxed);
-            if let Some((_, old)) = self.entries.insert(path.to_path_buf(), (arc.clone(), sz)) {
+            if let Some((_, _, old)) =
+                self.entries.insert(path.to_path_buf(), (arc.clone(), stamp, sz))
+            {
                 self.bytes.fetch_sub(old.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
             }
             self.evict_to_cap(path);
         }
-        Cached::Map(arc)
+        Cached::Map(arc, stamp)
     }
 
     /// Forget one path — its file changed, so its bake is void.
     pub fn invalidate(&self, path: &Path) {
-        if let Some((_, (_, sz))) = self.entries.remove(path) {
+        if let Some((_, (_, _, sz))) = self.entries.remove(path) {
             self.bytes
                 .fetch_sub(sz.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
         }
@@ -129,7 +135,7 @@ impl ConclusionCache {
                 .map(|e| e.key().clone())
                 .find(|p| p != keep);
             let Some(victim) = victim else { break };
-            if let Some((_, (_, sz))) = self.entries.remove(&victim) {
+            if let Some((_, (_, _, sz))) = self.entries.remove(&victim) {
                 self.bytes
                     .fetch_sub(sz.min(self.bytes.load(Ordering::Relaxed)), Ordering::Relaxed);
                 crate::util::ghost_stats::count("conclcache.evicted");

--- a/src/index/conclusion_cache_tests.rs
+++ b/src/index/conclusion_cache_tests.rs
@@ -2,7 +2,14 @@
 
 use super::*;
 use crate::model::witnesses::{Conclusion, ConclusionKey};
+use crate::index::module_cache::{Generation, RowStamp};
 use std::sync::atomic::AtomicUsize;
+
+/// Tests exercise the cache's memo/eviction behaviour, not row validity —
+/// judging a stamp is the consult path's job, so any stamp will do here.
+fn stamp() -> RowStamp {
+    RowStamp { source_fingerprint: 0, flush_generation: Generation(0) }
+}
 
 fn map_of(n: usize) -> ConclusionMap {
     let mut m = std::collections::HashMap::new();
@@ -54,14 +61,14 @@ fn invalidating_clears_the_absent_memo() {
         if c.fetch_add(1, Ordering::Relaxed) == 0 {
             None
         } else {
-            Some(map_of(1))
+            Some((map_of(1), stamp()))
         }
     });
     let p = Path::new("/later.pm");
     assert!(matches!(cache.get(p), Cached::NotBaked));
     cache.invalidate(p);
     assert!(
-        matches!(cache.get(p), Cached::Map(_)),
+        matches!(cache.get(p), Cached::Map(..)),
         "a file baked after being probed stayed permanently 'not baked'"
     );
 }
@@ -70,7 +77,7 @@ fn invalidating_clears_the_absent_memo() {
 #[test]
 fn the_cache_respects_its_cap() {
     let one = 64 + 10 * 160;
-    let cache = ConclusionCache::new(one * 2, |_p| Some(map_of(10)));
+    let cache = ConclusionCache::new(one * 2, |_p| Some((map_of(10), stamp())));
     for i in 0..20 {
         cache.get(&PathBuf::from(format!("/f{i}.pm")));
     }

--- a/src/index/conclusion_flush.rs
+++ b/src/index/conclusion_flush.rs
@@ -54,6 +54,12 @@ pub struct FlushOutcome {
     /// because a dispatch target is resolved through the index rather than
     /// read off a surface. Marking only what moved would skip exactly those.
     pub enqueued: Vec<PathBuf>,
+    /// The generation this flush published its seeds at, if it published.
+    ///
+    /// `None` means nothing was written: no seeds, a non-convergent wave, or
+    /// a failed transaction. Absent is always safe — the store keeps the
+    /// previous generation and a consult falls back to a decode.
+    pub published: Option<module_cache::Generation>,
     /// The round cap fired: the surfaces never stopped moving. The flush is
     /// abandoned rather than published — a half-propagated generation is worse
     /// than none, because a consult pinned to it would compose answers from a
@@ -321,27 +327,29 @@ fn flush_over_world(
 /// `candidates_of` maps a class to the files that declare it, the same
 /// relation the live `follow_link` resolves through.
 ///
-/// Deliberately does NOT publish. The seeds' fresh maps belong in the store —
-/// that is what keeps a consult on a just-edited file cheap — but their blobs
-/// were invalidated a moment ago, and a conclusion row with no `modules` row
-/// behind it can never be caught by a stamp check, because the stamp lives on
-/// the `modules` row. Writing one would re-open, by a different door, exactly
-/// the "a bake outlived its blob" hole that `invalidate_generation` was just
-/// taught to close. Publishing wants the conclusions table to carry its own
-/// freshness stamp first.
+/// Publishes the seeds at generation N+1 before returning, which is safe
+/// because each conclusions row now carries its OWN `source_fingerprint`: a
+/// row whose `modules` row was invalidated a moment ago is not trusted on the
+/// strength of that row's absence, it is checked against what the freshness
+/// index records for the path and reads absent when they disagree.
 ///
 /// The generation is read ONCE and frozen for the whole wave: reading it again
 /// mid-flush could compose answers from two worlds, which is the failure the
 /// pin exists to prevent.
 pub fn flush_refresh_set(
     conn: &Connection,
-    fresh: Vec<(PathBuf, ConclusionMap)>,
+    fresh: Vec<FreshBake>,
     frontier: Vec<PathBuf>,
     consumers_of: &dyn Fn(&Path) -> Vec<PathBuf>,
     candidates_of: &dyn Fn(&str) -> Vec<PathBuf>,
 ) -> FlushOutcome {
     let at = module_cache::current_generation(conn);
-    let supplied: HashMap<PathBuf, ConclusionMap> = fresh.into_iter().collect();
+    let fingerprints: HashMap<PathBuf, u64> = fresh
+        .iter()
+        .map(|f| (f.path.clone(), f.source_fingerprint))
+        .collect();
+    let supplied: HashMap<PathBuf, ConclusionMap> =
+        fresh.into_iter().map(|f| (f.path, f.map)).collect();
     let seeds: Vec<PathBuf> = supplied.keys().cloned().collect();
     let frozen_src = |path: &Path| {
         module_cache::load_conclusions(conn, &path.to_string_lossy(), at)
@@ -360,7 +368,79 @@ pub fn flush_refresh_set(
         Some(module_cache::bake_conclusion_map(&fa, &fa.witnesses))
     };
     let world = FlushWorld::new(&frozen_src, &re_bake, candidates_of, seeds);
-    flush_over_world(&world, frontier, consumers_of)
+    let mut out = flush_over_world(&world, frontier, consumers_of);
+    out.published = publish_seeds(conn, at, &out, &supplied, &fingerprints);
+    out
+}
+
+/// Write the seeds' fresh maps as one generation.
+///
+/// Only the SEEDS. A file the wave merely reached has the right map already —
+/// the bake is index-free, so a downstream change moves its answers without
+/// moving its map — and re-writing it would spend a transaction to store what
+/// is already stored.
+///
+/// A non-convergent wave publishes nothing: its refresh set is a half-finished
+/// propagation, and a consult pinned to that generation would compose answers
+/// from a wave that never settled.
+///
+/// The stamp is the fingerprint the CALLER computed from the analysis it baked
+/// from, carried through untouched. Reading it back from the freshness index
+/// here would let a concurrent record put a different file's fingerprint on
+/// this map, which is the one lie the consult-time compare cannot catch.
+fn publish_seeds(
+    conn: &Connection,
+    at: module_cache::Generation,
+    out: &FlushOutcome,
+    supplied: &HashMap<PathBuf, ConclusionMap>,
+    fingerprints: &HashMap<PathBuf, u64>,
+) -> Option<module_cache::Generation> {
+    if out.non_convergent || supplied.is_empty() {
+        return None;
+    }
+    let next = module_cache::Generation(at.0 + 1);
+    let entries: Vec<(String, ConclusionMap, u64)> = supplied
+        .iter()
+        .filter_map(|(path, map)| {
+            // No fingerprint means no publishable stamp. Skipping is right:
+            // an unstamped row would have to be trusted rather than checked.
+            let fp = fingerprints.get(path)?;
+            Some((path.to_string_lossy().into_owned(), map.clone(), *fp))
+        })
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+    if let Err(e) = module_cache::publish_generation(conn, next, &entries) {
+        // Never fatal. The previous generation stands, every consult falls
+        // back to a decode, and the next flush republishes.
+        crate::util::ghost_stats::count("flush.publish_failed");
+        log::warn!("conclusion flush: publishing generation {} failed: {e}", next.0);
+        return None;
+    }
+    crate::util::ghost_stats::count_by("flush.published", entries.len() as u64);
+    // Reclaim superseded rows immediately, which is safe precisely BECAUSE of
+    // the session pin: a walk still reading an older generation finds its row
+    // gone, reads absent, and decodes. The retention that made pruning
+    // dangerous protected correctness; the pin protects it better, so what is
+    // left to protect is only speed.
+    let reclaimed = module_cache::prune_generations_below(conn, next);
+    if reclaimed > 0 {
+        crate::util::ghost_stats::count_by("flush.pruned", reclaimed as u64);
+    }
+    Some(next)
+}
+
+/// One seed of a flush: a file whose blob just changed, the map the caller
+/// baked from its new analysis, and that analysis's surface fingerprint.
+///
+/// The three travel together because they must describe ONE state — the stamp
+/// is what a consult checks the map against, so a stamp gathered separately
+/// from the map is a stamp that can describe a different file.
+pub struct FreshBake {
+    pub path: PathBuf,
+    pub map: ConclusionMap,
+    pub source_fingerprint: u64,
 }
 
 #[cfg(test)]

--- a/src/index/conclusion_flush_store_tests.rs
+++ b/src/index/conclusion_flush_store_tests.rs
@@ -8,7 +8,7 @@
 use super::*;
 use crate::model::file_analysis::InferredType;
 use crate::model::witnesses::{Conclusion, ConclusionKey, ReceiverRule};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 fn key(class: &str, name: &str) -> ConclusionKey {
     ConclusionKey::MethodOnClass { class: class.into(), name: name.into() }
@@ -22,6 +22,12 @@ fn map_of(class: &str, name: &str, c: Conclusion) -> ConclusionMap {
     let mut enumerated = HashSet::new();
     enumerated.insert(class.to_string());
     ConclusionMap(m, HashSet::new(), enumerated, HashMap::new())
+}
+
+/// One flush seed. Spelled here so the publication tests and the propagation
+/// test agree on how a seed is built.
+fn seed(path: &PathBuf, map: ConclusionMap, fingerprint: u64) -> FreshBake {
+    FreshBake { path: path.clone(), map, source_fingerprint: fingerprint }
 }
 
 fn p(s: &str) -> PathBuf {
@@ -308,7 +314,7 @@ fn flush_refresh_set_moves_a_consumer_over_a_real_store() {
 
     let out = flush_refresh_set(
         &conn,
-        vec![(a.clone(), a_new)],
+        vec![seed(&a, a_new, 11)],
         vec![a.clone()],
         &consumers_of,
         &candidates_of,
@@ -319,5 +325,128 @@ fn flush_refresh_set_moves_a_consumer_over_a_real_store() {
         moved,
         vec![a.clone(), b.clone()],
         "A moved, and B moved through it — B's stored map never changed"
+    );
+}
+
+/// Publication, end to end: the seed's fresh map is in the store afterwards,
+/// at the next generation, carrying the fingerprint the caller supplied.
+///
+/// This is what makes a consult on a just-edited file cheap. Without it the
+/// flush computes the right answer and throws it away — the edited file's row
+/// still holds the pre-edit bake, so every consult against it either serves
+/// the old map or (once the stamp rejects it) decodes, forever.
+#[test]
+fn a_flush_publishes_its_seeds_at_the_next_generation() {
+    use crate::index::module_cache::{load_conclusions_stamped, publish_generation, Generation};
+    let conn = store_db();
+    let a = p("/pub/A.pm");
+    let old_map = map_of("A", "m", Conclusion::Value(InferredType::ClassName("Old".into())));
+    let new_map = map_of("A", "m", Conclusion::Value(InferredType::ClassName("New".into())));
+    publish_generation(&conn, Generation(1), &[(a.to_string_lossy().into_owned(), old_map, 1)])
+        .expect("baseline");
+
+    let none = |_: &str| Vec::new();
+    let no_consumers = |_: &Path| Vec::new();
+    let out = flush_refresh_set(
+        &conn,
+        vec![seed(&a, new_map.clone(), 42)],
+        vec![a.clone()],
+        &no_consumers,
+        &none,
+    );
+
+    assert_eq!(out.published, Some(Generation(2)), "the seed round must land");
+    let (stored, stamp) =
+        load_conclusions_stamped(&conn, &a.to_string_lossy(), Generation(2)).expect("published row");
+    assert_eq!(stored, new_map, "the published row holds the FRESH map");
+    assert_eq!(
+        stamp.source_fingerprint, 42,
+        "the caller's fingerprint must ride through untouched — a stamp \
+         gathered anywhere else can describe a different state than the map"
+    );
+    assert_eq!(stamp.flush_generation, Generation(2));
+}
+
+/// A wave that never settled publishes nothing.
+///
+/// Its refresh set is a half-finished propagation. A consult pinned to that
+/// generation would compose answers from a wave that did not converge, which
+/// is strictly worse than the decode it would otherwise have paid.
+///
+/// Driven at `publish_seeds` rather than through `flush_refresh_set`: a
+/// store-shaped world cannot be made to diverge on demand — `MAX_FOLLOW_HOPS`
+/// truncates a long chain, and the flush's own cutoff terminates a cycle,
+/// which is exactly what those are for. Fabricating divergence by defeating
+/// them would test the fabrication. `run_flush`'s own cap is covered by
+/// `conclusion_flush_tests::a_non_convergent_flush_reports_no_refresh_set`;
+/// this covers what publication does when it is told so.
+#[test]
+fn a_non_convergent_flush_publishes_nothing() {
+    use crate::index::module_cache::{current_generation, publish_generation, Generation};
+    let conn = store_db();
+    let a = p("/nonconv/A.pm");
+    let m = |v: &str| map_of("A", "m", Conclusion::Value(InferredType::ClassName(v.into())));
+    publish_generation(&conn, Generation(1), &[(a.to_string_lossy().into_owned(), m("Old"), 1)])
+        .expect("baseline");
+
+    let supplied: HashMap<PathBuf, ConclusionMap> = [(a.clone(), m("New"))].into_iter().collect();
+    let fingerprints: HashMap<PathBuf, u64> = [(a.clone(), 42)].into_iter().collect();
+
+    let abandoned = FlushOutcome { non_convergent: true, ..Default::default() };
+    assert_eq!(
+        publish_seeds(&conn, Generation(1), &abandoned, &supplied, &fingerprints),
+        None,
+        "a wave that never settled must not publish"
+    );
+    assert_eq!(
+        current_generation(&conn),
+        Generation(1),
+        "the generation must not advance past a wave that was abandoned"
+    );
+
+    // The control: identical inputs, convergent outcome. Without it the
+    // assertion above would hold against a publish that never works.
+    let settled = FlushOutcome::default();
+    assert_eq!(
+        publish_seeds(&conn, Generation(1), &settled, &supplied, &fingerprints),
+        Some(Generation(2))
+    );
+}
+
+/// Publishing reclaims what it supersedes.
+///
+/// Retaining every generation is what made a pin safe when absence could not
+/// be told from staleness; with the row stamp and the session pin, a walk that
+/// loses its generation reads absent and decodes. So the table must not grow a
+/// row per file per edit for the life of a session.
+#[test]
+fn publishing_reclaims_superseded_rows() {
+    use crate::index::module_cache::{publish_generation, Generation};
+    let conn = store_db();
+    let a = p("/prune/A.pm");
+    let m = |s: &str| map_of("A", "m", Conclusion::Value(InferredType::ClassName(s.into())));
+    publish_generation(&conn, Generation(1), &[(a.to_string_lossy().into_owned(), m("v1"), 1)])
+        .expect("baseline");
+    let none = |_: &str| Vec::new();
+    let no_consumers = |_: &Path| Vec::new();
+    for (i, v) in ["v2", "v3", "v4"].iter().enumerate() {
+        let out = flush_refresh_set(
+            &conn,
+            vec![seed(&a, m(v), 100 + i as u64)],
+            vec![a.clone()],
+            &no_consumers,
+            &none,
+        );
+        assert_eq!(out.published, Some(Generation(2 + i as i64)));
+    }
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM conclusions WHERE path = ?1", [a.to_string_lossy()], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        rows, 1,
+        "four publications left {rows} rows for one file — the table grows \
+         per edit for the life of the session"
     );
 }

--- a/src/index/conclusion_flush_store_tests.rs
+++ b/src/index/conclusion_flush_store_tests.rs
@@ -291,8 +291,8 @@ fn flush_refresh_set_moves_a_consumer_over_a_real_store() {
         &conn,
         Generation(1),
         &[
-            (a.to_string_lossy().into_owned(), a_old),
-            (b.to_string_lossy().into_owned(), b_map),
+            (a.to_string_lossy().into_owned(), a_old, 1),
+            (b.to_string_lossy().into_owned(), b_map, 2),
         ],
     )
     .expect("baseline");

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -639,6 +639,14 @@ pub fn encode_surface(s: &crate::model::surface::Surface) -> Option<Vec<u8>> {
 /// row's surface one my `Surface::project` would produce", and a
 /// database-wide stamp answers that only until the first mixed write.
 pub fn persist_surface(conn: &Connection, path: &str, enc: &EncodedAnalysis) {
+    // Delete unconditionally FIRST, the way a modules-row rewrite drops the
+    // path's stub: every exit below this line — empty encode, failed insert —
+    // must leave the row ABSENT, never carrying the previous content's
+    // projection at the current version. A stale row is the one outcome the
+    // reader cannot detect (`load_surface` keys on (path, version), and
+    // `paths_needing_repair` only sees NOT EXISTS), so it would pair a
+    // pre-edit fingerprint with a post-edit blob and read Unchanged forever.
+    let _ = conn.execute("DELETE FROM surfaces WHERE path = ?1", params![path]);
     if enc.surface.is_empty() {
         return;
     }

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -192,7 +192,7 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
     // Escape hatch and A/B control, same shape as `PERL_LSP_PD_NO_COMBINE`:
     // a new cost on the persist path should be switchable off without a
     // rebuild, so its price can be measured rather than argued about.
-    let conclusions = if std::env::var("PERL_LSP_NO_BAKE").is_ok() {
+    let conclusions = if crate::model::witnesses::bake_disabled() {
         Vec::new()
     } else {
     bake_conclusions_blob(fa, &bag)

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -120,6 +120,15 @@ pub struct EncodedAnalysis {
     /// answering ABSENT for the file, and absent means "no answer" rather than
     /// "not baked".
     pub conclusions: Vec<u8>,
+    /// The span-free `Surface` projected from the analysis these bytes were
+    /// encoded from, ready to persist.
+    ///
+    /// Carried rather than re-projected at the read side because the READ side
+    /// cannot produce it: the warm lane hands out bag-evicted copies, and
+    /// `Surface::project` reads the bag. Persisting the cold projection is the
+    /// only way the two lanes record the same surface for the same file —
+    /// `docs/prompt-surface-projection-drift.md`.
+    pub surface: Vec<u8>,
     /// The surface fingerprint of the analysis these bytes were baked from —
     /// the row's self-validation stamp. Carried here rather than looked up at
     /// write time so the value describes exactly what was encoded: a writer
@@ -197,16 +206,18 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
     } else {
     bake_conclusions_blob(fa, &bag)
     };
-    // Projected from the SAME analysis the map was baked from, in the same
-    // call — the row's stamp and its contents describe one state by
-    // construction.
-    let source_fingerprint = crate::model::surface::surface_fingerprint(
-        &crate::model::surface::Surface::project(fa),
-    );
+    // ONE projection, used for both the stamp and the persisted surface: the
+    // row's stamp, its map, and the surface a warm lane will record all
+    // describe one state by construction rather than by three callers
+    // agreeing.
+    let projected = crate::model::surface::Surface::project(fa);
+    let source_fingerprint = crate::model::surface::surface_fingerprint(&projected);
+    let surface = encode_surface(&projected).unwrap_or_default();
     Some(EncodedAnalysis {
         analysis,
         bag: bag_blob,
         conclusions,
+        surface,
         source_fingerprint,
     })
 }
@@ -598,6 +609,7 @@ pub fn save_blob_to_db_stamped(
         log::warn!("Failed to save module blob for '{}': {}", module_name, e);
     }
     persist_conclusions(conn, &path.to_string_lossy(), blob);
+    persist_surface(conn, &path.to_string_lossy(), blob);
     // A rewritten modules row orphans any prior stub for the path — a stale
     // skeleton paired with a fresh stamp would be served as valid on the
     // next warm. Writers that have a fresh stub re-insert it right after.
@@ -615,6 +627,48 @@ pub fn save_blob_to_db_stamped(
 /// A failure here is logged, never fatal. The blob is already written and
 /// remains the derivation of record; a missing map costs a decode, which is
 /// the cost we had before this layer existed.
+/// bincode + zstd, the same codec every other derived blob here uses.
+pub fn encode_surface(s: &crate::model::surface::Surface) -> Option<Vec<u8>> {
+    let bin = bincode::serialize(s).ok()?;
+    zstd::encode_all(bin.as_slice(), ZSTD_LEVEL).ok()
+}
+
+/// Store one file's projected surface at the CURRENT projection version.
+///
+/// Version stamped per row rather than per database: a reader wants "is THIS
+/// row's surface one my `Surface::project` would produce", and a
+/// database-wide stamp answers that only until the first mixed write.
+pub fn persist_surface(conn: &Connection, path: &str, enc: &EncodedAnalysis) {
+    if enc.surface.is_empty() {
+        return;
+    }
+    let r = conn.execute(
+        "INSERT OR REPLACE INTO surfaces (path, version, surface) VALUES (?1, ?2, ?3)",
+        params![path, super::surface_version(), enc.surface],
+    );
+    if let Err(e) = r {
+        log::warn!("Failed to save surface for '{path}': {e}");
+    }
+}
+
+/// One file's persisted surface, or `None` when there is none AT THE CURRENT
+/// PROJECTION VERSION.
+///
+/// A version mismatch reads absent rather than stale: the caller re-projects,
+/// which is exactly what it did before this store existed. Absence is a cost
+/// here, never a wrong answer.
+pub fn load_surface(conn: &Connection, path: &str) -> Option<crate::model::surface::Surface> {
+    let blob: Vec<u8> = conn
+        .query_row(
+            "SELECT surface FROM surfaces WHERE path = ?1 AND version = ?2",
+            params![path, super::surface_version()],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let bin = zstd::decode_all(blob.as_slice()).ok()?;
+    bincode::deserialize(&bin).ok()
+}
+
 fn persist_conclusions(conn: &Connection, path: &str, enc: &EncodedAnalysis) {
     if enc.conclusions.is_empty() {
         // The bake produced nothing encodable. Leaving no row is right: absent
@@ -718,6 +772,7 @@ pub fn save_to_db(
     if !path_str.is_empty() {
         if let Some(enc) = analysis_blob.as_ref() {
             persist_conclusions(conn, &path_str, enc);
+            persist_surface(conn, &path_str, enc);
         }
         // Same stale-stub guard as `save_blob_to_db_stamped`.
         delete_stub(conn, &path_str);

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -120,6 +120,12 @@ pub struct EncodedAnalysis {
     /// answering ABSENT for the file, and absent means "no answer" rather than
     /// "not baked".
     pub conclusions: Vec<u8>,
+    /// The surface fingerprint of the analysis these bytes were baked from —
+    /// the row's self-validation stamp. Carried here rather than looked up at
+    /// write time so the value describes exactly what was encoded: a writer
+    /// that re-read the index could stamp a fingerprint the map does not
+    /// correspond to, which is the one lie the compare cannot catch.
+    pub source_fingerprint: u64,
     /// The witness bag alone. NEVER empty for a row this code writes — the
     /// `bag IS NULL` test is how a reader tells a pre-split row (bag inline
     /// in `analysis`) from a post-split one, so an empty encoding here would
@@ -191,10 +197,17 @@ pub fn encode_analysis(fa: &FileAnalysis) -> Option<EncodedAnalysis> {
     } else {
     bake_conclusions_blob(fa, &bag)
     };
+    // Projected from the SAME analysis the map was baked from, in the same
+    // call — the row's stamp and its contents describe one state by
+    // construction.
+    let source_fingerprint = crate::model::surface::surface_fingerprint(
+        &crate::model::surface::Surface::project(fa),
+    );
     Some(EncodedAnalysis {
         analysis,
         bag: bag_blob,
         conclusions,
+        source_fingerprint,
     })
 }
 
@@ -611,8 +624,10 @@ fn persist_conclusions(conn: &Connection, path: &str, enc: &EncodedAnalysis) {
     }
     let at = current_generation(conn);
     let r = conn.execute(
-        "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
-        params![path, at.0, enc.conclusions],
+        "INSERT OR REPLACE INTO conclusions \
+         (path, generation, map, source_fingerprint, flush_generation) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![path, at.0, enc.conclusions, enc.source_fingerprint as i64, at.0],
     );
     if let Err(e) = r {
         log::warn!("Failed to save conclusions for '{path}': {e}");

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -66,16 +66,51 @@ pub fn load_conclusions(
     path: &str,
     at: Generation,
 ) -> Option<ConclusionMap> {
-    let blob: Vec<u8> = conn
+    load_conclusions_stamped(conn, path, at).map(|(m, _)| m)
+}
+
+/// `load_conclusions` plus the row's own stamps — what a validity check needs.
+///
+/// The map is returned WITHOUT judging it. Validity is the caller's compare,
+/// because only the caller knows the fingerprint the index currently records
+/// for this path, and re-deriving it here would mean hashing a surface on the
+/// consult path — which is the hot path this whole layer exists to shorten.
+pub fn load_conclusions_stamped(
+    conn: &Connection,
+    path: &str,
+    at: Generation,
+) -> Option<(ConclusionMap, RowStamp)> {
+    let (blob, fp, gen): (Vec<u8>, i64, i64) = conn
         .query_row(
-            "SELECT map FROM conclusions WHERE path = ?1 AND generation <= ?2 \
+            "SELECT map, source_fingerprint, flush_generation FROM conclusions \
+             WHERE path = ?1 AND generation <= ?2 \
              ORDER BY generation DESC LIMIT 1",
             params![path, at.0],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .ok()?;
     let bin = zstd::decode_all(blob.as_slice()).ok()?;
-    bincode::deserialize(&bin).ok()
+    let map = bincode::deserialize(&bin).ok()?;
+    Some((map, RowStamp { source_fingerprint: fp as u64, flush_generation: Generation(gen) }))
+}
+
+/// What a persisted conclusion row asserts about itself.
+///
+/// `source_fingerprint` is the surface fingerprint of the analysis the map was
+/// baked from — the same value `FreshnessIndex` records for the path. A row
+/// whose fingerprint differs from what the index currently records describes a
+/// file that has moved, and reads as absent.
+///
+/// That one compare subsumes three failure modes that used to need three
+/// different erasers to remember them: an ORPHANED row whose `modules` row was
+/// erased, a STALE row for an edited file, and a row from an INTERRUPTED write.
+/// None of them can match, so correctness stops depending on any caller
+/// remembering to delete anything — the erasers remain for space, not for
+/// truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowStamp {
+    pub source_fingerprint: u64,
+    pub flush_generation: Generation,
 }
 
 /// Write one file's conclusions at a generation.
@@ -95,6 +130,7 @@ pub fn save_conclusions(
     path: &str,
     at: Generation,
     map: &ConclusionMap,
+    stamp: RowStamp,
 ) -> bool {
     let Ok(bin) = bincode::serialize(map) else {
         return false;
@@ -103,8 +139,10 @@ pub fn save_conclusions(
         return false;
     };
     conn.execute(
-        "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
-        params![path, at.0, blob],
+        "INSERT OR REPLACE INTO conclusions \
+         (path, generation, map, source_fingerprint, flush_generation) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![path, at.0, blob, stamp.source_fingerprint as i64, stamp.flush_generation.0],
     )
     .is_ok()
 }
@@ -123,12 +161,16 @@ pub fn save_conclusions(
 pub fn publish_generation(
     conn: &Connection,
     at: Generation,
-    entries: &[(String, ConclusionMap)],
+    entries: &[(String, ConclusionMap, u64)],
 ) -> rusqlite::Result<()> {
     conn.execute_batch("BEGIN IMMEDIATE")?;
     let result = (|| -> rusqlite::Result<()> {
-        for (path, map) in entries {
-            if !save_conclusions(conn, path, at, map) {
+        for (path, map, fingerprint) in entries {
+            let stamp = RowStamp {
+                source_fingerprint: *fingerprint,
+                flush_generation: at,
+            };
+            if !save_conclusions(conn, path, at, map, stamp) {
                 // An entry that will not encode cannot be published, and
                 // publishing the rest under this generation would present a
                 // partial round as complete. Fail the round instead.
@@ -245,7 +287,7 @@ pub fn repair_conclusions_slice(
     paths: &[String],
     at: Generation,
 ) -> usize {
-    let baked: Vec<(&String, Vec<u8>)> = paths
+    let baked: Vec<(&String, Vec<u8>, u64)> = paths
         .iter()
         .filter_map(|path| {
             // WITH the bag: the bake reads witnesses, and a bagless decode
@@ -254,13 +296,19 @@ pub fn repair_conclusions_slice(
             // repair exists to undo.
             let fa = super::load_one_diag(conn, path, true).ok()?;
             let blob = super::bake_conclusions_blob(&fa, &fa.witnesses);
+            // Stamped from the analysis the repair actually decoded, not from
+            // the index: a repair races the writers, and a fingerprint read
+            // elsewhere could describe a newer state than these bytes.
+            let fingerprint = crate::model::surface::surface_fingerprint(
+                &crate::model::surface::Surface::project(&fa),
+            );
             if blob.is_empty() {
                 // Nothing encodable. Leaving the row absent is right: the
                 // reader falls back to a decode, which is where it already was.
                 crate::util::ghost_stats::count("repair.nothing_to_bake");
                 return None;
             }
-            Some((path, blob))
+            Some((path, blob, fingerprint))
         })
         .collect();
     if baked.is_empty() {
@@ -271,10 +319,12 @@ pub fn repair_conclusions_slice(
         log::warn!("conclusion repair: txn open failed; the slice defers to the next pass");
         return 0;
     }
-    for (path, blob) in &baked {
+    for (path, blob, fingerprint) in &baked {
         let r = conn.execute(
-            "INSERT OR REPLACE INTO conclusions (path, generation, map) VALUES (?1, ?2, ?3)",
-            params![path, at.0, blob],
+            "INSERT OR REPLACE INTO conclusions \
+             (path, generation, map, source_fingerprint, flush_generation) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![path, at.0, blob, *fingerprint as i64, at.0],
         );
         match r {
             Ok(_) => landed += 1,

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -219,7 +219,12 @@ pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
     .unwrap_or(0)
 }
 
-/// Paths holding a valid blob but no conclusion row a reader could use.
+/// Paths holding a valid blob but no conclusion row a reader could use, OR no
+/// persisted surface at the current projection version.
+///
+/// Both lanes share one frontier because they share the expensive step: a
+/// with-bag decode. Splitting them would decode each file twice to fix two
+/// products of one projection.
 ///
 /// The repair frontier. `validate_conclusion_fingerprint` clears conclusions
 /// and deliberately keeps the blobs, "because the repair is a re-bake" — but
@@ -238,14 +243,18 @@ pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
 ///
 /// Version-filtered: a row below `EXTRACT_VERSION` is going to be re-parsed
 /// anyway, and baking it would spend the work twice.
-pub fn paths_missing_conclusions(conn: &Connection, at: Generation) -> Vec<String> {
+pub fn paths_needing_repair(conn: &Connection, at: Generation) -> Vec<String> {
     let mut stmt = match conn.prepare(
         "SELECT DISTINCT m.path FROM modules m \
          WHERE m.analysis IS NOT NULL AND m.extract_version = ?1 \
-           AND NOT EXISTS ( \
-             SELECT 1 FROM conclusions c \
-             WHERE c.path = m.path AND c.generation <= ?2 \
-           )",
+           AND (NOT EXISTS ( \
+                 SELECT 1 FROM conclusions c \
+                 WHERE c.path = m.path AND c.generation <= ?2 \
+               ) \
+             OR NOT EXISTS ( \
+                 SELECT 1 FROM surfaces s \
+                 WHERE s.path = m.path AND s.version = ?3 \
+               ))",
     ) {
         Ok(s) => s,
         Err(e) => {
@@ -253,7 +262,9 @@ pub fn paths_missing_conclusions(conn: &Connection, at: Generation) -> Vec<Strin
             return Vec::new();
         }
     };
-    let rows = stmt.query_map(params![EXTRACT_VERSION, at.0], |r| r.get::<_, String>(0));
+    let rows = stmt.query_map(params![EXTRACT_VERSION, at.0, super::surface_version()], |r| {
+        r.get::<_, String>(0)
+    });
     match rows {
         Ok(it) => it.filter_map(|r| r.ok()).collect(),
         Err(e) => {
@@ -284,7 +295,7 @@ pub fn repair_conclusions_slice(
     paths: &[String],
     at: Generation,
 ) -> usize {
-    let baked: Vec<(&String, Vec<u8>, u64)> = paths
+    let baked: Vec<(&String, Vec<u8>, u64, Vec<u8>)> = paths
         .iter()
         .filter_map(|path| {
             // WITH the bag: the bake reads witnesses, and a bagless decode
@@ -296,16 +307,20 @@ pub fn repair_conclusions_slice(
             // Stamped from the analysis the repair actually decoded, not from
             // the index: a repair races the writers, and a fingerprint read
             // elsewhere could describe a newer state than these bytes.
-            let fingerprint = crate::model::surface::surface_fingerprint(
-                &crate::model::surface::Surface::project(&fa),
-            );
+            let projected = crate::model::surface::Surface::project(&fa);
+            let fingerprint = crate::model::surface::surface_fingerprint(&projected);
+            // The repair is the ONLY lane that decodes with the bag after a
+            // projection-version change, so it is where a surface written by
+            // an older `Surface::project` gets replaced. Free here: the
+            // fingerprint above already paid for the projection.
+            let surface = super::encode_surface(&projected).unwrap_or_default();
             if blob.is_empty() {
                 // Nothing encodable. Leaving the row absent is right: the
                 // reader falls back to a decode, which is where it already was.
                 crate::util::ghost_stats::count("repair.nothing_to_bake");
                 return None;
             }
-            Some((path, blob, fingerprint))
+            Some((path, blob, fingerprint, surface))
         })
         .collect();
     if baked.is_empty() {
@@ -316,7 +331,16 @@ pub fn repair_conclusions_slice(
         log::warn!("conclusion repair: txn open failed; the slice defers to the next pass");
         return 0;
     }
-    for (path, blob, fingerprint) in &baked {
+    for (path, blob, fingerprint, surface) in &baked {
+        if !surface.is_empty() {
+            let r = conn.execute(
+                "INSERT OR REPLACE INTO surfaces (path, version, surface) VALUES (?1, ?2, ?3)",
+                params![path, super::surface_version(), surface],
+            );
+            if let Err(e) = r {
+                log::warn!("conclusion repair: surface store failed for '{path}': {e}");
+            }
+        }
         let r = conn.execute(
             "INSERT OR REPLACE INTO conclusions \
              (path, generation, map, source_fingerprint, flush_generation) \

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -119,12 +119,11 @@ pub struct RowStamp {
 /// one generation, and letting each write pick its own would scatter a single
 /// logical round across several, which is exactly the half-built state the
 /// pinning is designed to prevent.
-/// Deliberately driver-less: the flush stopped publishing once it became
-/// clear that a conclusion row with no `modules` row behind it can never be
-/// caught by a stamp check. Publication waits on the conclusions table
-/// carrying its own freshness stamp; the store side is built and tested for
-/// when it does.
-#[allow(dead_code)]
+///
+/// The row carries its own `source_fingerprint`, so it does not depend on a
+/// `modules` row existing to be judged: a consult compares the stamp against
+/// what the freshness index records for the path, and a row describing any
+/// other state reads absent.
 pub fn save_conclusions(
     conn: &Connection,
     path: &str,
@@ -157,7 +156,6 @@ pub fn save_conclusions(
 /// all exist yet, and `load_conclusions` would serve absence — which the
 /// evaluator reads as a definite `None`, the one thing absence must never
 /// mean.
-#[allow(dead_code)] // see `save_conclusions` — publication awaits a conclusions-row stamp
 pub fn publish_generation(
     conn: &Connection,
     at: Generation,
@@ -207,7 +205,6 @@ pub fn forget_conclusions(conn: &Connection, path: &str) {
 /// automatic: a sweep that guessed would delete the generation a live consult
 /// is reading, which is the same absence-as-answer failure the retention
 /// exists to prevent, arriving by a different door.
-#[allow(dead_code)] // reclaims what publication would produce; see `save_conclusions`
 pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
     // Keep the newest row at or below `keep` for each path — that is the one a
     // reader pinned at `keep` still resolves to. Only rows OLDER than that are

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1878,7 +1878,7 @@ fn a_derivation_change_clears_conclusions_but_keeps_blobs() {
 /// derivation fingerprint exists to catch, arriving through the repair that
 /// fingerprint triggers.
 ///
-/// Base-verify by dropping `paths_missing_conclusions`' `NOT EXISTS` clause:
+/// Base-verify by dropping `paths_needing_repair`' `NOT EXISTS` clause:
 /// the frontier then also contains the file that already has a map, and the
 /// repair rewrites rows nothing asked for.
 #[test]
@@ -1906,7 +1906,7 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
         "precondition: the map is gone"
     );
 
-    let frontier = paths_missing_conclusions(&conn, at);
+    let frontier = paths_needing_repair(&conn, at);
     assert_eq!(
         frontier,
         vec!["/repair/App.pm".to_string()],
@@ -1935,7 +1935,7 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
     // Idempotent: nothing is left on the frontier, so a second pass is a no-op
     // rather than a rewrite loop.
     assert!(
-        paths_missing_conclusions(&conn, at).is_empty(),
+        paths_needing_repair(&conn, at).is_empty(),
         "a repaired file must leave the frontier, or the background pass never ends"
     );
 }
@@ -1986,4 +1986,108 @@ fn invalidating_a_generation_drops_the_bake_that_came_with_it() {
     );
 
     let _ = std::fs::remove_file(&pm);
+}
+
+/// The persist path stores the projection a warm lane can adopt, and it is the
+/// COLD one — the projection taken from the whole analysis, not from the
+/// stripped copy a warm reader holds.
+///
+/// `Surface::project` reads the witness bag. Re-projecting on the warm side
+/// therefore records a smaller surface for identical bytes, and nothing about
+/// the degraded result says it is partial: 76.7% of conclusions rows read
+/// stale against rows that were correct, and a warm-start freshness verdict
+/// was computed over a file that does not exist in that shape
+/// (`docs/prompt-surface-projection-drift.md`).
+#[test]
+fn the_persisted_surface_is_the_cold_projection() {
+    let conn = test_db();
+    let path = std::path::Path::new("/surf/App.pm");
+    let cached = parse_source_to_cached(
+        "package My::App;\nuse Mojolicious::Lite;\n\
+         plugin 'CloveApp', { alpha => 1, beta => 2 };\n\
+         sub helper { return 'x' }\n1;\n",
+        path,
+    );
+    let whole_fp = crate::model::surface::surface_fingerprint(
+        &crate::model::surface::Surface::project(&cached.analysis),
+    );
+    assert!(save_to_db(&conn, "My::App", &Some(cached.clone()), "workspace"));
+
+    let stored = load_surface(&conn, "/surf/App.pm").expect("the persist path stores a surface");
+    assert_eq!(
+        crate::model::surface::surface_fingerprint(&stored),
+        whole_fp,
+        "the persisted surface is not the one the cold lane projected"
+    );
+
+    // And it is NOT what a warm reader would have produced on its own.
+    let mut stripped = (*cached.analysis).clone();
+    stripped.evict_witness_bag();
+    assert_ne!(
+        crate::model::surface::surface_fingerprint(&crate::model::surface::Surface::project(
+            &stripped
+        )),
+        whole_fp,
+        "fixture no longer carries bag-derived surface content, so it cannot \
+         demonstrate what persisting the projection is for"
+    );
+}
+
+/// A surface written by an older `Surface::project` reads absent, and the
+/// repair frontier picks the file up.
+///
+/// A persisted projection outliving its projector is the same class as a
+/// derivation outliving its source: the bytes deserialize cleanly and simply
+/// describe a shape this build no longer produces. Version-gated per ROW, so
+/// the question a reader asks — "is this one MY projection would make" — is
+/// the question the row answers.
+#[test]
+fn a_surface_from_another_projection_version_reads_absent_and_is_repaired() {
+    let conn = test_db();
+    let path = std::path::Path::new("/surfver/App.pm");
+    let cached = parse_source_to_cached(
+        "package Ver::App;\nuse Mojolicious::Lite;\n\
+         plugin 'CloveApp', { alpha => 1 };\nsub helper { return 'x' }\n1;\n",
+        path,
+    );
+    assert!(save_to_db(&conn, "Ver::App", &Some(cached.clone()), "workspace"));
+    let at = current_generation(&conn);
+    assert!(load_surface(&conn, "/surfver/App.pm").is_some(), "precondition");
+    assert!(
+        paths_needing_repair(&conn, at).is_empty(),
+        "precondition: a freshly persisted file needs no repair"
+    );
+
+    // What a change to `Surface::project` looks like from the store's side.
+    conn.execute(
+        "UPDATE surfaces SET version = 'from-an-older-projection'",
+        [],
+    )
+    .unwrap();
+    assert!(
+        load_surface(&conn, "/surfver/App.pm").is_none(),
+        "a surface from another projection version must not be adopted — it \
+         describes a shape this build does not produce"
+    );
+    assert_eq!(
+        paths_needing_repair(&conn, at),
+        vec!["/surfver/App.pm".to_string()],
+        "a stale surface must put the file back on the repair frontier, or the \
+         first edit to the projection silently re-opens the drift for every \
+         file already in the cache"
+    );
+
+    repair_conclusions_slice(&conn, &["/surfver/App.pm".to_string()], at);
+    let repaired = load_surface(&conn, "/surfver/App.pm").expect("the repair rewrites the surface");
+    assert_eq!(
+        crate::model::surface::surface_fingerprint(&repaired),
+        crate::model::surface::surface_fingerprint(&crate::model::surface::Surface::project(
+            &cached.analysis
+        )),
+        "the repaired surface is not the cold projection"
+    );
+    assert!(
+        paths_needing_repair(&conn, at).is_empty(),
+        "a repaired file must leave the frontier"
+    );
 }

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -2091,3 +2091,49 @@ fn a_surface_from_another_projection_version_reads_absent_and_is_repaired() {
         "a repaired file must leave the frontier"
     );
 }
+
+/// A surface write that does not produce a row must leave the path ABSENT,
+/// never carrying the PREVIOUS content's projection at the current version.
+///
+/// Absence costs a re-projection; a stale row is a wrong answer that cannot be
+/// detected downstream and does not heal. `load_surface` keys on
+/// `(path, version)`, so a leftover row at the current version reads as valid;
+/// `paths_needing_repair` only asks `NOT EXISTS`, so a present-but-wrong row
+/// never joins the repair frontier. The pairing that produces — a pre-edit
+/// fingerprint against a post-edit blob — makes every consumer's freshness
+/// verdict read `Unchanged` for a file that did change, which is the same
+/// wrong-answer class this store exists to close.
+///
+/// Fails against the pre-fix writer, whose empty-encode early return ran
+/// before any delete and left the prior row in place.
+#[test]
+fn a_surface_write_that_stores_nothing_leaves_no_stale_row() {
+    let conn = test_db();
+    let path = std::path::Path::new("/surfstale/App.pm");
+
+    let before = parse_source_to_cached("package My::App;\nsub alpha { 1 }\n1;\n", path);
+    assert!(save_to_db(&conn, "My::App", &Some(before), "workspace"));
+    assert!(
+        load_surface(&conn, "/surfstale/App.pm").is_some(),
+        "precondition: the first persist stored a surface"
+    );
+
+    // The file changed, and this time the surface half produces no bytes.
+    // The modules row still commits, so the store must not be left pairing the
+    // OLD surface with the NEW blob.
+    let empty = EncodedAnalysis {
+        analysis: Vec::new(),
+        conclusions: Vec::new(),
+        surface: Vec::new(),
+        source_fingerprint: 0,
+        bag: Vec::new(),
+    };
+    persist_surface(&conn, "/surfstale/App.pm", &empty);
+
+    assert!(
+        load_surface(&conn, "/surfstale/App.pm").is_none(),
+        "a surface write that stored nothing left the previous content's \
+         projection readable at the current version — the reader cannot tell \
+         it is stale, and the repair frontier's NOT EXISTS will never see it"
+    );
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1716,13 +1716,13 @@ fn a_pinned_reader_does_not_see_a_later_generation() {
     };
 
     let g1 = Generation(1);
-    publish_generation(&conn, g1, &[("/a.pm".to_string(), mk("One"))]).expect("publish 1");
+    publish_generation(&conn, g1, &[("/a.pm".to_string(), mk("One"), 111)]).expect("publish 1");
     assert_eq!(current_generation(&conn), g1);
 
     let pinned = load_conclusions(&conn, "/a.pm", g1).expect("gen 1 visible at gen 1");
 
     let g2 = Generation(2);
-    publish_generation(&conn, g2, &[("/a.pm".to_string(), mk("Two"))]).expect("publish 2");
+    publish_generation(&conn, g2, &[("/a.pm".to_string(), mk("Two"), 222)]).expect("publish 2");
 
     // The pin still resolves, and to the OLD content.
     let after = load_conclusions(&conn, "/a.pm", g1).expect(
@@ -1750,7 +1750,7 @@ fn pruning_keeps_what_the_pin_still_needs() {
         ConclusionMap(m, Default::default(), Default::default(), Default::default())
     };
     for g in 1..=4i64 {
-        publish_generation(&conn, Generation(g), &[("/a.pm".to_string(), mk(&format!("G{g}")))])
+        publish_generation(&conn, Generation(g), &[("/a.pm".to_string(), mk(&format!("G{g}")), g as u64)])
             .expect("publish");
     }
     // A reader is pinned at 3; everything strictly older than what gen 3
@@ -1775,14 +1775,14 @@ fn pruning_keeps_what_the_pin_still_needs() {
 fn a_failed_round_leaves_the_previous_generation_intact() {
     use crate::model::witnesses::ConclusionMap;
     let conn = test_db();
-    publish_generation(&conn, Generation(1), &[("/a.pm".to_string(), ConclusionMap::default())])
+    publish_generation(&conn, Generation(1), &[("/a.pm".to_string(), ConclusionMap::default(), 1)])
         .expect("publish 1");
     // Force a failure mid-round by dropping the table the second write needs.
     conn.execute_batch("DROP TABLE conclusions").unwrap();
     let r = publish_generation(
         &conn,
         Generation(2),
-        &[("/b.pm".to_string(), ConclusionMap::default())],
+        &[("/b.pm".to_string(), ConclusionMap::default(), 2)],
     );
     assert!(r.is_err(), "a round that could not write reported success");
     assert_eq!(

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -18,6 +18,14 @@ pub const EXTRACT_VERSION: i64 = 184;
 /// next warm re-shreds rows from the already-decoded analyses for free.
 pub(super) const REF_ROWS_VERSION: &str = "6";
 
+/// Row format of the `conclusions` lane. Bump on any change to the row's
+/// SHAPE or to what its stamp means.
+///
+/// Separate from `REF_ROWS_VERSION` because the lanes fail differently: a
+/// stale ref row answers a retrieval wrongly, a stale conclusion row answers
+/// a TYPE wrongly. Sharing one version would make either change wipe both.
+pub(super) const CONCLUSION_ROWS_VERSION: &str = "1";
+
 /// Fingerprint over everything that can change what a derivation CONCLUDES,
 /// computed by `build.rs` at compile time.
 ///
@@ -248,6 +256,42 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
         // The rebuild above DROPPED `strings`; every id a live writer memoized
         // for the previous generation is now dangling.
         bump_strings_generation(conn)?;
+    }
+
+    // The conclusions lane's own version + shape probe, same policy and same
+    // reason: a DB stamped current by a build whose migration did not reshape
+    // the table would keep serving rows whose stamp columns do not exist, and
+    // every validity compare would fail open to "no stamp" — which reads as a
+    // usable row rather than an unusable one.
+    //
+    // Wipe and re-bake, never a blob drop: the blobs are the derivation of
+    // record and the repair frontier re-bakes from them.
+    let concl_version: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'conclusion_rows_version'",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    let concl_shape_ok = conn
+        .prepare("SELECT source_fingerprint, flush_generation FROM conclusions LIMIT 1")
+        .is_ok();
+    if concl_version.as_deref() != Some(CONCLUSION_ROWS_VERSION) || !concl_shape_ok {
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS conclusions;
+             CREATE TABLE conclusions (
+                path               TEXT NOT NULL,
+                generation         INTEGER NOT NULL,
+                map                BLOB NOT NULL,
+                source_fingerprint INTEGER NOT NULL,
+                flush_generation   INTEGER NOT NULL,
+                PRIMARY KEY (path, generation)
+             ) WITHOUT ROWID;",
+        )?;
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('conclusion_rows_version', ?1)",
+            params![CONCLUSION_ROWS_VERSION],
+        )?;
     }
     // Pre-existing tables (same schema version) predate `deps_stamp`; add it
     // in place rather than bumping SCHEMA_VERSION (a bump drops every row —

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -62,6 +62,25 @@ pub fn conclusion_fingerprint() -> &'static str {
     })
 }
 
+/// The projection version a persisted `Surface` is stamped with.
+///
+/// `Surface::project` reads the witness bag, so a warm lane that re-projects
+/// from a bag-EVICTED copy records a different surface for the same unchanged
+/// file than the cold lane did — measured at 76.7% of conclusions rows
+/// rejected against rows that were in fact correct, and a warm-start freshness
+/// verdict computed over a degraded projection
+/// (`docs/prompt-surface-projection-drift.md`). Persisting the cold projection
+/// is what makes the two lanes agree.
+///
+/// Its own gate, independent of `SCHEMA_VERSION`: a change to the projection
+/// must invalidate persisted surfaces without dropping blobs, and a version
+/// somebody has to remember to bump is the wrong instrument for a failure
+/// nothing downstream can see — a stale surface deserializes cleanly and
+/// simply describes a file that no longer exists in that shape.
+pub fn surface_version() -> &'static str {
+    env!("PERL_LSP_SURFACE_FINGERPRINT")
+}
+
 /// The env vars that change what a bake STORES. Consult-side flags do not
 /// belong here — see `conclusion_fingerprint`.
 const BAKE_STEERING_FLAGS: [&str; 2] = ["PERL_LSP_MINT_LINKS", "PERL_LSP_NO_BAKE"];
@@ -177,6 +196,11 @@ pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
         CREATE TABLE IF NOT EXISTS stubs (
             path TEXT PRIMARY KEY,
             stub BLOB NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS surfaces (
+            path    TEXT PRIMARY KEY,
+            version TEXT NOT NULL,
+            surface BLOB NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_modules_path ON modules(path);
         CREATE INDEX IF NOT EXISTS idx_modules_name ON modules(module_name);",

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -379,14 +379,47 @@ impl CrossFileLookup for ModuleIndex {
         path: &std::path::Path,
     ) -> Option<std::sync::Arc<crate::model::witnesses::ConclusionMap>> {
         use crate::index::conclusion_cache::Cached;
-        match self.conclusion_cache_ref()?.get(path) {
-            // The Arc, not a clone of what it holds. Handing back an owned map
-            // deep-copies a ~72-entry HashMap per consult, and the consult path
-            // runs this tens of thousands of times per check — measured at a
-            // 6.7% REGRESSION against no conclusions at all, which is the whole
-            // saving spent on copying the thing that produced it.
-            Cached::Map(m) => Some(m),
-            Cached::NotBaked => None,
+        // The Arc, not a clone of what it holds. Handing back an owned map
+        // deep-copies a ~72-entry HashMap per consult, and the consult path
+        // runs this tens of thousands of times per check — measured at a
+        // 6.7% REGRESSION against no conclusions at all, which is the whole
+        // saving spent on copying the thing that produced it.
+        let Cached::Map(m, stamp) = self.conclusion_cache_ref()?.get(path) else {
+            return None;
+        };
+        // THE validity decision, and the only one. A row asserts the surface
+        // fingerprint of the analysis it was baked from; the index knows what
+        // that path's surface fingerprints to NOW. Equal means the map still
+        // describes what a consumer can see of this file.
+        //
+        // Never re-hash here. The fingerprint is looked UP, not computed —
+        // consults run tens of thousands of times per check, and hashing a
+        // projected surface on that path would cost more than the chase this
+        // layer exists to avoid.
+        //
+        // One compare, three failure modes: an ORPHANED row whose `modules`
+        // row was erased, a STALE row for an edited file, and a row from an
+        // INTERRUPTED write all fail it identically and read as absent, which
+        // falls back to the live chase. Correctness therefore stops depending
+        // on any caller remembering an eraser — `invalidate_derived_copies`
+        // survives for space and hygiene, not for truth.
+        //
+        // No freshness record means absent, not valid: a path the index has
+        // never recorded is one we cannot vouch for, and the fail-open
+        // direction here is "decode", never "trust".
+        match self.freshness.fingerprint_of(path) {
+            Some(fp) if fp == stamp.source_fingerprint => {
+                crate::util::ghost_stats::count("conclrow.valid");
+                Some(m)
+            }
+            Some(_) => {
+                crate::util::ghost_stats::count("conclrow.stale");
+                None
+            }
+            None => {
+                crate::util::ghost_stats::count("conclrow.unrecorded");
+                None
+            }
         }
     }
 

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -409,6 +409,16 @@ impl CrossFileLookup for ModuleIndex {
         // direction here is "decode", never "trust".
         match self.freshness.fingerprint_of(path) {
             Some(fp) if fp == stamp.source_fingerprint => {
+                // Fresh, but is it from the world this walk already
+                // committed to? A flush publishes a whole round while walks
+                // are in flight; mixing generations within one walk takes
+                // two halves of a cross-file answer from different worlds.
+                if !crate::model::witnesses::ResolutionSession::admit_conclusion_generation(
+                    self,
+                    stamp.flush_generation.0,
+                ) {
+                    return None;
+                }
                 crate::util::ghost_stats::count("conclrow.valid");
                 Some(m)
             }

--- a/src/index/module_index/mod.rs
+++ b/src/index/module_index/mod.rs
@@ -161,6 +161,7 @@ pub(crate) use index_core::strip_import_copy_one;
 mod lookup;
 mod queries;
 mod registration;
+use registration::EnrichedEntry;
 pub use registration::SweepMemoGuard;
 
 /// Every file that provides one module name, in provider order. `[0]` is
@@ -218,7 +219,7 @@ pub struct ModuleIndex {
     /// `None` payload = a DECLINED build (byte-cap giant / cycle-tainted)
     /// at this key: repeat queries skip the deep-copy entirely until a
     /// provider change moves the key.
-    enriched: Arc<DashMap<std::path::PathBuf, (u64, Option<Arc<FileAnalysis>>, usize)>>,
+    enriched: Arc<DashMap<std::path::PathBuf, EnrichedEntry>>,
     enriched_order: Arc<std::sync::Mutex<std::collections::VecDeque<std::path::PathBuf>>>,
     /// Report-only ghost-list accounting for the overlay
     /// (`PERL_LSP_GHOST_STATS`). `None` when the gate is off.

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2557,3 +2557,76 @@ fn one_walk_reads_conclusions_from_one_generation() {
     );
 }
 
+
+/// The profile lattice's whole guarantee: never serve a partial copy to a
+/// fuller request, and always serve a full copy to a partial one.
+///
+/// Getting the direction backwards is silent. A `full` verb handed a
+/// `diagnostics` copy finds `method_target()` empty on every `MethodCall` and
+/// reports it as "no definition" — a missing ANSWER, not an error, and
+/// indistinguishable from a file that genuinely has none.
+///
+/// The profile rides the entry as a FIELD rather than the key, so the fuller
+/// build REPLACES the partial one; keying on it would keep two copies of one
+/// file's analysis for a distinction only one of them needs.
+#[test]
+fn the_overlay_never_serves_a_partial_copy_to_a_fuller_request() {
+    use crate::model::file_analysis::EnrichmentProfile;
+    use crate::model::witnesses::ResolutionSession;
+
+    if std::env::var_os("PERL_LSP_FULL_ENRICHMENT").is_some() {
+        // The A/B control forces `full()` everywhere, which is exactly what
+        // this test needs NOT to be in force.
+        return;
+    }
+
+    let idx = ModuleIndex::new_for_test();
+    let lib = parse_source_to_cached(
+        "package Lib;\nour @EXPORT_OK = ('make');\nsub make { my %h = (id => 1); return \\%h }\n1;\n",
+        "Lib",
+    );
+    let consumer = parse_source_to_cached(
+        "package App;\nuse Lib 'make';\nsub go { my $x = make(); return $x }\n1;\n",
+        "App",
+    );
+    idx.register_workspace_module(lib.path.to_path_buf(), Arc::clone(&lib.analysis));
+    idx.register_workspace_module(consumer.path.to_path_buf(), Arc::clone(&consumer.analysis));
+
+    // A diagnostics walk builds and caches a partial copy.
+    let partial = {
+        let _walk = ResolutionSession::enter(Some(&idx as &dyn CrossFileLookup));
+        ResolutionSession::declare_profile(EnrichmentProfile::diagnostics());
+        let a = idx.enriched_snapshot(&consumer).expect("diagnostics snapshot");
+        let b = idx.enriched_snapshot(&consumer).expect("diagnostics snapshot again");
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "a request at the SAME profile must hit — otherwise the lattice \
+             just disabled the overlay"
+        );
+        a
+    };
+
+    // A full walk must NOT be handed it.
+    let full = {
+        let _walk = ResolutionSession::enter(Some(&idx as &dyn CrossFileLookup));
+        ResolutionSession::declare_profile(EnrichmentProfile::full());
+        idx.enriched_snapshot(&consumer).expect("full snapshot")
+    };
+    assert!(
+        !Arc::ptr_eq(&partial, &full),
+        "a copy enriched for diagnostics was served to a request that reads \
+         the dispatch-target edge it never filled"
+    );
+
+    // ...and the fuller copy now serves the partial verb, in place.
+    let partial_again = {
+        let _walk = ResolutionSession::enter(Some(&idx as &dyn CrossFileLookup));
+        ResolutionSession::declare_profile(EnrichmentProfile::diagnostics());
+        idx.enriched_snapshot(&consumer).expect("diagnostics snapshot after full")
+    };
+    assert!(
+        Arc::ptr_eq(&full, &partial_again),
+        "the full copy contains everything diagnostics reads — refusing it \
+         makes the two verbs evict each other on every alternation"
+    );
+}

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -1554,7 +1554,7 @@ fn reregistering_one_file_keeps_evicted_sibling_edges() {
     let pb = PathBuf::from("/fake/pkgid/Beta.pm");
     // The sibling registers through the stripping door: its resident copy
     // has NO symbols, only the pre-strip name record.
-    let _ = idx.register_workspace_stripping(pb.clone(), build_fa(src_b), crate::model::file_analysis::Residency::Skeleton);
+    let _ = idx.register_workspace_stripping(pb.clone(), build_fa(src_b), crate::model::file_analysis::Residency::Skeleton, None);
     let _ = idx.register_workspace_resident(pa.clone(), Arc::new(build_fa(src_a)));
     assert!(!idx.modules_with_symbol("from_beta").is_empty(), "sibling edges fed");
     // Re-register the whole file; the evicted sibling's names must replay.
@@ -2282,6 +2282,7 @@ fn provider_edges_replay_for_a_symbol_evicted_copy() {
         pp,
         build_fa("package DateTime::PP;\n*{ 'DateTime::_ymd2rd' } = sub { 42 };\n1;\n"),
         crate::model::file_analysis::Residency::Skeleton,
+        None,
     );
     assert_eq!(
         idx.modules_providing_package("DateTime"),

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2496,3 +2496,64 @@ fn surface_fp(c: &Arc<CachedModule>) -> u64 {
         &c.analysis,
     ))
 }
+
+/// The torn-read pin: one walk reads conclusions from ONE generation.
+///
+/// A flush publishes a whole round at generation N+1 while walks are in
+/// flight. Without the pin a walk can read file A's map from N and file B's
+/// from N+1 and compose them into a single cross-file answer — two halves of
+/// one answer taken from different worlds, and nothing downstream can tell.
+/// The pin costs at worst a decode, which is the fallback the layer already
+/// has for an absent row.
+#[test]
+fn one_walk_reads_conclusions_from_one_generation() {
+    use crate::index::conclusion_cache::ConclusionCache;
+    use crate::index::module_cache::{Generation, RowStamp};
+    use crate::model::file_analysis::CrossFileLookup;
+    use crate::model::witnesses::{ConclusionMap, ResolutionSession};
+
+    let early = std::path::PathBuf::from("/fake/Early.pm");
+    let later = std::path::PathBuf::from("/fake/Later.pm");
+    let fa_e = parse_source_to_cached("package Early;\nsub a { 1 }\n1;\n", "Early");
+    let fa_l = parse_source_to_cached("package Later;\nsub b { 2 }\n1;\n", "Later");
+
+    // Both rows are FRESH — each stamp matches what the index records. The
+    // only thing separating them is the generation they were published at.
+    let (fp_e, fp_l) = (surface_fp(&fa_e), surface_fp(&fa_l));
+    let (e_path, l_path) = (early.clone(), later.clone());
+    let idx = ModuleIndex::new_for_cli();
+    idx.set_conclusion_cache(Arc::new(ConclusionCache::new(1 << 20, move |p| {
+        let stamp = if p == e_path {
+            RowStamp { source_fingerprint: fp_e, flush_generation: Generation(7) }
+        } else if p == l_path {
+            RowStamp { source_fingerprint: fp_l, flush_generation: Generation(8) }
+        } else {
+            return None;
+        };
+        Some((ConclusionMap::default(), stamp))
+    })));
+    idx.record_surface(&early, &fa_e.analysis);
+    idx.record_surface(&later, &fa_l.analysis);
+
+    // No walk open: independent consults make no coherence claim, so both
+    // answer. This is also the control — without it the assertions below
+    // would pass against a `conclusions_for` that answered nothing at all.
+    assert!(idx.conclusions_for(&early).is_some());
+    assert!(idx.conclusions_for(&later).is_some());
+
+    let _walk = ResolutionSession::enter(Some(&idx as &dyn CrossFileLookup));
+    assert!(
+        idx.conclusions_for(&early).is_some(),
+        "the first row consumed sets the pin; it must be readable"
+    );
+    assert!(
+        idx.conclusions_for(&later).is_none(),
+        "a row from a different generation was composed into a walk already \
+         reading generation 7 — half of this answer is from another world"
+    );
+    assert!(
+        idx.conclusions_for(&early).is_some(),
+        "the pin must admit its own generation for the rest of the walk"
+    );
+}
+

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2310,19 +2310,25 @@ fn invalidating_derived_copies_takes_the_bake_as_well_as_the_bag() {
     let l = Arc::clone(&loads);
     let cache = Arc::new(ConclusionCache::new(1 << 20, move |_p| {
         l.fetch_add(1, Ordering::Relaxed);
-        Some(ConclusionMap::default())
+        Some((
+            ConclusionMap::default(),
+            crate::index::module_cache::RowStamp {
+                source_fingerprint: 0,
+                flush_generation: crate::index::module_cache::Generation(0),
+            },
+        ))
     }));
 
     let idx = ModuleIndex::new_for_cli();
     idx.set_conclusion_cache(Arc::clone(&cache));
 
-    assert!(matches!(cache.get(&path), Cached::Map(_)));
-    assert!(matches!(cache.get(&path), Cached::Map(_)));
+    assert!(matches!(cache.get(&path), Cached::Map(..)));
+    assert!(matches!(cache.get(&path), Cached::Map(..)));
     assert_eq!(loads.load(Ordering::Relaxed), 1, "precondition: memoized");
 
     idx.invalidate_derived_copies(&path);
 
-    assert!(matches!(cache.get(&path), Cached::Map(_)));
+    assert!(matches!(cache.get(&path), Cached::Map(..)));
     assert_eq!(
         loads.load(Ordering::Relaxed),
         2,
@@ -2372,4 +2378,121 @@ fn a_mark_postdates_every_stamp_that_preceded_it() {
         idx.restamp_owed(&a, None),
         "never stamped is owed regardless — a rehydrated copy always reads None"
     );
+}
+
+/// SPEC 3's correctness argument, positive control.
+///
+/// A conclusions row carries the surface fingerprint of the analysis it was
+/// baked from. When that still matches what the index records for the path,
+/// the row describes the file a consumer can see, and the consult is answered
+/// from it — which is the entire point of persisting the layer.
+#[test]
+fn a_conclusions_row_matching_the_recorded_surface_is_used() {
+    use crate::index::conclusion_cache::ConclusionCache;
+    use crate::index::module_cache::{Generation, RowStamp};
+    use crate::model::file_analysis::CrossFileLookup;
+    use crate::model::witnesses::ConclusionMap;
+
+    let path = std::path::PathBuf::from("/fake/Steady.pm");
+    let fa = parse_source_to_cached("package Steady;\nsub a { 1 }\n1;\n", "Steady");
+    let stamp = RowStamp {
+        source_fingerprint: surface_fp(&fa),
+        flush_generation: Generation(0),
+    };
+
+    let idx = ModuleIndex::new_for_cli();
+    idx.set_conclusion_cache(Arc::new(ConclusionCache::new(1 << 20, move |_p| {
+        Some((ConclusionMap::default(), stamp))
+    })));
+    idx.record_surface(&path, &fa.analysis);
+
+    assert!(
+        idx.conclusions_for(&path).is_some(),
+        "a row whose stamp matches the recorded surface was rejected — the \
+         persisted layer would never be read and every consult pays the chase"
+    );
+}
+
+/// The stale arm: the file moved since the row was written.
+///
+/// This is the failure the stamp exists to catch. A row baked from a previous
+/// version of the file is not a slow answer, it is a WRONG one — it concludes
+/// over code that no longer exists, and nothing downstream can tell.
+#[test]
+fn a_conclusions_row_whose_source_moved_reads_absent() {
+    use crate::index::conclusion_cache::ConclusionCache;
+    use crate::index::module_cache::{Generation, RowStamp};
+    use crate::model::file_analysis::CrossFileLookup;
+    use crate::model::witnesses::ConclusionMap;
+
+    let path = std::path::PathBuf::from("/fake/Moved.pm");
+    let before = parse_source_to_cached("package Moved;\nsub a { 1 }\n1;\n", "Moved");
+    let after =
+        parse_source_to_cached("package Moved;\nsub a { 1 }\nsub b { 2 }\n1;\n", "Moved");
+    assert_ne!(
+        surface_fp(&before),
+        surface_fp(&after),
+        "fixture must actually move the cross-file-visible surface"
+    );
+
+    // The row on disk was baked from the OLD analysis...
+    let stamp = RowStamp {
+        source_fingerprint: surface_fp(&before),
+        flush_generation: Generation(0),
+    };
+    let idx = ModuleIndex::new_for_cli();
+    idx.set_conclusion_cache(Arc::new(ConclusionCache::new(1 << 20, move |_p| {
+        Some((ConclusionMap::default(), stamp))
+    })));
+    // ...while the index has since recorded the NEW one.
+    idx.record_surface(&path, &after.analysis);
+
+    assert!(
+        idx.conclusions_for(&path).is_none(),
+        "a row baked from a previous version of the file was served as its \
+         conclusions — consults would answer from deleted code"
+    );
+}
+
+/// The unrecorded arm, which is also the ORPHANED arm.
+///
+/// A row can outlive the `modules` row it was written beside (a partial clear,
+/// an interrupted write, a deleted file whose freshness record was removed),
+/// and a fresh process starts with an empty in-memory index regardless. In all
+/// of those the index has nothing to vouch with, and the only safe direction
+/// is to decode — never to trust a stamp we cannot compare against.
+#[test]
+fn a_conclusions_row_for_an_unrecorded_path_reads_absent() {
+    use crate::index::conclusion_cache::ConclusionCache;
+    use crate::index::module_cache::{Generation, RowStamp};
+    use crate::model::file_analysis::CrossFileLookup;
+    use crate::model::witnesses::ConclusionMap;
+
+    let path = std::path::PathBuf::from("/fake/Orphan.pm");
+    let fa = parse_source_to_cached("package Orphan;\nsub a { 1 }\n1;\n", "Orphan");
+    let stamp = RowStamp {
+        source_fingerprint: surface_fp(&fa),
+        flush_generation: Generation(0),
+    };
+
+    let idx = ModuleIndex::new_for_cli();
+    idx.set_conclusion_cache(Arc::new(ConclusionCache::new(1 << 20, move |_p| {
+        Some((ConclusionMap::default(), stamp))
+    })));
+    // Deliberately no `record_surface`: the row's own stamp is self-consistent
+    // and would pass any check that only asked the ROW whether it was valid.
+
+    assert!(
+        idx.conclusions_for(&path).is_none(),
+        "a row for a path the index has never recorded was trusted — an \
+         orphaned row survives a clear and its stamp always agrees with itself"
+    );
+}
+
+/// The fingerprint a conclusions row stamps itself with, spelled once for the
+/// row-validity tests so they cannot drift from what the writer computes.
+fn surface_fp(c: &Arc<CachedModule>) -> u64 {
+    crate::model::surface::surface_fingerprint(&crate::model::surface::Surface::project(
+        &c.analysis,
+    ))
 }

--- a/src/index/module_index/parts.rs
+++ b/src/index/module_index/parts.rs
@@ -568,6 +568,18 @@ impl WorkspaceRegistrationParts {
         &self.arc
     }
 
+    /// Replace the projection this token carries with a PERSISTED one.
+    ///
+    /// The warm lane's analysis is bag-evicted and `Surface::project` reads
+    /// the bag, so the projection minted here describes a smaller file than
+    /// the one on disk — and nothing about the result says it is partial. The
+    /// cold lane's projection was stored beside the blob precisely so the warm
+    /// lane can record what the cold lane recorded instead of re-deriving a
+    /// degraded twin (`docs/prompt-surface-projection-drift.md`).
+    pub(crate) fn adopt_surface(&mut self, surface: crate::model::surface::Surface) {
+        self.surface = Some(surface);
+    }
+
     /// See `PackRegistrationParts::record_surface` — takes, does not clone.
     pub(crate) fn record_surface(
         &mut self,

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -118,7 +118,7 @@ impl ModuleIndex {
                 let db = crate::index::module_cache::db_path_for(&dir, "perl");
                 let conn = crate::index::module_cache::open_reader_retrying(&db).ok()?;
                 let at = crate::index::module_cache::current_generation(&conn);
-                crate::index::module_cache::load_conclusions(
+                crate::index::module_cache::load_conclusions_stamped(
                     &conn,
                     &path.to_string_lossy(),
                     at,

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -457,9 +457,20 @@ impl ModuleIndex {
         });
         let path = &cached.path;
         let key = self.enrichment_key_memoized(cached);
+        // What THIS request reads. A walk declares it on its session; a
+        // one-shot CLI verb on the process cell; anything else gets `full()`.
+        let needed = crate::model::file_analysis::enrichment_profile();
         if let Some(e) = self.enriched.get(path) {
-            if e.0 == key {
-                let hit = e.1.clone();
+            // Fresh AND at least as full as this request needs. A fresh entry
+            // that does not cover falls through to the rebuild below — which
+            // is a cache miss, not an error: the partial copy is missing
+            // exactly the product this verb asked for, and serving it would
+            // read as a missing ANSWER.
+            if e.key == key && !e.profile.covers(needed) {
+                crate::util::ghost_stats::count("enriched_snapshot.profile_miss");
+            }
+            if e.key == key && e.profile.covers(needed) {
+                let hit = e.analysis.clone();
                 drop(e);
                 // LRU touch — a FIFO would let any sweep evict the hot dep
                 // entries the witness seams lean on, in insertion order.
@@ -556,7 +567,17 @@ impl ModuleIndex {
         let stored: Option<Arc<FileAnalysis>> =
             if tainted || bytes > enriched_byte_cap { None } else { Some(arc) };
         let entry_bytes = if stored.is_some() { bytes } else { 0 };
-        self.enriched.insert(path.clone(), (key, stored.clone(), entry_bytes));
+        // Recorded as what the build actually ran under. With one profile axis
+        // that IS the join with whatever the replaced entry held, because the
+        // only way `covers` fails is a partial entry meeting a fuller request.
+        // A second axis would make this a lossy replacement — still SOUND
+        // (every entry states exactly what it is, so `covers` keeps answering
+        // correctly), just a rebuild for the other verb. Join here if that
+        // ever costs more than it saves.
+        self.enriched.insert(
+            path.clone(),
+            EnrichedEntry { key, analysis: stored.clone(), bytes: entry_bytes, profile: needed },
+        );
         {
             let mut order = self.enriched_order.lock().unwrap();
             order.retain(|p| p != path);
@@ -565,7 +586,7 @@ impl ModuleIndex {
                 order
                     .iter()
                     .filter_map(|p| self.enriched.get(p))
-                    .map(|e| e.2)
+                    .map(|e| e.bytes)
                     .sum::<usize>()
             };
             while order.len() > 1
@@ -1611,4 +1632,24 @@ impl ModuleIndex {
             }
         }
     }
+}
+
+/// One entry in the enrichment overlay.
+///
+/// `profile` is a FIELD, not part of the key. Keying on it would let a
+/// `diagnostics` copy and a `full` copy of the same file coexist under one
+/// fingerprint, doubling the bytes for a distinction only one of them needs;
+/// as a field, the fuller build replaces the partial one and serves both.
+/// Acceptance is `profile.covers(needed)` — a copy enriched under a profile at
+/// least as full as the request's. Never equality: `full` must serve a
+/// `diagnostics` request, or every verb mix thrashes.
+pub(crate) struct EnrichedEntry {
+    /// Fingerprint of the file plus its providers — the freshness half.
+    pub key: u64,
+    /// `None` = a remembered DECLINE (byte-cap giant / cycle-tainted) at this
+    /// key: repeat queries skip the deep-copy until the key moves.
+    pub analysis: Option<Arc<FileAnalysis>>,
+    pub bytes: usize,
+    /// What this copy was actually enriched under.
+    pub profile: crate::model::file_analysis::EnrichmentProfile,
 }

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -811,13 +811,27 @@ impl ModuleIndex {
     /// arc for the caller's FileStore mirror. Synchronous-persistence
     /// callers only (the warm path — the blob already exists on disk);
     /// the bulk fresh path splits the halves around the writer's COMMIT.
+    /// `persisted` is the surface the COLD lane recorded for this file, when
+    /// the store has one at the current projection version. A warm caller
+    /// passes it because its own analysis is bag-evicted and `Surface::project`
+    /// reads the bag — re-projecting there records a degraded twin of what the
+    /// cold lane recorded, for identical bytes
+    /// (`docs/prompt-surface-projection-drift.md`). `None` keeps the
+    /// projection this token already carries.
     pub fn register_workspace_stripping(
         &self,
         path: std::path::PathBuf,
         fa: FileAnalysis,
         level: crate::model::file_analysis::Residency,
+        persisted: Option<crate::model::surface::Surface>,
     ) -> Arc<FileAnalysis> {
         let mut parts = self.prepare_workspace_parts(&path, fa, level);
+        if let Some(s) = persisted {
+            crate::util::ghost_stats::count("surface.adopted_persisted");
+            parts.adopt_surface(s);
+        } else {
+            crate::util::ghost_stats::count("surface.reprojected");
+        }
         parts.record_surface(self, &path);
         let arc = Arc::clone(parts.arc());
         self.register_workspace_residency(path, parts);

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -112,6 +112,17 @@ pub fn index_workspace_with_index(
 
     let count = AtomicUsize::new(0);
     let done = AtomicUsize::new(0);
+    // Paths whose surface CHANGED during this bulk — the re-stamp gate's
+    // seeds, collected through the walk and acted on once at the drain.
+    //
+    // Paths, not consumer sets. The reverse-dep answer is only correct once
+    // every file is registered, so asking `dirty_consumers` from inside the
+    // parallel walk would return a partial set for every file that happened
+    // to be indexed early — and would pay an O(corpus) reverse-dep walk on
+    // the hot lane to do it. Deferring to the drain is both the cheaper and
+    // the only correct time: the H9-2 defer/reconcile shape.
+    let surface_changed: std::sync::Mutex<Vec<std::path::PathBuf>> =
+        std::sync::Mutex::new(Vec::new());
     let total = paths.len();
 
     // Perl workspace persistence (`docs/adr/relational-ref-index.md`,
@@ -495,7 +506,16 @@ pub fn index_workspace_with_index(
                                 // the writer's registration half discards it, so
                                 // it would otherwise ride the queue only to be
                                 // dropped.
-                                crate::util::ghost_stats::timed("walk.record_surface", || parts.record_surface(idx, &canon));
+                                let verdict = crate::util::ghost_stats::timed("walk.record_surface", || parts.record_surface(idx, &canon));
+                                // The record half already happened here; what
+                                // was missing is the routing the record exists
+                                // to feed. `Changed` is the only verdict that
+                                // names stale consumers.
+                                if matches!(verdict, crate::model::surface::SurfaceVerdict::Changed) {
+                                    if let Ok(mut q) = surface_changed.lock() {
+                                        q.push(canon.clone());
+                                    }
+                                }
                                 (std::sync::Arc::clone(parts.arc()), Some(parts))
                             }
                             None => {
@@ -518,14 +538,28 @@ pub fn index_workspace_with_index(
                     } else {
                         // Whole copy (no persistence, degraded, or NO_EVICT):
                         // register immediately (no strip — the whole-copy door);
-                        // still persist when a blob exists. `false, false` mints
-                        // the token without evicting or recording surface, so
-                        // this path's freshness behavior is unchanged.
+                        // still persist when a blob exists.
                         let arc = match module_index {
                             Some(idx) => {
-                                let parts =
+                                let mut parts =
                                     idx.prepare_workspace_parts(&canon, analysis, crate::model::file_analysis::Residency::Whole);
                                 let arc = std::sync::Arc::clone(parts.arc());
+                                // Record here too. Whether a file's surface is
+                                // recorded must not depend on which residency
+                                // lane it took — that would make the freshness
+                                // engine's coverage a function of whether the
+                                // cache DB happened to open, so a workspace
+                                // running unpersisted or under NO_EVICT would
+                                // silently have no bulk records and no marks.
+                                // The projection is already in `parts` and is
+                                // otherwise dropped; `Background` writes for an
+                                // open path suppress themselves.
+                                let verdict = parts.record_surface(idx, &canon);
+                                if matches!(verdict, crate::model::surface::SurfaceVerdict::Changed) {
+                                    if let Ok(mut q) = surface_changed.lock() {
+                                        q.push(canon.clone());
+                                    }
+                                }
                                 idx.register_workspace_residency(canon.clone(), parts);
                                 // Deliberate whole pin (unpersistable /
                                 // degraded / NO_EVICT) — accounted for the
@@ -597,6 +631,46 @@ pub fn index_workspace_with_index(
                     idx.count_fully_resident(),
                     expected_whole.load(Ordering::Relaxed),
                 );
+            });
+        }
+    }
+
+    // End-of-bulk drain: the re-stamp gate's mark, once.
+    //
+    // Once, and here, for two reasons that point the same way. The reverse-dep
+    // answer is only complete now — every file is registered, so
+    // `dirty_consumers` finally returns the whole consumer set rather than
+    // whichever consumers happened to be indexed before the asker. And a
+    // per-file mark during the walk would mint one epoch per file, so a stamp
+    // taken mid-bulk could satisfy an early file's mark while a later file's
+    // change went unaccounted; one epoch for the whole bulk cannot express
+    // that.
+    //
+    // Deliberately a MARK and not a flush wave. The wave's product is a diff
+    // — which files' answers moved — and a bulk has no before-state to diff
+    // against: the persist writer has already written each seed's new map at
+    // the current generation, so the frozen map a wave would compare against
+    // IS the new one, and every surface would compare equal. Marking the
+    // consumers is the whole of what the gate needs, and it is the part a
+    // bulk can actually answer.
+    if let Some(idx) = module_index {
+        let seeds = surface_changed
+            .into_inner()
+            .unwrap_or_else(|e| e.into_inner());
+        if !seeds.is_empty() {
+            crate::util::timings::phase("index.restamp_mark", || {
+                let mut consumers: std::collections::HashSet<std::path::PathBuf> =
+                    Default::default();
+                for p in &seeds {
+                    consumers.extend(idx.dirty_consumers(p));
+                }
+                crate::util::ghost_stats::count_by(
+                    "bulk.surface_changed",
+                    seeds.len() as u64,
+                );
+                if !consumers.is_empty() {
+                    idx.mark_provider_diff(consumers);
+                }
             });
         }
     }

--- a/src/index/module_resolver/index_perl.rs
+++ b/src/index/module_resolver/index_perl.rs
@@ -238,6 +238,12 @@ pub fn index_workspace_with_index(
                         path.clone(),
                         fa,
                         level,
+                        // The cold lane's projection, when the store holds one
+                        // at this projection version. Without it the warm lane
+                        // records a bag-less twin and every cross-boundary
+                        // comparison asks a different question than the cold
+                        // run answered.
+                        module_cache::load_surface(conn, &path_str),
                     ),
                     None => {
                         // No index (CLI-less warm): no feeds to extract —

--- a/src/index/module_resolver/module_resolver_tests.rs
+++ b/src/index/module_resolver/module_resolver_tests.rs
@@ -598,3 +598,77 @@ fn the_writer_drains_more_entries_than_the_queue_holds() {
     producer.join().unwrap();
     assert_eq!(committed.load(O::SeqCst), 0, "no connection ⇒ drained unregistered");
 }
+
+/// A bulk index marks the consumers of every file whose surface CHANGED.
+///
+/// The gap this pins was a discarded return value. The bulk walk already
+/// RECORDED each file's surface — it called `record_surface` and threw the
+/// verdict away — so the freshness engine's write half ran and its read half
+/// never did. Nothing downstream could notice: the records were correct, the
+/// index was complete, and the only symptom was a re-stamp gate that stayed
+/// inert forever because no bulk ever marked anyone.
+///
+/// Two files, one importing the other. Index once to establish records and
+/// the consumer edge, edit the provider, index again: the consumer must come
+/// back marked, and marked at an epoch strictly newer than a stamp taken
+/// before the second bulk.
+#[test]
+fn a_bulk_index_marks_the_consumers_of_what_changed() {
+    use crate::model::file_analysis::CrossFileLookup;
+
+    let dir = std::env::temp_dir().join(format!("plsp_bulkmark_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let provider = dir.join("BulkProv.pm");
+    let consumer = dir.join("BulkCons.pm");
+    std::fs::write(
+        &provider,
+        "package BulkProv;\nsub build { return bless {}, 'Widget::One' }\n1;\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &consumer,
+        "package BulkCons;\nuse BulkProv;\nsub run { my $w = BulkProv->build; return $w->go }\n1;\n",
+    )
+    .unwrap();
+
+    let idx = crate::index::module_index::ModuleIndex::new_for_cli();
+    let files = crate::index::file_store::FileStore::new();
+    index_workspace_with_index(&dir, &files, Some(&idx), None, None);
+
+    let canon_cons = std::fs::canonicalize(&consumer).unwrap();
+    let before = idx.flush_epoch();
+
+    // The provider's surface moves: a different return class.
+    std::fs::write(
+        &provider,
+        "package BulkProv;\nsub build { return bless {}, 'Widget::Two' }\n1;\n",
+    )
+    .unwrap();
+    index_workspace_with_index(&dir, &files, Some(&idx), None, None);
+
+    let after = idx.flush_epoch();
+    assert!(
+        after > before,
+        "the bulk minted a mark epoch; without one the clock never moves"
+    );
+
+    // The DISCRIMINATING assertion, and the reason the obvious one is not.
+    // "a pre-bulk stamp is owed" is satisfied by the gate's fail-open default
+    // — an unmarked path is owed too — so it passes whether or not the bulk
+    // marked anything, and a first draft of this test did exactly that.
+    // Only the positive direction separates them: a stamp at the post-mark
+    // clock is COVERED, which requires a mark to exist at or below it.
+    assert!(
+        !idx.restamp_owed(&canon_cons, Some(after)),
+        "the consumer carries no mark, so the gate is failing open rather \
+         than answering — the bulk never routed its Changed verdict to \
+         dirty_consumers"
+    );
+    assert!(
+        idx.restamp_owed(&canon_cons, Some(before)),
+        "and a stamp predating the bulk is still owed"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -146,8 +146,14 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
     // repair run ahead of the loop would put minutes in front of the first
     // resolve. It runs in the gap where this thread would otherwise be blocked
     // on its condvar, which is the definition of "post-ready background".
+    //
+    // Not seeded at all when baking is switched off: the repair lane is the
+    // SECOND producer of a conclusions row, so leaving it on would let the
+    // control's own arm bake the whole corpus in the background and measure a
+    // full layer from its second warm run onward.
     let mut repair_frontier: Vec<String> = db
         .as_ref()
+        .filter(|_| !crate::model::witnesses::bake_disabled())
         .map(|conn| {
             let at = module_cache::current_generation(conn);
             let f = module_cache::paths_missing_conclusions(conn, at);

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -156,7 +156,7 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
         .filter(|_| !crate::model::witnesses::bake_disabled())
         .map(|conn| {
             let at = module_cache::current_generation(conn);
-            let f = module_cache::paths_missing_conclusions(conn, at);
+            let f = module_cache::paths_needing_repair(conn, at);
             if !f.is_empty() {
                 log::info!(
                     "Conclusion repair: {} file(s) hold a blob with no map; \

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -159,8 +159,9 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
             let f = module_cache::paths_needing_repair(conn, at);
             if !f.is_empty() {
                 log::info!(
-                    "Conclusion repair: {} file(s) hold a blob with no map; \
-                     re-baking in the background",
+                    "Derivation repair: {} file(s) hold a blob whose map or \
+                     surface is missing or from another version; re-deriving \
+                     in the background",
                     f.len()
                 );
             }
@@ -401,7 +402,7 @@ fn drain_or_repair(
         let at = module_cache::current_generation(conn);
         module_cache::repair_conclusions_slice(conn, &slice, at);
         if frontier.is_empty() {
-            log::info!("Conclusion repair: frontier drained");
+            log::info!("Derivation repair: frontier drained");
         }
     }
     drain_next_batch(queue)

--- a/src/layering_tests.rs
+++ b/src/layering_tests.rs
@@ -1273,3 +1273,44 @@ fn every_reduced_value_match_names_its_variants() {
         violations.join("\n")
     );
 }
+
+/// A bake-steering control must have exactly ONE reader.
+///
+/// There are two producers of a conclusions row — the persist path's
+/// `encode_analysis` and the background repair lane — and a control that gates
+/// only one of them is not a control. That was the shipped state: an A/B whose
+/// OFF arm was primed cold reported 72,305 provider fetches on its first run
+/// and 57,481 on its third, byte-identical to the ON arm, because repair had
+/// baked the frontier in between. The flag disabled itself after one warm run,
+/// the conclusions row count looked full and correct throughout, and no output
+/// distinguished a control that ran from a control that controlled.
+///
+/// Pinned as a source rule rather than a behaviour test because the failure is
+/// a MISSING call: no assertion about the two producers we know of would catch
+/// a third one added later reading the env directly.
+#[test]
+fn the_bake_gate_has_one_reader() {
+    let needle = "std::env::var(\"PERL_LSP_NO_BAKE\")";
+    let mut sites = Vec::new();
+    for (f, _layer, _module) in source_files() {
+        let text = fs::read_to_string(&f).expect("read source");
+        for (ln, line) in text.lines().enumerate() {
+            if line.contains(needle) {
+                sites.push(format!("{}:{}", f.display(), ln + 1));
+            }
+        }
+    }
+    assert_eq!(
+        sites.len(),
+        1,
+        "PERL_LSP_NO_BAKE must be read only by `conclusions::bake_disabled()` — \
+         every producer of a conclusions row asks it. Found:\n{}",
+        sites.join("\n")
+    );
+    assert!(
+        sites[0].contains("conclusions.rs"),
+        "the single reader must be the accessor in `model/witnesses/conclusions.rs`, \
+         found it at {}",
+        sites[0]
+    );
+}

--- a/src/lsp/backend/indexing.rs
+++ b/src/lsp/backend/indexing.rs
@@ -75,7 +75,7 @@ impl Backend {
             // starts. They differ for a DELETED file: it has no map and
             // nothing to evaluate, so it enters the wave as its direct
             // consumers instead.
-            let mut fresh: Vec<(PathBuf, crate::model::witnesses::ConclusionMap)> = Vec::new();
+            let mut fresh: Vec<crate::index::conclusion_flush::FreshBake> = Vec::new();
             let mut frontier: Vec<PathBuf> = Vec::new();
             // The persisted generation (blob + ref rows) is now stale for
             // these paths; drop it so warm starts re-parse and the
@@ -145,13 +145,26 @@ impl Backend {
                                 // The caller bakes: the analysis is in hand
                                 // and its blob was just invalidated, so the
                                 // flush has nothing to decode it from.
-                                fresh.push((
-                                    canon.clone(),
-                                    crate::index::module_cache::bake_conclusion_map(
-                                        &arc,
-                                        &arc.witnesses,
-                                    ),
-                                ));
+                                fresh.push(
+                                    crate::index::conclusion_flush::FreshBake {
+                                        path: canon.clone(),
+                                        map: crate::index::module_cache::bake_conclusion_map(
+                                            &arc,
+                                            &arc.witnesses,
+                                        ),
+                                        // Projected from the SAME analysis the
+                                        // map was baked from. For a path that
+                                        // is ALSO open, the freshness index
+                                        // holds the buffer's fingerprint
+                                        // instead, so this row reads absent —
+                                        // correctly, since consumers of an
+                                        // open file read its buffer.
+                                        source_fingerprint:
+                                            crate::model::surface::surface_fingerprint(
+                                                &crate::model::surface::Surface::project(&arc),
+                                            ),
+                                    },
+                                );
                                 frontier.push(canon.clone());
                             }
                         }

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -258,6 +258,29 @@ impl EnrichmentProfile {
     pub const fn stamps_method_targets(self) -> bool {
         self.stamp_method_targets
     }
+
+    /// Is a copy enriched under `self` usable by a request that needs
+    /// `needed`? The lattice's ≥, and the whole never-serve-partial-to-fuller
+    /// guarantee.
+    ///
+    /// Directional on purpose: `full` serves a `diagnostics` request (it
+    /// contains everything that one reads), and `diagnostics` does NOT serve a
+    /// `full` request. Getting this backwards is silent — the fuller verb
+    /// receives a copy missing exactly the product it asked for, and reads it
+    /// as a missing ANSWER.
+    pub const fn covers(self, needed: EnrichmentProfile) -> bool {
+        !needed.stamp_method_targets || self.stamp_method_targets
+    }
+
+    /// The least profile covering both — what a fuller request re-enriches
+    /// at. Joining rather than replacing means a `full` request arriving
+    /// after a `diagnostics` one leaves an entry that still serves the
+    /// diagnostics verb, instead of two verbs evicting each other forever.
+    pub const fn join(self, other: EnrichmentProfile) -> EnrichmentProfile {
+        EnrichmentProfile {
+            stamp_method_targets: self.stamp_method_targets || other.stamp_method_targets,
+        }
+    }
 }
 
 /// The process's declared profile. `full()` until a verb says otherwise.
@@ -270,14 +293,13 @@ static PROFILE: std::sync::OnceLock<EnrichmentProfile> = std::sync::OnceLock::ne
 /// surprised, and nothing it enriches outlives the process — the
 /// `enriched_snapshot` overlay is resident, not persisted.
 ///
-/// A SERVER verb must never call this. The overlay there is shared and
-/// fingerprint-keyed, so a partial copy cached under a profile-blind key would
-/// be served to a verb that reads more than it does — silently, and as a
-/// missing answer rather than an error. If a server verb ever wants a partial
-/// profile, the profile belongs IN the overlay key, and this cell is the wrong
-/// mechanism rather than one to extend. That form is deliberately not built:
-/// nothing wants it yet, and building it now would be a key change with no
-/// consumer to validate it.
+/// A SERVER verb must never call this — not because a partial profile is
+/// unavailable there, but because the cell is the wrong scope for it: one
+/// process serves many verbs, and a value set here outlives the verb that
+/// wanted it and answers the next one. A server verb declares its profile on
+/// its `ResolutionSession` instead (`ResolutionSession::declare_profile`),
+/// which is per-walk, and the overlay records the profile each copy was built
+/// under so a partial one is never served to a fuller request.
 pub fn declare_enrichment_profile(profile: EnrichmentProfile) {
     let _ = PROFILE.set(profile);
 }
@@ -294,7 +316,11 @@ pub fn enrichment_profile() -> EnrichmentProfile {
     static FULL_OVERRIDE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let forced = *FULL_OVERRIDE
         .get_or_init(|| std::env::var_os("PERL_LSP_FULL_ENRICHMENT").is_some());
-    resolve_profile(PROFILE.get().copied(), forced)
+    // The open walk's declaration wins over the process cell: a server serves
+    // many verbs from one process, and the cell cannot tell them apart.
+    let declared = crate::model::witnesses::ResolutionSession::declared_profile()
+        .or_else(|| PROFILE.get().copied());
+    resolve_profile(declared, forced)
 }
 
 /// The precedence rule, separated from the cells that hold it so it can be
@@ -1330,6 +1356,28 @@ mod profile_tests {
         assert!(!should_stamp_method_targets(full, true), "the ablation alone suppresses");
         assert!(!should_stamp_method_targets(diag, false), "the profile alone suppresses");
         assert!(!should_stamp_method_targets(diag, true), "both suppress");
+    }
+
+    /// The lattice's order, in the direction that matters.
+    ///
+    /// `covers` is not equality and not symmetry. A full copy contains
+    /// everything a diagnostics request reads, so refusing it would make two
+    /// verbs evict each other on every alternation; a diagnostics copy is
+    /// missing exactly what a full request came for, so serving it is a
+    /// silently short answer.
+    #[test]
+    fn the_profile_lattice_orders_full_above_diagnostics() {
+        let full = EnrichmentProfile::full();
+        let diag = EnrichmentProfile::diagnostics();
+        assert!(full.covers(diag), "full must serve a diagnostics request");
+        assert!(!diag.covers(full), "diagnostics must NOT serve a full request");
+        assert!(full.covers(full));
+        assert!(diag.covers(diag));
+        // The join is the least profile serving both, and it is full here
+        // because full is the top of a single-axis lattice.
+        assert_eq!(diag.join(full), full);
+        assert_eq!(full.join(diag), full);
+        assert_eq!(diag.join(diag), diag);
     }
 }
 

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -38,7 +38,7 @@ mod ancestry;
 pub use ancestry::*;
 mod queries;
 mod enrichment;
-pub use enrichment::{declare_enrichment_profile, EnrichmentProfile};
+pub use enrichment::{declare_enrichment_profile, enrichment_profile, EnrichmentProfile};
 mod class_queries;
 mod cursor_queries;
 mod invocants;

--- a/src/model/surface.rs
+++ b/src/model/surface.rs
@@ -471,12 +471,17 @@ struct SurfaceRecord {
     stale_provided: Vec<String>,
 }
 
-/// Process-local surface identity. In-memory only (SipHash keys are
-/// per-process) — the persisted form carries its own stable encoding.
-/// Streams the serialization straight into the hasher: record() runs per
-/// keystroke on open docs, so no intermediate buffer.
 /// The value `FreshnessIndex` records for a surface, and the value a
 /// persisted conclusion row is stamped with.
+///
+/// `DefaultHasher::new()` is fixed-key and therefore stable ACROSS
+/// processes — it is `RandomState` that is seeded per process. That
+/// distinction is load-bearing now that the value outlives the process
+/// in a row stamp: swapping in `RandomState` would leave every persisted
+/// stamp unmatchable, silently and with no error.
+///
+/// Streams the serialization straight into the hasher: record() runs per
+/// keystroke on open docs, so no intermediate buffer.
 ///
 /// Deterministic for a given build, and that is all it has to be: the
 /// conclusion-derivation fingerprint already wipes the lane whenever

--- a/src/model/surface.rs
+++ b/src/model/surface.rs
@@ -475,7 +475,21 @@ struct SurfaceRecord {
 /// per-process) — the persisted form carries its own stable encoding.
 /// Streams the serialization straight into the hasher: record() runs per
 /// keystroke on open docs, so no intermediate buffer.
-fn surface_fingerprint(s: &Surface) -> u64 {
+/// The value `FreshnessIndex` records for a surface, and the value a
+/// persisted conclusion row is stamped with.
+///
+/// Deterministic for a given build, and that is all it has to be: the
+/// conclusion-derivation fingerprint already wipes the lane whenever
+/// `src/**` changes, so a hasher that shifted between compiler versions
+/// costs one re-bake it was going to pay anyway. A mismatch always reads as
+/// "not valid", which degrades to the live chase.
+///
+/// Surface-keyed, not content-keyed, and deliberately: the map exists to
+/// answer CROSS-FILE consults, so two analyses with the same cross-file-
+/// visible projection give the same answers to every question the map is
+/// asked. A body edit that moves no surface moves no conclusion a consumer
+/// can observe.
+pub fn surface_fingerprint(s: &Surface) -> u64 {
     use std::hash::Hasher;
     struct HashWriter(std::collections::hash_map::DefaultHasher);
     impl std::io::Write for HashWriter {

--- a/src/model/surface_tests.rs
+++ b/src/model/surface_tests.rs
@@ -379,3 +379,45 @@ fn freshness_dirty_walk_covers_renamed_away_providers() {
         "stale-provided names last exactly one re-record: Bar has no consumers"
     );
 }
+
+/// A Surface projected from a bag-EVICTED analysis is a different Surface.
+///
+/// `Surface::project` reads the witness bag — `despan`ed `InferredType`s on
+/// methods and values, and the loader shapes — so a stripped copy projects a
+/// SMALLER surface that still claims to describe the file. Nothing about the
+/// result says it is partial.
+///
+/// This is why a warm lane cannot record a projection taken from a resident
+/// (stripped) copy: the cold run records one fingerprint for a file and the
+/// warm run records another for the same unchanged bytes, so anything
+/// comparing the two across the boundary is comparing two different questions.
+/// Measured on the substrate: 47,967 of 62,545 conclusions-row consults were
+/// rejected as stale against rows that were in fact correct, and the chase
+/// they fell back to cost 3.3x the provider fetches.
+///
+/// Pinned as an EQUALITY-FAILING property on purpose — it records what is
+/// true today so a fix flips this test rather than being invisible. Written
+/// up, with the measurement and the fix options, in
+/// `docs/prompt-surface-projection-drift.md`.
+#[test]
+fn a_bag_evicted_analysis_projects_a_different_surface() {
+    let src = "package Alpha;\nuse strict;\n\
+               sub new { my $c = shift; return bless {}, $c }\n\
+               sub name { my $s = shift; return 'alpha' }\n1;\n";
+    let mut parser = crate::build::builder::create_parser();
+    let tree = parser.parse(src, None).expect("parse");
+    let whole = crate::build::builder::build(&tree, src.as_bytes());
+    let fp_whole = surface_fingerprint(&Surface::project(&whole));
+
+    let mut stripped = whole.clone();
+    stripped.evict_witness_bag();
+    let fp_stripped = surface_fingerprint(&Surface::project(&stripped));
+
+    assert_ne!(
+        fp_whole, fp_stripped,
+        "bag eviction no longer moves the projected surface — if that is a \
+         FIX, delete this test and its write-up with it; if it is a \
+         fixture that stopped exercising the bag, make the fixture carry \
+         bag-derived surface content again"
+    );
+}

--- a/src/model/surface_tests.rs
+++ b/src/model/surface_tests.rs
@@ -395,10 +395,12 @@ fn freshness_dirty_walk_covers_renamed_away_providers() {
 /// rejected as stale against rows that were in fact correct, and the chase
 /// they fell back to cost 3.3x the provider fetches.
 ///
-/// Pinned as an EQUALITY-FAILING property on purpose — it records what is
-/// true today so a fix flips this test rather than being invisible. Written
-/// up, with the measurement and the fix options, in
-/// `docs/prompt-surface-projection-drift.md`.
+/// The warm lane now ADOPTS the cold projection out of the `surfaces` store
+/// rather than re-deriving it, so the drift is avoided — but it is still
+/// possible, and this pins that. Making it IMPOSSIBLE means baking the
+/// bag-derived parts of the surface into the analysis at build time, which is
+/// the recorded end state; that fix is what flips this test.
+/// `docs/prompt-surface-projection-drift.md` owns both.
 #[test]
 fn a_bag_evicted_analysis_projects_a_different_surface() {
     let src = "package Alpha;\nuse strict;\n\

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -557,6 +557,26 @@ pub fn not_local_disabled() -> bool {
     *OFF.get_or_init(|| std::env::var("PERL_LSP_NO_NOT_LOCAL").is_ok())
 }
 
+/// Is baking switched off?
+///
+/// ONE speller, because there are TWO producers of a conclusions row — the
+/// persist path (`encode_analysis`) and the background repair lane
+/// (`repair_conclusions_slice`, seeded from `paths_missing_conclusions`) — and
+/// a control that gates only the first is not a control at all. Measured on
+/// the substrate before this existed: an A/B whose OFF arm was primed cold
+/// answered 72,305 provider fetches on its first run and **57,481 on its
+/// third**, byte-identical to the ON arm, because the repair lane had quietly
+/// baked the entire frontier in between. The flag disabled itself after one
+/// warm run and nothing said so.
+///
+/// Read through `conclusions::bake_disabled()` from every producer;
+/// `layering_tests::the_bake_gate_has_one_reader` pins that there is no
+/// second `std::env::var` for this name.
+pub fn bake_disabled() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| std::env::var("PERL_LSP_NO_BAKE").is_ok())
+}
+
 pub fn mint_links_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var("PERL_LSP_MINT_LINKS").is_ok())

--- a/src/model/witnesses/conclusions.rs
+++ b/src/model/witnesses/conclusions.rs
@@ -561,7 +561,7 @@ pub fn not_local_disabled() -> bool {
 ///
 /// ONE speller, because there are TWO producers of a conclusions row — the
 /// persist path (`encode_analysis`) and the background repair lane
-/// (`repair_conclusions_slice`, seeded from `paths_missing_conclusions`) — and
+/// (`repair_conclusions_slice`, seeded from `paths_needing_repair`) — and
 /// a control that gates only the first is not a control at all. Measured on
 /// the substrate before this existed: an A/B whose OFF arm was primed cold
 /// answered 72,305 provider fetches on its first run and **57,481 on its

--- a/src/model/witnesses/session.rs
+++ b/src/model/witnesses/session.rs
@@ -62,6 +62,13 @@ struct SessionState {
     index_id: usize,
     /// `resolution_epoch()` when the memo was last known good.
     epoch: u64,
+    /// What this walk's verb READS out of enrichment.
+    ///
+    /// A server serves many verbs from one process, so the process-wide
+    /// declaration cell cannot express it — a partial profile set there would
+    /// outlive the verb that wanted it and answer the next one. The session is
+    /// the natural scope: it is opened per walk by the verb that knows.
+    profile: Option<crate::model::file_analysis::EnrichmentProfile>,
     /// The store generation this walk has committed to reading conclusions
     /// at, set by the first row it consumes.
     ///
@@ -175,6 +182,7 @@ impl ResolutionSession {
             *slot = Some(SessionState {
                 index_id: id,
                 epoch,
+                profile: None,
                 conclusion_generation: None,
                 paths: HashMap::new(),
                 memo: HashMap::new(),
@@ -212,6 +220,26 @@ impl ResolutionSession {
     /// `None` when no session is open.
     pub fn stats() -> Option<SessionStats> {
         SESSION.with(|s| s.borrow().as_ref().map(|st| st.stats))
+    }
+
+    /// Declare what this walk's verb reads out of enrichment.
+    ///
+    /// Call on an OPEN session. A verb that declares nothing gets `full()`,
+    /// so a new verb is never silently under-served — the failure direction is
+    /// "did more work than it needed", never "was handed a copy missing what
+    /// it asked for".
+    pub fn declare_profile(profile: crate::model::file_analysis::EnrichmentProfile) {
+        SESSION.with(|s| {
+            if let Some(st) = s.borrow_mut().as_mut() {
+                st.profile = Some(profile);
+            }
+        });
+    }
+
+    /// The profile the open walk declared, if any. `None` means no walk, or a
+    /// walk that declared nothing — both resolve to the process cell.
+    pub fn declared_profile() -> Option<crate::model::file_analysis::EnrichmentProfile> {
+        SESSION.with(|s| s.borrow().as_ref().and_then(|st| st.profile))
     }
 
     /// May this walk read a conclusions row published at `generation`?

--- a/src/model/witnesses/session.rs
+++ b/src/model/witnesses/session.rs
@@ -62,6 +62,17 @@ struct SessionState {
     index_id: usize,
     /// `resolution_epoch()` when the memo was last known good.
     epoch: u64,
+    /// The store generation this walk has committed to reading conclusions
+    /// at, set by the first row it consumes.
+    ///
+    /// A flush publishes a whole round at generation N+1 while a walk is in
+    /// flight, so without this a walk could read file A's map from N and
+    /// file B's from N+1 — two halves of a cross-file answer taken from
+    /// different worlds. Pinning costs at worst a decode: a row from another
+    /// generation reads as absent, which is the fallback the layer already
+    /// has. It is never wrong, and there is no version of this that is
+    /// cheaper AND coherent.
+    conclusion_generation: Option<i64>,
     paths: HashMap<PathBuf, u32>,
     memo: HashMap<CandidateKey, Arc<ReducedValue>>,
     /// `visible_def_candidates` is a clone + sort of the whole candidate
@@ -164,6 +175,7 @@ impl ResolutionSession {
             *slot = Some(SessionState {
                 index_id: id,
                 epoch,
+                conclusion_generation: None,
                 paths: HashMap::new(),
                 memo: HashMap::new(),
                 candidates: HashMap::new(),
@@ -200,6 +212,34 @@ impl ResolutionSession {
     /// `None` when no session is open.
     pub fn stats() -> Option<SessionStats> {
         SESSION.with(|s| s.borrow().as_ref().map(|st| st.stats))
+    }
+
+    /// May this walk read a conclusions row published at `generation`?
+    ///
+    /// The first row consumed sets the pin; every later row must agree with
+    /// it or read as absent for the rest of the walk. With no session open
+    /// the answer is always yes — a background cascade issues independent
+    /// consults and makes no cross-file coherence claim for the pin to
+    /// protect.
+    ///
+    /// Called with the index the consult is running against so a foreign
+    /// index's rows can't set (or trip over) this session's pin.
+    pub fn admit_conclusion_generation(
+        idx: &dyn CrossFileLookup,
+        generation: i64,
+    ) -> bool {
+        with_session(idx, |st| match st.conclusion_generation {
+            None => {
+                st.conclusion_generation = Some(generation);
+                true
+            }
+            Some(pinned) if pinned == generation => true,
+            Some(_) => {
+                crate::util::ghost_stats::count("conclrow.generation_skew");
+                false
+            }
+        })
+        .unwrap_or(true)
     }
 
     /// Declare that this walk answered with less than it could have. Any
@@ -261,6 +301,9 @@ fn with_session<R>(
         if now != st.epoch {
             crate::util::ghost_stats::count("session.epoch_clear");
             st.epoch = now;
+            // The pin goes with the memo: the index moved, so a later
+            // generation is not a torn read, it is the new truth.
+            st.conclusion_generation = None;
             st.memo.clear();
             st.candidates.clear();
             st.paths.clear();


### PR DESCRIPTION
Seven commits from `[C]` completing the §6 follow-ups. Opened by the coordinator; body amended by `[C]` with the bar, the scope limits, and **a correction to the stated mechanism**.

## ⚠ The mechanism in the original body is wrong, and the tip's regression is unattributed

The body said the tip "rejected 76.7% of maps as stale against a Surface fingerprint that differs between the cold and warm producers". **`643a25e2` has no row stamp.** `git show 643a25e2:src/index/module_cache/conclusions_store.rs | grep -c source_fingerprint` → `0`; same for `lookup.rs` and for the `conclrow` counters. The stamp arrives in `b587fdc6`, which is *on this branch, after #161*.

So the tip cannot reject a row as stale — it has nothing to reject with. The 76.7% is a measurement of **this branch**, in the window between `b587fdc6` and `25009e30`, on a warm substrate. It describes a regression this branch introduced and then closed; it does not describe the tip.

**The ≥13× on the tip therefore has no attributed mechanism.** The measurement stands — it is a clean before/after with no flags — but nothing on this thread yet explains it, and this PR should not be merged on the claim that it fixes a thing whose cause is unknown. It is still very likely the better of the three states (`b15c6d72` completed at 138 s where the tip has never been observed completing at all), but that is an empirical ordering, not an explanation.

## The measurement

Cold `--check` on a 12,889-file corpus (6,141 `.pm`, 6,748 `.t`), no flags, separately-built binaries verified by structural marker, `--clear-cache` before each run:

| binary | cold wall | status |
|---|---|---|
| `45dedac3` (pre-#161) | **64.14 s / 81.28 s** | completed |
| `643a25e2` (tip, #161 merged) | **1296.58 s / 944.11 s** | ⚠ possibly kill-truncated — **lower bounds** |
| `b15c6d72` (this branch) | **138.44 s** | completed |

A 2,122-file corpus is unaffected (7.33 s). A separate confirming run without ghost stats also exceeded 1,800 s, so instrumentation is excluded.

### What `[C]` could and could not reproduce

Built a corpus to `[E]`'s spec of the real one — 6,141 unique-package `.pm` providers plus 6,748 package-less `main` `.t` consumers with heavy `use` lists, the extreme point of the many-providers-per-name relation. It lands squarely on the pre-#161 number and shows **no regression at all**:

| binary | cold, 12,889-file `main`-heavy corpus |
|---|---:|
| `45dedac3` (pre-#161) | 72.01 s |
| `643a25e2` (tip) | 77.86 s / 71.24 s |
| `b587fdc6` (stamp, before the drift fix) | 72.44 s |
| `b15c6d72` (this branch) | 76.77 s |

All four within ~9%. The corpus reaches the pre-#161 absolute number (72.0 s against 64.1 / 81.3 s) and drives 259,070 provider fetches, so it is not inert the way `[C]`'s earlier all-unique corpus was.

**But it still never reaches `conclusions_for`:** 0 `conclrow.*` consults cold, against 36,089 on the 3,515-file gold substrate. Some property of real code puts the consult path in play that neither synthetic corpus reproduces, so **absence of a regression here is not evidence of absence.** Stated as a limit.

The instrument that can settle it is `PERL_LSP_PHASE_TIMING=1` on the real corpus — `cli_full_startup`'s phases are named `cli::*` — plus `PERL_LSP_NO_BAKE` (a real control as of `dfb7dff6`) and `PERL_LSP_GHOST_STATS=<path>`.

## Other caveats, stated rather than buried

- **The tip figures are lower bounds.** Process kills interleaved with the measurement batch. The tip has never been observed completing this corpus cold. Direction certain, magnitude not. The pre-#161 pair also spans 27% (64.1 vs 81.3 s) on one binary, which is worth knowing when reading any single number from that batch.
- **A ~1.9× cold cost remains** on this branch versus pre-#161 on the real corpus — unattributed, and absent on the synthetic one. It belongs in the ADR against the warm win as a stated tradeoff.
- **The warm win (8.4–9.3%) is a floor**, measured before `dfb7dff6` when `PERL_LSP_NO_BAKE` gated only one of two producers.
- **`[C]` retracted an earlier counter-argument in full** (#120, comment 5397710717): a 13k all-unique corpus that produced 0 provider fetches and 0 consults cold, i.e. measured the layer inert. Corpus validated on file count, never on consult density.

## Contents

- `7e3d63a6` the bulk walk recorded surfaces and threw the verdict away
- `b587fdc6` self-validating conclusions rows
- `dfb7dff6` the bake control gates both producers, not one
- `21ec3c65` resume conclusion publication, pinned to one generation
- `031e930b` the enrichment profile is a lattice on the overlay entry
- `25009e30` **persist the cold Surface so the warm lane stops re-deriving it**
- `b15c6d72` the repair frontier covers both derivations

## What the commits do

**Self-validating conclusion rows.** Each row carries `(source_fingerprint, flush_generation)`; validity is decided at consult against what `FreshnessIndex` records for the path. One compare subsumes three failure modes that each used to need a caller to remember an eraser — an orphaned row, a stale row, a row from an interrupted write. None can match, so all read absent and fall back to the live chase. The fingerprint is projected from the same analysis in the same call that bakes the map, and is looked *up* at consult, never recomputed. An unrecorded path reads absent rather than valid: a row's stamp always agrees with itself, so "ask the row" is not a check.

**Publication resumed.** The flush computed the right maps and threw them away. It now publishes its seeds at generation N+1 in one transaction — seeds only, because the bake is index-free and a downstream change moves a file's answers without moving its map. A non-convergent wave publishes nothing. `ResolutionSession` pins the generation its first consumed row was published at, which stops a walk composing file A's map from N with file B's from N+1 — and turned out to make **pruning** safe, since a walk that loses its generation degrades to a decode rather than to a wrong answer. Revives `save_conclusions` / `publish_generation` / `prune_generations_below`.

**The profile lattice.** `EnrichmentProfile` is a field on the fingerprint-keyed overlay entry, not part of the key. Acceptance is `covers(needed)`, never equality, and both directions are load-bearing: `full` must serve a `diagnostics` request or the verbs evict each other on every alternation; `diagnostics` must not serve a `full` one, or that verb gets a copy missing what it came for and answers "no definition". The per-request channel is `ResolutionSession::declare_profile`, not the process-wide cell — one process serves many verbs.

**The two controls that weren't controlling.** `PERL_LSP_NO_BAKE` gated the persist path but not the background repair lane, so the OFF arm re-baked the corpus anyway: 72,305 → 61,308 → 57,510 → 57,481 fetches across four consecutive warm runs, the last two byte-identical to the ON arm, with the row count reading full and correct throughout. And `Surface::project` reads the witness bag while the warm lane projects from bag-evicted copies, so the same unchanged file fingerprinted differently depending on whether the recording process built or decoded the analysis — which also meant a warm-start freshness verdict was computed over a degraded projection.

**The `surfaces` table** is created with `CREATE TABLE IF NOT EXISTS` in the always-run batch: no `SCHEMA_VERSION` bump, no cache-wide rebuild. Version-gated per row and independently of `SCHEMA_VERSION`; a mismatch reads absent and puts the file on the repair frontier, which shares the conclusion repair's with-bag decode and rewrites both products of the one projection.

## Warm measurements (substrate, per-arm caches, byte-identical counters within an arm)

| | before | after |
|---|---:|---:|
| `moc.provider_fetched` | 57,481 | **18,924** |
| `consult.baked_open` | 2,084 | 11,804 |
| `conclrow.valid` / `.stale` | 14,578 / 47,967 | 36,143 / **0** |
| `surface.adopted_persisted` / `.reprojected` | — | 3,336 / **0** |

The stamp costs 8.6% more fetches than bypassing it entirely rather than 230%; the residue is 1,635 `conclrow.unrecorded`, which is fail-open working as designed.

Upgrade path, substrate (3,515 files): the first warm run against a cache with no `surfaces` rows costs 5.09 s against ~4.7 s settled, drains the frontier in-run, and self-heals from the second run onward.

First published run, real server editing session, both equivalence switches on: `flush.published` 1, zero `CONCL_EQUIV` and `FLUSH_EQUIV` breaks.

## Bar at `b15c6d72`

`cargo test` **1,590 / 0** · `cargo test --features cpp` **1,651 / 0** · gold **503 PASS · 17 xfail · 0 FAIL · 0 XPASS · 0 CRASH · skip 0 · lang-skip 0 · warm-FAIL 0** · `./e2e/run.sh` **116 / 0** (nvim v0.11.0).

Every behavioural claim base-verified by breaking it independently — the row-validity compare in both directions, the drift guard, publication, pruning, the stamp's pass-through, both directions of `covers`, the persisted projection, and the version gate.

## Known residuals

- **The tip's ≥13× is unattributed** (above). This branch is empirically the best of the three states; it is not established that it *fixes* the tip's problem.
- **The drift is avoided, not impossible.** `Surface::project` is still bag-dependent, pinned by a tripwire test. Making it impossible means baking the bag-derived parts into the analysis at build time — recorded as the end state in `docs/prompt-surface-projection-drift.md`.
- **The ~1.9× residual cold cost** on the real corpus, unablated.
- **6a's re-stamp gate is routed correctly and inert.** `[E]` has ruled on the fix (option C, landing B first — `record_surface_write`'s predicate becomes "an OpenDoc-lane write has recorded this path", so a Background write on a never-recorded path lands and returns `FirstSeen`; then record `Document::baseline_surface` at `didOpen`). Not in this PR — the layer is under a commit hold.
- **No server verb declares an enrichment profile.** The license for the first profile was an ablation over `--check`'s lanes; the server's lanes owe the same evidence, and that ablation is not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185L9s42z92J8rhaQEAJNVv