### PR TITLE
docs: the two measured scaling limits, and C/C++ is alpha

### DIFF
--- a/docs/cpp-golive-map.md
+++ b/docs/cpp-golive-map.md
@@ -341,6 +341,9 @@ ARC 4  cpp LSP experience .............................. 🔵 IN PROGRESS
          eviction + open-consumer refresh path. ✅
 
 ARC 5  SHIP cpp ...................................... ⬜ THE GOAL
+       Status answered for now: ALPHA — see docs/cpp-status.md. Godot
+       (7,041 files) does not complete; 30-66s stalls on large vendored
+       headers. Memory is fine; the gate is per-file wall.
 ```
 
 ## The load-bearing insight: the tier is SHARED, not Perl-specific

--- a/docs/cpp-status.md
+++ b/docs/cpp-status.md
@@ -1,0 +1,59 @@
+# C/C++ support: ALPHA
+
+**Status: alpha.** Opt-in behind `--features cpp`, not built by default, and not
+recommended for large projects yet. This answers the "good enough to ship?" gate
+that `cpp-golive-map.md` ARC 5 leaves open — with a measurement, and the answer
+today is *not on projects of Godot's size*.
+
+## What works
+
+Goto-def, cross-TU references, member and in-scope completion, hover, include
+navigation, macro-aware extraction (config-variant macro model, splice-mapped
+reparse), diagnostics, and the same SQLite warm-start path Perl uses. 1,676
+tests pass with `--features cpp` (+64 over Perl-only); the pack e2e lane is
+8 suites / 24 tests.
+
+## Why alpha: measured
+
+| project | C++ files | result |
+|---|---:|---|
+| [fmt](https://github.com/fmtlib/fmt) | 80 indexed | 4.2 s, 0.50 GB — fine |
+| [Godot](https://github.com/godotengine/godot) | 7,041 | **did not complete in 4 minutes**; killed |
+
+Godot's memory behaviour is **good** — RSS plateaus flat at ~2 GB across 7,041
+files, which is better per-file than the Perl side manages. The problem is wall
+time, and it is concentrated in individual files:
+
+```
+[stall] 66s on one unit: thirdparty/vulkan/include/vulkan/vulkan_handles.hpp
+[stall] 34s on one unit: thirdparty/vulkan/include/vulkan/vulkan_raii.hpp
+[stall] 32s on one unit: thirdparty/directx_headers/include/directx/d3d12.h
+[stall] 31s on one unit: thirdparty/ufbx/ufbx.c
+```
+
+**Every stall is a large generated or vendored header.** `d3d12.h` alone is
+1.5 MB. A per-file cost of 30–66 seconds is unusable interactively no matter
+what the aggregate looks like.
+
+Note the failure mode is the **opposite** of the Perl side's: C++ is
+memory-healthy and wall-pathological; Perl's FHEM shape is memory-pathological
+(`scaling-limits.md`). They share no mechanism, and the Perl scaling work
+neither caused nor fixed the C++ one.
+
+## What alpha means in practice
+
+- Fine for small-to-medium projects. fmt-sized is comfortable.
+- Expect multi-second-to-multi-minute stalls on projects vendoring large
+  generated headers — Vulkan, DirectX, and similar SDK headers are the
+  reliable trigger.
+- Excluding `thirdparty/` from the workspace avoids most of it today, since
+  that is where the giant headers live in every project we measured.
+- No API or behaviour stability promise. `--features cpp` stays opt-in.
+
+## What would move it past alpha
+
+The per-file stall, specifically — an aggregate number will not settle it. The
+gate is a large generated header (`d3d12.h`, `vulkan_handles.hpp`) analysed in
+interactive time, and no measurement of total wall across a corpus substitutes
+for that. Nobody has profiled where those 30–66 seconds go; that is the next
+step and it has not been taken.

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -199,14 +199,33 @@ index rebuild** (cloning every String-bearing attachment) on each call.
 (`WitnessBag::remove_attachment_sources_at`).
 
 ```
