### PR TITLE
Huge-file build: two accidental quadratics and a serial startup cost

### DIFF
--- a/kick.sh
+++ b/kick.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Kick the tires on a real corpus without typing paths.
+#
+#   ./kick.sh                 pick a corpus from a menu
+#   ./kick.sh bmo             open a representative file from BMO
+#   ./kick.sh bmo Bug         ...the biggest BMO file matching /Bug/
+#   ./kick.sh bmo --list      show the ten biggest files, pick by number
+#   ./kick.sh --nodeps bmo    leave PERL5LIB unset (deps unresolvable)
+#   ./kick.sh --dry bmo       print what it would open, launch nothing
+#
+# Dependencies live OUTSIDE each workspace (corpus/README.md) so they land on
+# the @INC tier instead of joining the indexed workspace. This script sets
+# PERL5LIB for you, because with it unset half of what you want to click
+# through — hover and goto-def into CPAN — simply is not there.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+BULK=${PERL_CORPORA:-$HOME/perl-corpora}/bulk
+DEPS=${PERL_CORPORA:-$HOME/perl-corpora}/deps
+NODEPS=""; DRY=""
+while :; do case "${1:-}" in
+  --nodeps) NODEPS=1; shift;;
+  --dry)    DRY=1; shift;;
+  *) break;; esac; done
+
+# name|dir|cold wall|note   — walls are measured, deps installed, this box
+ROWS=(
+"bmo|BMO|13.8s|healthy reference, dense graph — good default"
+"evergreen|Evergreen|17.2s|high fan-out, properly packaged"
+"foswiki|Foswiki|12.8s|high fan-out, plugin-heavy"
+"webwork|WeBWorK|9.9s|small but slowest per file"
+"openfoodfacts|openfoodfacts|12.8s|densest static graph, tiny fan-out"
+"webmin|Webmin|8.8s|path-based require, few packages — odd shape"
+"koha|../koha|10.2s|library ILS (separate tree)"
+"znuny|Znuny|79s|HEAVY: 8.2 GB, 3k files"
+"fhem|FHEM|--|WILL NOT COMPLETE: dies at 12+ GB, see docs/scaling-limits.md"
+)
+
+pick_menu() {
+  echo "corpora (cold --check wall, measured with deps):" >&2
+  local i=1
+  for r in "${ROWS[@]}"; do IFS='|' read -r k d w n <<< "$r"
+    printf '  %2d) %-14s %-6s %s\n' "$i" "$k" "$w" "$n" >&2; i=$((i+1)); done
+  printf '  choose [1]: ' >&2; read -r c </dev/tty; c=${c:-1}
+  IFS='|' read -r KEY DIR W N <<< "${ROWS[$((c-1))]}"
+}
+
+if [ $# -eq 0 ]; then pick_menu; else
+  want=$1; shift
+  for r in "${ROWS[@]}"; do IFS='|' read -r k d w n <<< "$r"
+    case "$k" in "$want"*) KEY=$k DIR=$d W=$w N=$n; break;; esac; done
+  [ -z "${KEY:-}" ] && { echo "no corpus matching '$want'. run with no args for the menu." >&2; exit 1; }
+fi
+
+ROOT="$BULK/$DIR"
+[ -d "$ROOT" ] || { echo "missing: $ROOT — run corpus/bootstrap.sh" >&2; exit 1; }
+case "$N" in *"WILL NOT COMPLETE"*)
+  printf '\n  !! %s\n     The editor will hang and the box may OOM. Ctrl-C now unless\n     that is what you came for.\n     Survivable as: RAYON_NUM_THREADS=4 MALLOC_MMAP_THRESHOLD_=65536 ./kick.sh fhem\n\n' "$N" >&2
+  printf '  continue anyway? [y/N]: ' >&2; read -r y </dev/tty; [ "$y" = y ] || exit 0;;
+esac
+
+# Biggest files first: a 20-line module tells you nothing about how it feels.
+FILTER=${1:-}
+mapfile -t FILES < <(find "$ROOT" -name '*.pm' -not -path '*/local/*' -printf '%s\t%p\n' 2>/dev/null \
+  | { [ -n "$FILTER" ] && [ "$FILTER" != "--list" ] && grep -i -- "$FILTER" || cat; } \
+  | sort -rn | head -10 | cut -f2)
+[ ${#FILES[@]} -eq 0 ] && { echo "no .pm matching '${FILTER}' in $KEY" >&2; exit 1; }
+
+if [ "${FILTER:-}" = "--list" ]; then
+  echo "biggest files in $KEY:" >&2; i=1
+  for f in "${FILES[@]}"; do printf '  %2d) %6s lines  %s\n' "$i" "$(wc -l <"$f")" "${f#$ROOT/}" >&2; i=$((i+1)); done
+  printf '  choose [1]: ' >&2; read -r c </dev/tty; TARGET=${FILES[$(( ${c:-1} - 1 ))]}
+else
+  TARGET=${FILES[0]}
+fi
+
+DEPDIR="$DEPS/$(basename "$DIR")/lib/perl5"
+if [ -z "$NODEPS" ] && [ -d "$DEPDIR" ]; then
+  export PERL5LIB="$DEPDIR"
+  DEPNOTE="deps ON ($(find "$DEPDIR" -name '*.pm' 2>/dev/null | wc -l) modules on @INC)"
+else
+  DEPNOTE="deps OFF — CPAN imports will not resolve"
+fi
+
+printf '\n  %s  ·  %s cold  ·  %s\n  %s (%s lines)\n\n' \
+  "$KEY" "$W" "$DEPNOTE" "${TARGET#$ROOT/}" "$(wc -l <"$TARGET")" >&2
+[ -n "$DRY" ] && { echo "  (--dry: not launching)" >&2; exit 0; }
+exec ./dev.sh "$TARGET"

--- a/kick.sh
+++ b/kick.sh
@@ -7,6 +7,7 @@
 #   ./kick.sh bmo --list      show the ten biggest files, pick by number
 #   ./kick.sh --nodeps bmo    leave PERL5LIB unset (deps unresolvable)
 #   ./kick.sh --dry bmo       print what it would open, launch nothing
+#   ./kick.sh --debug bmo     debug log + phase timing + counters, paths printed
 #
 # Dependencies live OUTSIDE each workspace (corpus/README.md) so they land on
 # the @INC tier instead of joining the indexed workspace. This script sets
@@ -17,10 +18,11 @@ cd "$(dirname "$0")"
 
 BULK=${PERL_CORPORA:-$HOME/perl-corpora}/bulk
 DEPS=${PERL_CORPORA:-$HOME/perl-corpora}/deps
-NODEPS=""; DRY=""
+NODEPS=""; DRY=""; DEBUG=""
 while :; do case "${1:-}" in
   --nodeps) NODEPS=1; shift;;
   --dry)    DRY=1; shift;;
