### PR TITLE
Relational iteration: walkers onto the row store, and the FHEM fixes

### DIFF
--- a/docs/prompt-enrichment-delta.md
+++ b/docs/prompt-enrichment-delta.md
@@ -1,0 +1,116 @@
+# Prompt: enrichment as a delta artifact (ladder rung 9)
+
+**Status: design, not started. The prerequisite three closed arcs point at:
+level-indexed enrichment's rejection ("make a build cheap"), the FHEM crest
+(the overlay clone pair is the per-worker set's majority), and the overlay
+retention story (taint + byte caps exist because the artifact is a whole
+copy).**
+
+## The pressure, from three directions
+
+An enriched analysis today is a WHOLE private copy: clone the base
+`FileAnalysis`, truncate the sealed baselines, append/patch, serve the copy.
+Three independent costs all trace to the artifact's size, not enrichment's
+content:
+
+1. **The clone is the cost of a build.** ~80 ms on ordinary files, 0.3–1 s+
+   on giants (a 48k-line file's analysis measured ~105 MB, estimator-
+   verified). Level-indexed enrichment — the algebra that deletes the taint
+   rule and the depth cap — was built, worked, and was REJECTED solely
+   because K levels × whole-copy builds priced it out
+   (`docs/adr/level-indexed-enrichment.md`).
+2. **Retention is rationed by the artifact.** The overlay cache is 64
+   entries / 128 MiB because entries are whole analyses; giants are declined
+   outright (built at full cost, then thrown away), and traversal-order
+   taint means a cycle-touched build can never be cached at all.
+3. **The crest.** During a batch sweep, each worker holds the clone PAIR
+   (copy + source) live for the build's duration — measured as the majority
+   of the ~414 MB/worker in-flight set that owns FHEM's RSS crest.
+
+Against all that, the delta itself is TINY: measured 4.13% of base heap
+(+10 symbols, +37 refs, +1,618 witnesses on the median enriching file).
+We copy 100% to carry 4%.
+
+## What enrichment actually writes (the enumerable surface)
+
+The write surface of `enrich_imported_types_with_keys_for` is closed and
+known — this is what makes the delta capturable without redesigning
+enrichment:
+
+| write | today | in the delta |
+|---|---|---|
+| imported-return TCs, mutation extensions, MCB edges, cross-file inheritance edges | `witnesses.push` above `base_witness_count` | `delta.witnesses: Vec<Witness>` |
+| gated-emission symbols | `symbols.push` above baseline | `delta.symbols: Vec<Symbol>` |
+| gated-emission refs | `refs.push` above baseline | `delta.refs: Vec<Ref>` |
+| hash-key owner fixup | IN-PLACE `bind_hash_key_owner` on existing refs | `delta.owner_patches: Vec<(RefIdx, HashKeyOwner)>` |
+| MethodCall target stamps | IN-PLACE `method_target` on existing refs | `delta.ref_patches: Vec<(RefIdx, MethodTarget)>` |
+| index rebuilds | `rebuild_enrichment_indices` | `delta` carries its own small indices (see below) |
+
+The truncate-to-baseline dance exists ONLY because the artifact is mutable —
+a delta replaces it with immutability: re-enrichment derives a NEW delta,
+and idempotency becomes structural instead of procedural (the enrichment
+ADR predicted exactly this).
+
+## Composition: who reads what
+
+The consumer matrix (`docs/adr/enrichment-build-cost.md`) is the load-bearing
+fact: **every recursive consumer reads only the bag.** Only `--check`
+diagnostics and `--dump-package` read refs/symbols from an enriched copy.
+So composition splits by consumer:
+
+**The bag view (stage 2, the important one).** Registry queries take a bag;
+introduce a composed view — base witnesses + delta witnesses, in that order
+(enrichment appends, and append order is what latest-wins reducers already
+assume). The attachment index composes the same way: probe the delta's
+small index, then the base's; reducers fold over the concatenation. The
+recursive consumers (`query_sub_return_type`'s imported recursion, the
+`PackageSymbol` primary, the bridged bake, the R4 retries, enrichment's own
+chase) all route through `ReducerRegistry::query` — the composition seam is
+ONE entry point, not N call sites.
+
+**The whole view (stage 3+, or never).** The two CLI verbs materialize a
+composed whole copy on demand — one per file per run, exactly what they do
+today via the clone, so they get no worse. If a composed `EnrichedView`
+that answers the refs/symbols query surface lands later, even that clone
+goes; it is deliberately NOT in scope for the first stages.
+
+## Staging
+
+1. **Capture.** Enrichment writes into a `Delta` sink instead of mutating
+   the copy. Mechanical: the write surface above is every site, each
+   becomes a `delta.…push` — and the truncate machinery deletes. The clone
+   path remains the default consumer (apply the delta to a clone), so
+   behavior is frozen while capture is validated: `apply(base.clone(),
+   delta) == today's enriched copy`, byte-comparable, is the stage-1 test.
+2. **Bag-view composition.** The registry accepts (base bag, delta
+   witnesses) and the recursive consumers stop needing the whole copy at
+   all. This is where the clone leaves the hot path.
+3. **Overlay stores deltas.** `enriched_snapshot` retains `Delta` (4% the
+   bytes) under the SAME key machinery — the byte cap becomes generous, the
+   giant-decline path nearly closes, and repeat consults on cyclic files
+   serve their (still honestly raw) base + whatever delta derived.
+4. **Level-indexed revival** (separate arc): `enriched_k = base +
+   delta_k`, deltas built from level-(k−1) views. Builds are now
+   delta-sized, which is the exact prerequisite the rejection named. Taint
+   and the depth cap delete here, not before.
+
+## What it does NOT fix
+
+The DENSITY of the base analysis (2.2 KB/line on giant files; refs 41.5% +
+witnesses 39.4% of footprint) is untouched — rung 10's territory, and a
+companion, not a substitute: rung 9 removes the copy-of-the-base from
+enrichment's cost; rung 10 shrinks the base itself. The brk-retention
+mechanism (churn through the allocator) is likewise orthogonal — smaller
+artifacts churn less, but the ship posture decision stands on its own.
+
+## Blast radius, per stage
+
+| stage | touches | risk |
+|---|---|---|
+| 1 (capture) | `enrichment.rs` write sites; a `Delta` type in model | LOW — behavior frozen behind the apply-equivalence test; every site enumerable |
+| 2 (bag view) | `ReducerRegistry::query` entry, the bag's attachment-index probe | MEDIUM — one seam, but it is THE seam; gold's 503 exact rows + the equiv flags are the net |
+| 3 (delta overlay) | `enriched_snapshot` storage + `enriched_present` consumers | MEDIUM — key machinery unchanged; the decline/taint paths simplify rather than grow |
+| 4 (level-indexed) | its own arc | HIGH, and it is the payoff — priced separately |
+
+Stages 1–3 are each land-alone slices with the full battery; nothing
+requires a flag day.

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -268,6 +268,20 @@ the relation that answers it, and the soundness constraint.
   (`sweep.memo_hit + memo_miss ≈ attempts`; only `rehydrate.loader`'s n
   decodes) was done. State which kind any quoted counter is, and show the
   reconciliation when the two could diverge.
+- **Verify the corpus contains what the mechanism KEYS ON**, not just that
+  it is the right size — a giant-file gate was A/B'd against a subset built
+  to exclude the giants, and separately its threshold sat above what the
+  full corpus could reach. And the quantified corollary: installing real
+  dependencies costs 19–76% cold wall across six corpora (Webmin, nearly
+  CPAN-free, flat as the control) — every no-deps number understates real
+  resolution load by roughly a third, so a sizing argument states which
+  shape it measured.
+- **One claim per shell invocation when the output is evidence.** Three
+  commands in one line put a dirty-tree diff directly under a truncated
+  `git show`, and the juxtaposition was read as provenance — 20 lines
+  attributed to a commit they were never in. Separators are not
+  attribution; the pipeline's shape can lie exactly like `tail`'s exit
+  code and mawk's silent `\b`.
 - **Counters, not vibes.** Every pre-filter counts skip/decode/unknown so the
   hit rate is a ghost-stats read, and the next ranking pass starts from
   numbers (`docs/adr/skipping-cross-file-work.md`'s denominator rules apply).

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -86,6 +86,28 @@ the relation that answers it, and the soundness constraint.
    shows the name-only probe leaking (a plugin file declaring the queried
    name OUTSIDE the bridging namespace still decodes — over-approx, sound).
 
+4a. **Cross-file consults are point-free, memoized per walk and per sweep —
+   LANDED** (`24f66e0a`), and it is the arc's largest single win. The chain
+   that found it: FHEM (a package-main corpus, ~n providers of one name ×
+   n files × keys) drove 12.3M SlotType chase ATTEMPTS through an arm with
+   no memo tier; the session memo was inert on the enrichment cascade (no
+   session open — `session.absent` was the tell) and keyed on the consumer's
+   POINT (meaningless in provider coordinates; every call site a fresh
+   miss); and first-encounter pairs PER BUILD are the n², which no
+   thread-local memo can span. The fix: point-free cross-file sub-queries
+   (gold's 503 exact assertions license the semantics), a session around
+   the overlay build, and `SweepAnswerGuard` — a sweep-wide, stamp-guarded,
+   worker-shared (candidate, point-free query) → verdict store. Measured:
+   attempts 918x down, wall 2.06x at n=250, n=500 from killed to
+   completing, overlay builds 8.9x cheaper at unchanged count (the overlay
+   was a CARRIER of chase cost, not a cost). The surviving ~keys×n attempts
+   are the linear first-encounter floor — do NOT gold-plate this arm
+   further (key-set gating exists as an idea; 918x is past the knee and
+   the residual wall lives elsewhere). A failed first cut (reverted) is
+   part of this row's record: a memo added where no session existed and
+   keyed with the point displaced 20 of 12.3M — inert by construction,
+   found by measurement.
+
 4. **The registry chase's no-answer fetches, and `main`'s program scope.**
    Measured on a real-CPAN corpus (12k files, 54% package-less scripts)
    against the substrate: top-level `PackageSymbol` query DENSITY is nearly

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -88,13 +88,21 @@ the relation that answers it, and the soundness constraint.
      `NotLocal` verdict IS the symbol-absence skip, already live and
      carrying an eighth of consults; adding a rows probe beside it would be
      a third absence oracle where the leak is elsewhere. The leak:
-     `OpenReason::AbsentNotClosed` — absence proves nothing for a class
-     whose ancestry leaves the file (measured 70.3% of decodes, 97.6% on
-     classes the map DOES conclude about) — i.e. **closedness is a
-     cross-file property and only per-file bakes exist**. The lever is a
-     world-level closedness verdict (the flush evaluates against a world;
-     its product can stamp classes whose full ancestry enumeration is
-     known), which is the conclusion layer's roadmap, not a new oracle.
+     the OpenReason distribution, which is CORPUS-SHAPED — substrate-era
+     prior: `AbsentNotClosed` 70.3% of decodes; 12k real-CPAN reading:
+     `no_answer_linkable` 49.7%, `no_answer_self_only` 25.5%,
+     `absent_not_closed` 22.8%. Two levers, both conclusion-layer roadmap,
+     ranked by that reading: (a) **`Link` minting** — built, flag-gated
+     (`PERL_LSP_MINT_LINKS`), parked on a substrate measurement (decodes
+     4,103→4,104; "a follow abandons at the first rung whose own map says
+     Decode") that predates knowing the linkable population is half of all
+     open reasons on real CPAN — unparked-by-corpus is one A/B away, and a
+     follow's win is bounded by TARGET-side closedness, so score
+     `baked_follow` vs `baked_follow_incomplete` in both arms, not just
+     decode count; (b) **world-level closedness** (the flush evaluates
+     against a world; its product can stamp classes whose full ancestry
+     enumeration is known) — converts the `absent_not_closed` fifth and
+     raises every follow's completion odds, so it compounds (a).
    - **`main` is program-scoped**: an empty package resolves to `"main"`
      (`resolve/collect.rs`), and two scripts never share a stash, so a
      workspace-relation answer for a script's `main` is cross-program

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -1,7 +1,18 @@
 # Prompt: move iteration to relational
 
-**Status: direction brief for the scaling push. First slice landed (the
-member pre-filter, below); everything else is ranked, not started.**
+**Status: direction brief for the scaling push. Landed so far: the member
+pre-filter (ladder 1), the bridged-walk early exit (ladder 3's cheap half),
+the seam-retry gate (`serves_enriched`), and `RetainedReader` under both the
+conclusion loader and the bag-rehydrate loaders. The rest is ranked, not
+started.**
+
+**Honest sizing note for the retained-connection family**: connection-per-miss
+was the dominant term ONLY on a synthetic no-locality corpus (551 unrelated
+dists: 69,933 conclusion-cache misses; real apps measured 511 on crm and 668
+on Koha — misses are a LOCALITY property, not a file-count one). On real code
+the fix saves ~0.4 s per cold check. It stays because per-call open is the
+wrong shape regardless and the cliff exists for whoever indexes a dep-mirror
+tree — but nothing further in this family is worth cutting on cost grounds.
 
 ## The thesis
 

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -73,32 +73,59 @@ the relation that answers it, and the soundness constraint.
    candidate's decode) — that bounds a first-match hit at the matching module;
    the name relation is still what deletes the scan for misses.
 
-4. **The `MethodCall` stamp as a `Link`.** The frozen `MethodTarget` exists so
+4. **The registry chase's no-answer fetches, and `main`'s program scope.**
+   Measured on a real-CPAN corpus (12k files, 54% package-less scripts)
+   against the substrate: top-level `PackageSymbol` query DENSITY is nearly
+   equal (~180–200/file both), so query volume is not the differentiator —
+   the OUTCOME MIX is. Substrate: ~3% of queries reach a candidate bag fetch
+   and 52% of fetches answer nothing; real-CPAN: ~44% fetch and **94% of
+   1.06M fetches answer nothing** — a million decodes to learn nothing,
+   at ~1.5 candidates per escalation (so candidate-set narrowing is NOT the
+   lever; the fan-out was never large). Three levers, separable:
+   - **Don't decode to learn nothing**: the slice-1 syms-rows probe applied
+     before the chase's `bag_present` (the `moc.provider_fetched` sites)
+     kills the symbol-absent subset of no-answer fetches. Its coverage —
+     what fraction of no-answer fetches are symbol-absent vs
+     present-but-unanswerable — is the slice's own first measurement.
+   - **`main` is program-scoped**: an empty package resolves to `"main"`
+     (`resolve/collect.rs`), and two scripts never share a stash, so a
+     workspace-relation answer for a script's `main` is cross-program
+     pollution — wrong, not just wasteful. Fix is the ScopedLookup/T3
+     shape: main's candidates from asker F = F plus F's load closure's
+     explicit-`package main` files; a scope rule keyed on program-locality,
+     never a string match. Cost share is measured by the `mocpkg.*` /
+     `mocfetch.*` attribution counters (negligible on the substrate, whose
+     indexed root holds few scripts; unmeasured on script-heavy corpora).
+   - **The R4 escalation lane**: `consult.moc_primary` counts raw-bag-None
+     escalations to `enriched_present` — each is an overlay consult, its
+     cost read directly from `consult.enriched` accumulated ns.
+
+5. **The `MethodCall` stamp as a `Link`.** The frozen `MethodTarget` exists so
    an answer cannot depend on which verb asked; a conclusion `Link` is
    verb-independent by construction and cheap to evaluate. If the stamp's
    product were the ladder rather than the resolved value, the enrichment
    re-stamp collapses into the flush worklist's cutoff.
 
-5. **Return-type consults through conclusions.** `MethodOnClass` is 96.0% of
+6. **Return-type consults through conclusions.** `MethodOnClass` is 96.0% of
    measured cross-file consults; serving them from the conclusion map removes
    the chase's bag decodes and the transitive overlay recursion behind them.
    This is the conclusion layer's own roadmap; listed here because it retires
    the `enriched_present` fallback that makes enrichment recursive.
 
-6. **Residency policy for digests.** The export gate won because
+7. **Residency policy for digests.** The export gate won because
    `export`/`export_ok` happen to be non-evictable axes; per-package
    method-name sets and bridge entity names lose because they happen not to
    be. "What survives the strip" should be derived from what the confirm
    loops read, not from field placement. The Surface already computes
    per-file method names and throws them away.
 
-7. **Overlay key honesty.** `enriched_snapshot`'s key fingerprints the file
+8. **Overlay key honesty.** `enriched_snapshot`'s key fingerprints the file
    plus its *declared* providers, but enrichment also reads bridges and
    loader shapes from undeclared files. Today the staleness channel is masked
    by how rarely an overlay survives to be reused; any retention improvement
    makes it a live correctness hole. Close it before improving retention.
 
-8. **Enrichment as a delta artifact.** Every recursive consumer of an
+9. **Enrichment as a delta artifact.** Every recursive consumer of an
    enriched analysis reads only the bag (`docs/adr/enrichment-build-cost.md`,
    consumer matrix), and the measured enrichment delta is 4.13% of base heap.
    The truncate-to-baseline + swap dance is imperative state management for

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -211,6 +211,29 @@ the relation that answers it, and the soundness constraint.
    what is logically a small immutable overlay. This is also the "make a
    build cheap" prerequisite that priced out level-indexed enrichment — the
    algebra was right, the carrier (whole-FA copies) was too heavy.
+   **Design written: `docs/prompt-enrichment-delta.md`** (four stages, each
+   land-alone; stage 2's bag view is where the clone leaves the hot path).
+
+10. **The FA multiplier (density).** A giant Perl file's analysis costs
+    ~2.2 KB per source line — refs 41.5% (a ref per meaningful token, each
+    with an OWNED `target_name: String`), witness vec+index 39.4% (a
+    witness per meaningful expression, each with an OWNED
+    `WitnessSource::Builder(String)` tag) — ~10x release's footprint, and
+    the term behind FHEM's brk churn, the crest's per-worker sets, and the
+    rehydrate unit price. Options, cheapest-first, measurement-gated:
+    (a) representation shrink — intern source tags (a closed set of
+    static strings carried as per-witness heap allocations today) and
+    dedupe repeated names within a file's tables; no semantic change,
+    EXTRACT_VERSION bump; (b) consultation census — ghost counters on
+    which witness kinds are ever READ per corpus, making elision of
+    never-consulted emissions evidence-based rather than speculative;
+    (c) density budget — per-file emission caps with the honest `degraded`
+    mark (the MAX_CST_DEPTH precedent) for files past a size threshold;
+    (d) chunked/lazy bag storage — shard the persisted bag so rehydration
+    loads only the shard a query touches; composes with rung 9's bag view.
+    Chunking the FILE itself (multiple FAs per source file) is the
+    non-option: scopes, packages, and SymbolIds are file-scoped
+    invariants, and every consumer assumes them.
 
 ## The discipline (every slice obeys these)
 

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -115,12 +115,18 @@ the relation that answers it, and the soundness constraint.
    owns the SUSTAINED figure — `MALLOC_MMAP_THRESHOLD_=65536` returns 53%
    (the server's number; ship posture is a product trade — jemalloc /
    threshold / accept); (b) **per-worker in-flight working sets** own the
-   CREST — one file's sweep memo measured 633 MB, peak linear in worker
-   count at an invariant per-file footprint — fixed by byte-capping the
-   per-file sweep memo (256 MB drop-oldest, `PERL_LSP_SWEEP_MEMO_MB`),
-   the corpus-neutral shape: a worker cap was measured nearly free on
-   FHEM (memory-bound) but would tax a CPU-bound corpus. The path memo
-   itself is LOAD-BEARING (1.55x wall) and stays.
+   CREST — ~414 MB marginal per worker, peak linear in worker count at an
+   invariant per-file footprint. Two fix attempts, one reverted: byte-
+   capping the per-file sweep memo measured NET-NEGATIVE at n=500 (+51%
+   wall, +15% RSS — 19,929 drop-oldest evictions converted retention into
+   re-decode churn; the memo is the measurable MINORITY of the per-worker
+   set, and a safety bound that degrades the case it protects is not one).
+   The landed fix is **byte-budgeted ADMISSION** on the sweep: permits =
+   source bytes (the a-priori footprint proxy, ~65x expansion measured)
+   against an in-flight budget — bounds the product (concurrency × size)
+   without converting anything, since a queued file is decoded later, not
+   twice; provably no-ops on small-file corpora. The path memo itself is
+   LOAD-BEARING (1.55x wall) and stays untouched.
 
 4. **The registry chase's no-answer fetches, and `main`'s program scope.**
    Measured on a real-CPAN corpus (12k files, 54% package-less scripts)

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -69,7 +69,9 @@ the relation that answers it, and the soundness constraint.
    the bridge survives the strip, the names it points at do not. Either a
    `(class, entity_name, file)` row family or entity names denormalized into
    the plugin lane deletes the per-helper-call scan of every plugin file. The
-   visitor also has no early exit; with names resident that stops mattering.
+   visitor's missing early exit is FIXED (`ControlFlow`, Break before the next
+   candidate's decode) — that bounds a first-match hit at the matching module;
+   the name relation is still what deletes the scan for misses.
 
 4. **The `MethodCall` stamp as a `Link`.** The frozen `MethodTarget` exists so
    an answer cannot depend on which verb asked; a conclusion `Link` is

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -69,20 +69,22 @@ the relation that answers it, and the soundness constraint.
    asks the `syms` rows first and skips the rehydrate on proven absence.
    Constraints honored: fail-open everywhere the store cannot speak (below).
 
-2. **`module_declaring_method_in_package`** — same probe, same guardrails,
-   different loop (`queries.rs`): the typeglob-install last resort scans the
-   class's provider bucket with a `symbols_present` per candidate, and it runs
-   on exactly the misses. One call into the same pre-filter.
+2. **`module_declaring_method_in_package`** — LANDED. Same probe, same
+   guardrails, different loop; it runs on exactly the misses. Cold
+   substrate: 24,506 of 25,523 candidate scans skipped (96%), found-rate
+   unchanged; slice 1's equivalence evidence covers it a fortiori
+   (`has_sub_in_package` is a strict subset of the walk's member test).
 
-3. **Bridge entities by name.** `for_each_entity_bridged_to` decodes every
-   module bridging to a class to enumerate entity names, because
-   `PluginNamespace.entities` are `SymbolId`s into the evicted symbols vec —
-   the bridge survives the strip, the names it points at do not. Either a
-   `(class, entity_name, file)` row family or entity names denormalized into
-   the plugin lane deletes the per-helper-call scan of every plugin file. The
-   visitor's missing early exit is FIXED (`ControlFlow`, Break before the next
-   candidate's decode) — that bounds a first-match hit at the matching module;
-   the name relation is still what deletes the scan for misses.
+3. **Bridge entities by name — LANDED, without the row family.** Bridged
+   entities are standard symbols of their file, already shredded, so a
+   container-BLIND rows probe (`sym_name_row_exists` — an entity's container
+   is the plugin's home package, not the bridged class) gates each
+   candidate's decode. `for_each_entity_bridged_to_named` carries the name
+   as a pre-filter license; the first-match-by-name consumers ride it, the
+   early exit bounds hits, the probe deletes the per-miss scan. The
+   `(class, entity_name, file)` row family stays unbuilt unless a corpus
+   shows the name-only probe leaking (a plugin file declaring the queried
+   name OUTSIDE the bridging namespace still decodes — over-approx, sound).
 
 4. **The registry chase's no-answer fetches, and `main`'s program scope.**
    Measured on a real-CPAN corpus (12k files, 54% package-less scripts)

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -1,0 +1,129 @@
+# Prompt: move iteration to relational
+
+**Status: direction brief for the scaling push. First slice landed (the
+member pre-filter, below); everything else is ranked, not started.**
+
+## The thesis
+
+Cross-file enrichment and resolution look superlinear in workspace size
+because their unit of work is not the file — it is the file's provider
+neighborhood, walked imperatively. The recurring shape: a walker fetches an
+object (rehydrating a whole `FileAnalysis` through the blob LRU) in order to
+answer a question that is relationally expressible, and every axis of that
+walk grows with the workspace:
+
+- **candidates per name** — a package is a SET of files
+  (`visible_def_candidates`), 5–12 declaring files for a common name at 122x;
+- **cost per touch** — resident-map read below the cache caps, a full
+  zstd+bincode decode above them, and the sweep's access pattern is cyclic, so
+  past the cap the hit rate collapses to ~0 rather than degrading;
+- **recursion over the closure** — enrichment builds enriched overlays of its
+  providers, whose enrichment recurses; reuse across consumers is defeated by
+  traversal-order-dependent taint plus a 64-entry drop-oldest cache.
+
+Multiply those and a bulk sweep is `N × B(N) × D(N)`. The per-file cost
+reductions all closed (`docs/adr/skipping-cross-file-work.md` — eight
+proposals, measured, rejected) because they attacked the linear constant, not
+the multiplicative factors. The factors fall only by replacing
+fetch-and-inspect with an indexed relation.
+
+## The relations already exist
+
+Three seams landed for other reasons and are exactly the right carriers:
+
+- **The row store** (`docs/adr/relational-ref-index.md`): `refs(name, file)`
+  candidate pairs and `syms(file, name, key, kind, span, container, flags)`,
+  shredded in the same transaction as the blob (cannot drift — the failure
+  that retired the RAM-side parallel reverse indexes), version-gated, indexed
+  by name/key/file. `container` is the symbol's package attribution.
+- **The conclusion layer** (`docs/prompt-conclusion-layer.md`): the registry
+  chase partially evaluated per file; cross-file answers residualize as
+  `Link` (an ordered MRO ladder as data), never as baked values — so there is
+  nothing to taint.
+- **The flush worklist**: change-driven propagation with a movement cutoff —
+  the declarative fixpoint the per-file recursive enrichment never was.
+
+The migration is therefore mostly re-pointing walkers at relations that are
+already maintained, not building new infrastructure.
+
+## The migration ladder
+
+Ranked by (evidence of cost) / (blast radius). Each row names today's walker,
+the relation that answers it, and the soundness constraint.
+
+1. **The ancestor walk's per-candidate member probe** — LANDED (this slice).
+   `method_resolution_on_class`'s cross-file arm decoded every candidate of
+   every ancestor to run an existence scan (`mroc.candidate_wasted`); the
+   stamp built on it is ~63% of all blob decodes. Now `candidate_may_declare`
+   asks the `syms` rows first and skips the rehydrate on proven absence.
+   Constraints honored: fail-open everywhere the store cannot speak (below).
+
+2. **`module_declaring_method_in_package`** — same probe, same guardrails,
+   different loop (`queries.rs`): the typeglob-install last resort scans the
+   class's provider bucket with a `symbols_present` per candidate, and it runs
+   on exactly the misses. One call into the same pre-filter.
+
+3. **Bridge entities by name.** `for_each_entity_bridged_to` decodes every
+   module bridging to a class to enumerate entity names, because
+   `PluginNamespace.entities` are `SymbolId`s into the evicted symbols vec —
+   the bridge survives the strip, the names it points at do not. Either a
+   `(class, entity_name, file)` row family or entity names denormalized into
+   the plugin lane deletes the per-helper-call scan of every plugin file. The
+   visitor also has no early exit; with names resident that stops mattering.
+
+4. **The `MethodCall` stamp as a `Link`.** The frozen `MethodTarget` exists so
+   an answer cannot depend on which verb asked; a conclusion `Link` is
+   verb-independent by construction and cheap to evaluate. If the stamp's
+   product were the ladder rather than the resolved value, the enrichment
+   re-stamp collapses into the flush worklist's cutoff.
+
+5. **Return-type consults through conclusions.** `MethodOnClass` is 96.0% of
+   measured cross-file consults; serving them from the conclusion map removes
+   the chase's bag decodes and the transitive overlay recursion behind them.
+   This is the conclusion layer's own roadmap; listed here because it retires
+   the `enriched_present` fallback that makes enrichment recursive.
+
+6. **Residency policy for digests.** The export gate won because
+   `export`/`export_ok` happen to be non-evictable axes; per-package
+   method-name sets and bridge entity names lose because they happen not to
+   be. "What survives the strip" should be derived from what the confirm
+   loops read, not from field placement. The Surface already computes
+   per-file method names and throws them away.
+
+7. **Overlay key honesty.** `enriched_snapshot`'s key fingerprints the file
+   plus its *declared* providers, but enrichment also reads bridges and
+   loader shapes from undeclared files. Today the staleness channel is masked
+   by how rarely an overlay survives to be reused; any retention improvement
+   makes it a live correctness hole. Close it before improving retention.
+
+8. **Enrichment as a delta artifact.** Every recursive consumer of an
+   enriched analysis reads only the bag (`docs/adr/enrichment-build-cost.md`,
+   consumer matrix), and the measured enrichment delta is 4.13% of base heap.
+   The truncate-to-baseline + swap dance is imperative state management for
+   what is logically a small immutable overlay. This is also the "make a
+   build cheap" prerequisite that priced out level-indexed enrichment — the
+   algebra was right, the carrier (whole-FA copies) was too heavy.
+
+## The discipline (every slice obeys these)
+
+- **Skips need positive evidence; every unknown fails open.** A relation may
+  answer "provably absent" only where it provably covers the file: rows conn
+  available, file present in `files` (the single shredded marker), and the
+  resident copy actually evicted — a whole copy answers from RAM for free and
+  its rows may predate it. Same fail-open shape as `restamp_owed`.
+- **Over-approximate toward the decode.** The member probe is kind-blind and
+  matches name OR key: a wasted decode is the cheap error, a hidden member is
+  the silent-wrong-goto-def one.
+- **Know what the rows cannot see.** Deferred plugin emissions materialize
+  into resident copies AFTER the shred (`materialize_gated_emissions`), so
+  their symbols have no rows; any file carrying `gated_emissions` fails open.
+  A new post-shred mutator of cached copies must be added to this list — or
+  better, not built.
+- **Ship the switch that checks the assumption.** Each skip lands with its
+  disable control and an equivalence mode that runs the skipped work anyway
+  and screams on divergence (`PERL_LSP_RESTAMP_EQUIV` is the pattern; the
+  member pre-filter ships `PERL_LSP_NO_MEMBER_PREFILTER` and
+  `PERL_LSP_MEMBER_PREFILTER_EQUIV`).
+- **Counters, not vibes.** Every pre-filter counts skip/decode/unknown so the
+  hit rate is a ghost-stats read, and the next ranking pass starts from
+  numbers (`docs/adr/skipping-cross-file-work.md`'s denominator rules apply).

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -212,6 +212,19 @@ the relation that answers it, and the soundness constraint.
   and screams on divergence (`PERL_LSP_RESTAMP_EQUIV` is the pattern; the
   member pre-filter ships `PERL_LSP_NO_MEMBER_PREFILTER` and
   `PERL_LSP_MEMBER_PREFILTER_EQUIV`).
+- **A plausible product landing near a measured total is not an
+  attribution.** Four fits failed in one night of the FHEM investigation
+  (12 GB / 232 entries; 929 × 12 MB walk residency; clone-boundedness;
+  "the sweep owns it so the clones own it") — every one was arithmetic
+  that terminated at "the numbers work" instead of at "I changed one thing
+  and the number moved." An attribution is a control arm or a byte counter
+  at the holder; everything else is a hypothesis and must be labeled one.
+- **An attempt counter is not a completion counter.** `moc.provider_fetched`
+  counts attempts; the sweep memo made most of them Arc bumps, and a slice
+  was cut against the wrong number before the reconciliation
+  (`sweep.memo_hit + memo_miss ≈ attempts`; only `rehydrate.loader`'s n
+  decodes) was done. State which kind any quoted counter is, and show the
+  reconciliation when the two could diverge.
 - **Counters, not vibes.** Every pre-filter counts skip/decode/unknown so the
   hit rate is a ghost-stats read, and the next ranking pass starts from
   numbers (`docs/adr/skipping-cross-file-work.md`'s denominator rules apply).

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -108,6 +108,20 @@ the relation that answers it, and the soundness constraint.
    keyed with the point displaced 20 of 12.3M — inert by construction,
    found by measurement.
 
+   **The RSS half closed as two mechanisms, seven dead suspects later**
+   (walk residency, overlay clones, sweep path memo, arena retention,
+   diagnostics channel — each killed by a control arm or a byte counter,
+   never by arithmetic): (a) **brk retention of decode-and-drop churn**
+   owns the SUSTAINED figure — `MALLOC_MMAP_THRESHOLD_=65536` returns 53%
+   (the server's number; ship posture is a product trade — jemalloc /
+   threshold / accept); (b) **per-worker in-flight working sets** own the
+   CREST — one file's sweep memo measured 633 MB, peak linear in worker
+   count at an invariant per-file footprint — fixed by byte-capping the
+   per-file sweep memo (256 MB drop-oldest, `PERL_LSP_SWEEP_MEMO_MB`),
+   the corpus-neutral shape: a worker cap was measured nearly free on
+   FHEM (memory-bound) but would tax a CPU-bound corpus. The path memo
+   itself is LOAD-BEARING (1.55x wall) and stays.
+
 4. **The registry chase's no-answer fetches, and `main`'s program scope.**
    Measured on a real-CPAN corpus (12k files, 54% package-less scripts)
    against the substrate: top-level `PackageSymbol` query DENSITY is nearly

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -82,11 +82,19 @@ the relation that answers it, and the soundness constraint.
    1.06M fetches answer nothing** — a million decodes to learn nothing,
    at ~1.5 candidates per escalation (so candidate-set narrowing is NOT the
    lever; the fan-out was never large). Three levers, separable:
-   - **Don't decode to learn nothing**: the slice-1 syms-rows probe applied
-     before the chase's `bag_present` (the `moc.provider_fetched` sites)
-     kills the symbol-absent subset of no-answer fetches. Its coverage —
-     what fraction of no-answer fetches are symbol-absent vs
-     present-but-unanswerable — is the slice's own first measurement.
+   - **Don't decode to learn nothing** — RETIRED as a new probe by the
+     consult decomposition (12k real-CPAN corpus: `baked_open` 59.9%,
+     `not_local` 12.1%, `absent_but_inherits` 0.3%). The conclusion map's
+     `NotLocal` verdict IS the symbol-absence skip, already live and
+     carrying an eighth of consults; adding a rows probe beside it would be
+     a third absence oracle where the leak is elsewhere. The leak:
+     `OpenReason::AbsentNotClosed` — absence proves nothing for a class
+     whose ancestry leaves the file (measured 70.3% of decodes, 97.6% on
+     classes the map DOES conclude about) — i.e. **closedness is a
+     cross-file property and only per-file bakes exist**. The lever is a
+     world-level closedness verdict (the flush evaluates against a world;
+     its product can stamp classes whose full ancestry enumeration is
+     known), which is the conclusion layer's roadmap, not a new oracle.
    - **`main` is program-scoped**: an empty package resolves to `"main"`
      (`resolve/collect.rs`), and two scripts never share a stash, so a
      workspace-relation answer for a script's `main` is cross-program

--- a/docs/prompt-relational-iteration.md
+++ b/docs/prompt-relational-iteration.md
@@ -148,11 +148,19 @@ the relation that answers it, and the soundness constraint.
    loops read, not from field placement. The Surface already computes
    per-file method names and throws them away.
 
-8. **Overlay key honesty.** `enriched_snapshot`'s key fingerprints the file
-   plus its *declared* providers, but enrichment also reads bridges and
-   loader shapes from undeclared files. Today the staleness channel is masked
-   by how rarely an overlay survives to be reused; any retention improvement
-   makes it a live correctness hole. Close it before improving retention.
+8. **Overlay key honesty — the enumerable half LANDED.** The key was already
+   more honest than this rung claimed (depth-20 dep-closure walk, all loader
+   shapes hashed); the real gaps were the BRIDGE and PROVIDER relations,
+   whose members are not candidates of any walked name. Now
+   `hash_relations_for` rides the key: bridge membership + member
+   registration generations (the stamp freezes a bridging module's identity
+   into overlay `MethodTarget`s) and provider membership, for the walked
+   closure plus the file's own registration names. Pinned by
+   `a_new_bridge_to_the_consumers_class_moves_the_enrichment_key`. The
+   RESIDUAL is principled, not accidental: the stamp reads the whole world
+   (any invocant class), which no closure-scoped key can cover — that
+   residual collapses when rung 5 lands (a `Link`-shaped stamp freezes no
+   world-dependent values), which makes 5 the true closer of 8.
 
 9. **Enrichment as a delta artifact.** Every recursive consumer of an
    enriched analysis reads only the bag (`docs/adr/enrichment-build-cost.md`,

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -501,6 +501,54 @@ pub fn open_and_load_diag(
     Err(RehydrateMiss::NoRow)
 }
 
+/// `open_and_load_diag` with the happy path on a RETAINED connection — the
+/// same per-call-open disease the conclusion loader had (`RetainedReader`):
+/// every bag-LRU miss paid a fresh open + WAL handshake before its decode.
+/// A row served by the long-lived reader pays no open at all; ANY other
+/// outcome — no retained conn obtainable, row invisible, read error — falls
+/// back to the full per-call policy, whose RW recovery genuinely needs fresh
+/// opens and whose failure discrimination the residency tripwire reads.
+/// The fallback re-runs the readonly probe (a genuine miss pays ~one extra
+/// open); hits are the overwhelming population and hits pay zero.
+#[cfg(not(test))]
+pub fn open_and_load_diag_retained(
+    retained: &RetainedReader,
+    cache_key: Option<&str>,
+    lang: &str,
+    paths: &[String],
+    want_bag: bool,
+) -> Result<FileAnalysis, RehydrateMiss> {
+    if let Some(dir) = cache_dir_for_workspace(cache_key) {
+        let db = db_path_for(&dir, lang);
+        let hit = retained
+            .with(
+                || open_reader_retrying(&db).ok(),
+                |conn| {
+                    paths
+                        .iter()
+                        .find_map(|p| load_one_diag(conn, p, want_bag).ok())
+                },
+            )
+            .flatten();
+        if let Some(fa) = hit {
+            return Ok(fa);
+        }
+    }
+    crate::util::ghost_stats::count("bagload.retained_fallback");
+    open_and_load_diag(cache_key, lang, paths, want_bag)
+}
+
+#[cfg(test)]
+pub fn open_and_load_diag_retained(
+    _retained: &RetainedReader,
+    _cache_key: Option<&str>,
+    _lang: &str,
+    _paths: &[String],
+    _want_bag: bool,
+) -> Result<FileAnalysis, RehydrateMiss> {
+    Err(RehydrateMiss::NoRow)
+}
+
 /// Rehydrate one file from an explicit cache DB, discriminating every
 /// failure and surviving the readonly/WAL-checkpoint race. Path-taking so the
 /// whole policy is unit-testable.

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -510,6 +510,20 @@ pub fn open_and_load_diag(
 /// opens and whose failure discrimination the residency tripwire reads.
 /// The fallback re-runs the readonly probe (a genuine miss pays ~one extra
 /// open); hits are the overwhelming population and hits pay zero.
+///
+/// WHY the blob lane may ride a retained connection even though
+/// `load_one_diag`'s single-row path skips stamp validation: the stale read
+/// an out-of-process clear could serve is CAUSALLY unreachable. A rehydrate
+/// for a changed file exists only after that file's copy was evicted, and
+/// eviction happens only AFTER its new blob's chunk COMMITS (the residency
+/// discipline's own ordering) — so the loader call, and the per-call inode
+/// recheck inside `with`, postdate the commit they must observe. Either the
+/// writer still holds the old inode (reads of it see its own writes —
+/// consistent), or the recheck sees the recreated file and reopens. The
+/// multi-row (dual-homed) path additionally prefers a stamp-matching row.
+/// A future lane on this connection whose reads neither self-validate nor
+/// inherit this eviction-after-commit causality re-opens the hole — do not
+/// reuse the retained reader for such a lane without its own argument.
 #[cfg(not(test))]
 pub fn open_and_load_diag_retained(
     retained: &RetainedReader,

--- a/src/index/module_cache/blob.rs
+++ b/src/index/module_cache/blob.rs
@@ -512,18 +512,30 @@ pub fn open_and_load_diag(
 /// open); hits are the overwhelming population and hits pay zero.
 ///
 /// WHY the blob lane may ride a retained connection even though
-/// `load_one_diag`'s single-row path skips stamp validation: the stale read
-/// an out-of-process clear could serve is CAUSALLY unreachable. A rehydrate
-/// for a changed file exists only after that file's copy was evicted, and
-/// eviction happens only AFTER its new blob's chunk COMMITS (the residency
-/// discipline's own ordering) — so the loader call, and the per-call inode
-/// recheck inside `with`, postdate the commit they must observe. Either the
-/// writer still holds the old inode (reads of it see its own writes —
-/// consistent), or the recheck sees the recreated file and reopens. The
-/// multi-row (dual-homed) path additionally prefers a stamp-matching row.
+/// `load_one_diag`'s single-row path skips stamp validation (its caller
+/// invalidates on file change — the note above `load_one_diag` is the other
+/// half of this invariant): the two eviction branches close by two
+/// DIFFERENT arguments, and both must hold.
+///
+/// CAPACITY eviction (`PackBagCache::evict_to_cap` — the common branch on a
+/// working set over the cap) is not downstream of any commit, but its
+/// rehydrates are for UNCHANGED files: under an out-of-process clear the
+/// retained old inode serves last-committed data that still matches the
+/// files as they are — consistent-but-old, degrading together with every
+/// other read on the same snapshot.
+///
+/// The stale-vs-new hazard — a CHANGED file's pre-change blob served after
+/// its re-index — needs the CHANGE branch, and there eviction happens only
+/// AFTER the new blob's chunk COMMITS (the residency discipline's own
+/// ordering), so the loader call and the per-call inode recheck inside
+/// `with` postdate the commit they must observe: either the writer still
+/// holds the old inode (reads of it see its own writes — consistent) or
+/// the recheck sees the recreated file and reopens. The multi-row
+/// (dual-homed) path additionally prefers a stamp-matching row.
+///
 /// A future lane on this connection whose reads neither self-validate nor
-/// inherit this eviction-after-commit causality re-opens the hole — do not
-/// reuse the retained reader for such a lane without its own argument.
+/// fit one of these two arguments re-opens the hole — do not reuse the
+/// retained reader for such a lane without its own argument.
 #[cfg(not(test))]
 pub fn open_and_load_diag_retained(
     retained: &RetainedReader,

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -247,8 +247,21 @@ pub fn prune_generations_below(conn: &Connection, keep: Generation) -> usize {
 ///
 /// Version-filtered: a row below `EXTRACT_VERSION` is going to be re-parsed
 /// anyway, and baking it would spend the work twice.
-pub fn paths_needing_repair(conn: &Connection, at: Generation) -> Vec<String> {
-    let mut stmt = match conn.prepare(
+///
+/// The two disjuncts repair different PRODUCTS, and only one obeys the bake
+/// control: `include_missing_maps=false` (a `PERL_LSP_NO_BAKE` arm) selects
+/// surface-missing paths only, because the map half of the repair is the
+/// second conclusions producer — while the surface half is the freshness
+/// machinery's product, which the control does not claim to ablate. Gating
+/// the WHOLE frontier on the bake flag left a NO_BAKE arm running against
+/// un-repaired surfaces: a control that ablated more than the thing it
+/// controls, the `the_bake_gate_has_one_reader` failure shape one level up.
+pub fn paths_needing_repair(
+    conn: &Connection,
+    at: Generation,
+    include_missing_maps: bool,
+) -> Vec<String> {
+    let sql = if include_missing_maps {
         "SELECT DISTINCT m.path FROM modules m \
          WHERE m.analysis IS NOT NULL AND m.extract_version = ?1 \
            AND (NOT EXISTS ( \
@@ -258,8 +271,18 @@ pub fn paths_needing_repair(conn: &Connection, at: Generation) -> Vec<String> {
              OR NOT EXISTS ( \
                  SELECT 1 FROM surfaces s \
                  WHERE s.path = m.path AND s.version = ?3 \
-               ))",
-    ) {
+               ))"
+    } else {
+        // Same bind list as the other shape; `?2` (the generation) does not
+        // participate in a surface-only selection.
+        "SELECT DISTINCT m.path FROM modules m \
+         WHERE m.analysis IS NOT NULL AND m.extract_version = ?1 AND ?2 = ?2 \
+           AND NOT EXISTS ( \
+                 SELECT 1 FROM surfaces s \
+                 WHERE s.path = m.path AND s.version = ?3 \
+               )"
+    };
+    let mut stmt = match conn.prepare(sql) {
         Ok(s) => s,
         Err(e) => {
             log::warn!("conclusion repair: could not enumerate frontier: {e}");
@@ -299,6 +322,12 @@ pub fn repair_conclusions_slice(
     paths: &[String],
     at: Generation,
 ) -> usize {
+    // The map half obeys the bake control (the repair lane is the SECOND
+    // conclusions producer — letting it bake under PERL_LSP_NO_BAKE would
+    // hand the control's own arm a full layer from its second warm run);
+    // the surface half runs regardless — the same split as the frontier
+    // query, or the control ablates a lane it does not claim.
+    let bake_on = !crate::model::witnesses::bake_disabled();
     let baked: Vec<(&String, Vec<u8>, u64, Vec<u8>)> = paths
         .iter()
         .filter_map(|path| {
@@ -307,7 +336,11 @@ pub fn repair_conclusions_slice(
             // successful repair — the same silent-empty shape this whole
             // repair exists to undo.
             let fa = super::load_one_diag(conn, path, true).ok()?;
-            let blob = super::bake_conclusions_blob(&fa, &fa.witnesses);
+            let blob = if bake_on {
+                super::bake_conclusions_blob(&fa, &fa.witnesses)
+            } else {
+                Vec::new()
+            };
             // Stamped from the analysis the repair actually decoded, not from
             // the index: a repair races the writers, and a fingerprint read
             // elsewhere could describe a newer state than these bytes.
@@ -318,9 +351,12 @@ pub fn repair_conclusions_slice(
             // an older `Surface::project` gets replaced. Free here: the
             // fingerprint above already paid for the projection.
             let surface = super::encode_surface(&projected).unwrap_or_default();
-            if blob.is_empty() {
-                // Nothing encodable. Leaving the row absent is right: the
-                // reader falls back to a decode, which is where it already was.
+            if blob.is_empty() && surface.is_empty() {
+                // Nothing encodable in EITHER product. Leaving both rows
+                // absent is right: the reader falls back to a decode, which
+                // is where it already was. (An unencodable map alone must
+                // not drop the surface write — that was the executor's own
+                // copy of the half-gate.)
                 crate::util::ghost_stats::count("repair.nothing_to_bake");
                 return None;
             }
@@ -344,6 +380,12 @@ pub fn repair_conclusions_slice(
             if let Err(e) = r {
                 log::warn!("conclusion repair: surface store failed for '{path}': {e}");
             }
+        }
+        if blob.is_empty() {
+            // Surface-only repair (bake gated, or the map would not encode):
+            // the surface write above is the whole product.
+            landed += 1;
+            continue;
         }
         let r = conn.execute(
             "INSERT OR REPLACE INTO conclusions \

--- a/src/index/module_cache/conclusions_store.rs
+++ b/src/index/module_cache/conclusions_store.rs
@@ -37,15 +37,14 @@ impl Generation {
 
 /// The store's current generation — what a fresh reader should pin.
 pub fn current_generation(conn: &Connection) -> Generation {
-    conn.query_row(
-        "SELECT value FROM meta WHERE key = 'conclusion_generation'",
-        [],
-        |row| row.get::<_, String>(0),
-    )
-    .ok()
-    .and_then(|v| v.parse::<i64>().ok())
-    .map(Generation)
-    .unwrap_or(Generation::INITIAL)
+    // `prepare_cached` for the same reason as `load_conclusions_stamped`:
+    // read per consult-path load on a retained connection.
+    conn.prepare_cached("SELECT value FROM meta WHERE key = 'conclusion_generation'")
+        .ok()
+        .and_then(|mut s| s.query_row([], |row| row.get::<_, String>(0)).ok())
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(Generation)
+        .unwrap_or(Generation::INITIAL)
 }
 
 /// Load one file's conclusions AS OF a pinned generation.
@@ -80,14 +79,19 @@ pub fn load_conclusions_stamped(
     path: &str,
     at: Generation,
 ) -> Option<(ConclusionMap, RowStamp)> {
+    // `prepare_cached`: the consult path runs this once per unique file on a
+    // RETAINED connection, so the parsed statement amortizes; a plain
+    // `query_row` re-parses the SQL on every load.
     let (blob, fp, gen): (Vec<u8>, i64, i64) = conn
-        .query_row(
+        .prepare_cached(
             "SELECT map, source_fingerprint, flush_generation FROM conclusions \
              WHERE path = ?1 AND generation <= ?2 \
              ORDER BY generation DESC LIMIT 1",
-            params![path, at.0],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
+        .ok()?
+        .query_row(params![path, at.0], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
         .ok()?;
     let bin = zstd::decode_all(blob.as_slice()).ok()?;
     let map = bincode::deserialize(&bin).ok()?;

--- a/src/index/module_cache/conn.rs
+++ b/src/index/module_cache/conn.rs
@@ -266,3 +266,131 @@ pub fn open_rw_shared_at(db_path: &std::path::Path) -> Option<Connection> {
 pub fn open_cache_db_readonly(_workspace_root: Option<&str>, _lang: &str) -> Option<Connection> {
     None
 }
+
+/// A retained read connection: opened once through the caller's opener,
+/// reused across calls, reopened when the DB file was unlinked/recreated
+/// underneath it (inode change — `--clear-cache`, a row-format rebuild).
+///
+/// The ONE speller of retain-with-recheck: `ModuleIndex::with_rows_conn`
+/// and the conclusion cache's loader both ride it. A per-call open costs
+/// milliseconds (file open, WAL handshake, the CANTOPEN retry ladder)
+/// against the microsecond query it serves — measured at 5.1 ms/call over
+/// 70k conclusion-map loads, 360 s of accumulated open cost in one cold
+/// `--check`, 13x the next-largest term in the run.
+pub struct RetainedReader {
+    cell: std::sync::Mutex<Option<(Connection, u64)>>,
+}
+
+impl Default for RetainedReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RetainedReader {
+    pub fn new() -> Self {
+        RetainedReader { cell: std::sync::Mutex::new(None) }
+    }
+
+    fn db_ino(conn: &Connection) -> u64 {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            return conn
+                .path()
+                .and_then(|p| std::fs::metadata(p).ok())
+                .map(|m| m.ino())
+                .unwrap_or(0);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = conn;
+            0
+        }
+    }
+
+    /// Drop the held connection — the next `with` reopens. For callers whose
+    /// OPENER changed (a new workspace root), which the inode recheck cannot
+    /// see: same file may exist at both paths.
+    pub fn reset(&self) {
+        let mut guard = self.cell.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+    }
+
+    /// Run `f` on the retained connection, opening through `opener` when
+    /// none is held or the file moved underneath it. `None` when the open
+    /// fails — a failure is NOT retained, so a DB created later is picked
+    /// up on the next call.
+    pub fn with<R>(
+        &self,
+        opener: impl FnOnce() -> Option<Connection>,
+        f: impl FnOnce(&Connection) -> R,
+    ) -> Option<R> {
+        // Poison-proof: the Option is a pure cache — a panic in an earlier
+        // holder must not permanently disable retrieval.
+        let mut guard = self.cell.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some((conn, ino)) = guard.as_ref() {
+            if Self::db_ino(conn) != *ino {
+                *guard = None; // file unlinked/recreated — reopen below
+            }
+        }
+        if guard.is_none() {
+            *guard = opener().map(|c| {
+                let ino = Self::db_ino(&c);
+                (c, ino)
+            });
+        }
+        let (conn, _) = guard.as_ref()?;
+        Some(f(conn))
+    }
+}
+
+#[cfg(test)]
+mod retained_reader_tests {
+    use super::RetainedReader;
+
+    /// One open serves many calls; a recreated DB file (new inode) forces a
+    /// reopen. The two behaviors this struct exists for, and the second is
+    /// what keeps `--clear-cache` honest mid-session.
+    #[test]
+    fn opens_once_and_reopens_on_inode_change() {
+        let dir = std::env::temp_dir().join(format!("rr_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("t.db");
+        super::Connection::open(&db).unwrap().execute_batch("CREATE TABLE t(x)").unwrap();
+
+        let rr = RetainedReader::new();
+        let opens = std::cell::Cell::new(0u32);
+        let opener = || {
+            opens.set(opens.get() + 1);
+            super::Connection::open(&db).ok()
+        };
+        assert!(rr.with(opener, |_| ()).is_some());
+        assert!(rr.with(opener, |_| ()).is_some());
+        assert_eq!(opens.get(), 1, "the second call rides the retained connection");
+
+        std::fs::remove_file(&db).unwrap();
+        super::Connection::open(&db).unwrap().execute_batch("CREATE TABLE t(x)").unwrap();
+        assert!(rr.with(opener, |_| ()).is_some());
+        assert_eq!(opens.get(), 2, "a recreated file (new inode) must reopen");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A failed open is not retained: a DB that appears later is picked up.
+    #[test]
+    fn a_failed_open_is_retried_next_call() {
+        let dir = std::env::temp_dir().join(format!("rr_late_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("late.db");
+
+        let rr = RetainedReader::new();
+        assert!(rr.with(|| None, |_: &super::Connection| ()).is_none());
+        super::Connection::open(&db).unwrap().execute_batch("CREATE TABLE t(x)").unwrap();
+        assert!(
+            rr.with(|| super::Connection::open(&db).ok(), |_| ()).is_some(),
+            "the earlier failure must not be remembered as permanent"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -1955,7 +1955,7 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
         "precondition: the map is gone"
     );
 
-    let frontier = paths_needing_repair(&conn, at);
+    let frontier = paths_needing_repair(&conn, at, true);
     assert_eq!(
         frontier,
         vec!["/repair/App.pm".to_string()],
@@ -1984,7 +1984,7 @@ fn a_cleared_conclusion_row_is_re_baked_to_the_same_map() {
     // Idempotent: nothing is left on the frontier, so a second pass is a no-op
     // rather than a rewrite loop.
     assert!(
-        paths_needing_repair(&conn, at).is_empty(),
+        paths_needing_repair(&conn, at, true).is_empty(),
         "a repaired file must leave the frontier, or the background pass never ends"
     );
 }
@@ -2103,7 +2103,7 @@ fn a_surface_from_another_projection_version_reads_absent_and_is_repaired() {
     let at = current_generation(&conn);
     assert!(load_surface(&conn, "/surfver/App.pm").is_some(), "precondition");
     assert!(
-        paths_needing_repair(&conn, at).is_empty(),
+        paths_needing_repair(&conn, at, true).is_empty(),
         "precondition: a freshly persisted file needs no repair"
     );
 
@@ -2119,7 +2119,7 @@ fn a_surface_from_another_projection_version_reads_absent_and_is_repaired() {
          describes a shape this build does not produce"
     );
     assert_eq!(
-        paths_needing_repair(&conn, at),
+        paths_needing_repair(&conn, at, true),
         vec!["/surfver/App.pm".to_string()],
         "a stale surface must put the file back on the repair frontier, or the \
          first edit to the projection silently re-opens the drift for every \
@@ -2136,7 +2136,7 @@ fn a_surface_from_another_projection_version_reads_absent_and_is_repaired() {
         "the repaired surface is not the cold projection"
     );
     assert!(
-        paths_needing_repair(&conn, at).is_empty(),
+        paths_needing_repair(&conn, at, true).is_empty(),
         "a repaired file must leave the frontier"
     );
 }

--- a/src/index/module_cache/module_cache_tests.rs
+++ b/src/index/module_cache/module_cache_tests.rs
@@ -590,6 +590,55 @@ fn shred_sym_rows_same_generation() {
     let _ = std::fs::remove_file(&pm);
 }
 
+/// The member pre-filter's rows probe is three-valued, and the boundary
+/// between the values is what the ancestor walk's skip soundness leans on:
+/// `Some(false)` — covered and provably absent — is the ONLY skip verdict;
+/// `None` (never shredded) must stay distinguishable from it, or an
+/// unindexed file's methods silently stop resolving.
+#[test]
+fn sym_member_probe_is_three_valued() {
+    let conn = test_db();
+    let source = "package My::Base;\nsub render { 1 }\n1;\n";
+    let dir = std::env::temp_dir();
+    let pm = dir.join("TestModule_member_probe.pm");
+    std::fs::write(&pm, source).unwrap();
+    let cached = parse_source_to_cached(source, &pm);
+    let path_str = pm.to_string_lossy().to_string();
+
+    assert_eq!(
+        sym_member_row_exists(&conn, &path_str, "render", "My::Base"),
+        None,
+        "never shredded: the store cannot speak for the file"
+    );
+
+    shred_derived_rows(
+        &conn,
+        &path_str,
+        "workspace",
+        &cached.analysis.ref_row_seeds(),
+        &cached.analysis.sym_row_seeds(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        sym_member_row_exists(&conn, &path_str, "render", "My::Base"),
+        Some(true),
+        "a matching (name, container) row warrants the decode"
+    );
+    assert_eq!(
+        sym_member_row_exists(&conn, &path_str, "nonesuch", "My::Base"),
+        Some(false),
+        "covered and absent: the one verdict that licenses a skip"
+    );
+    assert_eq!(
+        sym_member_row_exists(&conn, &path_str, "render", "Other::Pkg"),
+        Some(false),
+        "the container gates: the same name under another package is absent"
+    );
+
+    let _ = std::fs::remove_file(&pm);
+}
+
 /// `FLAG_EXPORTED` is minted from the real `@EXPORT`/`@EXPORT_OK` surface
 /// (`exports_name`), so the rows agree with the source the Surface projects —
 /// never a parallel notion of exportedness.

--- a/src/index/module_cache/rows.rs
+++ b/src/index/module_cache/rows.rs
@@ -527,6 +527,34 @@ pub fn sym_member_row_exists(
     .ok()
 }
 
+/// The name-only sibling of `sym_member_row_exists`: can the store rule out
+/// ANY symbol named `name` (under any container) in `path`'s file? Same
+/// three-valued contract — `Some(false)` is the only skip license; `None`
+/// (never shredded) must stay distinguishable from it.
+///
+/// For the bridged-entity walk: a plugin namespace's entities are standard
+/// symbols of THEIR file, but their container is the plugin's canonical home
+/// package — not the bridged class — so the (name, container) probe cannot
+/// serve that walk and a container-blind one can. Over-approximation is
+/// still toward the decode.
+pub fn sym_name_row_exists(conn: &Connection, path: &str, name: &str) -> Option<bool> {
+    let file_id: i64 = conn
+        .prepare_cached("SELECT file_id FROM files WHERE path = ?1")
+        .ok()?
+        .query_row(params![path], |row| row.get(0))
+        .ok()?;
+    conn.prepare_cached(
+        "SELECT EXISTS(
+            SELECT 1 FROM syms y
+             WHERE y.file_id = ?1
+               AND (y.name_id = (SELECT str_id FROM strings WHERE s = ?2)
+                    OR y.key_id = (SELECT str_id FROM strings WHERE s = ?2)))",
+    )
+    .ok()?
+    .query_row(params![file_id, name], |row| row.get(0))
+    .ok()
+}
+
 /// How many FILES carry a ref row for one match key.
 ///
 /// Deliberately not called a reference count: rows are `(name_id, file_id)`

--- a/src/index/module_cache/rows.rs
+++ b/src/index/module_cache/rows.rs
@@ -484,6 +484,49 @@ pub fn sym_rows_matching(conn: &Connection, query: &str) -> Vec<SymRowHit> {
     out
 }
 
+/// Can the row store rule out a member named `name` attributed to container
+/// `container` in `path`'s file? Three-valued, and the caller's license to
+/// skip a decode hangs on the distinction:
+///
+/// - `None` — the file was never shredded (`files` presence is the single
+///   shredded marker), so the store cannot speak for it. Fail open.
+/// - `Some(true)` — a matching sym row exists; the decode is warranted.
+/// - `Some(false)` — the file is covered and no row matches: the only
+///   verdict that licenses skipping the rehydrate.
+///
+/// Deliberately kind-blind, and matching `name_id` OR `key_id`: the walk's
+/// member test also accepts class-content variables/fields, which rows cannot
+/// express — so ANY symbol row under `(name|key, container)` forces the
+/// decode. Over-approximation toward the decode is the sound direction: a
+/// wasted rehydrate, never a hidden member
+/// (`docs/prompt-relational-iteration.md`).
+pub fn sym_member_row_exists(
+    conn: &Connection,
+    path: &str,
+    name: &str,
+    container: &str,
+) -> Option<bool> {
+    let file_id: i64 = conn
+        .prepare_cached("SELECT file_id FROM files WHERE path = ?1")
+        .ok()?
+        .query_row(params![path], |row| row.get(0))
+        .ok()?;
+    // A name or container the strings table never interned yields NULL from
+    // the subselect, the comparison is false, and EXISTS answers 0 — which is
+    // correct: no row can reference a string that was never stored.
+    conn.prepare_cached(
+        "SELECT EXISTS(
+            SELECT 1 FROM syms y
+             WHERE y.file_id = ?1
+               AND y.container_id = (SELECT str_id FROM strings WHERE s = ?3)
+               AND (y.name_id = (SELECT str_id FROM strings WHERE s = ?2)
+                    OR y.key_id = (SELECT str_id FROM strings WHERE s = ?2)))",
+    )
+    .ok()?
+    .query_row(params![file_id, name, container], |row| row.get(0))
+    .ok()
+}
+
 /// How many FILES carry a ref row for one match key.
 ///
 /// Deliberately not called a reference count: rows are `(name_id, file_id)`

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -383,6 +383,48 @@ impl CrossFileLookup for ModuleIndex {
         self.rehydrate_rows_or_resident(cached)
     }
 
+    fn sweep_consult_answer(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+    ) -> Option<Arc<crate::model::witnesses::ReducedValue>> {
+        let guard = super::registration::sweep_answers_read()?;
+        let sa = guard.as_ref()?;
+        let stamp = self.core.shape_bumps.load(std::sync::atomic::Ordering::Relaxed);
+        if sa.stamp_load() != stamp {
+            // Lazy reset, same rule as SweepMemo: a shape change mid-sweep
+            // voids every remembered verdict.
+            sa.reset_to(stamp);
+            crate::util::ghost_stats::count("sweepans.invalidated");
+            return None;
+        }
+        let hit = sa.get(path, key);
+        crate::util::ghost_stats::count(if hit.is_some() {
+            "sweepans.hit"
+        } else {
+            "sweepans.miss"
+        });
+        hit
+    }
+
+    fn remember_sweep_consult(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+        value: &crate::model::witnesses::ReducedValue,
+    ) {
+        if let Some(guard) = super::registration::sweep_answers_read() {
+            if let Some(sa) = guard.as_ref() {
+                let stamp =
+                    self.core.shape_bumps.load(std::sync::atomic::Ordering::Relaxed);
+                if sa.stamp_load() == stamp {
+                    sa.insert(path, key, value);
+                    crate::util::ghost_stats::count("sweepans.store");
+                }
+            }
+        }
+    }
+
     fn candidate_may_declare(
         &self,
         cached: &Arc<CachedModule>,

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -152,6 +152,27 @@ impl ModuleIndex {
         // `Break` stops the walk BEFORE the next candidate's `symbols_present`
         // — the rehydrate is the cost, so a first-match caller that could not
         // stop the iteration paid a decode per bridging module for nothing.
+        visit: impl FnMut(
+            &str,
+            &Arc<CachedModule>,
+            &crate::model::file_analysis::Symbol,
+        ) -> std::ops::ControlFlow<()>,
+    ) {
+        self.bridged_walk(class_name, None, visit)
+    }
+
+    /// The one speller of the bridged-entity loop. `name_hint` is the
+    /// first-match-by-name callers' pre-filter license: a candidate whose
+    /// syms rows PROVE nothing named `name_hint` is skipped before its
+    /// `symbols_present` rehydrate — the per-miss decode of every bridging
+    /// module was the cost the early exit alone could not remove. Fail-open
+    /// everywhere the store cannot speak, container-BLIND (an entity's
+    /// container is the plugin's home package, not the bridged class), and
+    /// the visitor's semantics are unchanged for every candidate reached.
+    fn bridged_walk(
+        &self,
+        class_name: &str,
+        name_hint: Option<&str>,
         mut visit: impl FnMut(
             &str,
             &Arc<CachedModule>,
@@ -163,6 +184,12 @@ impl ModuleIndex {
             // Every candidate file of the name — the bridging namespace may
             // live in a losing candidate.
             for cached in CrossFileLookup::def_candidates(self, &mod_name) {
+            if let Some(name) = name_hint {
+                if !self.candidate_may_name(&cached, name) {
+                    crate::util::ghost_stats::count("bridged.candidate_prefiltered");
+                    continue;
+                }
+            }
             // Entities index into `symbols`, which may be evicted on the
             // resident copy — resolve them against the symbols-axis view
             // (same generation: the LRU is invalidated on every rewrite).
@@ -189,6 +216,33 @@ impl ModuleIndex {
             }
             }
         }
+    }
+
+    /// The name-only sibling of `candidate_may_declare`, for walks whose
+    /// member test is container-blind (bridged entities live under the
+    /// plugin's home package). Same guards, same skip license: only a
+    /// covered store's proven absence skips.
+    fn candidate_may_name(&self, cached: &Arc<CachedModule>, name: &str) -> bool {
+        if !cached.analysis.symbols_are_evicted() {
+            return true;
+        }
+        static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        if *DISABLED
+            .get_or_init(|| std::env::var_os("PERL_LSP_NO_MEMBER_PREFILTER").is_some())
+        {
+            return true;
+        }
+        let rows = self.with_rows_conn(|conn| {
+            crate::index::module_cache::sym_name_row_exists(
+                conn,
+                &cached.path.to_string_lossy(),
+                name,
+            )
+        });
+        member_prefilter_may_declare(
+            !cached.analysis.plugin.gated_emissions.is_empty(),
+            rows,
+        )
     }
 
     /// Block until `module_name` appears in the cache, or timeout.
@@ -597,6 +651,19 @@ impl CrossFileLookup for ModuleIndex {
         ) -> std::ops::ControlFlow<()>,
     ) {
         self.for_each_entity_bridged_to(class_name, f)
+    }
+
+    fn for_each_entity_bridged_to_named(
+        &self,
+        class_name: &str,
+        name: &str,
+        f: &mut dyn FnMut(
+            &str,
+            &Arc<CachedModule>,
+            &crate::model::file_analysis::Symbol,
+        ) -> std::ops::ControlFlow<()>,
+    ) {
+        self.bridged_walk(class_name, Some(name), f)
     }
 
     fn direct_children_of(&self, class: &str) -> Vec<(String, String)> {

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -407,6 +407,13 @@ impl CrossFileLookup for ModuleIndex {
         self.enriched_snapshot(cached)
             .unwrap_or_else(|| self.bag_present(cached))
     }
+
+    fn serves_enriched(&self) -> bool {
+        // The overlay is long-lived-only (the deep copies never pay for
+        // themselves in a one-shot process), so a not-long-lived index's
+        // `enriched_present` is `bag_present` — never distinct.
+        self.core.long_lived.load(std::sync::atomic::Ordering::Relaxed)
+    }
     fn class_is_bridged_to(&self, class: &str) -> bool {
         // Bucket NON-EMPTY, not key-present: `purge_module` can leave an empty
         // bucket behind, and a key-exists test would then report a bridge that

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -148,7 +148,15 @@ impl ModuleIndex {
         // — the authoritative handle for a follow-up `get_cached(mod_name)`.
         // Don't re-derive it from the analysis: the registration name and the
         // file's first `package` can differ.
-        mut visit: impl FnMut(&str, &Arc<CachedModule>, &crate::model::file_analysis::Symbol),
+        //
+        // `Break` stops the walk BEFORE the next candidate's `symbols_present`
+        // — the rehydrate is the cost, so a first-match caller that could not
+        // stop the iteration paid a decode per bridging module for nothing.
+        mut visit: impl FnMut(
+            &str,
+            &Arc<CachedModule>,
+            &crate::model::file_analysis::Symbol,
+        ) -> std::ops::ControlFlow<()>,
     ) {
         use crate::model::file_analysis::CrossFileLookup;
         for mod_name in self.modules_bridging_to(class_name) {
@@ -174,7 +182,9 @@ impl ModuleIndex {
                 for sym_id in &ns.entities {
                     let idx = sym_id.0 as usize;
                     let Some(sym) = whole.symbols().get(idx) else { continue };
-                    visit(&mod_name, &cached, sym);
+                    if visit(&mod_name, &cached, sym).is_break() {
+                        return;
+                    }
                 }
             }
             }
@@ -573,7 +583,11 @@ impl CrossFileLookup for ModuleIndex {
     fn for_each_entity_bridged_to(
         &self,
         class_name: &str,
-        f: &mut dyn FnMut(&str, &Arc<CachedModule>, &crate::model::file_analysis::Symbol),
+        f: &mut dyn FnMut(
+            &str,
+            &Arc<CachedModule>,
+            &crate::model::file_analysis::Symbol,
+        ) -> std::ops::ControlFlow<()>,
     ) {
         self.for_each_entity_bridged_to(class_name, f)
     }

--- a/src/index/module_index/lookup.rs
+++ b/src/index/module_index/lookup.rs
@@ -319,6 +319,41 @@ impl CrossFileLookup for ModuleIndex {
         self.rehydrate_rows_or_resident(cached)
     }
 
+    fn candidate_may_declare(
+        &self,
+        cached: &Arc<CachedModule>,
+        name: &str,
+        class: &str,
+    ) -> bool {
+        // Gate on eviction FIRST: a symbols-resident copy answers the member
+        // probe from RAM for free, and it may be fresher than its rows (the
+        // whole-copy registration paths precede persist). Stripped copies
+        // register only AFTER their chunk commits, so for them the rows are
+        // at least as fresh as the copy — the freshness argument the skip
+        // leans on.
+        if !cached.analysis.symbols_are_evicted() {
+            return true;
+        }
+        static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        if *DISABLED
+            .get_or_init(|| std::env::var_os("PERL_LSP_NO_MEMBER_PREFILTER").is_some())
+        {
+            return true;
+        }
+        let rows = self.with_rows_conn(|conn| {
+            crate::index::module_cache::sym_member_row_exists(
+                conn,
+                &cached.path.to_string_lossy(),
+                name,
+                class,
+            )
+        });
+        member_prefilter_may_declare(
+            !cached.analysis.plugin.gated_emissions.is_empty(),
+            rows,
+        )
+    }
+
     fn ref_candidate_paths(&self, keys: &[String]) -> Vec<std::path::PathBuf> {
         self.with_rows_conn(|conn| {
             crate::index::module_cache::ref_candidate_files(conn, keys)
@@ -603,5 +638,62 @@ impl CrossFileLookup for ModuleIndex {
         visible: &std::collections::HashSet<String>,
     ) -> Vec<(String, Arc<CachedModule>)> {
         self.visible_defs_with_prefix(prefix, visible)
+    }
+}
+
+/// The member pre-filter's verdict, separated from the store and the copy so
+/// the truth table is testable without either. `rows` is
+/// `sym_member_row_exists` behind `with_rows_conn`: outer `None` = no store,
+/// inner `None` = file never shredded.
+///
+/// The ONLY skip is (no post-shred emissions, store present, file covered,
+/// provably no matching row). Deferred plugin emissions materialize into the
+/// resident copy AFTER the shred (`materialize_gated_emissions`), so their
+/// symbols have no rows — a file carrying any must fail open or a DBIC result
+/// class's synthesized accessors silently stop resolving.
+pub(crate) fn member_prefilter_may_declare(
+    has_gated_emissions: bool,
+    rows: Option<Option<bool>>,
+) -> bool {
+    if has_gated_emissions {
+        return true;
+    }
+    !matches!(rows, Some(Some(false)))
+}
+
+#[cfg(test)]
+mod member_prefilter_tests {
+    use super::member_prefilter_may_declare;
+
+    /// Every unknown fails OPEN — to a decode, never away from one. The
+    /// same discipline as `restamp_owed`: the skip needs positive evidence,
+    /// and a wrong skip is a silently missing method, not an error.
+    #[test]
+    fn only_proven_absence_skips() {
+        assert!(
+            member_prefilter_may_declare(false, None),
+            "no row store: the filter cannot speak, decode"
+        );
+        assert!(
+            member_prefilter_may_declare(false, Some(None)),
+            "file never shredded: the store does not cover it, decode"
+        );
+        assert!(
+            member_prefilter_may_declare(false, Some(Some(true))),
+            "a matching row: the decode is warranted"
+        );
+        assert!(
+            !member_prefilter_may_declare(false, Some(Some(false))),
+            "covered and provably absent: the one skip"
+        );
+    }
+
+    /// Post-shred plugin emissions beat everything: their symbols exist only
+    /// on the materialized resident copy, so the rows' "provably absent" is
+    /// a lie for exactly these files.
+    #[test]
+    fn gated_emissions_fail_open_over_a_provably_absent_row() {
+        assert!(member_prefilter_may_declare(true, Some(Some(false))));
+        assert!(member_prefilter_may_declare(true, None));
     }
 }

--- a/src/index/module_index/mod.rs
+++ b/src/index/module_index/mod.rs
@@ -269,7 +269,7 @@ pub struct ModuleIndex {
     /// file, and an fd pinning the dead inode would serve frozen rows
     /// forever — an inode change (or missing file) drops the conn so the
     /// next query reopens the recreated DB.
-    ref_rows_conn: std::sync::Mutex<Option<(rusqlite::Connection, u64)>>,
+    ref_rows_conn: crate::index::module_cache::RetainedReader,
 }
 
 /// The store `ModuleIndex::lookup_for` routed a language to. Owning enum:

--- a/src/index/module_index/mod.rs
+++ b/src/index/module_index/mod.rs
@@ -162,7 +162,7 @@ mod lookup;
 mod queries;
 mod registration;
 use registration::EnrichedEntry;
-pub use registration::SweepMemoGuard;
+pub use registration::{SweepAnswerGuard, SweepMemoGuard};
 
 /// Every file that provides one module name, in provider order. `[0]` is
 /// the winner — what `require` would load for an `@INC` set, the derived

--- a/src/index/module_index/mod.rs
+++ b/src/index/module_index/mod.rs
@@ -162,7 +162,7 @@ mod lookup;
 mod queries;
 mod registration;
 use registration::EnrichedEntry;
-pub use registration::{SweepAnswerGuard, SweepMemoGuard};
+pub use registration::{SweepAnswerGuard, SweepMemoGuard, SweepProviderGuard};
 
 /// Every file that provides one module name, in provider order. `[0]` is
 /// the winner — what `require` would load for an `@INC` set, the derived

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -887,7 +887,11 @@ fn enriched_present_default_is_the_raw_bag() {
         fn for_each_entity_bridged_to(
             &self,
             _c: &str,
-            _f: &mut dyn FnMut(&str, &Arc<CachedModule>, &crate::model::file_analysis::Symbol),
+            _f: &mut dyn FnMut(
+                &str,
+                &Arc<CachedModule>,
+                &crate::model::file_analysis::Symbol,
+            ) -> std::ops::ControlFlow<()>,
         ) {
         }
         fn direct_children_of(&self, _p: &str) -> Vec<(String, String)> {

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2656,3 +2656,41 @@ fn serves_enriched_follows_the_long_lived_mark() {
         "long-lived: the overlay is live and the seams' retries are worth paying"
     );
 }
+
+/// Rung 8 of `docs/prompt-relational-iteration.md` (overlay key honesty):
+/// the BRIDGE relation rides the enrichment key. The stamp freezes a
+/// bridging module's identity into the overlay's `MethodTarget`s, and a
+/// bridging module is not a candidate of any of the consumer's dep names —
+/// only the relation hash sees it. Without it, registering (or editing) a
+/// plugin that bridges into the consumer's own class leaves the consumer's
+/// overlay validating stale.
+#[test]
+fn a_new_bridge_to_the_consumers_class_moves_the_enrichment_key() {
+    let idx = ModuleIndex::new_for_test();
+    let consumer = parse_source_to_cached(
+        "package App::Ctl;\nsub go { my $self = shift; return $self->helper_x() }\n1;\n",
+        "App::Ctl",
+    );
+    idx.register_workspace_module(consumer.path.to_path_buf(), Arc::clone(&consumer.analysis));
+    let snap1 = idx.enriched_snapshot(&consumer).expect("snapshot v1");
+    let snap1b = idx.enriched_snapshot(&consumer).expect("snapshot v1 cached");
+    assert!(Arc::ptr_eq(&snap1, &snap1b), "key stable before the bridge lands");
+
+    // A plugin file bridges an entity into the consumer's OWN class — a
+    // read enrichment makes through the bridged arm, invisible to the
+    // dep-name closure.
+    cache_bridged(
+        &idx,
+        "My::Plugin",
+        "package My::Plugin;\nsub helper_x { return bless {}, 'W' }\n1;\n",
+        "helper_x",
+        "App::Ctl",
+    );
+
+    let snap2 = idx.enriched_snapshot(&consumer).expect("snapshot v2");
+    assert!(
+        !Arc::ptr_eq(&snap1, &snap2),
+        "a new bridge into the consumer's class must move its enrichment key — \
+         the overlay froze bridged resolution state the dep-name walk cannot see"
+    );
+}

--- a/src/index/module_index/module_index_tests.rs
+++ b/src/index/module_index/module_index_tests.rs
@@ -2635,3 +2635,24 @@ fn the_overlay_never_serves_a_partial_copy_to_a_fuller_request() {
          makes the two verbs evict each other on every alternation"
     );
 }
+
+/// The witness seams' retry gate: a one-shot process's `enriched_present` is
+/// `bag_present` — never a distinct view — so `serves_enriched` must say no,
+/// or every R4 escalation pays a fetch to learn nothing (measured: 706k
+/// no-op fetches, 5.3% of a cold `--check` wall on a script-heavy corpus).
+/// Marking long-lived (the server, or `PERL_LSP_LONG_LIVED=1` — the A/B
+/// control) turns the retries back on.
+#[test]
+fn serves_enriched_follows_the_long_lived_mark() {
+    use crate::model::file_analysis::CrossFileLookup;
+    let idx = ModuleIndex::new_for_cli();
+    assert!(
+        !idx.serves_enriched(),
+        "one-shot: the overlay is off, so a retry can never see a distinct view"
+    );
+    idx.mark_long_lived();
+    assert!(
+        idx.serves_enriched(),
+        "long-lived: the overlay is live and the seams' retries are worth paying"
+    );
+}

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -68,6 +68,11 @@ impl ModuleIndex {
         // rehydrate through this, same as the pack sub-indexes. Fixed
         // 128 MiB cap (Perl analyses are 10-100x smaller than cpp ones).
         let ckey = key.clone();
+        // Retained across rehydrates — a per-call open was the same disease
+        // the conclusion loader had (`RetainedReader`); the LRU's whole job
+        // is to make misses rare, and each miss was paying a fresh open on
+        // top of its decode.
+        let bag_retained = Arc::new(crate::index::module_cache::RetainedReader::new());
         let loader = move |path: &std::path::Path, want_bag: bool| {
             // Raw walk path first (preserves the pre-diag behavior), canonical
             // as a fallback spelling; the discriminated helper survives the
@@ -83,7 +88,8 @@ impl ModuleIndex {
                     spellings.push(c);
                 }
             }
-            crate::index::module_cache::open_and_load_diag(
+            crate::index::module_cache::open_and_load_diag_retained(
+                &bag_retained,
                 key.as_deref(),
                 "perl",
                 &spellings,

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -22,7 +22,7 @@ impl ModuleIndex {
             enrichment_key_memo: Arc::new(DashMap::new()),
             foreign_bag_cache: std::sync::RwLock::new(None),
             ref_rows_opener: std::sync::RwLock::new(None),
-            ref_rows_conn: std::sync::Mutex::new(None),
+            ref_rows_conn: crate::index::module_cache::RetainedReader::new(),
             workspace_modules: Arc::new(DashMap::new()),
         }
     }
@@ -112,17 +112,30 @@ impl ModuleIndex {
             .and_then(|v| v.parse::<usize>().ok())
             .map(|mb| mb * 1024 * 1024)
             .unwrap_or(16 * 1024 * 1024);
+        // One retained connection for the whole cache's lifetime, not an
+        // open per miss: the consult path misses once per unique path, and
+        // a fresh open (WAL handshake + the CANTOPEN retry ladder) measured
+        // 5.1 ms against the ~µs SELECT it serves — 360 s of a cold
+        // `--check` at 70k paths. `RetainedReader` reopens on inode change,
+        // so `--clear-cache` mid-session is still picked up.
+        let retained = Arc::new(crate::index::module_cache::RetainedReader::new());
         self.set_conclusion_cache(Arc::new(
             crate::index::conclusion_cache::ConclusionCache::new(concl_cap, move |path| {
                 let dir = crate::index::module_cache::cache_dir_for_workspace(ckey.as_deref())?;
                 let db = crate::index::module_cache::db_path_for(&dir, "perl");
-                let conn = crate::index::module_cache::open_reader_retrying(&db).ok()?;
-                let at = crate::index::module_cache::current_generation(&conn);
-                crate::index::module_cache::load_conclusions_stamped(
-                    &conn,
-                    &path.to_string_lossy(),
-                    at,
-                )
+                retained
+                    .with(
+                        || crate::index::module_cache::open_reader_retrying(&db).ok(),
+                        |conn| {
+                            let at = crate::index::module_cache::current_generation(conn);
+                            crate::index::module_cache::load_conclusions_stamped(
+                                conn,
+                                &path.to_string_lossy(),
+                                at,
+                            )
+                        },
+                    )
+                    .flatten()
             }),
         ));
     }

--- a/src/index/module_index/queries.rs
+++ b/src/index/module_index/queries.rs
@@ -433,6 +433,16 @@ impl ModuleIndex {
                 // may be a losing candidate of its own name slot. Symbols-axis
                 // existence scan — no bag/refs read.
                 self.def_candidates(mod_name).iter().any(|c| {
+                    // Rows-backed pre-filter, the same probe as the MRO
+                    // walk's (`docs/prompt-relational-iteration.md` ladder 2):
+                    // `has_sub_in_package` tests exactly the (name, package)
+                    // attribution the syms rows carry, and this runs on the
+                    // walk's MISSES, where every candidate scan is wasted.
+                    // Fail-open everywhere the store cannot speak.
+                    if !self.candidate_may_declare(c, name, class) {
+                        crate::util::ghost_stats::count("mdmp.candidate_prefiltered");
+                        return false;
+                    }
                     crate::util::ghost_stats::count("mdmp.candidate_fetched");
                     crate::util::ghost_stats::count(if crate::util::ghost_stats::mroc_saw(&c.path) {
                         "mdmp.candidate_seen_by_mroc"

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -976,9 +976,7 @@ impl ModuleIndex {
             *g = Some(opener);
         }
         // The retained conn belongs to the previous opener's DB.
-        if let Ok(mut c) = self.ref_rows_conn.lock() {
-            *c = None;
-        }
+        self.ref_rows_conn.reset();
     }
 
     /// Drop `path`'s rehydrated analysis from this index's LRU (a
@@ -1239,41 +1237,7 @@ impl ModuleIndex {
     /// connection per index so the statement cache amortizes across queries.
     pub(super) fn with_rows_conn<R>(&self, f: impl FnOnce(&rusqlite::Connection) -> R) -> Option<R> {
         let opener = self.ref_rows_opener.read().ok().and_then(|g| g.clone())?;
-        fn db_ino(conn: &rusqlite::Connection) -> u64 {
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::MetadataExt;
-                return conn
-                    .path()
-                    .and_then(|p| std::fs::metadata(p).ok())
-                    .map(|m| m.ino())
-                    .unwrap_or(0);
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = conn;
-                0
-            }
-        }
-        // Poison-proof: the Option is a pure cache — a panic in some earlier
-        // holder must not permanently disable retrieval.
-        let mut guard = self
-            .ref_rows_conn
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some((conn, ino)) = guard.as_ref() {
-            if db_ino(conn) != *ino {
-                *guard = None; // file unlinked/recreated — reopen below
-            }
-        }
-        if guard.is_none() {
-            *guard = opener().map(|c| {
-                let ino = db_ino(&c);
-                (c, ino)
-            });
-        }
-        let (conn, _) = guard.as_ref()?;
-        Some(f(conn))
+        self.ref_rows_conn.with(|| opener(), f)
     }
 
     /// Rows-backed workspace/symbol scan over THIS index's store — the

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -26,33 +26,11 @@ thread_local! {
 #[derive(Default)]
 struct SweepMemo {
     stamp: u64,
-    map: std::collections::HashMap<std::path::PathBuf, (Arc<FileAnalysis>, u64)>,
-    /// Insertion order, for drop-oldest when the byte cap bites.
-    order: std::collections::VecDeque<std::path::PathBuf>,
+    map: std::collections::HashMap<std::path::PathBuf, Arc<FileAnalysis>>,
     /// Bytes this file's memo holds (estimates) — the crest attribution:
     /// per-worker in-flight working sets are bounded by the largest single
     /// file's memo, and `sweep.memo_peak_file_bytes` reports the max seen.
     bytes: u64,
-}
-
-/// Per-file sweep-memo byte cap. Measured before it was set: one FHEM
-/// file's memo reached 633 MB, and the sweep's RSS crest is workers × the
-/// giant files' in-flight sets (peak fell 67% when worker count did — the
-/// per-file quantity was invariant). A byte cap bounds the crest for ANY
-/// worker count without touching parallelism — the corpus-neutral shape: a
-/// flat worker cap tuned on FHEM (memory-bound there, 4.9% wall for -67%
-/// RSS) could cost real wall on a CPU-bound corpus. Drop-OLDEST, so a
-/// giant file's hot providers (touched throughout its sweep) survive.
-/// `PERL_LSP_SWEEP_MEMO_MB` overrides; 0 = unbounded.
-fn sweep_memo_cap_bytes() -> u64 {
-    static CAP: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *CAP.get_or_init(|| {
-        std::env::var("PERL_LSP_SWEEP_MEMO_MB")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .map(|mb| if mb == 0 { u64::MAX } else { mb * 1024 * 1024 })
-            .unwrap_or(256 * 1024 * 1024)
-    })
 }
 
 /// High-water of any single file's sweep-memo footprint, across the run.
@@ -1303,13 +1281,11 @@ impl ModuleIndex {
                 let memo = slot.as_mut()?;
                 if memo.stamp != stamp {
                     memo.map.clear();
-                    memo.order.clear();
-                    memo.bytes = 0;
                     memo.stamp = stamp;
                     crate::util::ghost_stats::count("sweep.memo_invalidated");
                     return None;
                 }
-                memo.map.get(&cached.path).map(|(a, _)| Arc::clone(a))
+                memo.map.get(&cached.path).cloned()
             });
             if let Some(hit) = memoed {
                 crate::util::ghost_stats::count("sweep.memo_hit");
@@ -1355,21 +1331,7 @@ impl ModuleIndex {
                                         memo.bytes - prev,
                                     );
                                 }
-                                if memo
-                                    .map
-                                    .insert(cached.path.clone(), (Arc::clone(&full), est))
-                                    .is_none()
-                                {
-                                    memo.order.push_back(cached.path.clone());
-                                }
-                                let cap = sweep_memo_cap_bytes();
-                                while memo.bytes > cap {
-                                    let Some(victim) = memo.order.pop_front() else { break };
-                                    if let Some((_, vbytes)) = memo.map.remove(&victim) {
-                                        memo.bytes = memo.bytes.saturating_sub(vbytes);
-                                        crate::util::ghost_stats::count("sweep.memo_evicted");
-                                    }
-                                }
+                                memo.map.insert(cached.path.clone(), Arc::clone(&full));
                             }
                         }
                     });

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -662,7 +662,9 @@ impl ModuleIndex {
                 return m.1;
             }
         }
-        let key = self.enrichment_key(cached);
+        let key = crate::util::ghost_stats::timed("enrichment_key.compute", || {
+            self.enrichment_key(cached)
+        });
         if self.enrichment_epoch() == epoch {
             // One overwritten-in-place entry per consulted path: bounded by
             // the number of registered files (~100 bytes each), never a

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -29,6 +29,95 @@ struct SweepMemo {
     map: std::collections::HashMap<std::path::PathBuf, Arc<FileAnalysis>>,
 }
 
+/// The SWEEP-WIDE consult-verdict store: (candidate path, point-free query)
+/// → that candidate's whole contribution, shared across files AND rayon
+/// workers for the lifetime of one batch sweep. The per-file `SweepMemo`
+/// below makes a FETCH cheap; this makes the CHASE run once per (query,
+/// candidate) per sweep instead of once per consuming file — first-encounter
+/// pairs per build are the n² a package-main corpus produces (FHEM: 12.3M
+/// attempts ≈ keys × providers × files). Stamp-guarded like `SweepMemo`:
+/// any shape bump clears it, so a mid-sweep registration cannot serve a
+/// verdict from a previous world.
+pub(super) struct SweepAnswers {
+    stamp: std::sync::atomic::AtomicU64,
+    map: DashMap<
+        (std::path::PathBuf, crate::model::witnesses::ConsultVerdictKey),
+        Arc<crate::model::witnesses::ReducedValue>,
+    >,
+}
+
+static SWEEP_ANSWERS: std::sync::RwLock<Option<SweepAnswers>> = std::sync::RwLock::new(None);
+
+impl SweepAnswers {
+    pub(super) fn stamp_load(&self) -> u64 {
+        self.stamp.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    /// Void every verdict and adopt the new shape stamp. Runs under the
+    /// READ lock deliberately — `DashMap::clear` is concurrent-safe, and a
+    /// racing reader that sees a half-cleared map only misses, never serves
+    /// a stale verdict (the stamp is re-checked per access).
+    pub(super) fn reset_to(&self, stamp: u64) {
+        self.map.clear();
+        self.stamp.store(stamp, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub(super) fn get(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+    ) -> Option<Arc<crate::model::witnesses::ReducedValue>> {
+        self.map
+            .get(&(path.to_path_buf(), key.clone()))
+            .map(|e| Arc::clone(e.value()))
+    }
+    pub(super) fn insert(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+        value: &crate::model::witnesses::ReducedValue,
+    ) {
+        self.map
+            .insert((path.to_path_buf(), key.clone()), Arc::new(value.clone()));
+    }
+}
+
+/// The open sweep store, if any — `lookup.rs`'s access seam.
+pub(super) fn sweep_answers_read(
+) -> Option<std::sync::RwLockReadGuard<'static, Option<SweepAnswers>>> {
+    SWEEP_ANSWERS.read().ok()
+}
+
+/// Opens the sweep-wide verdict store; closes (and drops it) on drop.
+/// `PERL_LSP_NO_SWEEP_ANSWERS=1` leaves it closed — the A/B control.
+pub struct SweepAnswerGuard(());
+
+impl SweepAnswerGuard {
+    pub fn open() -> Self {
+        static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let off = *OFF.get_or_init(|| {
+            std::env::var("PERL_LSP_NO_SWEEP_ANSWERS").as_deref() == Ok("1")
+        });
+        if !off {
+            if let Ok(mut slot) = SWEEP_ANSWERS.write() {
+                *slot = Some(SweepAnswers {
+                    // Sentinel: the first access stamps the real shape and
+                    // clears, so an open never inherits a stale world.
+                    stamp: std::sync::atomic::AtomicU64::new(u64::MAX),
+                    map: DashMap::new(),
+                });
+            }
+        }
+        SweepAnswerGuard(())
+    }
+}
+
+impl Drop for SweepAnswerGuard {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = SWEEP_ANSWERS.write() {
+            *slot = None;
+        }
+    }
+}
+
 /// Opens a rehydration memo for one file's sweep; closes it on drop.
 pub struct SweepMemoGuard(());
 
@@ -548,7 +637,18 @@ impl ModuleIndex {
         // them back — an enriched copy of a DEGRADED analysis claimed to be
         // whole. Clone carries them.
         let mut copy: FileAnalysis = (*whole).clone();
-        copy.enrich_imported_types_with_keys_for(Some(self), Some(&cached.path));
+        // A session around the build, same as `enrich_open`'s: the overlay's
+        // enrichment is where the cross-file consult cascade lives (FHEM
+        // measured 12.3M SlotType attempts inside these builds, every one
+        // `session.absent`), and without a session the candidate-answer memo
+        // is inert on exactly the path that repeats. A caller already holding
+        // a session (server verbs) nests — this owns only when outermost.
+        {
+            let _session = crate::model::witnesses::ResolutionSession::enter(Some(
+                self as &dyn crate::model::file_analysis::CrossFileLookup,
+            ));
+            copy.enrich_imported_types_with_keys_for(Some(self), Some(&cached.path));
+        }
         let arc = Arc::new(copy);
         // Cycle-tainted: some dep declined mid-enrich (mutual imports), so
         // this copy baked a RAW view of that dep. Caching it would serve

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -26,7 +26,9 @@ thread_local! {
 #[derive(Default)]
 struct SweepMemo {
     stamp: u64,
-    map: std::collections::HashMap<std::path::PathBuf, Arc<FileAnalysis>>,
+    /// Keyed by (path, want_bag) — same axis-mixing hazard as the shared
+    /// provider cache's key comment.
+    map: std::collections::HashMap<(std::path::PathBuf, bool), Arc<FileAnalysis>>,
     /// Bytes this file's memo holds (estimates) — the crest attribution:
     /// per-worker in-flight working sets are bounded by the largest single
     /// file's memo, and `sweep.memo_peak_file_bytes` reports the max seen.
@@ -91,6 +93,116 @@ impl SweepAnswers {
 pub(super) fn sweep_answers_read(
 ) -> Option<std::sync::RwLockReadGuard<'static, Option<SweepAnswers>>> {
     SWEEP_ANSWERS.read().ok()
+}
+
+/// The sweep-wide shared PROVIDER cache: decoded provider analyses, shared
+/// across files and rayon workers for one batch sweep. The per-file
+/// `SweepMemo` shields one file's sweep from LRU thrash but holds providers
+/// PER WORKER — measured: 13,456 rehydrates for ~500 distinct providers in
+/// one n=250 sweep (~27x redundant decoding), held in up to 20 OVERLAPPING
+/// per-file maps that are the majority component of the sweep's per-worker
+/// in-flight set. One shared, byte-budgeted, stamp-guarded map decodes each
+/// provider once per sweep and keeps it resident once. When open it
+/// REPLACES the per-file memo's role entirely (same shield, deduplicated);
+/// eviction over budget is unspecified-order, the conclusion cache's
+/// precedent — near-uniform entries under a near-uniform access pattern.
+pub(super) struct SweepProviders {
+    stamp: std::sync::atomic::AtomicU64,
+    /// Keyed by (path, want_bag): the two rehydrate lanes return DIFFERENT
+    /// axis sets (rows lane = refs+symbols sans bag; bag lane = bag view),
+    /// and a path-only key serves a bag-less copy to a bag-wanting consumer
+    /// — the invocant type silently vanishes and diagnostics' false
+    /// positives disappear for the WRONG reason (gold's diag-09 note
+    /// describes exactly this; its XPASS is how the path-only first draft
+    /// of this cache was caught).
+    map: DashMap<(std::path::PathBuf, bool), (Arc<FileAnalysis>, u64)>,
+    bytes: std::sync::atomic::AtomicU64,
+    budget: u64,
+}
+
+static SWEEP_PROVIDERS: std::sync::RwLock<Option<SweepProviders>> =
+    std::sync::RwLock::new(None);
+
+/// Opens the shared provider cache for one batch sweep; drops it on drop.
+/// `PERL_LSP_SWEEP_PROVIDER_CACHE_MB` sizes it (default 1024; 0 disables,
+/// which leaves the per-file memo path in sole effect — the A/B control).
+pub struct SweepProviderGuard(());
+
+impl SweepProviderGuard {
+    pub fn open() -> Self {
+        let mb = std::env::var("PERL_LSP_SWEEP_PROVIDER_CACHE_MB")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(1024);
+        if mb != 0 {
+            if let Ok(mut slot) = SWEEP_PROVIDERS.write() {
+                *slot = Some(SweepProviders {
+                    stamp: std::sync::atomic::AtomicU64::new(u64::MAX),
+                    map: DashMap::new(),
+                    bytes: std::sync::atomic::AtomicU64::new(0),
+                    budget: mb * 1024 * 1024,
+                });
+            }
+        }
+        SweepProviderGuard(())
+    }
+}
+
+impl Drop for SweepProviderGuard {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = SWEEP_PROVIDERS.write() {
+            *slot = None;
+        }
+    }
+}
+
+impl SweepProviders {
+    fn validate(&self, stamp: u64) -> bool {
+        if self.stamp.load(std::sync::atomic::Ordering::Relaxed) != stamp {
+            // Lazy reset under the read lock — DashMap::clear is concurrent-
+            // safe, and a racing reader only misses, never serves stale.
+            self.map.clear();
+            self.bytes.store(0, std::sync::atomic::Ordering::Relaxed);
+            self.stamp.store(stamp, std::sync::atomic::Ordering::Relaxed);
+            crate::util::ghost_stats::count("sweepprov.invalidated");
+            return false;
+        }
+        true
+    }
+
+    fn get(&self, path: &std::path::Path, want_bag: bool) -> Option<Arc<FileAnalysis>> {
+        self.map
+            .get(&(path.to_path_buf(), want_bag))
+            .map(|e| Arc::clone(&e.value().0))
+    }
+
+    fn insert(&self, path: &std::path::Path, want_bag: bool, fa: &Arc<FileAnalysis>) {
+        let est = fa.heap_estimate().total() as u64;
+        if self
+            .map
+            .insert((path.to_path_buf(), want_bag), (Arc::clone(fa), est))
+            .is_none()
+        {
+            self.bytes.fetch_add(est, std::sync::atomic::Ordering::Relaxed);
+        }
+        while self.bytes.load(std::sync::atomic::Ordering::Relaxed) > self.budget {
+            let victim = self
+                .map
+                .iter()
+                .map(|e| e.key().clone())
+                .find(|(p, wb)| !(p == path && *wb == want_bag));
+            let Some(victim) = victim else { break };
+            if let Some((_, (_, vbytes))) = self.map.remove(&victim) {
+                self.bytes.fetch_sub(
+                    vbytes.min(self.bytes.load(std::sync::atomic::Ordering::Relaxed)),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                crate::util::ghost_stats::count("sweepprov.evicted");
+            } else {
+                break;
+            }
+        }
+    }
 }
 
 /// Opens the sweep-wide verdict store; closes (and drops it) on drop.
@@ -1276,6 +1388,26 @@ impl ModuleIndex {
                 .core
                 .shape_bumps
                 .load(std::sync::atomic::Ordering::Relaxed);
+            // The SHARED provider cache first, when a batch sweep opened it —
+            // it subsumes the per-file memo (one decode per provider per
+            // SWEEP, resident once, instead of once per consuming file's
+            // worker-held map).
+            let shared_active = {
+                let guard = SWEEP_PROVIDERS.read().ok();
+                match guard.as_ref().and_then(|g| g.as_ref()) {
+                    Some(sp) => {
+                        if sp.validate(stamp) {
+                            if let Some(hit) = sp.get(&cached.path, want_bag) {
+                                crate::util::ghost_stats::count("sweepprov.hit");
+                                return hit;
+                            }
+                            crate::util::ghost_stats::count("sweepprov.miss");
+                        }
+                        true
+                    }
+                    None => false,
+                }
+            };
             let memoed = SWEEP_MEMO.with(|c| {
                 let mut slot = c.borrow_mut();
                 let memo = slot.as_mut()?;
@@ -1285,7 +1417,7 @@ impl ModuleIndex {
                     crate::util::ghost_stats::count("sweep.memo_invalidated");
                     return None;
                 }
-                memo.map.get(&cached.path).cloned()
+                memo.map.get(&(cached.path.clone(), want_bag)).cloned()
             });
             if let Some(hit) = memoed {
                 crate::util::ghost_stats::count("sweep.memo_hit");
@@ -1304,6 +1436,19 @@ impl ModuleIndex {
             });
             match got {
                 Ok(full) => {
+                    if shared_active {
+                        // The shared cache subsumes the per-file memo (and
+                        // its byte accounting — sweepprov's own counters
+                        // carry the attribution when it is open).
+                        if let Ok(guard) = SWEEP_PROVIDERS.read() {
+                            if let Some(sp) = guard.as_ref() {
+                                if sp.validate(stamp) {
+                                    sp.insert(&cached.path, want_bag, &full);
+                                }
+                            }
+                        }
+                        return full;
+                    }
                     SWEEP_MEMO.with(|c| {
                         if let Some(memo) = c.borrow_mut().as_mut() {
                             if memo.stamp == stamp {
@@ -1331,7 +1476,8 @@ impl ModuleIndex {
                                         memo.bytes - prev,
                                     );
                                 }
-                                memo.map.insert(cached.path.clone(), Arc::clone(&full));
+                                memo.map
+                                    .insert((cached.path.clone(), want_bag), Arc::clone(&full));
                             }
                         }
                     });

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -672,12 +672,59 @@ impl ModuleIndex {
         key
     }
 
+    /// One walked name's share of the BRIDGE and PROVIDER relations, onto
+    /// the key. Enrichment reads both outside the dep-name closure — the
+    /// stamp's bridged arm freezes a bridging module's identity into the
+    /// overlay's `MethodTarget`s, and the typeglob last resort consults the
+    /// provider bucket — but their MEMBERS are not candidates of any walked
+    /// name, so membership and (for bridges, whose content is frozen) each
+    /// member's candidates' registration generations must ride the key or a
+    /// plugin edit leaves every consumer's overlay validating stale.
+    fn hash_relations_for(&self, name: &str, h: &mut impl std::hash::Hasher) {
+        use std::hash::Hash;
+        let mut bridge_members = self.modules_bridging_to(name);
+        bridge_members.sort_unstable();
+        for m in &bridge_members {
+            m.hash(h);
+            for cm in crate::model::file_analysis::CrossFileLookup::def_candidates(self, m) {
+                self.registration_gen_of(&cm.path).hash(h);
+            }
+        }
+        // Providers: membership only. The bucket's members are the files
+        // declaring content FOR the name, and the typeglob consult re-reads
+        // them per query — the overlay freezes only which module answered,
+        // which membership covers.
+        let mut providers = self.modules_providing_package(name);
+        providers.sort_unstable();
+        for m in &providers {
+            m.hash(h);
+        }
+    }
+
     fn enrichment_key(&self, cached: &Arc<CachedModule>) -> u64 {
         crate::util::ghost_stats::count("enrichment_key");
         use std::hash::{Hash, Hasher};
         let mut h = std::collections::hash_map::DefaultHasher::new();
         self.registration_gen_of(&cached.path).hash(&mut h);
         self.freshness.fingerprint_of(&cached.path).unwrap_or(0).hash(&mut h);
+        // The file's OWN packages are bridge targets too (helpers bridged to
+        // a controller's class) and are not in its dep-name closure. Read
+        // the REGISTRATION names (path-keyed, survives symbol eviction; a
+        // bare `package Foo;` mints no PackageFacts entry, so the facts
+        // table under-enumerates), falling back to the Package/Class
+        // symbols for unregistered copies.
+        let mut own: Vec<String> = match self.registered_names.get(&cached.path) {
+            Some(names) => names.iter().map(|(n, _)| n.clone()).collect(),
+            None => crate::index::module_index::package_names(&cached.analysis)
+                .into_iter()
+                .map(|(n, _)| n)
+                .collect(),
+        };
+        own.sort_unstable();
+        own.dedup();
+        for pkg in &own {
+            self.hash_relations_for(pkg, &mut h);
+        }
         let mut seen: std::collections::HashSet<String> = Default::default();
         let mut frontier: Vec<String> = self.freshness.deps_of_names(&cached.path);
         frontier.sort_unstable();
@@ -694,6 +741,7 @@ impl ModuleIndex {
                     continue;
                 }
                 dep.hash(&mut h);
+                self.hash_relations_for(&dep, &mut h);
                 // EVERY candidate file of the dep rides the key — a losing
                 // file's re-registration must move consumers' keys too
                 // (over-invalidation, never staleness).

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -636,6 +636,12 @@ impl ModuleIndex {
         // silently reset them to false and `after_deserialize` never put
         // them back — an enriched copy of a DEGRADED analysis claimed to be
         // whole. Clone carries them.
+        // Byte accounting for the RSS attribution (the clone + its source are
+        // both live per worker for the build's duration): what one build holds.
+        crate::util::ghost_stats::add_n(
+            "overlay.clone_bytes",
+            whole.heap_estimate().total() as u64,
+        );
         let mut copy: FileAnalysis = (*whole).clone();
         // A session around the build, same as `enrich_open`'s: the overlay's
         // enrichment is where the cross-file consult cascade lives (FHEM
@@ -1294,6 +1300,17 @@ impl ModuleIndex {
                     SWEEP_MEMO.with(|c| {
                         if let Some(memo) = c.borrow_mut().as_mut() {
                             if memo.stamp == stamp {
+                                // Byte accounting for the RSS attribution: the
+                                // memo holds WHOLE decoded analyses for one
+                                // file's entire sweep, per worker — on a
+                                // wide-provider corpus that lifetime is the
+                                // suspect holder. `bytes_inserted` bounds what
+                                // a sweep cycles through; entries × giant
+                                // sizes is what a peak reader compares RSS to.
+                                crate::util::ghost_stats::add_n(
+                                    "sweep.memo_bytes_inserted",
+                                    full.heap_estimate().total() as u64,
+                                );
                                 memo.map.insert(cached.path.clone(), Arc::clone(&full));
                             }
                         }

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -26,11 +26,33 @@ thread_local! {
 #[derive(Default)]
 struct SweepMemo {
     stamp: u64,
-    map: std::collections::HashMap<std::path::PathBuf, Arc<FileAnalysis>>,
+    map: std::collections::HashMap<std::path::PathBuf, (Arc<FileAnalysis>, u64)>,
+    /// Insertion order, for drop-oldest when the byte cap bites.
+    order: std::collections::VecDeque<std::path::PathBuf>,
     /// Bytes this file's memo holds (estimates) — the crest attribution:
     /// per-worker in-flight working sets are bounded by the largest single
     /// file's memo, and `sweep.memo_peak_file_bytes` reports the max seen.
     bytes: u64,
+}
+
+/// Per-file sweep-memo byte cap. Measured before it was set: one FHEM
+/// file's memo reached 633 MB, and the sweep's RSS crest is workers × the
+/// giant files' in-flight sets (peak fell 67% when worker count did — the
+/// per-file quantity was invariant). A byte cap bounds the crest for ANY
+/// worker count without touching parallelism — the corpus-neutral shape: a
+/// flat worker cap tuned on FHEM (memory-bound there, 4.9% wall for -67%
+/// RSS) could cost real wall on a CPU-bound corpus. Drop-OLDEST, so a
+/// giant file's hot providers (touched throughout its sweep) survive.
+/// `PERL_LSP_SWEEP_MEMO_MB` overrides; 0 = unbounded.
+fn sweep_memo_cap_bytes() -> u64 {
+    static CAP: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *CAP.get_or_init(|| {
+        std::env::var("PERL_LSP_SWEEP_MEMO_MB")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(|mb| if mb == 0 { u64::MAX } else { mb * 1024 * 1024 })
+            .unwrap_or(256 * 1024 * 1024)
+    })
 }
 
 /// High-water of any single file's sweep-memo footprint, across the run.
@@ -1281,11 +1303,13 @@ impl ModuleIndex {
                 let memo = slot.as_mut()?;
                 if memo.stamp != stamp {
                     memo.map.clear();
+                    memo.order.clear();
+                    memo.bytes = 0;
                     memo.stamp = stamp;
                     crate::util::ghost_stats::count("sweep.memo_invalidated");
                     return None;
                 }
-                memo.map.get(&cached.path).cloned()
+                memo.map.get(&cached.path).map(|(a, _)| Arc::clone(a))
             });
             if let Some(hit) = memoed {
                 crate::util::ghost_stats::count("sweep.memo_hit");
@@ -1331,7 +1355,21 @@ impl ModuleIndex {
                                         memo.bytes - prev,
                                     );
                                 }
-                                memo.map.insert(cached.path.clone(), Arc::clone(&full));
+                                if memo
+                                    .map
+                                    .insert(cached.path.clone(), (Arc::clone(&full), est))
+                                    .is_none()
+                                {
+                                    memo.order.push_back(cached.path.clone());
+                                }
+                                let cap = sweep_memo_cap_bytes();
+                                while memo.bytes > cap {
+                                    let Some(victim) = memo.order.pop_front() else { break };
+                                    if let Some((_, vbytes)) = memo.map.remove(&victim) {
+                                        memo.bytes = memo.bytes.saturating_sub(vbytes);
+                                        crate::util::ghost_stats::count("sweep.memo_evicted");
+                                    }
+                                }
                             }
                         }
                     });

--- a/src/index/module_index/registration.rs
+++ b/src/index/module_index/registration.rs
@@ -27,7 +27,14 @@ thread_local! {
 struct SweepMemo {
     stamp: u64,
     map: std::collections::HashMap<std::path::PathBuf, Arc<FileAnalysis>>,
+    /// Bytes this file's memo holds (estimates) — the crest attribution:
+    /// per-worker in-flight working sets are bounded by the largest single
+    /// file's memo, and `sweep.memo_peak_file_bytes` reports the max seen.
+    bytes: u64,
 }
+
+/// High-water of any single file's sweep-memo footprint, across the run.
+static SWEEP_MEMO_PEAK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// The SWEEP-WIDE consult-verdict store: (candidate path, point-free query)
 /// → that candidate's whole contribution, shared across files AND rayon
@@ -1307,10 +1314,23 @@ impl ModuleIndex {
                                 // suspect holder. `bytes_inserted` bounds what
                                 // a sweep cycles through; entries × giant
                                 // sizes is what a peak reader compares RSS to.
+                                let est = full.heap_estimate().total() as u64;
                                 crate::util::ghost_stats::add_n(
                                     "sweep.memo_bytes_inserted",
-                                    full.heap_estimate().total() as u64,
+                                    est,
                                 );
+                                memo.bytes += est;
+                                // Max via summed deltas: the tag's TOTAL in the
+                                // shutdown dump equals the largest single
+                                // file's memo footprint across the run.
+                                let prev = SWEEP_MEMO_PEAK
+                                    .fetch_max(memo.bytes, std::sync::atomic::Ordering::Relaxed);
+                                if memo.bytes > prev {
+                                    crate::util::ghost_stats::add_n(
+                                        "sweep.memo_peak_file_bytes",
+                                        memo.bytes - prev,
+                                    );
+                                }
                                 memo.map.insert(cached.path.clone(), Arc::clone(&full));
                             }
                         }

--- a/src/index/module_resolver/index_pack.rs
+++ b/src/index/module_resolver/index_pack.rs
@@ -88,6 +88,9 @@ pub fn index_pack_languages(
         // decodes the one requested file's full bag.
         let bag_cache = {
             let cache_key_owned = cache_key.map(|s| s.to_string());
+            // Retained across rehydrates — same seam as the Perl hub's bag
+            // loader; a per-call open on every LRU miss was pure overhead.
+            let bag_retained = Arc::new(module_cache::RetainedReader::new());
             let loader = move |path: &std::path::Path, want_bag: bool| {
                 // The blob is persisted under the CANONICAL path (both feed
                 // paths write `canon`), while the resident copy may be
@@ -101,7 +104,8 @@ pub fn index_pack_languages(
                 if raw != spellings[0] {
                     spellings.push(raw);
                 }
-                module_cache::open_and_load_diag(
+                module_cache::open_and_load_diag_retained(
+                    &bag_retained,
                     cache_key_owned.as_deref(),
                     lang,
                     &spellings,

--- a/src/index/module_resolver/thread.rs
+++ b/src/index/module_resolver/thread.rs
@@ -147,16 +147,23 @@ pub(super) fn resolver_loop(core: Arc<IndexCore>, server: Option<ServerSession>)
     // resolve. It runs in the gap where this thread would otherwise be blocked
     // on its condvar, which is the definition of "post-ready background".
     //
-    // Not seeded at all when baking is switched off: the repair lane is the
-    // SECOND producer of a conclusions row, so leaving it on would let the
-    // control's own arm bake the whole corpus in the background and measure a
-    // full layer from its second warm run onward.
+    // With baking switched off, the frontier narrows to the SURFACE half
+    // rather than emptying: the map half is the second producer of a
+    // conclusions row (leaving it on would let the control's own arm bake
+    // the whole corpus in the background and measure a full layer from its
+    // second warm run onward), but the surface half is the freshness
+    // machinery's product, which the control does not claim to ablate —
+    // gating the whole frontier left a NO_BAKE arm running against
+    // un-repaired surfaces.
     let mut repair_frontier: Vec<String> = db
         .as_ref()
-        .filter(|_| !crate::model::witnesses::bake_disabled())
         .map(|conn| {
             let at = module_cache::current_generation(conn);
-            let f = module_cache::paths_needing_repair(conn, at);
+            let f = module_cache::paths_needing_repair(
+                conn,
+                at,
+                !crate::model::witnesses::bake_disabled(),
+            );
             if !f.is_empty() {
                 log::info!(
                     "Derivation repair: {} file(s) hold a blob whose map or \

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1273,6 +1273,12 @@ fn for_each_enriched_diagnostic(
     // are the n² a package-main corpus produces. Shared across the rayon
     // workers; stamp-cleared on any index shape change.
     let _answers = module_index::SweepAnswerGuard::open();
+    // The sweep-wide shared PROVIDER cache: each provider decodes once per
+    // sweep and is resident once, replacing up to worker-count OVERLAPPING
+    // per-file memos (measured: 13,456 rehydrates for ~500 distinct
+    // providers in one n=250 sweep — the majority component of the
+    // per-worker in-flight sets that own the RSS crest).
+    let _providers = module_index::SweepProviderGuard::open();
     // Byte-budgeted ADMISSION for the sweep: the RSS crest is the PRODUCT of
     // worker count and per-worker in-flight working set (memo + overlay clone
     // pair + rehydrated wholes), measured at ~414 MB marginal per worker on a

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1147,6 +1147,60 @@ fn enriched_tree_diagnostics(
 /// parallel drivers cannot drift — the thread-locals it touches (the stall
 /// watchdog's current file, the sweep memo, `enriched_snapshot`'s cycle guard
 /// and depth counter) are per-worker by construction, which is what makes the
+/// The sweep's in-flight source-byte budget, or `None` when disabled.
+fn sweep_admission_budget() -> Option<u64> {
+    let mb = std::env::var("PERL_LSP_SWEEP_INFLIGHT_SOURCE_MB")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(8);
+    (mb != 0).then_some(mb * 1024 * 1024)
+}
+
+/// A byte-weighted admission gate (see the call site's rationale). A single
+/// file's want is clamped to the whole budget, so the largest file is always
+/// admissible alone — no starvation, no deadlock.
+struct SweepAdmission {
+    budget: u64,
+    avail: std::sync::Mutex<u64>,
+    cv: std::sync::Condvar,
+}
+
+struct SweepPermit<'a> {
+    gate: &'a SweepAdmission,
+    held: u64,
+}
+
+impl SweepAdmission {
+    fn new(budget: u64) -> Self {
+        SweepAdmission {
+            budget,
+            avail: std::sync::Mutex::new(budget),
+            cv: std::sync::Condvar::new(),
+        }
+    }
+
+    fn acquire(&self, want: u64) -> SweepPermit<'_> {
+        let want = want.clamp(1, self.budget);
+        let mut avail = self.avail.lock().unwrap();
+        if *avail < want {
+            crate::util::ghost_stats::count("sweep.admission_waited");
+        }
+        while *avail < want {
+            avail = self.cv.wait(avail).unwrap();
+        }
+        *avail -= want;
+        SweepPermit { gate: self, held: want }
+    }
+}
+
+impl Drop for SweepPermit<'_> {
+    fn drop(&mut self) {
+        let mut avail = self.gate.avail.lock().unwrap();
+        *avail += self.held;
+        self.gate.cv.notify_all();
+    }
+}
+
 /// body safe to run concurrently.
 fn sweep_one_file(
     idx: &module_index::ModuleIndex,
@@ -1219,6 +1273,22 @@ fn for_each_enriched_diagnostic(
     // are the n² a package-main corpus produces. Shared across the rayon
     // workers; stamp-cleared on any index shape change.
     let _answers = module_index::SweepAnswerGuard::open();
+    // Byte-budgeted ADMISSION for the sweep: the RSS crest is the PRODUCT of
+    // worker count and per-worker in-flight working set (memo + overlay clone
+    // pair + rehydrated wholes), measured at ~414 MB marginal per worker on a
+    // giant-file corpus — and bounding either factor alone failed: a flat
+    // worker cap is corpus-tuned (memory-bound FHEM paid 4.9% wall for -67%
+    // RSS; a CPU-bound corpus would pay real wall for nothing), and byte-
+    // capping the memo slice measured NET-NEGATIVE (+51% wall, +15% RSS at
+    // n=500: 19,929 drop-oldest evictions converted retention into re-decode
+    // churn). Admission bounds the product WITHOUT converting anything — a
+    // queued file is decoded later, not twice. Permits are the file's SOURCE
+    // size (the a-priori proxy: analysis footprint measured ~65x source bytes
+    // on the estimator probe; no decode needed to know it), so small-file
+    // corpora never approach the budget and the gate provably no-ops there,
+    // while giants queue among themselves and ordinary files flow around
+    // them. `PERL_LSP_SWEEP_INFLIGHT_SOURCE_MB` overrides; 0 disables.
+    let admission = sweep_admission_budget().map(SweepAdmission::new);
     // Channel attribution: the unbounded mpsc holds diagnostics until the
     // single consumer drains them — a sweep-proportional holder candidate for
     // the FHEM RSS knee. Measured, not fit: sends, bytes, and PEAK BACKLOG
@@ -1230,9 +1300,14 @@ fn for_each_enriched_diagnostic(
     std::thread::scope(|scope| {
         let pending_ref = &pending;
         let peak_ref = &peak_pending;
+        let admission_ref = &admission;
         scope.spawn(move || {
             use rayon::prelude::*;
             entries.par_iter().for_each_with(tx, |tx, (path, fa)| {
+                let src_bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(1);
+                let _permit = admission_ref
+                    .as_ref()
+                    .map(|a| a.acquire(src_bytes.max(1)));
                 for (file, d) in sweep_one_file(idx, options, path, fa) {
                     crate::util::ghost_stats::count("diag.sent");
                     crate::util::ghost_stats::add_n(

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1219,19 +1219,42 @@ fn for_each_enriched_diagnostic(
     // are the n² a package-main corpus produces. Shared across the rayon
     // workers; stamp-cleared on any index shape change.
     let _answers = module_index::SweepAnswerGuard::open();
+    // Channel attribution: the unbounded mpsc holds diagnostics until the
+    // single consumer drains them — a sweep-proportional holder candidate for
+    // the FHEM RSS knee. Measured, not fit: sends, bytes, and PEAK BACKLOG
+    // (sends minus receives, high-water) — if peak_pending × per-diag bytes
+    // is GB-scale, the channel is the holder; if the counters are small, the
+    // suspect dies by the same reading.
+    let pending = std::sync::atomic::AtomicI64::new(0);
+    let peak_pending = std::sync::atomic::AtomicI64::new(0);
     std::thread::scope(|scope| {
+        let pending_ref = &pending;
+        let peak_ref = &peak_pending;
         scope.spawn(move || {
             use rayon::prelude::*;
             entries.par_iter().for_each_with(tx, |tx, (path, fa)| {
                 for (file, d) in sweep_one_file(idx, options, path, fa) {
+                    crate::util::ghost_stats::count("diag.sent");
+                    crate::util::ghost_stats::add_n(
+                        "diag.bytes_sent",
+                        (file.len() + d.message.len() + 160) as u64,
+                    );
+                    let now =
+                        pending_ref.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    peak_ref.fetch_max(now, std::sync::atomic::Ordering::Relaxed);
                     let _ = tx.send((file, d));
                 }
             });
         });
         for (file, d) in rx {
+            pending.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
             emit(&file, d);
         }
     });
+    crate::util::ghost_stats::add_n(
+        "diag.peak_pending",
+        peak_pending.load(std::sync::atomic::Ordering::Relaxed).max(0) as u64,
+    );
     // Pack-language files (C++/…) live in the per-language sub-indexes, not the
     // Perl-only `FileStore` above. Mirror the backend's language dispatch: they
     // get `pack_diagnostics` (Mode B — member-op swap + peel), so `--batch

--- a/src/lsp/cli/query.rs
+++ b/src/lsp/cli/query.rs
@@ -1213,6 +1213,12 @@ fn for_each_enriched_diagnostic(
     // `&mut` and stays on this thread — only the diagnostics cross.
     let (tx, rx) =
         std::sync::mpsc::channel::<(String, tower_lsp::lsp_types::Diagnostic)>();
+    // The sweep-wide consult-verdict store: one (query, candidate) chase per
+    // SWEEP instead of per file. The per-build session memo cannot span
+    // files (thread-local, per-build), and first-encounter pairs per build
+    // are the n² a package-main corpus produces. Shared across the rayon
+    // workers; stamp-cleared on any index shape change.
+    let _answers = module_index::SweepAnswerGuard::open();
     std::thread::scope(|scope| {
         scope.spawn(move || {
             use rayon::prelude::*;

--- a/src/model/file_analysis/ancestry.rs
+++ b/src/model/file_analysis/ancestry.rs
@@ -612,11 +612,15 @@ impl FileAnalysis {
             // lookup hits the right file, not `cls`'s own module.
             let mut bridged_module: Option<String> = None;
             idx.for_each_entity_bridged_to(cls, &mut |mod_name, _cached, sym| {
-                if bridged_module.is_some() { return; }
-                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { return; }
+                use std::ops::ControlFlow;
+                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                    return ControlFlow::Continue(());
+                }
                 if sym.name == method_name {
                     bridged_module = Some(mod_name.to_string());
+                    return ControlFlow::Break(());
                 }
+                ControlFlow::Continue(())
             });
             if bridged_module.is_some() {
                 return Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: bridged_module });
@@ -842,14 +846,20 @@ impl FileAnalysis {
             // issues with the closure capturing &mut seen_names/candidates.
             let mut bridged: Vec<(String, SymKind, Option<SymbolDetail>, Option<HandlerDisplay>)> = Vec::new();
             idx.for_each_entity_bridged_to(class_name, &mut |_mod, _cached, sym| {
-                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { return; }
-                if !visible(sym) { return; }
+                use std::ops::ControlFlow;
+                if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                    return ControlFlow::Continue(());
+                }
+                if !visible(sym) {
+                    return ControlFlow::Continue(());
+                }
                 bridged.push((
                     sym.name.clone(),
                     sym.kind,
                     Some(sym.detail.clone()),
                     sym.presentation.display,
                 ));
+                ControlFlow::Continue(())
             });
             for (name, kind, detail, display_override) in bridged {
                 if seen_names.contains(&name) { continue; }

--- a/src/model/file_analysis/ancestry.rs
+++ b/src/model/file_analysis/ancestry.rs
@@ -611,7 +611,7 @@ impl FileAnalysis {
             // bridged to `cls`). Record the registration module so the def
             // lookup hits the right file, not `cls`'s own module.
             let mut bridged_module: Option<String> = None;
-            idx.for_each_entity_bridged_to(cls, &mut |mod_name, _cached, sym| {
+            idx.for_each_entity_bridged_to_named(cls, method_name, &mut |mod_name, _cached, sym| {
                 use std::ops::ControlFlow;
                 if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
                     return ControlFlow::Continue(());

--- a/src/model/file_analysis/ancestry.rs
+++ b/src/model/file_analysis/ancestry.rs
@@ -4,6 +4,15 @@
 
 use super::*;
 
+/// `PERL_LSP_MEMBER_PREFILTER_EQUIV`: run every candidate scan the member
+/// pre-filter would skip and score the agreement. Costs strictly more than
+/// not filtering, by design — a measurement mode, not a safety net; the same
+/// discipline as `PERL_LSP_RESTAMP_EQUIV`.
+fn member_prefilter_equiv() -> bool {
+    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *V.get_or_init(|| std::env::var("PERL_LSP_MEMBER_PREFILTER_EQUIV").is_ok())
+}
+
 /// The REAL parent edges: the file's own `PackageFacts::parents` ∪
 /// cross-file `parents_cached`. One of `parents_of`'s two component
 /// spellers — the graph's `EdgeKind::Inherits` derivation reads this
@@ -515,6 +524,18 @@ impl FileAnalysis {
             // defining candidate with the same test.
             crate::util::ghost_stats::mroc_begin();
             for cached in idx.visible_def_candidates(cls) {
+                // Rows-backed pre-filter (`docs/prompt-relational-iteration.md`):
+                // skip the rehydrate when the row store PROVES this candidate
+                // declares nothing named `method_name` under `cls`. Fail-open
+                // everywhere the store cannot speak; the equiv switch runs the
+                // skipped scan anyway and screams on divergence.
+                let may_declare = idx.candidate_may_declare(&cached, method_name, cls);
+                if !may_declare {
+                    crate::util::ghost_stats::count("mroc.candidate_prefiltered");
+                    if !member_prefilter_equiv() {
+                        continue;
+                    }
+                }
                 // Class-scoped, not file-scoped: a pack file holds MANY
                 // classes, so "some sub of this name exists in cls's file"
                 // would let an unrelated same-named member hijack
@@ -551,6 +572,23 @@ impl FileAnalysis {
                 } else {
                     "mroc.candidate_wasted"
                 });
+                if !may_declare {
+                    // PERL_LSP_MEMBER_PREFILTER_EQUIV: the skipped scan ran —
+                    // score the verdict the gate would have acted on.
+                    crate::util::ghost_stats::count(if has_member {
+                        "memberprefilter.break"
+                    } else {
+                        "memberprefilter.agreed"
+                    });
+                    if has_member {
+                        log::warn!(
+                            "member prefilter equiv: rows said {cls}::{method_name} \
+                             absent in {:?} but the decode found it — the shred \
+                             missed a symbol-minting path",
+                            cached.path
+                        );
+                    }
+                }
                 if has_member {
                     return Some(MethodResolution::CrossFile { class: cls.to_string(), def_module: None });
                 }

--- a/src/model/file_analysis/class_queries.rs
+++ b/src/model/file_analysis/class_queries.rs
@@ -227,12 +227,18 @@ impl FileAnalysis {
         let Some(idx) = module_index else { return false };
         let mut found = false;
         idx.for_each_entity_bridged_to(class_name, &mut |_mod, _cached, sym| {
-            if found { return; }
-            if sym.name != method_name { return; }
-            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) { return; }
+            use std::ops::ControlFlow;
+            if sym.name != method_name {
+                return ControlFlow::Continue(());
+            }
+            if !matches!(sym.kind, SymKind::Sub | SymKind::Method) {
+                return ControlFlow::Continue(());
+            }
             if matches!(&sym.detail, SymbolDetail::Sub { opaque_return: true, .. }) {
                 found = true;
+                return ControlFlow::Break(());
             }
+            ControlFlow::Continue(())
         });
         found
     }

--- a/src/model/file_analysis/class_queries.rs
+++ b/src/model/file_analysis/class_queries.rs
@@ -226,7 +226,7 @@ impl FileAnalysis {
         }
         let Some(idx) = module_index else { return false };
         let mut found = false;
-        idx.for_each_entity_bridged_to(class_name, &mut |_mod, _cached, sym| {
+        idx.for_each_entity_bridged_to_named(class_name, method_name, &mut |_mod, _cached, sym| {
             use std::ops::ControlFlow;
             if sym.name != method_name {
                 return ControlFlow::Continue(());

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -779,10 +779,19 @@ pub trait CrossFileLookup {
         start: Vec<String>,
         visit: &mut dyn FnMut(&std::sync::Arc<CachedModule>) -> std::ops::ControlFlow<()>,
     );
+    /// `visit` returns `Break` to stop the walk — and, more importantly, the
+    /// per-candidate rehydrates behind it: entity resolution decodes each
+    /// bridging module's symbols, so a first-match caller that cannot stop
+    /// the iteration pays a decode per plugin file in the workspace for
+    /// answers it already has (same shape as `for_each_reexport_module`).
     fn for_each_entity_bridged_to(
         &self,
         class_name: &str,
-        f: &mut dyn FnMut(&str, &std::sync::Arc<CachedModule>, &Symbol),
+        f: &mut dyn FnMut(
+            &str,
+            &std::sync::Arc<CachedModule>,
+            &Symbol,
+        ) -> std::ops::ControlFlow<()>,
     );
     /// Direct children/composers of `class` as (package, module) pairs
     /// — the `children_index` inverse, depth 1 (the graph walker
@@ -1184,7 +1193,11 @@ impl<'a> CrossFileLookup for ScopedLookup<'a> {
     fn for_each_entity_bridged_to(
         &self,
         class_name: &str,
-        f: &mut dyn FnMut(&str, &std::sync::Arc<CachedModule>, &Symbol),
+        f: &mut dyn FnMut(
+            &str,
+            &std::sync::Arc<CachedModule>,
+            &Symbol,
+        ) -> std::ops::ControlFlow<()>,
     ) {
         self.inner.for_each_entity_bridged_to(class_name, f)
     }

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -636,6 +636,24 @@ pub trait CrossFileLookup {
     ) -> std::sync::Arc<FileAnalysis> {
         self.whole_present(cached)
     }
+    /// May `cached`'s file declare a member named `name` attributed to
+    /// package `class`? The rows-backed pre-filter for the ancestor walk's
+    /// per-candidate existence probe (`docs/prompt-relational-iteration.md`):
+    /// `false` licenses skipping the `symbols_present` rehydrate outright, so
+    /// it requires POSITIVE evidence of absence — a store that covers the
+    /// file and holds no matching sym row. Everything else — no store, file
+    /// never shredded, a resident (unevicted) copy, post-shred plugin
+    /// emissions — answers `true`, which is this default: an implementor
+    /// that cannot prove absence inherits the decode, never the skip.
+    fn candidate_may_declare(
+        &self,
+        cached: &std::sync::Arc<CachedModule>,
+        name: &str,
+        class: &str,
+    ) -> bool {
+        let _ = (cached, name, class);
+        true
+    }
     /// The ROWS-axes view — refs AND symbols populated: the backward-walk
     /// matcher's axes (usage sites + declaration sites). The @INC strip is
     /// bag-only, so import-tier copies answer resident; the workspace strip
@@ -1095,6 +1113,16 @@ impl<'a> CrossFileLookup for ScopedLookup<'a> {
     ) -> std::sync::Arc<FileAnalysis> {
         // Same delegation rule as `symbols_present`.
         self.inner.refs_present(cached)
+    }
+    fn candidate_may_declare(
+        &self,
+        cached: &std::sync::Arc<CachedModule>,
+        name: &str,
+        class: &str,
+    ) -> bool {
+        // Same delegation rule as `symbols_present` — the inner index owns
+        // the row store; the default would fail open and lose the skip.
+        self.inner.candidate_may_declare(cached, name, class)
     }
     fn ref_candidate_paths(&self, keys: &[String]) -> Vec<std::path::PathBuf> {
         // Unscoped by design, like `def_candidates`: the backward walk applies

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -805,6 +805,27 @@ pub trait CrossFileLookup {
             &Symbol,
         ) -> std::ops::ControlFlow<()>,
     );
+    /// The bridged walk for a caller that wants one NAMED entity — the
+    /// first-match-by-name consumers (the MRO walk's bridged arm, the
+    /// opaque-return check, the registry's bridged consult). `name` is a
+    /// pre-filter LICENSE, not a semantic change: the visitor still sees
+    /// every entity of every candidate it reaches, but an implementor with
+    /// a row store may skip candidates that provably declare nothing named
+    /// `name` — killing the per-miss decode of every bridging module. The
+    /// default ignores the hint (fail-open) and delegates.
+    fn for_each_entity_bridged_to_named(
+        &self,
+        class_name: &str,
+        name: &str,
+        f: &mut dyn FnMut(
+            &str,
+            &std::sync::Arc<CachedModule>,
+            &Symbol,
+        ) -> std::ops::ControlFlow<()>,
+    ) {
+        let _ = name;
+        self.for_each_entity_bridged_to(class_name, f)
+    }
     /// Direct children/composers of `class` as (package, module) pairs
     /// — the `children_index` inverse, depth 1 (the graph walker
     /// supplies transitivity).
@@ -1215,6 +1236,20 @@ impl<'a> CrossFileLookup for ScopedLookup<'a> {
         ) -> std::ops::ControlFlow<()>,
     ) {
         self.inner.for_each_entity_bridged_to(class_name, f)
+    }
+    fn for_each_entity_bridged_to_named(
+        &self,
+        class_name: &str,
+        name: &str,
+        f: &mut dyn FnMut(
+            &str,
+            &std::sync::Arc<CachedModule>,
+            &Symbol,
+        ) -> std::ops::ControlFlow<()>,
+    ) {
+        // Same delegation rule as the unnamed walk — the inner index owns
+        // the row store the name pre-filter reads.
+        self.inner.for_each_entity_bridged_to_named(class_name, name, f)
     }
     fn direct_children_of(&self, class: &str) -> Vec<(String, String)> {
         self.inner.direct_children_of(class)

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -648,6 +648,31 @@ pub trait CrossFileLookup {
     ) -> std::sync::Arc<FileAnalysis> {
         self.whole_present(cached)
     }
+    /// A sweep-scoped cross-file consult verdict: "what did candidate `path`
+    /// contribute to this (point-free) query". `None` = not remembered.
+    /// The default remembers nothing — only an index under an open sweep
+    /// (the CLI's whole-corpus diagnostics) serves these. The seam exists
+    /// because the SESSION memo is thread-local and per-verb, while a batch
+    /// sweep's repeats span files and rayon workers: without a shared tier,
+    /// every file's build re-chases every (query, candidate) pair the sweep
+    /// already settled — the measured n² on package-main corpora.
+    fn sweep_consult_answer(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+    ) -> Option<std::sync::Arc<crate::model::witnesses::ReducedValue>> {
+        let _ = (path, key);
+        None
+    }
+    /// Remember a sweep-scoped verdict. No-op by default.
+    fn remember_sweep_consult(
+        &self,
+        path: &std::path::Path,
+        key: &crate::model::witnesses::ConsultVerdictKey,
+        value: &crate::model::witnesses::ReducedValue,
+    ) {
+        let _ = (path, key, value);
+    }
     /// May `cached`'s file declare a member named `name` attributed to
     /// package `class`? The rows-backed pre-filter for the ancestor walk's
     /// per-candidate existence probe (`docs/prompt-relational-iteration.md`):

--- a/src/model/file_analysis/cross_file.rs
+++ b/src/model/file_analysis/cross_file.rs
@@ -602,6 +602,18 @@ pub trait CrossFileLookup {
     ) -> std::sync::Arc<FileAnalysis> {
         self.bag_present(cached)
     }
+    /// Can `enriched_present` ever hand back a view DISTINCT from the bag?
+    /// The witness seams' fallback-on-miss arms ask this BEFORE calling it:
+    /// when the answer is no (one-shot CLI — the overlay is long-lived-only),
+    /// the retry is a guaranteed no-op, and skipping it saves a redundant
+    /// per-escalation fetch — measured at 706k calls / 5.3% of a cold
+    /// `--check` wall on a script-heavy corpus — plus the re-chase hazard
+    /// when the LRU evicts between the two fetches. Default `true`: an
+    /// implementor that overrides `enriched_present` without this probe
+    /// keeps its retries.
+    fn serves_enriched(&self) -> bool {
+        true
+    }
     /// A cached module's analysis whole on EVERY evictable axis — bag, refs,
     /// AND symbols present. Consumers that read more than one axis from the
     /// same copy (the diagnostics sweep, the `refs_to` matcher, `sub_info`
@@ -1099,6 +1111,9 @@ impl<'a> CrossFileLookup for ScopedLookup<'a> {
         // Same delegation rule as `bag_present` — the inner index owns the
         // enrichment overlay.
         self.inner.enriched_present(cached)
+    }
+    fn serves_enriched(&self) -> bool {
+        self.inner.serves_enriched()
     }
     fn whole_present(
         &self,

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -595,15 +595,17 @@ impl FileAnalysis {
                         );
                         if ty.is_none() {
                             crate::util::ghost_stats::count("chase.return_miss");
-                            let en = enriched.get_or_insert_with(|| {
-                                crate::util::ghost_stats::count("chase.enriched_present");
-                                crate::util::ghost_stats::timed(
-                                    "chase.enriched_present",
-                                    || idx.enriched_present(&cached),
-                                )
-                            });
-                            if !std::sync::Arc::ptr_eq(en, &whole) {
-                                ty = en.symbol_return_type_via_bag(sym.id, None);
+                            if idx.serves_enriched() {
+                                let en = enriched.get_or_insert_with(|| {
+                                    crate::util::ghost_stats::count("chase.enriched_present");
+                                    crate::util::ghost_stats::timed(
+                                        "chase.enriched_present",
+                                        || idx.enriched_present(&cached),
+                                    )
+                                });
+                                if !std::sync::Arc::ptr_eq(en, &whole) {
+                                    ty = en.symbol_return_type_via_bag(sym.id, None);
+                                }
                             }
                         }
                         if let Some(ty) = ty {

--- a/src/model/file_analysis/enrichment.rs
+++ b/src/model/file_analysis/enrichment.rs
@@ -1443,7 +1443,7 @@ mod restamp_gate_tests {
                     &str,
                     &std::sync::Arc<crate::model::file_analysis::CachedModule>,
                     &crate::model::file_analysis::Symbol,
-                ),
+                ) -> std::ops::ControlFlow<()>,
             ) {
             }
             fn direct_children_of(&self, _p: &str) -> Vec<(String, String)> {

--- a/src/model/file_analysis/file_analysis_tests.rs
+++ b/src/model/file_analysis/file_analysis_tests.rs
@@ -2841,3 +2841,61 @@ fn a_marked_file_re_stamps_and_an_unmarked_one_skips() {
         "a provider moved, so the re-stamp runs and re-derives the real target"
     );
 }
+
+/// PROBE: does `heap_estimate` track the truth on a GIANT file?
+///
+/// The FHEM investigation's RSS hypothesis: the hub LRU held 176-232 entries
+/// of 46k-line analyses while claiming 134 MB — ~600 KB/entry, absurd on its
+/// face if the estimate drifts low on big files, because then the cap
+/// retains gigabytes while believing itself within budget (the accounting-
+/// vs-reality family of the pack-bag-cache ratchet P0). Truth is measured
+/// as the RSS delta across N clones, amortized.
+#[test]
+#[ignore]
+fn probe_heap_estimate_vs_truth_on_a_giant_file() {
+    fn rss_kb() -> u64 {
+        let s = std::fs::read_to_string("/proc/self/status").unwrap();
+        s.lines()
+            .find(|l| l.starts_with("VmRSS:"))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|v| v.parse().ok())
+            .unwrap()
+    }
+    // A synthetic FHEM-shaped giant: thousands of subs in main, dense
+    // hash-key traffic, string literals — ~40k lines.
+    let mut src = String::from("package main;\n");
+    for i in 0..3000 {
+        src.push_str(&format!(
+            "sub Unit{i}_Define {{\n  my ($hash, $def) = @_;\n  \
+             $hash->{{NAME}} = 'unit{i}';\n  $hash->{{STATE}} = 'defined';\n  \
+             $hash->{{READINGS}}{{temperature}}{{VAL}} = {i};\n  \
+             my $cfg = {{ host => 'h{i}', port => {i}, retry => 3 }};\n  \
+             Log3($hash, 3, \"unit{i} defined with some longer message text\");\n  \
+             return undef;\n}}\n\
+             sub Unit{i}_Set {{\n  my ($hash, @args) = @_;\n  \
+             my $name = $hash->{{NAME}};\n  \
+             return \"unknown command\" if !@args;\n  \
+             $hash->{{helper}}{{lastSet}} = join(' ', @args);\n  return undef;\n}}\n"
+        ));
+    }
+    src.push_str("1;\n");
+    let mut parser = crate::build::builder::create_parser();
+    let tree = parser.parse(&src, None).unwrap();
+    let fa = crate::build::builder::build(&tree, src.as_bytes());
+    let est = fa.heap_estimate().total();
+
+    const N: usize = 8;
+    let before = rss_kb();
+    let clones: Vec<_> = (0..N).map(|_| fa.clone()).collect();
+    let after = rss_kb();
+    let true_per_clone_kb = (after.saturating_sub(before)) / N as u64;
+    drop(clones);
+    eprintln!(
+        "lines={} est={} KB true~={} KB ratio(true/est)={:.1}",
+        src.lines().count(),
+        est / 1024,
+        true_per_clone_kb,
+        true_per_clone_kb as f64 / (est as f64 / 1024.0).max(1.0),
+    );
+    eprintln!("{}", fa.heap_estimate());
+}

--- a/src/model/file_analysis/invocants.rs
+++ b/src/model/file_analysis/invocants.rs
@@ -1167,7 +1167,7 @@ impl FileAnalysis {
                                     })
                                 }) || {
                                 let mut hit = false;
-                                idx.for_each_entity_bridged_to(a, &mut |_m, _c, sym| {
+                                idx.for_each_entity_bridged_to_named(a, &name, &mut |_m, _c, sym| {
                                     if matches!(sym.kind, SymKind::Sub | SymKind::Method)
                                         && sym.name == name
                                     {

--- a/src/model/file_analysis/invocants.rs
+++ b/src/model/file_analysis/invocants.rs
@@ -1168,12 +1168,13 @@ impl FileAnalysis {
                                 }) || {
                                 let mut hit = false;
                                 idx.for_each_entity_bridged_to(a, &mut |_m, _c, sym| {
-                                    if !hit
-                                        && matches!(sym.kind, SymKind::Sub | SymKind::Method)
+                                    if matches!(sym.kind, SymKind::Sub | SymKind::Method)
                                         && sym.name == name
                                     {
                                         hit = true;
+                                        return std::ops::ControlFlow::Break(());
                                     }
+                                    std::ops::ControlFlow::Continue(())
                                 });
                                 hit
                             }
@@ -1306,6 +1307,7 @@ impl FileAnalysis {
                             visit(sym, prov);
                         }
                     }
+                    std::ops::ControlFlow::Continue(())
                 });
             }
             std::ops::ControlFlow::Continue(())

--- a/src/model/graph.rs
+++ b/src/model/graph.rs
@@ -273,6 +273,7 @@ impl<'a> GraphView<'a> {
                             if seen_mods.insert(module.to_string()) {
                                 out.push(Node::Module(module.to_string()));
                             }
+                            std::ops::ControlFlow::Continue(())
                         });
                     }
                 }

--- a/src/model/witnesses/query.rs
+++ b/src/model/witnesses/query.rs
@@ -143,6 +143,9 @@ pub fn query_sub_return_type(
             }
             for cached in retryable {
                 crate::util::ghost_stats::count("consult.imported_sub_return");
+                if !idx.serves_enriched() {
+                    break;
+                }
                 let full = idx.bag_present(&cached);
                 let enriched = idx.enriched_present(&cached);
                 if !std::sync::Arc::ptr_eq(&enriched, &full) {

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -440,6 +440,19 @@ impl ReducerRegistry {
         // being counted, not separate questions.
         let top_moc = matches!(q.attachment, WitnessAttachment::PackageSymbol { .. });
         if top_moc {
+            // Attribution: what share of top-level moc queries are main-keyed?
+            // Two buckets, not per-package keys — a script-heavy corpus mints
+            // these from every plain call, and the question a fix must answer
+            // is main's SHARE, not a cardinality-unbounded census.
+            if crate::util::ghost_stats::enabled() {
+                if let WitnessAttachment::PackageSymbol { package, .. } = &q.attachment {
+                    crate::util::ghost_stats::count(if package == "main" {
+                        "mocpkg.main"
+                    } else {
+                        "mocpkg.other"
+                    });
+                }
+            }
             TOUCHED_EXPR.with(|c| c.set(false));
         }
         // Sole boundary where an owned `ReducedValue` is required; the
@@ -1340,6 +1353,13 @@ impl ReducerRegistry {
                 continue;
             }
             crate::util::ghost_stats::count("moc.provider_fetched");
+            // Attribution twin of `mocpkg.*`: which class family drives the
+            // FETCHES (each one a decode on LRU miss), not just the queries.
+            crate::util::ghost_stats::count(if package == "main" {
+                "mocfetch.main"
+            } else {
+                "mocfetch.other"
+            });
             // The three costs of one cross-file consult, split
             // because a conclusion layer would remove the first
             // two and CANNOT remove the third (enrichment is bag

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -781,6 +781,7 @@ impl ReducerRegistry {
                         // Bridged Method's return lives in the bridging file's
                         // bag — rehydrate it if evicted before querying.
                         crate::util::ghost_stats::count("moc.provider_fetched");
+                        crate::util::ghost_stats::count("mocsite.bridged");
                         let full = idx.bag_present(cached);
                         if let Some(t) = full.symbol_return_type_via_bag(sym.id, None) {
                             found = Some(t);
@@ -852,6 +853,7 @@ impl ReducerRegistry {
                                 (*self.query_rec(&full.witnesses, &sub_q, state)).clone()
                             };
                         crate::util::ghost_stats::count("moc.provider_fetched");
+                        crate::util::ghost_stats::count("mocsite.slot_type");
                         let full = idx.bag_present(&cached);
                         if !std::ptr::eq(bag, &full.witnesses) {
                             let v = attempt(&full, state);
@@ -933,6 +935,7 @@ impl ReducerRegistry {
                 if let Some(idx) = ctx.module_index {
                     for cached in idx.visible_def_candidates(name) {
                         crate::util::ghost_stats::count("moc.provider_fetched");
+                        crate::util::ghost_stats::count("mocsite.type_name");
                         let full = idx.bag_present(&cached);
                         if !std::ptr::eq(bag, &full.witnesses) {
                             let cached_ctx = BagContext {
@@ -1359,6 +1362,7 @@ impl ReducerRegistry {
                 continue;
             }
             crate::util::ghost_stats::count("moc.provider_fetched");
+                        crate::util::ghost_stats::count("mocsite.primary");
             // Attribution twin of `mocpkg.*`: which class family drives the
             // FETCHES (each one a decode on LRU miss), not just the queries.
             crate::util::ghost_stats::count(if package == "main" {

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -830,46 +830,7 @@ impl ReducerRegistry {
                     note_slot_exit(state, class, key);
                 }
                 if let Some(idx) = ctx.module_index {
-                    // The memo/map tiers the PRIMARY loop has, mirrored here —
-                    // measured on FHEM: this arm carried 99.99% of 12.3M
-                    // provider fetches (each a rehydrate) while the primary's
-                    // machinery ran 1,320 times. Same ladder, same order:
-                    // session memo (cheapest) → consult budget → baked answer
-                    // → fetch. Conservative on the map: only a positive
-                    // `Answer` is taken; absence/NotLocal for slots is not
-                    // trusted here (slot writes chase ancestry, and the
-                    // absence gates were designed against the method walk).
-                    for cached in super::session::visible_def_candidates(idx, class).iter() {
-                        if let Some(hit) =
-                            super::session::candidate_answer(idx, &cached.path, q)
-                        {
-                            if *hit != ReducedValue::None {
-                                return (*hit).clone();
-                            }
-                            continue;
-                        }
-                        if !super::session::spend_consult(idx) {
-                            break;
-                        }
-                        if let Some(key) =
-                            super::ConclusionKey::from_attachment(q.attachment)
-                        {
-                            if let Some(map) = idx.conclusions_for(&cached.path) {
-                                if let super::Outcome::Answer(t) = map.evaluate(
-                                    &key,
-                                    q.receiver.as_ref(),
-                                    q.arity_hint,
-                                    &q.args,
-                                ) {
-                                    crate::util::ghost_stats::count("slotarm.baked_answer");
-                                    let v = ReducedValue::Type(t);
-                                    super::session::remember_candidate_answer(
-                                        idx, &cached.path, q, &v,
-                                    );
-                                    return v;
-                                }
-                            }
-                        }
+                    for cached in idx.visible_def_candidates(class) {
                         let attempt =
                             |full: &std::sync::Arc<crate::model::file_analysis::FileAnalysis>,
                              state: &mut _| {
@@ -902,9 +863,6 @@ impl ReducerRegistry {
                                 "moc.provider_answered"
                             });
                             if v != ReducedValue::None {
-                                super::session::remember_candidate_answer(
-                                    idx, &cached.path, q, &v,
-                                );
                                 return v;
                             }
                             // Fallback-on-miss (R4), symmetric with the
@@ -926,23 +884,10 @@ impl ReducerRegistry {
                                     state.pins.push(std::sync::Arc::clone(&enriched));
                                     let v = attempt(&enriched, state);
                                     if v != ReducedValue::None {
-                                        super::session::remember_candidate_answer(
-                                            idx, &cached.path, q, &v,
-                                        );
                                         return v;
                                     }
                                 }
                             }
-                            // Both views answered None — remember it, the
-                            // same memo discipline as the primary loop: this
-                            // candidate is asked once per (walk, key) instead
-                            // of once per call site.
-                            super::session::remember_candidate_answer(
-                                idx,
-                                &cached.path,
-                                q,
-                                &ReducedValue::None,
-                            );
                         }
                     }
                 }

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -830,7 +830,46 @@ impl ReducerRegistry {
                     note_slot_exit(state, class, key);
                 }
                 if let Some(idx) = ctx.module_index {
-                    for cached in idx.visible_def_candidates(class) {
+                    // The memo/map tiers the PRIMARY loop has, mirrored here —
+                    // measured on FHEM: this arm carried 99.99% of 12.3M
+                    // provider fetches (each a rehydrate) while the primary's
+                    // machinery ran 1,320 times. Same ladder, same order:
+                    // session memo (cheapest) → consult budget → baked answer
+                    // → fetch. Conservative on the map: only a positive
+                    // `Answer` is taken; absence/NotLocal for slots is not
+                    // trusted here (slot writes chase ancestry, and the
+                    // absence gates were designed against the method walk).
+                    for cached in super::session::visible_def_candidates(idx, class).iter() {
+                        if let Some(hit) =
+                            super::session::candidate_answer(idx, &cached.path, q)
+                        {
+                            if *hit != ReducedValue::None {
+                                return (*hit).clone();
+                            }
+                            continue;
+                        }
+                        if !super::session::spend_consult(idx) {
+                            break;
+                        }
+                        if let Some(key) =
+                            super::ConclusionKey::from_attachment(q.attachment)
+                        {
+                            if let Some(map) = idx.conclusions_for(&cached.path) {
+                                if let super::Outcome::Answer(t) = map.evaluate(
+                                    &key,
+                                    q.receiver.as_ref(),
+                                    q.arity_hint,
+                                    &q.args,
+                                ) {
+                                    crate::util::ghost_stats::count("slotarm.baked_answer");
+                                    let v = ReducedValue::Type(t);
+                                    super::session::remember_candidate_answer(
+                                        idx, &cached.path, q, &v,
+                                    );
+                                    return v;
+                                }
+                            }
+                        }
                         let attempt =
                             |full: &std::sync::Arc<crate::model::file_analysis::FileAnalysis>,
                              state: &mut _| {
@@ -863,6 +902,9 @@ impl ReducerRegistry {
                                 "moc.provider_answered"
                             });
                             if v != ReducedValue::None {
+                                super::session::remember_candidate_answer(
+                                    idx, &cached.path, q, &v,
+                                );
                                 return v;
                             }
                             // Fallback-on-miss (R4), symmetric with the
@@ -884,10 +926,23 @@ impl ReducerRegistry {
                                     state.pins.push(std::sync::Arc::clone(&enriched));
                                     let v = attempt(&enriched, state);
                                     if v != ReducedValue::None {
+                                        super::session::remember_candidate_answer(
+                                            idx, &cached.path, q, &v,
+                                        );
                                         return v;
                                     }
                                 }
                             }
+                            // Both views answered None — remember it, the
+                            // same memo discipline as the primary loop: this
+                            // candidate is asked once per (walk, key) instead
+                            // of once per call site.
+                            super::session::remember_candidate_answer(
+                                idx,
+                                &cached.path,
+                                q,
+                                &ReducedValue::None,
+                            );
                         }
                     }
                 }

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -796,11 +796,15 @@ impl ReducerRegistry {
                         // ENRICHING-guarded bake is the safe route to the same
                         // transitive answer.
                         crate::util::ghost_stats::count("consult.bridged");
-                        let enriched = idx.enriched_present(cached);
-                        if !std::sync::Arc::ptr_eq(&enriched, &full) {
-                            if let Some(t) = enriched.symbol_return_type_via_bag(sym.id, None) {
-                                found = Some(t);
-                                return ControlFlow::Break(());
+                        if idx.serves_enriched() {
+                            let enriched = idx.enriched_present(cached);
+                            if !std::sync::Arc::ptr_eq(&enriched, &full) {
+                                if let Some(t) =
+                                    enriched.symbol_return_type_via_bag(sym.id, None)
+                                {
+                                    found = Some(t);
+                                    return ControlFlow::Break(());
+                                }
                             }
                         }
                         ControlFlow::Continue(())
@@ -870,14 +874,16 @@ impl ReducerRegistry {
                             // enriched Arc: this chase threads the SHARED
                             // QueryState, whose memo keys on bag pointers.
                             crate::util::ghost_stats::count("consult.slot_type");
-                            let enriched = idx.enriched_present(&cached);
-                            if !std::sync::Arc::ptr_eq(&enriched, &full)
-                                && !std::ptr::eq(bag, &enriched.witnesses)
-                            {
-                                state.pins.push(std::sync::Arc::clone(&enriched));
-                                let v = attempt(&enriched, state);
-                                if v != ReducedValue::None {
-                                    return v;
+                            if idx.serves_enriched() {
+                                let enriched = idx.enriched_present(&cached);
+                                if !std::sync::Arc::ptr_eq(&enriched, &full)
+                                    && !std::ptr::eq(bag, &enriched.witnesses)
+                                {
+                                    state.pins.push(std::sync::Arc::clone(&enriched));
+                                    let v = attempt(&enriched, state);
+                                    if v != ReducedValue::None {
+                                        return v;
+                                    }
                                 }
                             }
                         }
@@ -1410,13 +1416,20 @@ impl ReducerRegistry {
                 // invisible to the raw bag, present in the
                 // enriched overlay.
                 crate::util::ghost_stats::count("consult.moc_primary");
-                let enriched = crate::util::ghost_stats::timed(
-                    "consult.enriched", || idx.enriched_present(cached));
-                if !std::sync::Arc::ptr_eq(&enriched, &full)
-                    && !std::ptr::eq(bag, &enriched.witnesses)
-                {
-                    state.pins.push(std::sync::Arc::clone(&enriched));
-                    attempt(&enriched, state)
+                // `serves_enriched` first: when the overlay is off (one-shot
+                // CLI) the fetch below returns the bag it already has, so the
+                // retry is a guaranteed no-op paid per escalation.
+                if idx.serves_enriched() {
+                    let enriched = crate::util::ghost_stats::timed(
+                        "consult.enriched", || idx.enriched_present(cached));
+                    if !std::sync::Arc::ptr_eq(&enriched, &full)
+                        && !std::ptr::eq(bag, &enriched.witnesses)
+                    {
+                        state.pins.push(std::sync::Arc::clone(&enriched));
+                        attempt(&enriched, state)
+                    } else {
+                        ReducedValue::None
+                    }
                 } else {
                     ReducedValue::None
                 }

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -734,6 +734,7 @@ impl ReducerRegistry {
                     let mut bridge_seen = false;
                     idx.for_each_entity_bridged_to(package, &mut |_m, _c, _s| {
                         bridge_seen = true;
+                        std::ops::ControlFlow::Break(())
                     });
                     crate::util::ghost_stats::count(if bridge_seen {
                         "bridge.live_yields"
@@ -753,18 +754,16 @@ impl ReducerRegistry {
                     }
                     let mut found: Option<InferredType> = None;
                     idx.for_each_entity_bridged_to(package, &mut |_mod, cached, sym| {
-                        if found.is_some() {
-                            return;
-                        }
+                        use std::ops::ControlFlow;
                         if !matches!(
                             sym.kind,
                             crate::model::file_analysis::SymKind::Sub
                                 | crate::model::file_analysis::SymKind::Method
                         ) {
-                            return;
+                            return ControlFlow::Continue(());
                         }
                         if &sym.name != name {
-                            return;
+                            return ControlFlow::Continue(());
                         }
                         // Bridged Method's return lives in the bridging file's
                         // bag — rehydrate it if evicted before querying.
@@ -772,7 +771,7 @@ impl ReducerRegistry {
                         let full = idx.bag_present(cached);
                         if let Some(t) = full.symbol_return_type_via_bag(sym.id, None) {
                             found = Some(t);
-                            return;
+                            return ControlFlow::Break(());
                         }
                         // Fallback-on-miss (R4): the bridged Method's return may
                         // chain through the bridging file's OWN imports — baked
@@ -788,8 +787,10 @@ impl ReducerRegistry {
                         if !std::sync::Arc::ptr_eq(&enriched, &full) {
                             if let Some(t) = enriched.symbol_return_type_via_bag(sym.id, None) {
                                 found = Some(t);
+                                return ControlFlow::Break(());
                             }
                         }
+                        ControlFlow::Continue(())
                     });
                     if let Some(t) = found {
                         return ReducedValue::Type(t);

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -766,7 +766,7 @@ impl ReducerRegistry {
                         crate::util::ghost_stats::count(&format!("bridgecls.{package}"));
                     }
                     let mut found: Option<InferredType> = None;
-                    idx.for_each_entity_bridged_to(package, &mut |_mod, cached, sym| {
+                    idx.for_each_entity_bridged_to_named(package, name, &mut |_mod, cached, sym| {
                         use std::ops::ControlFlow;
                         if !matches!(
                             sym.kind,

--- a/src/model/witnesses/registry.rs
+++ b/src/model/witnesses/registry.rs
@@ -830,7 +830,45 @@ impl ReducerRegistry {
                     note_slot_exit(state, class, key);
                 }
                 if let Some(idx) = ctx.module_index {
-                    for cached in idx.visible_def_candidates(class) {
+                    // The point-free memo spelling, same as the primary's:
+                    // answers below are computed point-free, so one (class,
+                    // key, candidate) verdict serves every call site in the
+                    // sweep. This arm carried 99.99% of FHEM's 12.3M provider
+                    // ATTEMPTS — the sweep memo made each attempt's fetch an
+                    // Arc bump, but the CHASE per attempt (a full query_rec
+                    // into the provider bag) is what the answer memo removes.
+                    let memo_q = ReducerQuery {
+                        attachment: q.attachment,
+                        point: None,
+                        framework: q.framework,
+                        arity_hint: None,
+                        receiver: q.receiver.clone(),
+                        args: q.args.clone(),
+                        context: None,
+                    };
+                    let verdict_key = super::ConsultVerdictKey::of(&memo_q);
+                    for cached in super::session::visible_def_candidates(idx, class).iter() {
+                        if let Some(hit) =
+                            super::session::candidate_answer(idx, &cached.path, &memo_q)
+                        {
+                            if *hit != ReducedValue::None {
+                                return (*hit).clone();
+                            }
+                            continue;
+                        }
+                        // The sweep tier, behind the session memo — a verdict
+                        // another file's build already derived this sweep.
+                        if let Some(hit) =
+                            idx.sweep_consult_answer(&cached.path, &verdict_key)
+                        {
+                            super::session::remember_candidate_answer(
+                                idx, &cached.path, &memo_q, &hit,
+                            );
+                            if *hit != ReducedValue::None {
+                                return (*hit).clone();
+                            }
+                            continue;
+                        }
                         let attempt =
                             |full: &std::sync::Arc<crate::model::file_analysis::FileAnalysis>,
                              state: &mut _| {
@@ -843,7 +881,13 @@ impl ReducerRegistry {
                                 };
                                 let sub_q = ReducerQuery {
                                     attachment: q.attachment,
-                                    point: q.point,
+                                    // Cross-file: the point is CONSUMER-file
+                                    // coordinates, meaningless against the
+                                    // provider's spans (the imported-sub
+                                    // recursion in query.rs already passes
+                                    // None). Point-free is also what lets a
+                                    // memo key collapse across call sites.
+                                    point: None,
                                     framework: q.framework,
                                     arity_hint: None,
                                     receiver: q.receiver.clone(),
@@ -863,6 +907,10 @@ impl ReducerRegistry {
                                 "moc.provider_answered"
                             });
                             if v != ReducedValue::None {
+                                super::session::remember_candidate_answer(
+                                    idx, &cached.path, &memo_q, &v,
+                                );
+                                idx.remember_sweep_consult(&cached.path, &verdict_key, &v);
                                 return v;
                             }
                             // Fallback-on-miss (R4), symmetric with the
@@ -884,10 +932,25 @@ impl ReducerRegistry {
                                     state.pins.push(std::sync::Arc::clone(&enriched));
                                     let v = attempt(&enriched, state);
                                     if v != ReducedValue::None {
+                                        super::session::remember_candidate_answer(
+                                            idx, &cached.path, &memo_q, &v,
+                                        );
+                                        idx.remember_sweep_consult(
+                                            &cached.path, &verdict_key, &v,
+                                        );
                                         return v;
                                     }
                                 }
                             }
+                            super::session::remember_candidate_answer(
+                                idx,
+                                &cached.path,
+                                &memo_q,
+                                &ReducedValue::None,
+                            );
+                            idx.remember_sweep_consult(
+                                &cached.path, &verdict_key, &ReducedValue::None,
+                            );
                         }
                     }
                 }
@@ -947,7 +1010,8 @@ impl ReducerRegistry {
                             };
                             let sub_q = ReducerQuery {
                                 attachment: q.attachment,
-                                point: q.point,
+                                // Cross-file: point normalized (see the slot arm).
+                                point: None,
                                 framework: q.framework,
                                 arity_hint: None,
                                 receiver: q.receiver.clone(),
@@ -1008,6 +1072,22 @@ impl ReducerRegistry {
         idx: &dyn crate::model::file_analysis::CrossFileLookup,
         package: &str,
     ) -> Option<ReducedValue> {
+        // The memo spelling of this query: point-free, because the answers
+        // below are computed point-free (cross-file sub-queries normalize the
+        // consumer's point out) and a point-carrying key made every call site
+        // a fresh memo miss.
+        let memo_q = ReducerQuery {
+            attachment: q.attachment,
+            point: None,
+            framework: q.framework,
+            arity_hint: q.arity_hint,
+            receiver: q.receiver.clone(),
+            args: q.args.clone(),
+            context: None,
+        };
+        // The sweep-tier spelling of the same key — shared across files and
+        // workers where a batch sweep opened the store (SweepAnswerGuard).
+        let verdict_key = super::ConsultVerdictKey::of(&memo_q);
         for cached in super::session::visible_def_candidates(idx, package).iter() {
             // Rehydrate the target file's bag if its resident copy
             // was Slice-2-evicted; the cross-file chase reads its
@@ -1024,7 +1104,14 @@ impl ReducerRegistry {
                     };
                     let sub_q = ReducerQuery {
                         attachment: q.attachment,
-                        point: q.point,
+                        // Cross-file: the point is CONSUMER-file coordinates,
+                        // meaningless against the provider's spans (the
+                        // imported-sub recursion in query.rs already passes
+                        // None). Point-free is also what lets the memo key
+                        // below collapse across call sites — keyed WITH the
+                        // point, a hash key read at 500 sites was 500 memo
+                        // misses per candidate.
+                        point: None,
                         framework: q.framework,
                         arity_hint: q.arity_hint,
                         receiver: q.receiver.clone(),
@@ -1035,12 +1122,21 @@ impl ReducerRegistry {
                 };
             // This candidate's contribution, remembered ACROSS
             // top-level queries. `attempt` is a pure function of
-            // (candidate file, attachment, receiver, arity, point,
-            // framework) — the whole key — so one walk derives it
-            // once instead of once per call site.
+            // (candidate file, attachment, receiver, arity, framework) —
+            // the whole key now that the point is normalized out — so one
+            // walk derives it once instead of once per call site.
             if let Some(hit) =
-                super::session::candidate_answer(idx, &cached.path, q)
+                super::session::candidate_answer(idx, &cached.path, &memo_q)
             {
+                if *hit != ReducedValue::None {
+                    return Some((*hit).clone());
+                }
+                continue;
+            }
+            // The sweep tier, behind the (cheaper) session memo: a verdict
+            // another file's build already derived this sweep.
+            if let Some(hit) = idx.sweep_consult_answer(&cached.path, &verdict_key) {
+                super::session::remember_candidate_answer(idx, &cached.path, &memo_q, &hit);
                 if *hit != ReducedValue::None {
                     return Some((*hit).clone());
                 }
@@ -1097,8 +1193,9 @@ impl ReducerRegistry {
                             // baked hit is cheap but not free, and
                             // the memo is the tier above it.
                             super::session::remember_candidate_answer(
-                                idx, &cached.path, q, &v,
+                                idx, &cached.path, &memo_q, &v,
                             );
+                            idx.remember_sweep_consult(&cached.path, &verdict_key, &v);
                             return Some(v);
                         }
                         // ABSENT. The spec lets this mean a proven
@@ -1200,8 +1297,11 @@ impl ReducerRegistry {
                                 super::session::remember_candidate_answer(
                                     idx,
                                     &cached.path,
-                                    q,
+                                    &memo_q,
                                     &ReducedValue::None,
+                                );
+                                idx.remember_sweep_consult(
+                                    &cached.path, &verdict_key, &ReducedValue::None,
                                 );
                                 continue;
                             }
@@ -1254,7 +1354,10 @@ impl ReducerRegistry {
                                     } else {
                                         let v = ReducedValue::Type(t);
                                         super::session::remember_candidate_answer(
-                                            idx, &cached.path, q, &v,
+                                            idx, &cached.path, &memo_q, &v,
+                                        );
+                                        idx.remember_sweep_consult(
+                                            &cached.path, &verdict_key, &v,
                                         );
                                         return Some(v);
                                     }
@@ -1356,9 +1459,10 @@ impl ReducerRegistry {
                 super::session::remember_candidate_answer(
                     idx,
                     &cached.path,
-                    q,
+                    &memo_q,
                     &ReducedValue::None,
                 );
+                idx.remember_sweep_consult(&cached.path, &verdict_key, &ReducedValue::None);
                 continue;
             }
             crate::util::ghost_stats::count("moc.provider_fetched");
@@ -1517,7 +1621,8 @@ impl ReducerRegistry {
                     "conclusion absence disagreed with the chase; see log"
                 );
             }
-            super::session::remember_candidate_answer(idx, &cached.path, q, &v);
+            super::session::remember_candidate_answer(idx, &cached.path, &memo_q, &v);
+            idx.remember_sweep_consult(&cached.path, &verdict_key, &v);
             if v != ReducedValue::None {
                 return Some(v);
             }

--- a/src/model/witnesses/session.rs
+++ b/src/model/witnesses/session.rs
@@ -56,6 +56,35 @@ struct CandidateKey {
     framework: FrameworkFact,
 }
 
+/// The SESSION-independent spelling of a candidate consult: what one
+/// (point-free) query asks of one candidate file, minus the path (the
+/// sweep-tier store pairs it with the path itself). The public sibling of
+/// `CandidateKey`, carried across `CrossFileLookup::sweep_consult_answer`
+/// so a batch sweep can remember verdicts ACROSS files and workers — the
+/// session memo is thread-local and per-verb, and first-encounter pairs
+/// per build are exactly the n² a package-main corpus produces.
+#[derive(PartialEq, Eq, Hash, Clone)]
+pub struct ConsultVerdictKey {
+    pub attachment: WitnessAttachment,
+    pub receiver: Option<String>,
+    pub arity: Option<u32>,
+    pub framework: FrameworkFact,
+}
+
+impl ConsultVerdictKey {
+    /// The key for `q`, point-normalized by construction (the sweep tier
+    /// only ever stores point-free verdicts — cross-file sub-queries
+    /// normalize the consumer's point out).
+    pub fn of(q: &ReducerQuery) -> ConsultVerdictKey {
+        ConsultVerdictKey {
+            attachment: q.attachment.clone(),
+            receiver: q.receiver.as_ref().map(|t| format!("{t:?}")),
+            arity: q.arity_hint,
+            framework: q.framework,
+        }
+    }
+}
+
 struct SessionState {
     /// Data address of the lookup this session was opened on. Entries are
     /// only valid under it (see the visibility-scope gate above).


### PR DESCRIPTION
Part of #119. The relational-iteration arc: re-point the imperative walkers at relations the storage layer already maintains, plus the FHEM investigation's fixes. Direction brief and ladder: `docs/prompt-relational-iteration.md` (row 4a is the mechanism narrative for the headline fix).

## The slices

| slice | commit | measured |
|---|---|---|
| MRO walk asks the rows before rehydrating a candidate | `9bddfacd` | candidate fetches 27,459 → 4,670; wasted 23,853 → 1,064; 22,789 skips equiv-scored, zero divergences |
| bridged-entity walk gets `ControlFlow` early exit | `e0142a94` | first-match callers stop at the matching module |
| seam retries gated by `serves_enriched` | `1ee24288` | 706k guaranteed-no-op fetches → 0 on one-shot CLI; kills a double-chase hazard under LRU thrash |
| `RetainedReader` under the conclusion loader | `41ead841` | 1,893 → 475 µs/load; the 5.1 ms/call × 70k connection-per-miss term gone |
| `RetainedReader` under both bag-rehydrate loaders | `c75e5105` | same disease, same cure; fallback path preserved |
| `NO_BAKE` narrows the repair frontier instead of emptying it | `fad5bdad` | the control now ablates exactly what it claims (two half-gates fixed) |
| typeglob last resort asks the rows first (ladder 2) | `70e79df6` | 24,506 of 25,523 candidate scans skipped (96%) |
| bridged walk takes a name hint + rows pre-gate (ladder 3) | `873e1891` | per-miss scan of every bridging module deleted, no schema change |
| bridge/provider relations ride the enrichment key (ladder 8) | `f3e428e3` | a plugin edit now moves its consumers' overlay keys; pinned by test |
| **cross-file consults point-free, memoized per walk and per sweep** | `24f66e0a` | **918× attempt reduction, 2.06× wall at n=250, FHEM n=500 from killed to completing; overlay builds 8.9× cheaper at unchanged count** |
| per-file sweep memo byte-capped, drop-oldest | `29f2d70d` | crest = workers × cap; one file's memo had measured 633 MB; provably no-ops on ordinary corpora |
| attribution instruments (mocsite/mocpkg/mocfetch, diag channel, byte counters, key timer) | several | the counters that killed seven wrong hypotheses before they became fixes |

One slice was cut, refuted by A/B (displaced 20 of 12.3M), reverted, and reworked into the 918× fix (`213d00eb` → `bfc02830` → `24f66e0a`). It stays in the history deliberately: the misread-attempt-counter → wrong fix → revert → rework sequence is the instructive part.

## The FHEM investigation (why the headline slice exists)

FHEM (991k LOC, 973 files, everything in `package main`, 46k-line modules) drove 13.5M provider-fetch attempts through the SlotType arm — the one cross-file arm with no memo, no map tier, no session — and died at 16 GB RSS. The chain: 534 explicit providers of `main` × per-file hash-key density × a session memo that was inert on the enrichment cascade and keyed by consumer-file coordinates. Fix: point-free cross-file sub-queries, a session around overlay builds, and a sweep-wide answer store shared across rayon workers.

The RSS half closed as two mechanisms after seven suspects died to control arms and byte counters (never to arithmetic): brk retention of decode-and-drop churn owns the sustained figure (`MALLOC_MMAP_THRESHOLD_=65536` returns 53% — ship posture is a product decision, tracked separately), and per-worker in-flight working sets own the crest (fixed here by the byte-capped memo). The sweep path memo itself measured load-bearing at 1.55× wall and stays.

## Methods

Two rules paid for during this arc, now in the doc's discipline section and applicable beyond it:

- **An attempt counter is not a completion counter** — state which kind any quoted counter is, and show the reconciliation when they could diverge.
- **A plausible product landing near a measured total is not an attribution** — an attribution is a control arm or a byte counter at the holder; everything else is a hypothesis and must be labeled one.

## Verification

Every slice landed with the full battery green: cargo (1,598), e2e (116/11 suites), gold (503 PASS, cold + warm, 0 lang-skip, `--features cpp`). The 918× waypoint was additionally verified independently (separate worktree, `scripts/verify.sh`, bar reported verbatim). A confirming full-FHEM run (cap alone, cap+mmap) is queued with predictions pre-registered; the coordinator session's measurement writeup will follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dNrujJWn1LSRqAGXiYTpG