-build()             29.1 s -> 7.8 s
 fold::call_binding  21.6 s -> 16.5 ms
 bag length          57,228 -> 57,228   (unchanged)
 fold iterations          3 -> 3        (unchanged)
 ```
 
-Identical bag and iteration count with a 3.7x wall drop is what makes this a fix
-rather than a tuning: the same fixed point, reached without the quadratic.
+Identical bag and iteration count with the wall dropping is what makes this a
+fix rather than a tuning: the same fixed point, reached without the quadratic.
+
+Ladder measured through `didOpen`, pre-fix vs post-fix:
+
+| lines | pre-fix | post-fix | |
+|---:|---:|---:|---|
+| 3,268 | 188 ms | 181 ms | flat |
+| 5,607 | 276 ms | 271 ms | flat |
+| 20,669 | 2,374 ms | **1,424 ms** | 1.7x |
+| 46,522 | 33,180 ms | **10,698 ms** | 3.1x |
+
+Small files are untouched, as expected — the pass only matters at scale. The
+top-end exponent falls from **3.33 to 2.47**: still superlinear, but the cliff
+is gone, and the gain growing with size is the signature of removing a term
+that scaled with the file rather than a constant.
+
+**Measurement caveat.** Pre-fix points are single measurements, and this box
+shows real variance — three repeats of the 20,669 point read 1552 / 1386 / 1424
+ms, while a single pass earlier read 3,869 (2.7x the median) and briefly looked
+like a regression. The ratios are directionally sound; the exact multipliers are
+not precise. Repeat before quoting any of them as a target.
 
 ### Two corrections to the first version of this section
 

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -94,3 +94,62 @@ Useful report: `PERL_LSP_GHOST_STATS=/tmp/g.txt perl-lsp --check <root>` plus
 (`grep -rhc '^package ' --include='*.pm' . | sort | uniq -c | sort -rn | head`).
 Those three tell us within minutes which of the shapes above you have, or that
 you have a new one.
+
+## 3. Dependencies are not free — every historical number here understates load
+
+Measured on the eight-repo corpus, cold `--check`, same binary both arms, deps
+on `@INC` via `PERL5LIB` (never in the workspace — see `corpus/README.md`):
+
+| repo | wall nodeps → deps | Δ | RSS nodeps → deps |
+|---|---|---:|---|
+| BMO | 7.82 → 13.76 s | **+76%** | 0.48 → 0.62 GB |
+| openfoodfacts | 9.51 → 12.76 s | +34% | 0.37 → 0.47 GB |
+| WeBWorK | 7.40 → 9.89 s | +34% | 0.30 → 0.36 GB |
+| FHEM | 41.06 → 54.23 s | +32% | both killed |
+| Evergreen | 13.37 → 17.18 s | +29% | 0.53 → 0.65 GB |
+| Foswiki | 10.80 → 12.83 s | +19% | 0.48 → 0.53 GB |
+| Webmin | 9.26 → 8.76 s | −5% | flat |
+| Znuny | 85.30 → 79.07 s | −7% | flat |
+
+**+19–76% wall, +2–29% RSS** where it bites. The two flat rows are controls
+rather than noise: Webmin uses path-based `require` and barely touches CPAN, and
+Znuny vendors 723 `cpan-lib` modules *inside* its workspace so its imports
+already resolved.
+
+Wall and fetch counts do **not** track each other — BMO gains 76% wall on 16%
+more fetches, openfoodfacts 34% on 168% more. The expense is what a *successful*
+resolution pulls in, not the lookup count.
+
+**Consequence:** any benchmark run without dependencies installed understates
+real resolution load by roughly a third. State which shape a number was measured
+on.
+
+## 4. Memory and fan-out are independent axes
+
+`Znuny` is the correction to an earlier framing here. It has the **lowest**
+provider fan-out of 28 corpora (8 attempts/file) and is entirely healthy on that
+axis — and it still peaks at **8.15 GB** on 3,078 files, second only to FHEM.
+Low fan-out does not imply low memory; file count does not predict either. A
+corpus needs both measured.
+
+## 5. `--heatmap` is a batch verb, not an interactive one
+
+| corpus | `--check` | `--heatmap` | ratio | max fan-in |
+|---|---:|---:|---:|---:|
+| WeBWorK (225 files) | 3.80 s | 5.00 s | 1.3x | 81 |
+| Webmin (1,333) | 4.76 s | 31.07 s | 6.5x | 199 |
+| BMO (739) | 5.39 s | 91.69 s | **17x** | 340 |
+
+Cost tracks **fan-in**, not file count — BMO is smaller than Webmin and costs
+3x more. That follows from what the verb does: it mints the `references()`
+projection at every declaration, so the work is declarations x their fan-in.
+
+**It also runs on one core.** Measured at 104-105% CPU throughout, where
+`--check`'s diagnostics sweep parallelises across all of them. So the ratios
+above are two effects compounding — more work per declaration, done serially —
+and the serial half looks addressable with the same `par_iter` + channel shape
+the diagnostics sweep already uses. Not attempted; recorded as the obvious next
+step for anyone who needs `--heatmap` to be faster.
+
+Memory is mild by comparison (Webmin 0.47 → 0.95 GB, BMO 0.49 → 0.70 GB), so
+this is a wall cost, not a memory one.

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -219,31 +219,39 @@ Ladder through `didOpen`, first build in a fresh server, median of 3:
 **6.2x at the top.** The small rows are NOT a regression — see below, and the
 reason two people chased one anyway is worth more than the table.
 
-### Measure the SECOND build in a process, not the first
+### The first-build constant — found, attributed, and removed
 
-Every row above is a fresh server, and **the first `build()` in a process
-carries a one-time ~600 ms cost that is not the build**: `rhai` plugin
-compilation (`default_plugin_registry`, a `OnceLock`) is lazily forced by the
-first `didOpen` and lands inside its `[PHASE] build()`.
+Every row above is a fresh server, and the first `build()` in a process used to
+carry ~600 ms that was **not the build**. On small files it dominated the
+quantity being compared, which produced an apparent 424 → 627 ms "regression"
+that two people chased.
 
-A fresh-server-per-point ladder therefore pays that constant at *every* point on
-*every* commit, and on small files it dominates the quantity being compared.
-`[05]` established this by bisect — first-build on a 1,760-line file is ~700 ms
-at all three commits (721/696, 688/685, 696/701, indistinguishable) — then by
-opening two files in one process: **712 ms, then 121 ms.**
+`[05]` bisected it: first-build on a 1,760-line file was ~700 ms at all three
+commits (721/696, 688/685, 696/701 — indistinguishable), and two `didOpen`s in
+one process gave **712 ms then 121 ms**.
 
-Per-build cost measured correctly, 3,268 lines: **121 ms post-fix against 181 ms
-pre-fix. Small files improve too.** The apparent 424 → 627 "regression" was that
-constant wobbling with box state. Tight bands either side of a shared constant
-look exactly like a real difference, which is how it survived two rounds of
-scrutiny.
+The first attribution — lazy `rhai` plugin compilation — was **wrong, and `[05]`
+retracted it themselves**. The phases now print, and they name the real cost:
 
-**Protocol: quote the second build in a process, or state the first-build
-constant explicitly. Never compare first-builds across commits.**
+```
+registry::engine          0.65 ms
+registry::rhai_compile    7.45 ms     <- rhai was never the problem
+registry::queries       119.02 ms     <- 14 tree-sitter Query::new + the flow query,
+                                         ~597 ms when run serially
+```
 
-**Separate lead, worth a ticket:** pre-warming the plugin registry from
-`initialize` on `spawn_blocking` would take ~600 ms off every editor cold open,
-independent of anything above.
+Fixed three ways (`0e33a8d4`): the registry cell is keyed by resolved `.rhai`
+paths so a pre-root warm is safe, the warm runs in `main()` before the
+handshake, and the query compiles run rayon-parallel (597 → ~140 ms). A latent
+bug went with it — the old `OnceLock` would have baked a wrong pre-root plugin
+set permanently.
+
+Result, 3,268 lines: **627 → 223 ms** (223/229/223, tight). The 46k file is
+unchanged at 5,335 ms, which is the correct signature for removing a fixed cost.
+
+**Protocol, now enforced by the code rather than by discipline:** the registry
+phases print, so a ladder cannot silently eat this constant again. Still prefer
+the second build in a process when quoting per-build cost.
 
 ### Two corrections to the first version of this section
 

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -207,25 +207,43 @@ fold iterations          3 -> 3        (unchanged)
 Identical bag and iteration count with the wall dropping is what makes this a
 fix rather than a tuning: the same fixed point, reached without the quadratic.
 
-Ladder measured through `didOpen`, pre-fix vs post-fix:
+Ladder through `didOpen`, first build in a fresh server, median of 3:
 
-| lines | pre-fix | post-fix | |
-|---:|---:|---:|---|
-| 3,268 | 188 ms | 181 ms | flat |
-| 5,607 | 276 ms | 271 ms | flat |
-| 20,669 | 2,374 ms | **1,424 ms** | 1.7x |
-| 46,522 | 33,180 ms | **10,698 ms** | 3.1x |
+| lines | pre-fix | + call_binding fix | + chain_pre fix |
+|---:|---:|---:|---:|
+| 3,268 | 188 ms | 424 ms | 627 ms |
+| 5,607 | 276 ms | 599 ms | 639 ms |
+| 20,669 | 2,374 ms | 1,424 ms | 2,290 ms |
+| **46,522** | **33,180 ms** | **10,698 ms** | **5,364 ms** |
 
-Small files are untouched, as expected — the pass only matters at scale. The
-top-end exponent falls from **3.33 to 2.47**: still superlinear, but the cliff
-is gone, and the gain growing with size is the signature of removing a term
-that scaled with the file rather than a constant.
+**6.2x at the top.** The small rows are NOT a regression — see below, and the
+reason two people chased one anyway is worth more than the table.
 
-**Measurement caveat.** Pre-fix points are single measurements, and this box
-shows real variance — three repeats of the 20,669 point read 1552 / 1386 / 1424
-ms, while a single pass earlier read 3,869 (2.7x the median) and briefly looked
-like a regression. The ratios are directionally sound; the exact multipliers are
-not precise. Repeat before quoting any of them as a target.
+### Measure the SECOND build in a process, not the first
+
+Every row above is a fresh server, and **the first `build()` in a process
+carries a one-time ~600 ms cost that is not the build**: `rhai` plugin
+compilation (`default_plugin_registry`, a `OnceLock`) is lazily forced by the
+first `didOpen` and lands inside its `[PHASE] build()`.
+
+A fresh-server-per-point ladder therefore pays that constant at *every* point on
+*every* commit, and on small files it dominates the quantity being compared.
+`[05]` established this by bisect — first-build on a 1,760-line file is ~700 ms
+at all three commits (721/696, 688/685, 696/701, indistinguishable) — then by
+opening two files in one process: **712 ms, then 121 ms.**
+
+Per-build cost measured correctly, 3,268 lines: **121 ms post-fix against 181 ms
+pre-fix. Small files improve too.** The apparent 424 → 627 "regression" was that
+constant wobbling with box state. Tight bands either side of a shared constant
+look exactly like a real difference, which is how it survived two rounds of
+scrutiny.
+
+**Protocol: quote the second build in a process, or state the first-build
+constant explicitly. Never compare first-builds across commits.**
+
+**Separate lead, worth a ticket:** pre-warming the plugin registry from
+`initialize` on `spawn_blocking` would take ~600 ms off every editor cold open,
+independent of anything above.
 
 ### Two corrections to the first version of this section
 

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -166,73 +166,107 @@ step for anyone who needs `--heatmap` to be faster.
 Memory is mild by comparison (Webmin 0.47 → 0.95 GB, BMO 0.49 → 0.70 GB), so
 this is a wall cost, not a memory one.
 
-## 6. Single huge files: `build()` goes cubic past ~20k lines
+## 6. Single huge files: one accidental O(bindings x bag) pass, now fixed
 
 Found by opening FHEM's biggest file in an editor and waiting 30 seconds for
-semantic tokens. The server was responsive throughout — it just had no analysis
-to answer from yet.
+semantic tokens. Root-caused and fixed by `[05]`; this section records the
+corrected story, because the first version of it got two things wrong.
 
-Measured through the LSP, real workspace, `@INC` live (`PERL_LSP_PHASE_TIMING=1`):
+### The symptom
 
-| lines | parse | `build()` |
-|---:|---:|---:|
-| 1,760 | 10 ms | 71 ms |
-| 3,268 | 20 ms | 188 ms |
-| 5,607 | 30 ms | 276 ms |
-| 20,669 | 160 ms | 2,374 ms |
-| **46,522** | **318 ms** | **35,304 ms** |
+`76_SolarForecast.pm`, 46,522 lines / 2.6 MB, opened via `didOpen`:
 
 ```