+  --debug)  DEBUG=1; shift;;
   *) break;; esac; done
 
 # name|dir|cold wall|note   — walls are measured, deps installed, this box
@@ -33,7 +35,7 @@ ROWS=(
 "webmin|Webmin|8.8s|path-based require, few packages — odd shape"
 "koha|../koha|10.2s|library ILS (separate tree)"
 "znuny|Znuny|79s|HEAVY: 8.2 GB, 3k files"
-"fhem|FHEM|--|WILL NOT COMPLETE: dies at 12+ GB, see docs/scaling-limits.md"
+"fhem|FHEM|slow start|editor OK; --check dies at 12+ GB (batch verb only)"
 )
 
 pick_menu() {
@@ -54,9 +56,8 @@ fi
 
 ROOT="$BULK/$DIR"
 [ -d "$ROOT" ] || { echo "missing: $ROOT — run corpus/bootstrap.sh" >&2; exit 1; }
-case "$N" in *"WILL NOT COMPLETE"*)
-  printf '\n  !! %s\n     The editor will hang and the box may OOM. Ctrl-C now unless\n     that is what you came for.\n     Survivable as: RAYON_NUM_THREADS=4 MALLOC_MMAP_THRESHOLD_=65536 ./kick.sh fhem\n\n' "$N" >&2
-  printf '  continue anyway? [y/N]: ' >&2; read -r y </dev/tty; [ "$y" = y ] || exit 0;;
+case "$N" in *"batch verb only"*)
+  printf '\n  note: FHEM startup is slow (534 files declare `package main`), but the\n        editor is fine — the 12 GB blowup is --check sweeping every file,\n        not the server, which only enriches what you open.\n\n' >&2;;
 esac
 
 # Biggest files first: a 20-line module tells you nothing about how it feels.
@@ -84,5 +85,21 @@ fi
 
 printf '\n  %s  ·  %s cold  ·  %s\n  %s (%s lines)\n\n' \
   "$KEY" "$W" "$DEPNOTE" "${TARGET#$ROOT/}" "$(wc -l <"$TARGET")" >&2
+if [ -n "$DEBUG" ]; then
+  STAMP=$(date +%H%M%S)
+  RUN=/tmp/perl-lsp-kick/$KEY-$STAMP; mkdir -p "$RUN"
+  export PERL_LSP_DEBUG=1                    # server log -> /tmp/perl-lsp.log (dev.sh's path)
+  export PERL_LSP_PHASE_TIMING=1             # cli::*/phase attribution
+  export PERL_LSP_GHOST_STATS="$RUN/ghost.txt"   # counters, flushed at shutdown
+  : > /tmp/perl-lsp.log
+  cat >&2 <<EOF
+  debug on:
+    tail -f /tmp/perl-lsp.log            server log (live)
+    $RUN/ghost.txt
+                                         counters — written at SHUTDOWN, so
+                                         :q the editor before reading them.
+                                         A killed server writes nothing.
+EOF
+fi
 [ -n "$DRY" ] && { echo "  (--dry: not launching)" >&2; exit 0; }
 exec ./dev.sh "$TARGET"

