### PR TITLE
corpus: the scaling corpus reconstructs itself on any box

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,104 @@
+# The scaling corpus
+
+Eight large open-source Perl applications, kept because each one measures
+something the others do not. Reconstruct on any box with `corpus/bootstrap.sh`.
+
+```
+corpus/bootstrap.sh                  # ~/perl-corpora/{bulk,deps}
+corpus/bootstrap.sh /data/corpora    # elsewhere
+corpus/bootstrap.sh ~/corpora FHEM   # one repo
+```
+
+Then measure with dependencies on `@INC`, **not** in the workspace:
+
+```
+PERL5LIB=~/perl-corpora/deps/FHEM/lib/perl5 \
+  perl-lsp --check ~/perl-corpora/bulk/FHEM --severity hint
+```
+
+## Why deps live outside the repo
+
+The workspace walker indexes everything under the root. A `local/` inside the
+repo therefore joins the **workspace** tier, and the measurement stops being
+about the application. Measured, not assumed: installing FHEM's dependencies
+in-repo took it from **929 to 33,912 indexed files**, 97% of them `Paws` — the
+AWS SDK ships one `.pm` per API call. The corpus would have been measuring the
+AWS SDK.
+
+Installed to `../deps/<name>` and reached via `PERL5LIB`, the same install moves
+FHEM's resolved-module count from **125 to 195** while the workspace stays at
+929 files. That is the split the server already models — workspace tier vs
+`@INC` tier — and it is what an editor session actually sees.
+
+**Installing deps at all is not optional for honest numbers.** An unresolvable
+`use` costs the resolver nothing to answer. A corpus whose imports mostly fail
+to resolve systematically understates resolution load, which is exactly how a
+5,004-distribution pile produced a "cliff" that no real codebase has.
+
+## The eight, and what each is for
+
+| repo | files | measures |
+|---|---:|---|
+| [FHEM](https://github.com/fhem/fhem-mirror) | 973 | **`main` monoculture.** 503 of 614 `.pm` files explicitly declare `package main` (+31 declaring none) — 534 providers of one name, genuinely sharing one stash because `fhem.pl` do-loads them all. Exposed a superlinear memory regression invisible on every other corpus. |
+| [Foswiki](https://github.com/foswiki/distro) | 917 | High fan-out (~1,128 attempts/file) that is **`other`-driven** — a different mechanism from FHEM's. |
+| [Evergreen](https://github.com/evergreen-library-system/Evergreen) | 468 | Same high fan-out, but **262/262 files properly packaged** — proves the Foswiki mechanism is not a packaging artifact. |
+| [WeBWorK](https://github.com/openwebwork/webwork2) | 213 | **Worst per-file cost** (36 ms/file), topping a different axis than fan-out. |
+| [Znuny](https://github.com/Znuny/Znuny) | 3,093 | **Control: largest corpus, lowest fan-out** (8 attempts/file). Size and fan-out are independent axes. |
+| [Webmin](https://github.com/webmin/webmin) | 1,383 | **Control: path-based `require`.** 101 package declarations across 1,383 files; lowest hit rate (95.95%). A genuinely different resolution shape. |
+| [BMO](https://github.com/mozilla-bteam/bmo) | 739 | **Control: healthy reference.** 206 attempts/file at 99.90% hit. |
+| [openfoodfacts](https://github.com/openfoodfacts/openfoodfacts-server) | 537 | **Control: densest static graph, near-zero fan-out.** A dense import graph does not imply expensive resolution. |
+
+Deliberately excluded: `perl5` (44% vendored `cpan/` — a distribution pile
+wearing a repo's clothes), and MovableType / Freeside (30% / 28% vendored).
+Twenty other repos were measured and dropped: they cluster at 8–206
+attempts/file and 98–99.9% hit, telling us nothing the four controls do not.
+
+## Dependency manifests
+
+Six of the eight ship **no machine-readable manifest** — they are applications
+distributed as packages, not CPAN dists. `derive-cpanfile.pl` reconstructs one
+by scanning for `use`/`require` targets, subtracting what the repo defines and
+what is core for the running perl.
+
+It is **over-inclusive on purpose**: a spurious requirement costs one failed
+install line, while a missing one silently leaves an import unresolvable — and
+unresolvable imports are the bias described above. Expect false positives
+(`Foo::Bar` from documentation examples, `PGrandom` from a comment).
+
+## System libraries
+
+Most XS builds fine with no system packages. The failures are missing
+**libraries**, not compilers, and they are concentrated in graphics, database
+drivers and platform-specific modules:
+
+| need | dists that failed without it |
+|---|---|
+| `libgd` | GD, GDGraph, GD-Graph3d, GDTextUtil, Template-GD, Chart |
+| ImageMagick | Image-Magick, Image-OCR-Tesseract |
+| `libdb` | DB_File |
+| MySQL client | DBD-mysql |
+| aspell | Text-Aspell |
+| zbar / zxing | Barcode-ZBar, Imager-zxing |
+| libheif / libavif / libwebp | Imager-File-HEIF, Imager-File-AVIF, Imager-File-WEBP |
+| apache2 dev | mod_perl, libapreq, libapreq2, Apache2-Connection-XForwardedFor |
+| libxslt | XML-LibXSLT |
+
+Windows/VMS-only dists (`Win32-*`, `VMS::Feature`) fail to resolve on Linux and
+always will; that is correct, not a gap.
+
+**None of these are needed for language-server measurement.** They are runtime
+dependencies of the applications, and a missing one leaves a handful of imports
+unresolvable out of thousands resolved. Install them only if a specific
+measurement turns out to depend on that import resolving.
+
+If you do want them without root, `nix-shell -p gd imagemagick db mariadb aspell`
+gives a local, non-root, reproducible set — no system mutation. `micromamba`
+covers most of the same ground. Both are heavier than the problem currently
+warrants.
+
+## Reproducibility caveat
+
+`bootstrap.sh` clones **default branches at depth 1** and installs **current**
+CPAN. Two runs weeks apart are not the same corpus. Nothing here is pinned,
+because the corpus exists to find pathologies rather than to gate CI — if it
+ever gates anything, pin the clones to SHAs and the deps to a snapshot first.

--- a/corpus/bootstrap.sh
+++ b/corpus/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Reconstruct the scaling corpus on a fresh box (cloud agent, CI, new laptop).
+#
+#   corpus/bootstrap.sh [dest]        # default: ~/perl-corpora/bulk
+#   corpus/bootstrap.sh dest FHEM     # one repo
+#
+# Needs: git, perl >= 5.20 with Module::CoreList (core), cpm
+#   curl -sSL https://raw.githubusercontent.com/skaji/cpm/main/cpm -o /tmp/cpm && chmod +x /tmp/cpm
+#
+# Idempotent: existing clones are left alone, existing local/ trees are topped up.
+set -u
+DEST="${1:-$HOME/perl-corpora/bulk}"
+DEPS="$(dirname "$DEST")/deps"
+ONLY="${2:-}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CPM="$(command -v cpm || echo /tmp/cpm)"
+
+# The eight keepers. Each earned its slot; see README.md for the measurement.
+#   name|url|why
+REPOS=(
+"FHEM|https://github.com/fhem/fhem-mirror|main-monoculture: 534 providers of one package name"
+"Foswiki|https://github.com/foswiki/distro|high fan-out, 'other'-driven — a second mechanism"
+"Evergreen|https://github.com/evergreen-library-system/Evergreen|high fan-out, 262/262 properly packaged"
+"WeBWorK|https://github.com/openwebwork/webwork2|worst per-file cost, not fan-out"
+"Znuny|https://github.com/Znuny/Znuny|largest corpus, LOWEST fan-out — size/fan-out are independent"
+"Webmin|https://github.com/webmin/webmin|path-based require, 101 package decls, lowest hit rate"
+"BMO|https://github.com/mozilla-bteam/bmo|healthy reference: 206 att/file at 99.90% hit"
+"openfoodfacts|https://github.com/openfoodfacts/openfoodfacts-server|densest static graph, near-zero fan-out"
+)
+
+mkdir -p "$DEST" || exit 1
+for ENTRY in "${REPOS[@]}"; do
+  IFS='|' read -r NAME URL WHY <<< "$ENTRY"
+  [ -n "$ONLY" ] && [ "$ONLY" != "$NAME" ] && continue
+  echo "══ $NAME — $WHY"
+  if [ -d "$DEST/$NAME/.git" ]; then
+    echo "   clone: present"
+  else
+    git clone --depth 1 -q "$URL" "$DEST/$NAME" || { echo "   CLONE FAILED"; continue; }
+    echo "   clone: ok"
+  fi
+
+  # Dependency manifest: use the repo's own if it has one, else derive.
+  # Six of the eight ship none — they are applications, not CPAN dists.
+  CF=""
+  for c in cpanfile Makefile.PL Build.PL; do [ -f "$DEST/$NAME/$c" ] && CF="$c" && break; done
+  if [ -z "$CF" ]; then
+    perl "$HERE/derive-cpanfile.pl" "$DEST/$NAME" > "$DEST/$NAME/cpanfile.derived" 2>/dev/null
+    CF=cpanfile.derived
+    echo "   manifest: derived ($(grep -c '^requires' "$DEST/$NAME/$CF") deps)"
+  else
+    echo "   manifest: $CF (shipped)"
+  fi
+
+  # Install into the repo's own local/. Failures are EXPECTED and non-fatal:
+  # XS modules wanting system headers we may not have. A partial local/ is
+  # strictly better than none — the point is to make imports RESOLVABLE, and an
+  # unresolvable import costs the resolver nothing, which is the bias that makes
+  # a corpus measure the wrong thing.
+  # Install OUTSIDE the repo, into $DEPS/$NAME. This is load-bearing, not tidiness:
+  # the workspace walker indexes everything under the root, so a local/ inside the
+  # repo joins the WORKSPACE tier. Measured: FHEM went 929 -> 33,912 indexed files,
+  # 97% of them Paws (the AWS SDK ships one .pm per API call). The corpus would
+  # have been measuring Paws. Deps belong on the @INC/dependency tier, which is
+  # also how a real editor session sees them.
+  mkdir -p "$DEPS"
+  ( cd "$DEST/$NAME" || exit
+    ARGS=(install -L "$DEPS/$NAME" --no-test)
+    [ "$CF" = cpanfile.derived ] && ARGS+=(--cpanfile cpanfile.derived)
+    timeout 2400 "$CPM" "${ARGS[@]}" > "$DEPS/$NAME.cpm.log" 2>&1
+    N=$(find "$DEPS/$NAME" -name '*.pm' 2>/dev/null | wc -l)
+    R=$(grep -c '^FAIL resolve' "$DEPS/$NAME.cpm.log" 2>/dev/null || echo 0)
+    I=$(grep -c '^FAIL install' "$DEPS/$NAME.cpm.log" 2>/dev/null || echo 0)
+    echo "   deps: $N modules -> $DEPS/$NAME  ($R unresolvable, $I build-failed)"
+  )
+done
+echo
+echo "Workspace corpora: $DEST"
+echo "Dependencies:      $DEPS   (per-repo logs: $DEPS/<name>.cpm.log)"
+echo
+echo "Measure with deps on @INC, NOT in the workspace:"
+echo "  PERL5LIB=$DEPS/FHEM/lib/perl5 perl-lsp --check $DEST/FHEM"

--- a/corpus/derive-cpanfile.pl
+++ b/corpus/derive-cpanfile.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+# Derive a cpanfile for a Perl APPLICATION that ships no manifest.
+#
+# Most large open-source Perl applications are distributed as packages, not CPAN
+# dists: of the eight corpus repos, six declare their dependencies nowhere a tool
+# can read. Their real dependency set is what they `use`, minus what they define,
+# minus what ships with perl. That is derivable, and deriving it beats a
+# hand-curated list that rots.
+#
+# Deliberately over-includes: a name we cannot classify is emitted, because a
+# spurious requirement costs one failed install line while a missing one silently
+# leaves the import unresolvable — and an unresolvable import costs the resolver
+# NOTHING to answer, which is exactly the bias that makes a corpus measure the
+# wrong thing.
+use strict;
+use warnings;
+use File::Find;
+use Module::CoreList;
+
+my $root = shift // '.';
+my %used, my %defined;
+
+find(sub {
+    return unless -f && /\.(pm|pl|t|cgi)$/;
+    open my $fh, '<', $_ or return;
+    while (my $line = <$fh>) {
+        next if $line =~ /^\s*#/;
+        # package declarations = what this repo PROVIDES
+        $defined{$1} = 1 if $line =~ /^\s*package\s+([A-Za-z_][\w:]*)/;
+        # use/require of a bareword module = what it CONSUMES
+        if ($line =~ /^\s*(?:use|require)\s+([A-Za-z_][\w:]*)/) {
+            my $m = $1;
+            $used{$m} = 1;
+        }
+    }
+}, $root);
+
+# Pragmas and feature-ish bareword targets that are not distributions.
+my %pragma = map { $_ => 1 } qw(
+    strict warnings utf8 lib vars constant parent base overload feature
+    integer bytes locale open sort subs bigint bignum bigrat encoding
+    if less mro re sigtrap version fields attributes autouse blib
+    diagnostics filetest inc iso8859 charnames deprecate experimental
+);
+
+my @want;
+for my $m (sort keys %used) {
+    next if $pragma{$m};
+    next if $defined{$m};                      # provided in-repo
+    next if $m =~ /^[a-z]/ && $m !~ /::/;      # lowercase bareword: pragma-shaped
+    # core for the running perl? then no install needed.
+    my $first = Module::CoreList->first_release($m);
+    next if defined $first && Module::CoreList->is_core($m, undef, $]);
+    push @want, $m;
+}
+
+print "# Derived by corpus/derive-cpanfile.pl — see corpus/README.md\n";
+print "# Over-inclusive on purpose: a missing dep silently makes an import\n";
+print "# unresolvable, and unresolvable imports cost the resolver nothing,\n";
+print "# which biases every measurement taken against this corpus.\n";
+printf "requires '%s';\n", $_ for @want;
+printf STDERR "%s: %d used, %d in-repo, %d to install\n",
+    $root, scalar(keys %used), scalar(keys %defined), scalar(@want);


### PR DESCRIPTION
Adds `corpus/` — a bootstrap for the eight-repo scaling corpus, so a cloud agent or a fresh box gets the same workload rather than an approximation of it.

```
corpus/bootstrap.sh                  # ~/perl-corpora/{bulk,deps}
corpus/bootstrap.sh ~/corpora FHEM   # one repo
```

## Why these eight

Twenty-eight large open-source Perl codebases were measured; twenty were dropped for clustering at 8–206 provider-fetch attempts/file and 98–99.9% hit, telling us nothing the controls do not. What survived:

| repo | measures |
|---|---|
| **FHEM** | `main` monoculture — 503 of 614 `.pm` files explicitly declare `package main`, genuinely sharing one stash. Exposed a superlinear memory regression invisible on every other corpus. |
| **Foswiki** / **Evergreen** | high fan-out via a *different*, `other`-driven mechanism; Evergreen is 262/262 properly packaged, which shows it is not a packaging artifact |
| **WeBWorK** | worst per-file cost (36 ms/file) — a different axis from fan-out |
| **Znuny** | control: largest corpus (3,093 files), *lowest* fan-out (8/file). Size and fan-out are independent. |
| **Webmin** | control: path-based `require`, 101 package decls, lowest hit rate |
| **BMO** | control: healthy reference, 206/file at 99.90% |
| **openfoodfacts** | control: densest static graph, near-zero fan-out |

Excluded: `perl5` (44% vendored `cpan/`), MovableType and Freeside (30% / 28% vendored) — distribution piles wearing a repo's clothes.

## Two decisions that are load-bearing

**Deps install outside the repo.** The workspace walker indexes everything under the root, so an in-repo `local/` joins the *workspace* tier. Measured: FHEM went **929 → 33,912 indexed files**, 97% of them `Paws` (one `.pm` per AWS API call). The corpus would have been measuring the AWS SDK. Installed to `../deps/<name>` and reached via `PERL5LIB`, the same install moves resolved modules **125 → 195** while the workspace stays at 929 — the workspace/`@INC` split the server already models.

**Deps get installed at all** because an unresolvable `use` costs the resolver nothing to answer. A corpus whose imports mostly fail to resolve understates resolution load — which is how a 5,004-distribution pile produced a "cliff" that no real codebase has.

## Derived manifests

Six of the eight ship no machine-readable manifest; they are applications, not CPAN dists. `derive-cpanfile.pl` reconstructs one by scanning `use`/`require` targets minus in-repo packages minus core. Over-inclusive on purpose — a spurious requirement costs one failed install line, a missing one silently reintroduces the bias above. Expect false positives.

## System libraries

Most XS builds with no system packages. The ~53 build failures are missing *libraries* (libgd, ImageMagick, libdb, MySQL client, aspell, zbar, libxslt, apache2 dev), concentrated in graphics and DB drivers, and **none are needed for language-server measurement** — they are runtime deps of the applications. `nix-shell -p gd imagemagick db mariadb aspell` covers them locally without root if a specific measurement ever needs one. Windows/VMS-only dists fail to resolve on Linux and always will; that is correct.

## Caveat, stated in the README

Depth-1 clones of default branches plus current CPAN — two runs weeks apart are **not** the same corpus. Nothing is pinned, because this exists to find pathologies rather than gate CI. If it ever gates anything, pin clones to SHAs and deps to a snapshot first.

Tooling only — no `src/` changes, so no test-surface impact. `bootstrap.sh` was run end-to-end (clone-detection, derivation, install, idempotent re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)