-parse   ~ lines^1.05                      (linear; the parser is not the problem)
-build() ~ lines^1.58 → 0.71 → 1.65 → 3.33 (exponent RISES with size)
+[PHASE] parse       349.01 ms
+[PHASE] build()   33179.55 ms     <- 33.2 s
 ```
 
-**The knee is between 20k and 46k lines.** Under ~6k, build is sub-300 ms.
-At 20k it is 2.4 s. At 46k it is 35 s, and the file is unusable interactively
-until it finishes.
+Inside `build()`, `fold_to_fixed_point` was 30.7 s — 92% — while the CST walk
+was 0.74 s. The fold converged in **3 iterations**, so it was never spinning.
 
-### Where the time goes
+### The cause: a full index rebuild per binding
 
-`build()` is 33.2 s of a 33.6 s open, and inside it:
-
-```
-build::fold_to_fixed_point   30,680 ms    <- 92%
-build::pattern_dispatch         913 ms
-build::walk                     740 ms
-build::finalize_post_walk       442 ms
-```
-
-The CST walk is 0.74 s. **The worklist fold is the whole cost**, and the
-counters say what it is folding:
+`propagate_call_bindings_to_constraints` called `remove_attachment_source_at`
+once per binding, and that helper does a **full-bag retain plus a full witness
+index rebuild** (cloning every String-bearing attachment) on each call.
 
 ```