--- a/src/build/builder/fold.rs
+++ b/src/build/builder/fold.rs
@@ -118,7 +118,9 @@ impl<'a> Builder<'a> {
     ) {
         match mode {
             ChainPassMode::PreFold => {
-                self.apply_chain_typing_assignments(idx);
+                crate::util::ghost_stats::timed("chain::assignments", || {
+                    self.apply_chain_typing_assignments(idx)
+                });
                 // Refresh `invocant_class` each iteration too.
                 // Variable invocants whose TC just landed in the
                 // worklist's previous iteration become resolvable
@@ -128,7 +130,9 @@ impl<'a> Builder<'a> {
                 // see them until the loop already terminated.
                 // `apply_chain_typing_invocants` is idempotent (skips
                 // refs whose class is already pinned).
-                self.apply_chain_typing_invocants(idx);
+                crate::util::ghost_stats::timed("chain::invocants", || {
+                    self.apply_chain_typing_invocants(idx)
+                });
             }
             ChainPassMode::PostFold => {
                 self.apply_chain_typing_invocants(idx);
@@ -365,6 +369,10 @@ impl<'a> Builder<'a> {
     /// a point-query gives the right answer at any byte.
     pub(super) fn apply_chain_typing_assignments(&mut self, idx: &ChainTypingIndex<'a>) {
         let mut to_push: Vec<(String, ScopeId, Span, InferredType)> = Vec::new();
+        crate::util::ghost_stats::count_by(
+            "chain.assignment_nodes",
+            idx.assignment_nodes.len() as u64,
+        );
         for &node in &idx.assignment_nodes {
             let (Some(left), Some(right)) = (
                 node.child_by_field_name("left"),
@@ -439,9 +447,11 @@ impl<'a> Builder<'a> {
             // already-resolved RHS.)
             let saved_pkg_probe = self.current_package.clone();
             self.current_package = self.package_at_pos(span.start).map(|s| s.to_string());
-            let fresh = self
-                .invocant_type_at_node(right)
-                .or_else(|| self.resolve_invocant_class_tree(right).map(InferredType::ClassName));
+            let fresh = {
+                let _t = crate::util::ghost_stats::ScopedNs::start("chain::rhs_probe");
+                self.invocant_type_at_node(right)
+                    .or_else(|| self.resolve_invocant_class_tree(right).map(InferredType::ClassName))
+            };
             self.current_package = saved_pkg_probe;
 
             // Idempotency: skip if an already-pushed Variable witness at
@@ -463,6 +473,7 @@ impl<'a> Builder<'a> {
                 continue;
             }
             // Innermost scope containing this assignment.
+            let _t_scope = crate::util::ghost_stats::ScopedNs::start("chain::scope_pick");
             let scope_idx = self
                 .scopes
                 .iter()
@@ -478,6 +489,7 @@ impl<'a> Builder<'a> {
                     r * 1_000_000 + c
                 })
                 .map(|(i, _)| i);
+            drop(_t_scope);
 
             let scope_pkg = self.package_at_pos(span.start).map(|s| s.to_string());
 
@@ -492,10 +504,12 @@ impl<'a> Builder<'a> {
             // for the bareword-degrade tail (a non-class type on a
             // bareword maps to "treat the syntactic text as a
             // class") which the type-aware path doesn't model.
-            let ty_opt = self
-                .invocant_type_at_node(right)
-                .or_else(|| self.resolve_invocant_class_tree(right).map(InferredType::ClassName))
-                .or(fresh);
+            let ty_opt = {
+                let _t = crate::util::ghost_stats::ScopedNs::start("chain::rhs_type");
+                self.invocant_type_at_node(right)
+                    .or_else(|| self.resolve_invocant_class_tree(right).map(InferredType::ClassName))
+                    .or(fresh)
+            };
             self.current_package = saved_pkg;
 
             if let Some(ty) = ty_opt {
@@ -542,6 +556,8 @@ impl<'a> Builder<'a> {
                 }
             }
         }
+        crate::util::ghost_stats::count_by("chain.invocants_pending", pending.len() as u64);
+        let _t = crate::util::ghost_stats::ScopedNs::start("chain::invoc_resolve");
         for (i, node) in pending {
             if let Some(class) = self.resolve_invocant_class_tree(node) {
                 self.method_call_invocant.insert(i, class);

--- a/src/build/builder/fold.rs
+++ b/src/build/builder/fold.rs
@@ -1736,6 +1736,14 @@ impl<'a> Builder<'a> {
     ) {
         use crate::model::witnesses::{Witness, WitnessAttachment, WitnessPayload, WitnessSource};
 
+        // Batched: collect every replacement first, then ONE bulk removal and
+        // the pushes. The per-binding remove-then-push spelling costs a full
+        // bag retain + index rebuild PER BINDING — O(bindings * bag), the
+        // dominant term of the giant-file fold (~22 s of a 46k-line file's
+        // 30 s build). Each (attachment, point) names one binding site, so
+        // removing them together is equivalent.
+        let mut to_remove: Vec<(WitnessAttachment, tree_sitter::Point)> = Vec::new();
+        let mut to_push: Vec<Witness> = Vec::new();
         for binding in &self.call_bindings {
             let rt = return_types
                 .get(&binding.func_name)
@@ -1746,9 +1754,8 @@ impl<'a> Builder<'a> {
                     name: binding.variable.clone(),
                     scope: binding.scope,
                 };
-                self.bag
-                    .remove_attachment_source_at(&att, "call_binding", binding.span.start);
-                self.bag.push(Witness {
+                to_remove.push((att.clone(), binding.span.start));
+                to_push.push(Witness {
                     attachment: att,
                     source: WitnessSource::Builder("call_binding".into()),
                     payload: WitnessPayload::InferredType(rt),
@@ -1758,6 +1765,10 @@ impl<'a> Builder<'a> {
                     },
                 });
             }
+        }
+        self.bag.remove_attachment_sources_at(&to_remove, "call_binding");
+        for w in to_push {
+            self.bag.push(w);
         }
     }
 

--- a/src/build/builder/fold.rs
+++ b/src/build/builder/fold.rs
@@ -223,12 +223,16 @@ impl<'a> Builder<'a> {
                 );
                 break;
             }
-            self.run_chain_typing_reducer(idx, ChainPassMode::PreFold);
+            {
+                let _t = crate::util::ghost_stats::ScopedNs::start("fold::chain_pre");
+                self.run_chain_typing_reducer(idx, ChainPassMode::PreFold);
+            }
             self.resolve_return_types(idx, &reg, &ref_by_span, &method_sym_by_name);
             // Mutation extension: fold key writes into variable shapes
             // (re-emittable, clear-and-emit). After the return-type
             // passes so call-binding-propagated shapes are visible.
             {
+                let _t = crate::util::ghost_stats::ScopedNs::start("fold::mutation_ext");
                 let ctx = crate::model::witnesses::BagContext {
                     scopes: &self.scopes,
                     package_framework: &self.package_framework,
@@ -243,13 +247,18 @@ impl<'a> Builder<'a> {
                     true,
                 );
             }
-            let cur = self.fold_state_snapshot(&reg);
+            let cur = crate::util::ghost_stats::timed("fold::snapshot", || {
+                self.fold_state_snapshot(&reg)
+            });
             if cur == prev {
                 break;
             }
             prev = cur;
         }
-        self.run_chain_typing_reducer(idx, ChainPassMode::PostFold);
+        {
+            let _t = crate::util::ghost_stats::ScopedNs::start("fold::chain_post");
+            self.run_chain_typing_reducer(idx, ChainPassMode::PostFold);
+        }
         // Totals, not a line per file: at corpus scale the per-file form is
         // 138k unreadable lines, and the average is what says whether the
         // lattice is settling. `build::fold_to_fixed_point`'s sample count is
@@ -834,18 +843,20 @@ impl<'a> Builder<'a> {
         ref_by_span: &std::collections::HashMap<(Point, Point), usize>,
         method_sym_by_name: &std::collections::HashMap<String, Vec<usize>>,
     ) {
-        self.emit_arity_return_witnesses();
+        use crate::util::ghost_stats::timed;
+        timed("fold::arity", || self.emit_arity_return_witnesses());
         // Brand BEFORE method-call edges so `route_branded_refs` is
         // current when `emit_method_call_return_edges` consults it to
         // skip route calls — otherwise the skip set lags one iteration
         // and the bag oscillates (the fold never reaches a fixed point).
-        self.emit_route_brand_witnesses(idx, ref_by_span);
-        self.emit_method_call_return_edges();
-        self.emit_defined_narrowing_witnesses();
-        let (return_types, return_provenance) = self.seed_return_types_from_bag(reg, method_sym_by_name);
-        self.write_back_sub_return_types(&return_provenance);
-        self.propagate_call_bindings_to_constraints(&return_types);
-        self.fixup_call_bound_hash_key_owners(&return_types);
+        timed("fold::route_brand", || self.emit_route_brand_witnesses(idx, ref_by_span));
+        timed("fold::mc_edges", || self.emit_method_call_return_edges());
+        timed("fold::narrowing", || self.emit_defined_narrowing_witnesses());
+        let (return_types, return_provenance) =
+            timed("fold::seed", || self.seed_return_types_from_bag(reg, method_sym_by_name));
+        timed("fold::writeback", || self.write_back_sub_return_types(&return_provenance));
+        timed("fold::call_binding", || self.propagate_call_bindings_to_constraints(&return_types));
+        timed("fold::fixup_hko", || self.fixup_call_bound_hash_key_owners(&return_types));
     }
 
     /// Re-emittable: stamp the resolved `BrandedRoute` onto the

--- a/src/build/builder/fold.rs
+++ b/src/build/builder/fold.rs
@@ -373,6 +373,29 @@ impl<'a> Builder<'a> {
             "chain.assignment_nodes",
             idx.assignment_nodes.len() as u64,
         );
+        // Snapshot of the bag's typed-Variable witnesses, keyed by
+        // (name, span.start) — the idempotency checks below ask exactly this
+        // question per assignment, and a full-bag scan per assignment is
+        // O(assignments * bag) (6+ s of a 46k-line file's fold). Safe as a
+        // snapshot: the RHS typer takes `&self`, and this pass's own pushes
+        // land only after the loop, so the bag cannot change mid-loop.
+        let mut typed_at: std::collections::HashMap<(String, Point), Vec<usize>> =
+            std::collections::HashMap::new();
+        {
+            let _t = crate::util::ghost_stats::ScopedNs::start("chain::already_index");
+            for (i, w) in self.bag.all().iter().enumerate() {
+                if let (
+                    crate::model::witnesses::WitnessAttachment::Variable { name, .. },
+                    crate::model::witnesses::WitnessPayload::InferredType(_),
+                ) = (&w.attachment, &w.payload)
+                {
+                    typed_at
+                        .entry((name.clone(), w.span.start))
+                        .or_default()
+                        .push(i);
+                }
+            }
+        }
         for &node in &idx.assignment_nodes {
             let (Some(left), Some(right)) = (
                 node.child_by_field_name("left"),
@@ -425,14 +448,18 @@ impl<'a> Builder<'a> {
                     let row_ty = InferredType::ClassName(row);
                     let sid = self.innermost_scope_id_at(span.start);
                     for name in list_scalars {
-                        let already = self.bag.all().iter().any(|w| {
-                            let crate::model::witnesses::WitnessPayload::InferredType(t) = &w.payload else {
-                                return false;
-                            };
-                            matches!(&w.attachment, crate::model::witnesses::WitnessAttachment::Variable { name: n, .. } if n == &name)
-                                && w.span.start == span.start
-                                && t.subsumes_narrowing(&row_ty)
-                        });
+                        let already = typed_at
+                            .get(&(name.clone(), span.start))
+                            .is_some_and(|idxs| {
+                                idxs.iter().any(|&i| {
+                                    let crate::model::witnesses::WitnessPayload::InferredType(t) =
+                                        &self.bag.all()[i].payload
+                                    else {
+                                        return false;
+                                    };
+                                    t.subsumes_narrowing(&row_ty)
+                                })
+                            });
                         if !already {
                             to_push.push((name, sid, span, row_ty.clone()));
                         }
@@ -461,13 +488,15 @@ impl<'a> Builder<'a> {
             // walk-time materialization on a later fold iteration; once
             // the brand is in the bag it subsumes the next (identical)
             // brand and the loop settles.
-            let already_typed = self.bag.all().iter().any(|w| {
-                let crate::model::witnesses::WitnessPayload::InferredType(t) = &w.payload else {
-                    return false;
-                };
-                matches!(&w.attachment, crate::model::witnesses::WitnessAttachment::Variable { name, .. } if name == &var)
-                    && w.span.start == span.start
-                    && fresh.as_ref().map_or(true, |f| t.subsumes_narrowing(f))
+            let already_typed = typed_at.get(&(var.clone(), span.start)).is_some_and(|idxs| {
+                idxs.iter().any(|&i| {
+                    let crate::model::witnesses::WitnessPayload::InferredType(t) =
+                        &self.bag.all()[i].payload
+                    else {
+                        return false;
+                    };
+                    fresh.as_ref().map_or(true, |f| t.subsumes_narrowing(f))
+                })
             });
             if already_typed {
                 continue;
@@ -491,12 +520,6 @@ impl<'a> Builder<'a> {
                 .map(|(i, _)| i);
             drop(_t_scope);
 
-            let scope_pkg = self.package_at_pos(span.start).map(|s| s.to_string());
-
-            let saved_pkg = self.current_package.clone();
-            if scope_pkg.is_some() {
-                self.current_package = scope_pkg;
-            }
             // Read the RHS's full `InferredType` first — Parametric
             // shapes need to land on the variable as Parametric, not
             // unwrapped to their `base` via `class_name()`. Falls
@@ -504,13 +527,21 @@ impl<'a> Builder<'a> {
             // for the bareword-degrade tail (a non-class type on a
             // bareword maps to "treat the syntactic text as a
             // class") which the type-aware path doesn't model.
-            let ty_opt = {
+            //
+            // When `package_at_pos` answered Some, the `fresh` probe above
+            // already ran this exact computation under this exact package
+            // override — the typer is `&self` and deterministic, so
+            // recomputing is a straight 2x on the symbolic executor. Only
+            // the None case differs (the probe typed under `None`, this
+            // path types under the walk's stale `current_package`).
+            let ty_opt = if self.package_at_pos(span.start).is_some() {
+                fresh
+            } else {
                 let _t = crate::util::ghost_stats::ScopedNs::start("chain::rhs_type");
                 self.invocant_type_at_node(right)
                     .or_else(|| self.resolve_invocant_class_tree(right).map(InferredType::ClassName))
                     .or(fresh)
             };
-            self.current_package = saved_pkg;
 
             if let Some(ty) = ty_opt {
                 let sid = scope_idx.map(|i| self.scopes[i].id).unwrap_or(ScopeId(0));

--- a/src/build/builder/pattern_dispatch.rs
+++ b/src/build/builder/pattern_dispatch.rs
@@ -126,12 +126,20 @@ fn cached_pattern_query(source: &str) -> Result<&'static Query, String> {
 /// the memo here, single-threaded before any parallel build starts, makes
 /// every per-file dispatch a pure cache hit and removes the race entirely.
 pub(crate) fn warm_pattern_queries<'a>(specs: impl Iterator<Item = &'a PatternSpec>) {
-    for spec in specs {
-        if spec.language != "perl" {
-            continue;
-        }
-        let _ = cached_pattern_query(&spec.query);
-    }
+    use rayon::prelude::*;
+    let sources: Vec<&str> = specs
+        .filter(|s| s.language == "perl")
+        .map(|s| s.query.as_str())
+        .collect();
+    // Distinct sources compile independently, and `cached_pattern_query`
+    // compiles outside its lock — parallel warming populates the same memo,
+    // it just pays the wall of the slowest single `Query::new` instead of
+    // the sum (~520 ms serial for the bundled set; the whole registry warm
+    // sits on the first didOpen's critical path when a client opens a file
+    // immediately after the handshake).
+    sources.par_iter().for_each(|src| {
+        let _ = cached_pattern_query(src);
+    });
 }
 
 /// Verify a pattern's `expect` snippets against the real grammar:

--- a/src/build/builder/pipeline.rs
+++ b/src/build/builder/pipeline.rs
@@ -220,6 +220,10 @@ pub(super) fn build_with_plugins_inner(
     plugins: Arc<PluginRegistry>,
     extra_re_fold: bool,
 ) -> FileAnalysis {
+    let _scope = crate::util::ghost_stats::BuildScope::start(
+        crate::util::timings::current_file(),
+        source.len(),
+    );
     let fa = build_once(tree, source, plugins.clone(), extra_re_fold);
     // `PERL_LSP_WALK_EQUIV=1 cargo test` re-builds every file the suite
     // touches with the recursive descent and asserts the two agree. Running

--- a/src/build/plugin/mod.rs
+++ b/src/build/plugin/mod.rs
@@ -18,16 +18,37 @@ use crate::model::file_analysis::{
 
 pub mod rhai_host;
 
-/// Process-wide plugin registry, built once with the bundled Rhai plugins
-/// plus anything in `plugin_search_dirs()` (`$PERL_LSP_PLUGIN_DIR` and the
+/// Process-wide plugin registry, built with the bundled Rhai plugins plus
+/// anything in `plugin_search_dirs()` (`$PERL_LSP_PLUGIN_DIR` and the
 /// nearest repo-local `.perl-lsp/`). All `build()` calls share it; tests
 /// that need isolation use `build_with_plugins()`.
+///
+/// Keyed by `plugin_source_paths()` rather than built once: the ~600 ms
+/// compile (rhai plugins + pattern/flow queries) can then start at PROCESS
+/// start, before the workspace root is known. If `initialize`'s root leaves
+/// the on-disk plugin set unchanged — every workspace without a repo-local
+/// `.perl-lsp/`, i.e. almost all of them — the early warm IS the registry
+/// and the first `didOpen` build pays nothing. A root that does change the
+/// set rebuilds here, exactly as expensive as the old lazy path. Racing
+/// callers block on the mutex while one builds, same as the old `OnceLock`.
 pub fn default_plugin_registry() -> std::sync::Arc<PluginRegistry> {
-    use std::sync::{Arc, OnceLock};
-    static REG: OnceLock<Arc<PluginRegistry>> = OnceLock::new();
-    REG.get_or_init(|| {
-        let engine = Arc::new(rhai_host::make_engine());
-        let mut reg = PluginRegistry::new();
+    use std::sync::{Arc, Mutex, OnceLock};
+    type Cell = Mutex<Option<(Vec<std::path::PathBuf>, Arc<PluginRegistry>)>>;
+    static REG: OnceLock<Cell> = OnceLock::new();
+    let key = rhai_host::plugin_source_paths();
+    let mut cell = REG
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if let Some((cached_key, reg)) = cell.as_ref() {
+        if *cached_key == key {
+            return reg.clone();
+        }
+    }
+    let engine =
+        crate::util::timings::phase("registry::engine", || Arc::new(rhai_host::make_engine()));
+    let mut reg = PluginRegistry::new();
+    crate::util::timings::phase("registry::rhai_compile", || {
         for p in rhai_host::load_bundled(engine.clone()) {
             reg.register(p);
         }
@@ -36,16 +57,25 @@ pub fn default_plugin_registry() -> std::sync::Arc<PluginRegistry> {
                 reg.register(p);
             }
         }
-        // Compile every pattern query now, once, while we're single-threaded —
-        // before the parallel workspace index charges `Query::new` to per-file
-        // build. See `pattern_dispatch::warm_pattern_queries`.
-        crate::build::builder::pattern_dispatch::warm_pattern_queries(
-            reg.plugins.iter().flat_map(|p| p.patterns().iter()),
-        );
-        crate::build::builder::warm_flow_query();
-        Arc::new(reg)
-    })
-    .clone()
+    });
+    // Compile every pattern query now, once, while the cell is held —
+    // before the parallel workspace index charges `Query::new` to per-file
+    // build. See `pattern_dispatch::warm_pattern_queries`. The flow query
+    // is independent of the pattern set, so it compiles alongside rather
+    // than after.
+    crate::util::timings::phase("registry::queries", || {
+        rayon::join(
+            || {
+                crate::build::builder::pattern_dispatch::warm_pattern_queries(
+                    reg.plugins.iter().flat_map(|p| p.patterns().iter()),
+                )
+            },
+            crate::build::builder::warm_flow_query,
+        )
+    });
+    let reg = Arc::new(reg);
+    *cell = Some((key, reg.clone()));
+    reg
 }
 
 // ---- Context snapshots passed to plugins ----

--- a/src/build/plugin/rhai_host.rs
+++ b/src/build/plugin/rhai_host.rs
@@ -883,6 +883,28 @@ pub fn plugin_fingerprint() -> String {
     format!("{:016x}", hasher.finish())
 }
 
+/// The on-disk `.rhai` files the next `default_plugin_registry()` build
+/// would load, sorted — the registry cache's identity key. Paths only, no
+/// content reads: the registry never hot-reloads an edited plugin within a
+/// process (that has always required a restart), so content is not part of
+/// this identity; what CAN legitimately change mid-process is the search
+/// path itself, when `initialize` delivers a workspace root and repo-local
+/// `.perl-lsp/` discovery kicks in. Cheap enough to call per build.
+pub fn plugin_source_paths() -> Vec<std::path::PathBuf> {
+    let mut out: Vec<std::path::PathBuf> = Vec::new();
+    for dir in plugin_search_dirs() {
+        if let Ok(read) = std::fs::read_dir(&dir) {
+            out.extend(
+                read.flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rhai")),
+            );
+        }
+    }
+    out.sort();
+    out
+}
+
 /// Load all `*.rhai` files from a directory. Used for user-installed plugins.
 pub fn load_plugin_dir(
     dir: &std::path::Path,

--- a/src/lsp/backend/server.rs
+++ b/src/lsp/backend/server.rs
@@ -27,16 +27,16 @@ impl LanguageServer for Backend {
         // Same root drives repo-local `.perl-lsp/` plugin discovery, so the
         // plugin set and the per-project cache key can't disagree.
         crate::build::plugin::rhai_host::set_workspace_root(root);
-        // The registry's one-time cost (rhai-compiling the bundled plugins,
-        // warming every pattern query + the flow query) is ~1 s of CPU.
-        // Paid lazily it lands inside the FIRST didOpen's build — the exact
-        // window the cold-open bounded wait (400 ms) cannot cover, so a
-        // session's first pull verb answers null on any box where that
-        // second runs long. Warm it here instead, off the handler, where it
-        // overlaps the client's own startup; the first build then finds the
-        // registry ready (`OnceLock` — a racing build blocks on this warm
-        // rather than duplicating it). AFTER set_workspace_root, so the
-        // repo-local plugin set is the one being warmed.
+        // Re-validate the plugin registry now that the root is known. The
+        // heavy compile (~600 ms: rhai plugins + pattern/flow queries)
+        // already started at PROCESS start (`main`), before the handshake —
+        // the registry cell is keyed by the resolved plugin-source paths, so
+        // when this root doesn't change the on-disk set (no repo-local
+        // `.perl-lsp/`) this call is a cache hit and the first didOpen build
+        // pays nothing. When the root DOES add repo-local plugins, this is
+        // the rebuild with the right set — off the handler, and a racing
+        // build blocks on the cell rather than duplicating the work. AFTER
+        // set_workspace_root, so the repo-local plugin set is the one warmed.
         tokio::task::spawn_blocking(crate::build::plugin::default_plugin_registry);
 
         // LSP spec: `initialize` carries the client `processId`; "if the parent

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,17 @@ async fn main() {
     let stdin = stdio_bridge::reader();
     let stdout = stdio_bridge::writer();
 
+    // Warm the plugin registry NOW, overlapping the client's own startup and
+    // the initialize handshake — the compile is ~600 ms, and paid lazily it
+    // lands inside the first didOpen's build (measured: first build() 712 ms
+    // vs 121 ms for the second, same file class). The workspace root isn't
+    // known yet, but the registry cell is keyed by the resolved plugin-source
+    // paths: when `initialize`'s root doesn't change the on-disk plugin set
+    // (any workspace without a repo-local `.perl-lsp/`), this warm is the
+    // registry the first build uses; when it does, `initialize`'s own warm
+    // rebuilds with the right set and this one cost only background CPU.
+    std::thread::spawn(build::plugin::default_plugin_registry);
+
     let (service, socket) = LspService::new(Backend::new);
 
     // Wrap the service so a panic in any handler degrades to a logged warning +

--- a/src/model/witnesses/mod.rs
+++ b/src/model/witnesses/mod.rs
@@ -222,6 +222,36 @@ impl WitnessBag {
         removed
     }
 
+    /// Batch form of `remove_attachment_source_at`: one retain + at most one
+    /// index rebuild for the whole set. The per-binding form costs a full
+    /// bag scan AND a full index rebuild per call, which turns a pass with N
+    /// bindings into O(N * bag) — 20+ seconds of the 46k-line-file fold was
+    /// exactly this. Each (attachment, point) pair identifies one binding
+    /// site, so removing them together is equivalent to removing them one at
+    /// a time.
+    pub fn remove_attachment_sources_at(
+        &mut self,
+        items: &[(WitnessAttachment, Point)],
+        tag: &str,
+    ) -> usize {
+        if items.is_empty() {
+            return 0;
+        }
+        let _t = crate::util::ghost_stats::ScopedNs::start("bag::remove_at_batch");
+        let keys: std::collections::HashSet<(&WitnessAttachment, Point)> =
+            items.iter().map(|(a, p)| (a, *p)).collect();
+        let before = self.witnesses.len();
+        self.witnesses.retain(|w| {
+            !(matches!(&w.source, WitnessSource::Builder(s) if s == tag)
+                && keys.contains(&(&w.attachment, w.span.start)))
+        });
+        let removed = before - self.witnesses.len();
+        if removed > 0 {
+            self.rebuild_index();
+        }
+        removed
+    }
+
     pub fn len(&self) -> usize {
         self.witnesses.len()
     }

--- a/src/model/witnesses/mod.rs
+++ b/src/model/witnesses/mod.rs
@@ -126,6 +126,8 @@ impl WitnessBag {
     }
 
     pub fn rebuild_index(&mut self) {
+        let _t = crate::util::ghost_stats::ScopedNs::start("bag::rebuild_index");
+        crate::util::ghost_stats::count_by("bag.rebuild_index_witnesses", self.witnesses.len() as u64);
         self.index.clear();
         for (i, w) in self.witnesses.iter().enumerate() {
             self.index.entry(w.attachment.clone()).or_default().push(i);
@@ -160,6 +162,7 @@ impl WitnessBag {
     /// at the start of each fold iteration so the bag stays
     /// duplicate-free no matter how many times the fold runs.
     pub fn remove_by_source_tag(&mut self, tag: &str) -> usize {
+        let _t = crate::util::ghost_stats::ScopedNs::start("bag::remove_tag");
         let before = self.witnesses.len();
         self.witnesses.retain(|w| match &w.source {
             WitnessSource::Builder(s) => s != tag,
@@ -205,6 +208,7 @@ impl WitnessBag {
         tag: &str,
         at: Point,
     ) -> usize {
+        let _t = crate::util::ghost_stats::ScopedNs::start("bag::remove_at");
         let before = self.witnesses.len();
         self.witnesses.retain(|w| {
             !(&w.attachment == att

--- a/src/util/ghost_stats.rs
+++ b/src/util/ghost_stats.rs
@@ -227,6 +227,12 @@ fn scope_add_ns(tag: &str, nanos: u128) {
 /// between construction and drop, then emits one `[build-scope]` block to the
 /// sink. Inert when the gate is off. Nesting restores the outer scope (the
 /// inner build's events are attributed to the inner scope only).
+///
+/// The gate itself is not free: with `PERL_LSP_GHOST_STATS` set, a
+/// witness-heavy build pays for every hop counter and timed region it crosses
+/// (measured ~25% wall on a 46k-line Perl file). The block's RELATIVE shares
+/// are trustworthy; its `ms=` total is not comparable to a gate-off run, so
+/// never quote gate-on and gate-off walls against each other.
 pub struct BuildScope {
     started: Option<std::time::Instant>,
     prev: Option<ScopeData>,

--- a/src/util/ghost_stats.rs
+++ b/src/util/ghost_stats.rs
@@ -129,6 +129,7 @@ pub fn count(tag: &str) {
     if !enabled() {
         return;
     }
+    scope_count(tag, 1);
     {
         let mut c = counters().lock().unwrap_or_else(|e| e.into_inner());
         *c.entry(tag.to_string()).or_insert(0) += 1;
@@ -173,11 +174,110 @@ pub fn count_by(tag: &str, n: u64) {
     if !enabled() || n == 0 {
         return;
     }
+    scope_count(tag, n);
     {
         let mut c = counters().lock().unwrap_or_else(|e| e.into_inner());
         *c.entry(tag.to_string()).or_insert(0) += n;
     }
     maybe_reemit_attribution();
+}
+
+// ---------------------------------------------------------------------------
+// Per-build scope: a thread-local delta of the SAME counters and timers,
+// opened around one build() and emitted as one self-contained block. The
+// global maps are process-cumulative and re-emitted on an interval, which
+// makes per-FILE numbers unrecoverable three ways at once: concurrent builds
+// pollute the totals, repeated re-emits compound when a log is summed, and a
+// killed run loses the tail. This scope is exact by construction — a build's
+// fold runs on one thread, and only that thread's events land in its scope —
+// so one grep gives one file's counters regardless of what else the process
+// was doing.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static BUILD_SCOPE: std::cell::RefCell<Option<ScopeData>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[derive(Default)]
+struct ScopeData {
+    counts: HashMap<String, u64>,
+    ns: HashMap<String, (u128, u64)>,
+}
+
+fn scope_count(tag: &str, n: u64) {
+    BUILD_SCOPE.with(|s| {
+        if let Some(d) = s.borrow_mut().as_mut() {
+            *d.counts.entry(tag.to_string()).or_insert(0) += n;
+        }
+    });
+}
+
+fn scope_add_ns(tag: &str, nanos: u128) {
+    BUILD_SCOPE.with(|s| {
+        if let Some(d) = s.borrow_mut().as_mut() {
+            let e = d.ns.entry(tag.to_string()).or_insert((0, 0));
+            e.0 += nanos;
+            e.1 += 1;
+        }
+    });
+}
+
+/// Scope guard: captures every `count`/`count_by`/`add_ns` on THIS thread
+/// between construction and drop, then emits one `[build-scope]` block to the
+/// sink. Inert when the gate is off. Nesting restores the outer scope (the
+/// inner build's events are attributed to the inner scope only).
+pub struct BuildScope {
+    started: Option<std::time::Instant>,
+    prev: Option<ScopeData>,
+    label: String,
+    bytes: usize,
+}
+
+impl BuildScope {
+    /// `label` names the input (file path when the caller knows it);
+    /// `bytes` is the source size, the stable join key for size-ladder runs.
+    pub fn start(label: Option<String>, bytes: usize) -> Self {
+        if !enabled() {
+            return BuildScope { started: None, prev: None, label: String::new(), bytes };
+        }
+        let prev = BUILD_SCOPE.with(|s| s.borrow_mut().replace(ScopeData::default()));
+        BuildScope {
+            started: Some(std::time::Instant::now()),
+            prev,
+            label: label.unwrap_or_else(|| "?".into()),
+            bytes,
+        }
+    }
+}
+
+impl Drop for BuildScope {
+    fn drop(&mut self) {
+        let Some(t) = self.started else { return };
+        let data = BUILD_SCOPE
+            .with(|s| std::mem::replace(&mut *s.borrow_mut(), self.prev.take()));
+        let Some(data) = data else { return };
+        let total_ms = t.elapsed().as_secs_f64() * 1000.0;
+        let mut out = format!(
+            "[build-scope] bytes={} ms={total_ms:.1} file={}\n",
+            self.bytes, self.label
+        );
+        let mut times: Vec<(&String, &(u128, u64))> = data.ns.iter().collect();
+        times.sort_by(|x, y| y.1 .0.cmp(&x.1 .0).then_with(|| x.0.cmp(y.0)));
+        for (k, (ns, n)) in times {
+            out.push_str(&format!(
+                "[build-scope]   {:>10.1} ms  n={n:<8} {k}\n",
+                *ns as f64 / 1e6
+            ));
+        }
+        let mut counts: Vec<(&String, &u64)> = data.counts.iter().collect();
+        counts.sort_by(|x, y| y.1.cmp(x.1).then_with(|| x.0.cmp(y.0)));
+        for (k, v) in counts {
+            out.push_str(&format!("[build-scope]   count {v:<12} {k}\n"));
+        }
+        out.push_str("[build-scope-end]\n");
+        emit_text(&out);
+    }
 }
 
 /// tag -> (total nanos, call count). A per-call `[PHASE]` line is useless for
@@ -193,6 +293,7 @@ pub fn add_ns(tag: &str, nanos: u128) {
     if !enabled() {
         return;
     }
+    scope_add_ns(tag, nanos);
     let mut a = accum().lock().unwrap_or_else(|e| e.into_inner());
     let e = a.entry(tag.to_string()).or_insert((0, 0));
     e.0 += nanos;


### PR DESCRIPTION
Found by opening FHEM's biggest module in an editor and waiting 30 seconds for semantic tokens. Root-caused and fixed by `[05]`; measurements by the coordinator.

## Result

| lines | before | after |
|---:|---:|---:|
| 3,268 | 627 ms | **223 ms** |
| 46,522 | **33,180 ms** | **5,335 ms** — 6.2× |

`didOpen`, real workspace, median of 3.

## Three defects

**1. `propagate_call_bindings_to_constraints` rebuilt the witness index per binding** (`7fc6fd3a`). `remove_attachment_source_at` does a full-bag retain plus a full index rebuild on each call: 4,857 calls → 3,246 rebuilds → **185,757,638 cumulative re-insertions**, 20.7 s of 30. Batched to one retain + one rebuild per pass. `fold::call_binding` 21.6 s → 16.5 ms.

**2. Chain typing's idempotency check scanned the whole bag per assignment** (`74a26b59`). 28,998 scans × 57k witnesses = 6.2 s, plus every RHS typed twice. Snapshot index + reuse the fresh probe. `fold::chain_pre` 5.3 s → 0.73 s.

**3. The first `build()` in a process carried ~600 ms that wasn't the build** (`0e33a8d4`). 14 tree-sitter `Query::new` calls plus the flow query, compiled serially and forced lazily by the first `didOpen`. Registry cell now keyed by resolved `.rhai` paths (pre-root warm is safe), warmed in `main()` before the handshake, compiles run rayon-parallel — 597 → ~140 ms. Took a latent bug with it: the old `OnceLock` would have baked a wrong pre-root plugin set permanently.

In all three, **bag length (57,228) and fold iterations (3) are unchanged** — the same fixed point, reached without the quadratics.

## Instrumentation (`5501c0cc`, `9ddef5bb`)

A thread-local per-build `[build-scope]` block, delta'd per build, plus fold sub-pass timers and `registry::*` phases. This is what made the root-cause possible: per-build counters were previously unobtainable — the default re-emit interval never fires on a short build, and a short one re-adds per emission (~665× inflation, measured). Worth having independently of the fixes.

## Tooling (`9bc43d72`, `51637ded`)

`kick.sh` — open a corpus in an editor without typing paths, with `PERL5LIB` set to that corpus's dep tree (deps live outside the workspace by design, and without it half the features silently aren't there). `--debug` turns on the log + phase timing + counters and prints where they land.

## Methodology, because two of us chased a phantom

The apparent small-file "regression" (424 → 627 ms) was the ~600 ms startup constant wobbling with box state — a fresh-server-per-point ladder pays it at *every* point on *every* commit. First-build on a 1,760-line file measured 721/696, 688/685, 696/701 across the three commits: indistinguishable. **Quote the second build in a process, or attribute the constant.** The `registry::*` phases now print, so a ladder can't eat it silently again.

Also recorded in `docs/scaling-limits.md` §6 (#165), along with the corrections: the superlinearity was accidental rather than intrinsic to the witness bag, so **chunking the solver would have masked a bug**.

## Verification

unit 1612 · unit-cpp 1676 (+64) · gold PASS=503 FAIL=0 CRASH=0 lang-skip=0 · e2e 116/0 · e2e-cpp 24/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)