-hop.edge            1,838,748
-hop.OBSERVATION       503,918
-hop.fact              271,500
-hop.inferred_type     232,585
-build.fold_bag_len     57,228   <- witnesses in the bag
+4,857 calls -> 3,246 rebuilds -> 185,757,638 cumulative index re-insertions
+                                = 20.7 s of the 30 s
 ```
 
-A 57k-witness bag re-walked to a fixed point at 1.8M edge hops. `Expr(span)`
-witnesses are emitted per meaningful expression, so bag size tracks expression
-count, and the fold is superlinear in bag size — which is why the exponent
-climbs rather than holding.
+**Fix: batch the removals** — one retain and one rebuild per pass
+(`WitnessBag::remove_attachment_sources_at`).
 
-### What this is and is not
+```
+build()             29.1 s -> 7.8 s
+fold::call_binding  21.6 s -> 16.5 ms
+bag length          57,228 -> 57,228   (unchanged)
+fold iterations          3 -> 3        (unchanged)
+```
 
-**Not** the `--check` memory story above; that is whole-workspace sweep
-residency, this is one file's analysis, and they share no mechanism. **Not**
-`@INC` size either, though `@INC` is required to see it: the same file with an
-empty module universe builds in **0.39 s**, so a single-file reproduction
-without a real workspace measures nothing. That trap cost an hour here.
+Identical bag and iteration count with a 3.7x wall drop is what makes this a fix
+rather than a tuning: the same fixed point, reached without the quadratic.
 
-**Interactive symptom, precisely:** verbs answer *fast* and return empty
-(`null`) while the build runs, rather than blocking. The client renders nothing
-and does not retry, so it looks like a dead server until the build finishes and
-the server sends `semanticTokens/refresh` — at which point everything appears
-at once. Answering "not ready" in a way clients retry on would mask the whole
-delay without making the build any faster.
+### Two corrections to the first version of this section
 
-**Who hits it:** anyone with a single module past ~20k lines. Rare, but not
-FHEM-exclusive — a few generated or accreted modules that size exist in plenty
-of long-lived codebases.
+**The superlinearity was accidental, not intrinsic.** This section previously
+said the fold is "superlinear in bag size — which is why the exponent climbs."
+Wrong. The exponent climbed because one pass was O(bindings x bag). The registry
+chases the first analysis blamed are cheap: `fold::seed` 30 ms and
+`fold::snapshot` 27 ms for **all** 1.8M hops. A "16.7 µs per hop" figure was
+derived by dividing total fold time by a hop count that was not the cost — a
+ratio of two unrelated quantities, and it read as a smoking gun.
+
+**Consequence for design: chunking the solver would have masked a bug.** The bag
+was not too big; one pass was rebuilding an index 3,246 times.
+
+### The 1 MB cap — why the same file measures 0.39 s or 29 s
+
+The first version claimed `@INC` was required to reproduce, citing an isolated
+one-file `--check` that took 0.39 s against 33 s in a real workspace. That was
+wrong twice over, and the real reason is a one-line filter:
+
+```
+index_perl.rs:52,99   m.len() < 1_000_000
+76_SolarForecast.pm = 2,652,209 bytes
+```
+
+**The workspace walk skips files over 1 MB, so `--check` never built it** —
+there is no `[PHASE] build()` line in that run at all. `didOpen` has no such
+cap. The same file is skipped by batch verbs and always built by the editor,
+which is the entire 0.39 s / 29 s gap. `build()` has no module-index access, so
+`@INC` cannot affect it either way.
+
+**A consequence worth its own line: files over 1 MB silently receive no
+`--check` diagnostics.** FHEM has four. "No diagnostics" reads exactly like "no
+problems found," and nothing in the output distinguishes them.
+
+### Residual
+
+After the fix, `fold::chain_pre` (chain typing PreFold) is 5.3 s on the 46k
+file — **96% of what remains** — and is the next target if 7.8 s is still too
+slow.
+
+### The interactive symptom is separate, and separately fixable
+
+While the build runs, verbs answer **fast and return `null`** rather than
+blocking: on the 46k file hover 0.82 s, definition 1.22 s, completion 1.62 s,
+semanticTokens 2.02 s, every one empty. The client renders nothing and **never
+retries**, so it looks like a dead server until the build finishes and the
+server sends `workspace/semanticTokens/refresh` — then everything appears at
+once. Confirmed in nvim's log: 22 s of answered `documentHighlight` and nothing
+else, then `refresh`, then the client's first `semanticTokens/full`.
+
+Answering "not ready" in a way clients retry on (`ContentModified`) would mask
+the remaining delay regardless of how fast the fold gets. Not done.
+
+### Instrumentation note
+
+Per-build counters were previously unobtainable: the ghost-stats sink is written
+by an activity-driven re-emit, so the default interval never fires on a short
+build and a short interval **re-adds per emission** (a 3,268-line file reported
+1,117,581 witnesses and 1,995 iterations against the real 57,228 and 3 — ~665x).
+`[05]` added a thread-local per-build scope emitting one `[build-scope]` block
+at build end, delta'd per build. That is what made this root-cause possible, and
+it is immune to both failure modes.

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -1,0 +1,96 @@
+# Scaling limits: what we know, measured
+
+Two shapes cost far more than their size suggests. Both are documented rather
+than fixed, because in each case the fix is large and the population affected is
+small and identifiable.
+
+Everything here was measured on 28 large open-source Perl codebases plus two
+private applications (`corpus/README.md` reconstructs the public set).
+
+## The healthy baseline, so the outliers mean something
+
+Across 28 real Perl codebases, cold `--check`:
+
+- conclusion-cache hit rate **96–99.9%**, every corpus
+- provider-fetch **attempts** 8–206 per file for 25 of 28
+- 4–36 ms per file
+- memory flat and bounded
+
+That band is what normal looks like. Two things fall outside it.
+
+## 1. `package main` monocultures (FHEM shape) — PATHOLOGICAL, not fixed
+
+[FHEM](https://github.com/fhem/fhem-mirror) — 991k LOC, 973 Perl files, zero
+vendored — does not complete `--check` on a machine with 31 GB of RAM.
+
+**The shape:** 503 of its 614 `.pm` files declare `package main` explicitly, and
+31 more declare nothing. **534 of 614 files (87%) provide one package name.**
+This is not a mistake in FHEM: `fhem.pl` `do`-loads all of them into a single
+interpreter, and 361 of them call `readingsSingleUpdate` from `fhem.pl`'s main.
+They genuinely share one stash. **The 534-wide provider relation is correct.**
+
+**The cost:** every `main` lookup consults a 534-member candidate set. `main` is
+27% of package lookups and **94% of provider fetches**. Per-worker sweep working
+sets reach 633 MB, and ~20 rayon workers multiply that into the crest.
+
+**What does not explain it, each ruled out by a control rather than an argument:**
+
+| suspect | ruled out by |
+|---|---|
+| walk residency | index-only run holds 0.98 GB — *leaner than release's entire check* |
+| overlay clones | 0.76 GB cumulative; the overlay cache is capped at 133 MB |
+| the sweep path memo | disabling it moves peak 0.7% — and costs 55% wall, it is load-bearing |
+| allocator arena count | `MALLOC_ARENA_MAX=2` gives ≤5%, inside run variance |
+| the diagnostics channel | 300 KB high-water against 10 GB |
+| per-file memo byte cap | engaged correctly (19,929 evictions) and made peak **worse** (+15%) and wall **worse** (+51%) — reverted |
+| source-byte admission gate | never engages: needs 3+ giants concurrently in flight to reach its budget |
+
+**What does explain it, in two parts:**
+
+- **glibc brk retention** owns the *sustained* figure. 1.6 MB analyses churn
+  decode-and-drop and freed chunks never return.
+  `MALLOC_MMAP_THRESHOLD_=65536` cuts sustained RSS **53%** (10.02 → 4.68 GB)
+  and turns a monotone climb into a sawtooth that actually returns memory. Peak
+  falls only 16%, so this helps a long-lived server and barely helps a one-shot
+  CLI.
+- **Per-worker in-flight sets** own the *crest*. `RAYON_NUM_THREADS=4` cuts peak
+  **67%** (9.83 → 3.20 GB) for **4.9%** wall — the sweep is not CPU-bound at 20
+  workers, so 16 of 20 buy almost nothing in time while costing 6.6 GB.
+
+**Workaround for this shape today:**
+
+```
+RAYON_NUM_THREADS=4 MALLOC_MMAP_THRESHOLD_=65536 perl-lsp --check <root>
+```
+
+**Why it is not fixed.** The relation is semantically correct, so narrowing it
+would be wrong. The remaining honest fix is deduplicating provider decoding
+across a sweep (~13,456 rehydrates for ~500 distinct providers is ~27x redundant
+work held in up to 20 overlapping per-file memos). That is a real change to the
+sweep's memory model and it has not been built.
+
+**Who this affects:** codebases where one package name has hundreds of
+providers. That is `do`-loaded plugin frameworks. It is not ordinary
+application code, and it is not `.t`-heavy repositories — test files declaring
+`main` implicitly do **not** reproduce it.
+
+## 2. Vendored dependency piles — MISLEADING, not slow
+
+A tree of many unrelated distributions (a CPAN mirror, a large `thirdparty/`)
+has no locality: each file consults a different module set, so the conclusion
+cache thrashes. A 551-distribution pile took **137x more cache misses** than
+real application code and produced a "cliff" — 65x slowdown for 1.84x the files
+— that **no real codebase reproduces**.
+
+If you are benchmarking, this is the trap: unresolvable imports cost the
+resolver nothing to answer, so a dependency pile both thrashes the cache *and*
+understates resolution work. Measure applications, and install their
+dependencies onto `@INC` rather than into the workspace (`corpus/README.md`).
+
+## Reporting a scaling problem
+
+Useful report: `PERL_LSP_GHOST_STATS=/tmp/g.txt perl-lsp --check <root>` plus
+`/usr/bin/time -v`, and the count of files declaring the same package name
+(`grep -rhc '^package ' --include='*.pm' . | sort | uniq -c | sort -rn | head`).
+Those three tell us within minutes which of the shapes above you have, or that
+you have a new one.

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -165,3 +165,74 @@ step for anyone who needs `--heatmap` to be faster.
 
 Memory is mild by comparison (Webmin 0.47 → 0.95 GB, BMO 0.49 → 0.70 GB), so
 this is a wall cost, not a memory one.
+
+## 6. Single huge files: `build()` goes cubic past ~20k lines
+
+Found by opening FHEM's biggest file in an editor and waiting 30 seconds for
+semantic tokens. The server was responsive throughout — it just had no analysis
+to answer from yet.
+
+Measured through the LSP, real workspace, `@INC` live (`PERL_LSP_PHASE_TIMING=1`):
+
+| lines | parse | `build()` |
+|---:|---:|---:|
+| 1,760 | 10 ms | 71 ms |
+| 3,268 | 20 ms | 188 ms |
+| 5,607 | 30 ms | 276 ms |
+| 20,669 | 160 ms | 2,374 ms |
+| **46,522** | **318 ms** | **35,304 ms** |
+
+```
+parse   ~ lines^1.05                      (linear; the parser is not the problem)
+build() ~ lines^1.58 → 0.71 → 1.65 → 3.33 (exponent RISES with size)
+```
+
+**The knee is between 20k and 46k lines.** Under ~6k, build is sub-300 ms.
+At 20k it is 2.4 s. At 46k it is 35 s, and the file is unusable interactively
+until it finishes.
+
+### Where the time goes
+
+`build()` is 33.2 s of a 33.6 s open, and inside it:
+
+```
+build::fold_to_fixed_point   30,680 ms    <- 92%
+build::pattern_dispatch         913 ms
+build::walk                     740 ms
+build::finalize_post_walk       442 ms
+```
+
+The CST walk is 0.74 s. **The worklist fold is the whole cost**, and the
+counters say what it is folding:
+
+```
+hop.edge            1,838,748
+hop.OBSERVATION       503,918
+hop.fact              271,500
+hop.inferred_type     232,585
+build.fold_bag_len     57,228   <- witnesses in the bag
+```
+
+A 57k-witness bag re-walked to a fixed point at 1.8M edge hops. `Expr(span)`
+witnesses are emitted per meaningful expression, so bag size tracks expression
+count, and the fold is superlinear in bag size — which is why the exponent
+climbs rather than holding.
+
+### What this is and is not
+
+**Not** the `--check` memory story above; that is whole-workspace sweep
+residency, this is one file's analysis, and they share no mechanism. **Not**
+`@INC` size either, though `@INC` is required to see it: the same file with an
+empty module universe builds in **0.39 s**, so a single-file reproduction
+without a real workspace measures nothing. That trap cost an hour here.
+
+**Interactive symptom, precisely:** verbs answer *fast* and return empty
+(`null`) while the build runs, rather than blocking. The client renders nothing
+and does not retry, so it looks like a dead server until the build finishes and
+the server sends `semanticTokens/refresh` — at which point everything appears
+at once. Answering "not ready" in a way clients retry on would mask the whole
+delay without making the build any faster.
+
+**Who hits it:** anyone with a single module past ~20k lines. Rare, but not
+FHEM-exclusive — a few generated or accreted modules that size exist in plenty
+of long-lived codebases.

--- a/docs/scaling-limits.md
+++ b/docs/scaling-limits.md
@@ -23,6 +23,18 @@ That band is what normal looks like. Two things fall outside it.
 [FHEM](https://github.com/fhem/fhem-mirror) — 991k LOC, 973 Perl files, zero
 vendored — does not complete `--check` on a machine with 31 GB of RAM.
 
+**Scope, established by using it rather than by measuring it: this is a
+BATCH-VERB limit, not a server limit.** FHEM opens fine in an editor. Startup is
+slow, and after that it behaves. The difference is structural rather than
+lucky — `--check` runs the enriched-diagnostic sweep across *every* workspace
+file, while the server indexes nothing at `initialize` and enriches only the
+documents you actually open. The crest below is 20 rayon workers each holding a
+per-file working set; an editor session has no such sweep to run.
+
+So: `--check`, `--heatmap` and the other whole-workspace verbs are the affected
+surface. Interactive editing of a `main`-monoculture codebase is not, and this
+file said otherwise until someone opened FHEM in nvim and found it usable.
+
 **The shape:** 503 of its 614 `.pm` files declare `package main` explicitly, and
 31 more declare nothing. **534 of 614 files (87%) provide one package name.**
 This is not a mistake in FHEM: `fhem.pl` `do`-loads all of them into a single


### PR DESCRIPTION
Turns the scaling arc's findings into two decisions and stops fighting them.

## 1. `docs/scaling-limits.md` — FHEM is pathological, documented not fixed

**FHEM does not complete `--check` on 31 GB.** 503 of its 614 `.pm` files declare `package main` explicitly (+31 declaring nothing) — **534 of 614 provide one package name**. That is *correct*: `fhem.pl` `do`-loads them all into one interpreter and 361 of them call `readingsSingleUpdate` from its main. The 534-wide relation is real, so narrowing it would be wrong.

Seven candidate causes, each killed by a control rather than an argument:

| suspect | ruled out by |
|---|---|
| walk residency | index-only holds 0.98 GB — leaner than release's whole check |
| overlay clones | 0.76 GB cumulative, cache capped at 133 MB |
| sweep path memo | disabling moves peak 0.7% **and costs 55% wall** — load-bearing |
| arena count | `MALLOC_ARENA_MAX=2` ≤5%, inside variance |
| diagnostics channel | 300 KB high-water against 10 GB |
| per-file byte cap | engaged correctly, made peak **+15%** and wall **+51%** — reverted |
| admission gate | never engages; needs 3+ giants concurrent to reach its budget |

What survives: **brk retention** owns sustained RSS (`MALLOC_MMAP_THRESHOLD_=65536`, −53%), **per-worker in-flight sets** own the crest (`RAYON_NUM_THREADS=4`, −67% for 4.9% wall — the sweep is not CPU-bound at 20 workers). Both shipped as documented workarounds.

Also records the **dependency-pile trap**: a 551-distribution tree took 137× the cache misses of real code and produced a 65× "cliff" that no real codebase reproduces. Unresolvable imports cost the resolver nothing, so a pile both thrashes the cache and understates resolution work.

Baseline these are read against: **28 real Perl codebases at 96–99.9% hit, 8–206 fetch attempts/file.**

## 2. `docs/cpp-status.md` — C/C++ is alpha

Answers the ship gate `cpp-golive-map.md` ARC 5 leaves open, with a measurement:

| project | files | result |
|---|---:|---|
| fmt | 80 | 4.2 s, 0.50 GB — fine |
| **Godot** | **7,041** | **did not complete in 4 min** |

Godot's *memory* is good — flat ~2 GB, better per-file than the Perl side. The problem is per-file wall, concentrated in large vendored headers: 66 s on `vulkan_handles.hpp`, 32 s on `d3d12.h` (1.5 MB). Unusable interactively regardless of the aggregate.

The failure mode is the **opposite** of Perl's — C++ is memory-healthy/wall-pathological, FHEM is memory-pathological. No shared mechanism; the Perl scaling work neither caused nor fixed it.

Alpha is the honest label for something already opt-in behind `--features cpp`. What would move it past alpha is profiling those 30–66 s per-file stalls — an aggregate number will not settle it, and nobody has profiled them yet.

Docs only — no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)