### PR TITLE
docs: open work as epics — each carrying its language-pack and scaling beats

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,128 +3,67 @@
 Landed work lives in `docs/adr/` and `CHANGELOG.md` — never here.
 This file is only what's NEXT, in order.
 
-> **`spike/cpp-support` branch:** the multi-language (cpp/python) go-live arc has
-> its own altitude map — `docs/cpp-golive-map.md`. The Flow/value-flow tier
-> (FlowEdge spine, query-driven assignment shapes, narrowing-on-edges) lives
-> there; it's shared seam, not Perl-specific. Consult it before zooming into a
-> Flow slice.
+## The schedule lives in `docs/epics/`
 
-## Now (in order)
+Open work is organized as **epics** — self-contained implementation
+prompts with anchors, phased ladders, per-phase acceptance criteria,
+non-goals and a verification gate. `docs/epics/README.md` is the index,
+the schedule, and the coverage map that accounts for every open design
+doc.
 
-1. **Narrowing / Optional — completeness.** The flow-narrowing +
-   `Optional<T>` + `Undef` lattice and the bug-detection diagnostics it
-   feeds have both landed (decision records: `adr/flow-narrowing.md`,
-   `adr/optional-types.md`, `adr/narrowing-diagnostics.md`). What remains
-   is **completeness** — widen what the narrower recognizes: direct-element
-   places (`$hash{key}`, `$arr[0]`), and dynamic-key places (`$self->{$k}`)
-   where the key scalar is stable enough to stay sound
-   (`prompt-flow-narrowing.md` / `prompt-optional-types.md`) — and graduate
-   the opt-in diagnostic flags to default-on per code as the gold substrate
-   and real projects show no false-positive flood (the promotion path in
-   `adr/narrowing-diagnostics.md`).
-2. **DBIC out of core — phases 2–3.** Phase 1 landed (`visit_dbic_*`
-   gone; `frameworks/dbic.rhai`, trigger `ClassIsa("DBIx::Class")`).
-   Remaining: meta-method suppression → manifest (the `universal_methods`
-   rule-#10 debt still hardcoded in `symbols.rs`) and parametric
-   emission + per-method return projection (the one axis-shaped piece).
-   Ladder in `prompt-dbic-as-plugin.md`. Ends with core plugin-free
-   except generic dispatch.
+Each epic carries three axes, not one: its own ladder, plus a
+**Language-pack beat** (what it owes C/C++ and the other pack languages)
+and a **Scaling beat** (the measured cost it must respect). Those two
+are not a separate workstream — this is a multi-language engine with a
+measured scaling envelope, and both are properties of every seam.
 
-## Queued (pull-driven — QA findings decide order)
+| # | Epic | Why now |
+|---|---|---|
+| 1 | [Provider identity](epics/01-provider-identity.md) | A class of confidently-wrong answers, not misses |
+| 2 | [DBIC out of core](epics/02-dbic-out-of-core.md) | Finishes "core is plugin-free except generic dispatch" |
+| 3 | [Openness](epics/03-openness.md) | One verdict replaces six partial suppression rules; unlocks flag promotion |
+| 4 | [Value provenance, tier 1](epics/04-value-provenance.md) | The named gate for instance brands and the untyped-receiver residual |
+| 5 | [One-seam sweep](epics/05-one-seam-sweep.md) | Small, self-contained; the good warm-up |
+| 6 | [Rename provenance](epics/06-rename-provenance.md) | `folded_from` landed; three residuals left |
+| 7 | [Diagnostic framework](epics/07-diagnostic-framework.md) | The CI-readiness gate |
+| 8 | [Heatmap residuals](epics/08-heatmap-residuals.md) | Closes a verified false positive against the heatmap's own promise |
+| 9 | [Mojo polish](epics/09-mojo-polish.md) | User-facing feature work |
+| 10 | [CLI analysis + `--migrate`](epics/10-cli-analysis-and-migrate.md) | Rounds out the CLI surface |
+| 11 | [Program boundaries](epics/11-program-boundaries.md) | MAIN-1; ~270 FPs each direction on the AWStats shape |
+| 12 | [Type::Tiny completeness](epics/12-type-tiny-completeness.md) | Check-guards feed a lattice that already exists |
+| 13 | [Pack-language ceiling](epics/13-pack-language-ceiling.md) | Calibration is the ship gate; it is half the work |
+| 14 | [The per-file stall](epics/14-per-file-stall.md) | C/C++ is unusable at Godot size; nobody has profiled it yet |
+| 15 | [Query paths at scale](epics/15-query-paths-at-scale.md) | Storage holds at 122x; query paths break |
 
-Type intelligence:
-- Residual fact classes Parts 1–5 (invocant mutations, hash-key
-  unions, method loops, functional operators, value-indexed returns)
-  — `prompt-type-inference-residual.md`.
-- Conditional-reassignment disagreement-to-widen (`$spec = {...}
-  unless ref $spec`) — replaces the `reassigned_scalars` trust-gate
-  clause with a real lattice fold.
-- A4 v2: cross-FILE slot writes (`$self->{k} = Obj->new` in another
-  file) — the `PackageSymbol` bridge pattern.
+**Suggested order:** 1 first, then 14 and 15 — those two are where the
+product is unusable rather than merely incomplete — then 2–4, then
+pull-driven.
 
-Graph / diagnostics (graph-walking pillar landed; residual only):
-- Scope-node taxonomy + Openness diagnostic (`home_namespace`,
-  "when is an unresolved call real?") — forward work in
-  `prompt-graph-walking.md`; subsumes the coarse qualified-name
-  suppression noted in `open-problems.md`.
+## Not in an epic
 
-Plugin genericity:
-- `has_options` final dissolution: the option pairing already moved out
-  of core — the plugin reads accessor options via the shared
-  `classified_pairs` over the flattened, per-arg `value_shape`-classified
-  args. The one Moo-semantic field still in core is the
-  `isa`-string→`InferredType` mapping; moving it onto the
-  `type_constraint_names()` / `type_constraint_inner()` plugin seam is the
-  last step, after which `HasOptions` dissolves entirely (attr names come
-  from `value_shape`/`arg_names`, options from `classified_pairs`).
+Small items that have no epic home and need none. Take them
+opportunistically; each is a commit, not an arc.
 
-Hardening:
-- Options schema: `DiagnosticOptions` is serde-driven (the struct is the
-  schema). A `Config` god-struct (own-at-top, pass-slices), a generated
-  editor schema (`schemars`), and the per-code-config shape wait for their
-  forcing functions — `prompt-config-schema.md`.
-- Fold safety net: `eprintln!` → `tracing::error!` (builder.rs
-  ~12061) + a synthetic-oscillator test so the release-mode
-  `MAX_FOLD_ITERATIONS` break can't bit-rot.
-- Full-bag scans in `apply_chain_typing_assignments` /
-  `FileAnalysis::inferred_type` — index when profiling flags them.
-- DBIC parametric column-key completion at an empty `->search({ | })`
-  (goto-def proves the chain; `complete_keyval_args` lacks the
-  parametric-receiver branch; pin in `e2e/dbic_parametric.lua`).
-- Cursor-context qualified-path/invocant detection should ask the
-  tree, not byte-walk (`extract_package_from_prefix` & sibling).
-- `return_via_edge` chases lack `TypeProvenance` (stamp
-  `Delegation{kind: "callable_return_edge"}` on the chase).
-- cst/conventions migration backlog — `prompt-cst-migration.md`.
-- Unify autoquoted-key-as-literal into `cst::string_list`. Today
-  `string_list` routes `autoquoted_bareword` through the caller's
-  `fold` (const resolution), so the DSL-arg callers (`extract_arg_name_list`)
-  carry a per-caller fold that special-cases autoquoted→literal. An
-  autoquoted bareword is a grammar-certified literal for *every* caller,
-  so the right home for the rule is `string_list` itself — then
-  `extract_arg_name_list` deletes and the DBIC/keyval paths just use
-  `extract_string_list`. **Blocked on** a latent use-import bug it
-  unmasks: `use constant NAME => v`'s autoquoted key gets emitted as a
-  spurious `FunctionCall` import ref (resolved_package `"constant"`) by
-  the use-list walker — the old fold hid it by dropping non-constant
-  barewords. Regression-guarded by `const_call_form_not_double_reffed`.
-  Fix the use-`constant` path to not feed its declared names to the
-  generic import-ref emitter (it already routes them to
-  `accumulate_use_constant`), THEN move the autoquoted arm into
-  `string_list` and drop the per-caller fold. Proper unification; not
-  urgent (the per-caller fold is correct, just not DRY).
-
-QA tail:
-- MAIN-1 (`main::` across `require`) and H1 (duplicate packages) —
-  designs in `docs/open-problems.md`. MooseX::Role::Parameterized — no
-  design yet.
-- Per-row known gaps: `gold-corpus/KNOWN-GAPS.md` (xfail rows are the
-  live tracker).
-
-Protocol surface (breadth, not depth):
-- **Advertised verb surface** — a capability listing reads the
-  `initialize` response, not the answers, so verbs the analysis can
-  already answer should be advertised. The cluster worth doing is type
-  hierarchy + call hierarchy + typeDefinition: all three are projections
-  over machinery that already exists (`GraphView`, the `references()`
-  projection, `dispatch_class()`). Non-goals and the reasoning are in
-  `prompt-lsp-surface-parity.md`; `linkedEditingRange` stays OFF (#117).
-
-## Scale validation (2026-08-17) — the Tier 1 queue
-
-The first measurements outside `crm`: a 4.65 h soak, Koha (3.1x), and a
-5,000-dist CPAN sample (122x — the target rung). Storage and startup hold
-scale-free; query paths break. Findings, tiers, corpora and repros:
-`prompt-scale-validation-hitlist.md`. Tier 1, in order:
-
-1. **Post-cold-index availability hole** — ~10 min where every verb times
-   out; a warm restart of the same state is ready in 1 s. Restarting beats
-   staying up.
-2. **Fatal stack overflow on deep CSTs (P0)** — one XML-as-`.pm` aborts the
-   whole server; `catch_unwind` cannot catch it. Depth gate before build.
-3. **`references` terminal at scale** — no refs-axis reader, so the backward
-   walk decodes a whole blob per candidate (~4x of the cost).
-4. **Completion payload unbounded** — 7.8 MB / ~50k items per keystroke.
+- Fold safety net: `eprintln!` → `tracing::error!` at the release-mode
+  `MAX_FOLD_ITERATIONS` break, plus a synthetic-oscillator test so it
+  can't bit-rot.
+- Full-bag scans in `apply_chain_typing_assignments` — index when
+  profiling flags them.
+- Cursor-context qualified-path/invocant detection should ask the tree,
+  not byte-walk (`extract_package_from_prefix` and sibling).
+- `return_via_edge` chases lack `TypeProvenance` — stamp
+  `Delegation { kind: "callable_return_edge" }` on the chase.
+- Unify autoquoted-key-as-literal into `cst::string_list`. **Blocked
+  on** a latent use-import bug it unmasks: `use constant NAME => v`'s
+  autoquoted key gets emitted as a spurious `FunctionCall` import ref
+  (resolved_package `"constant"`) by the use-list walker — the old fold
+  hid it by dropping non-constant barewords. Regression-guarded by
+  `const_call_form_not_double_reffed`. Fix the use-`constant` path to
+  not feed its declared names to the generic import-ref emitter, THEN
+  move the autoquoted arm into `string_list` and drop the per-caller
+  fold. Proper unification; not urgent.
+- Per-row known gaps: `gold-corpus/KNOWN-GAPS.md` — the xfail rows are
+  the live tracker.
 
 ## Parked (explicit unblock conditions)
 
@@ -141,23 +80,21 @@ scale-free; query paths break. Findings, tiers, corpora and repros:
 - **Type-is-the-gate generalization** — waits for a second motivating
   site. `prompt-type-is-the-gate.md`.
 
-## Backburner (user-facing, ship-when-ready)
+## Backburner (no epic, no unblock condition — just not now)
 
-- Mojo polish: route naming/url_for, stash intelligence, hooks,
-  transitive plugin chains, config completion —
-  `prompt-mojo-todo.md`.
-- CLI diagnostic framework (PL-codes, suppression, SARIF), --migrate —
-  `prompt-cli-tools.md`.
-- Ref provenance: constant-fold `folded_from`, package→file rename,
-  inheritance override scoping — `prompt-ref-provenance.md`.
 - Aspirational type features (effects/throws) —
-  `prompt-type-system-futures.md`.
-- Web extension — `prompt-wasm-web-extension.md` (the crate split it
-  assumed was executed and REJECTED; branch `workspace-split` is the
-  playbook if wasm ever forces it).
-- Multi-language engine — the go-live arc (cpp/python) is live on
-  mainline (`build/language_driver.rs`, altitude map in
-  `docs/cpp-golive-map.md`); design in `docs/prompt-multi-language.md`.
+  `prompt-type-system-futures.md`. Pillar 1 (narrowing) landed; pillar 2
+  is out of the QA loop by its own charter.
+- Web extension — `prompt-wasm-web-extension.md`. The crate split it
+  assumed was executed and REJECTED (layering tests enforce the DAG
+  instead); branch `workspace-split` is the playbook if wasm ever
+  forces it.
+- The `lsp-engine` crate cut — parked by `prompt-multi-language.md`'s
+  own text until a second pack language's ceiling work (Epic 13) makes
+  the split pay for itself.
+- Incremental analysis — `prompt-incremental-build.md`, with a named
+  bar in-doc. Epic 15's diagnostics-after-edit row is its forcing
+  function.
 
 ## Out of scope
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ measured scaling envelope, and both are properties of every seam.
 | 5 | [One-seam sweep](epics/05-one-seam-sweep.md) | Small, self-contained; the good warm-up |
 | 6 | [Rename provenance](epics/06-rename-provenance.md) | `folded_from` landed; three residuals left |
 | 7 | [Diagnostic framework](epics/07-diagnostic-framework.md) | The CI-readiness gate |
-| 8 | [Heatmap residuals](epics/08-heatmap-residuals.md) | Closes a verified false positive against the heatmap's own promise |
+| 8 | [Heatmap: parallelize + residuals](epics/08-heatmap-residuals.md) | Runs on one core (up to 17x `--check`); then a verified FP against its own promise |
 | 9 | [Mojo polish](epics/09-mojo-polish.md) | User-facing feature work |
 | 10 | [CLI analysis + `--migrate`](epics/10-cli-analysis-and-migrate.md) | Rounds out the CLI surface |
 | 11 | [Program boundaries](epics/11-program-boundaries.md) | MAIN-1; ~270 FPs each direction on the AWStats shape |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,10 +34,13 @@ measured scaling envelope, and both are properties of every seam.
 | 13 | [Pack-language ceiling](epics/13-pack-language-ceiling.md) | Calibration is the ship gate; it is half the work |
 | 14 | [The per-file stall](epics/14-per-file-stall.md) | C/C++ is unusable at Godot size; nobody has profiled it yet |
 | 15 | [Query paths at scale](epics/15-query-paths-at-scale.md) | Storage holds at 122x; query paths break |
+| 16 | [The CFG tier](epics/16-cfg-tier.md) | UAM, the cpp D-codes and D9 are all parked on it |
 
 **Suggested order:** 1 first, then 14 and 15 — those two are where the
 product is unusable rather than merely incomplete — then 2–4, then
-pull-driven.
+pull-driven. Epic 16 is scheduled late but **binds early**: its P1/P2
+obligations and its cycle-cut change are free today and unrecoverable
+retrofits, so Epics 4, 7 and 12 carry pointers back to it.
 
 ## Not in an epic
 

--- a/docs/epics/01-provider-identity.md
+++ b/docs/epics/01-provider-identity.md
@@ -1,0 +1,255 @@
+# Epic 1 — Provider identity: retire the single-winner assumption
+
+> **Status:** scheduled, FIRST. This is a class of confidently-wrong
+> answers, not a class of misses, which is why it outranks every
+> feature epic on the slate.
+> **Design owner-docs:** `docs/open-problems.md` §"Duplicate-package
+> resolution", the commit message of `b32814a0` (the relation's own
+> rationale), and `docs/adr/file-store-and-resolve.md` +
+> `docs/adr/resolution-candidate-set.md` (the seam the consumers move
+> onto).
+
+## Mission
+
+`name → one provider` is not a model of any language this engine
+serves. It is a model of *well-behaved* code, and the difference shows
+up as a wrong file, confidently returned.
+
+The **relation** is landed (`b32814a0`): `IndexCore.all_defs` holds
+every file per declared name, `best_candidate` derives the name-keyed
+cache slot from that set (class-over-value, then smallest canonical
+path — derived, never inserted, which is what killed the order
+dependence), `rebuild_name_registration` is the one mutation seam, and
+gold rows `pkgid-01..05` pin it on `gold-corpus/pkgsplit-fixture`.
+
+What did **not** land is the consumer conversion. **~75 `get_cached`
+call sites still read the derived single winner.** Each is wrong
+whenever the queried fact lives in a losing file. This epic converts
+the user-visible ones to the candidate relation and leaves the winner
+only where it is genuinely bookkeeping.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — "Cross-file resolution" (especially "**A module name
+   maps to a SET of files, not one file**"), the resolution
+   CandidateSet paragraph, and the `VisibilityAxis` paragraph.
+2. `git show b32814a0` — the whole commit message. It states the model
+   and names the seams; do not re-derive them.
+3. `docs/adr/resolution-candidate-set.md` — every user-visible verb is
+   a projection; a fix that lands in a handler is in the wrong place.
+4. `src/model/file_analysis/cross_file.rs` —
+   `CrossFileLookup::visible_def_candidates` (the shared accessor,
+   default = the full relation) and `ScopedLookup.closure_scoped`.
+5. `src/index/module_index/queries.rs` + `lookup.rs` — where
+   `get_cached` lives and who calls it.
+
+## Current state — exact anchors (verify before editing)
+
+| Thing | Where | Find it |
+| --- | --- | --- |
+| The landed relation | `index/module_index/index_core.rs` | `grep -n 'all_defs' src/index/module_index/*.rs` |
+| The derived winner | `index/module_index/` | `grep -n 'fn best_candidate' src/index/module_index/` |
+| The one mutation seam | `index/module_index/registration.rs` | `grep -n 'rebuild_name_registration' src/index/` |
+| The shared candidate accessor | `model/file_analysis/cross_file.rs` | `grep -n 'visible_def_candidates' src/` |
+| The residual call sites | everywhere | `grep -rn 'get_cached' src/ --include=*.rs \| grep -v tests \| wc -l` — triage this list; it is the epic's worklist |
+| The visibility rule per language | `model/file_analysis/cross_file.rs` | `grep -n 'VisibilityAxis\|IncludeClosure\|SearchPath' src/` |
+
+### The named contract-level residuals
+
+Each of these *returns a shape that assumes one provider*, so no
+amount of care at the call site fixes them:
+
+- `module_declaring_method_in_package` returns a module **name**; the
+  caller's `get_cached` then takes the winner, not the definer.
+- `parents_cached` is winner-keyed, so a losing file's `use parent`
+  edges are invisible to ancestry.
+- Enrichment's import scan, likewise.
+- The `@INC` tier is single-provider **by current construction, not by
+  language semantics**. Per-entrypoint `@INC` (`t/lib` vs `lib` vs a
+  vendored `local/` vs a container image) wants the same `all_defs`
+  relation keyed `(name, root)`, with the asker's own search path as
+  the `ScopedLookup` axis — which `VisibilityAxis::SearchPath` already
+  describes.
+
+## Phase breakdown
+
+### Phase A — pin the wrong answers first
+
+This is the move that worked twice already on this codebase, and it is
+not optional here: a conversion this wide will otherwise land with no
+evidence it fixed anything.
+
+1. Build fixtures where the queried fact lives in the **losing** file:
+   a reopened package whose second file declares the method being
+   hovered / completed / chased; a multi-package file whose later
+   packages hold the target.
+2. Author gold rows as `xfail` with `gold-corpus/run.pl --emit <cap>`
+   across the user-visible verb families: hover, completion,
+   goto-def-through-a-chain, `MethodOnClass` type chases,
+   `definitions`' PackageRef and import lanes.
+3. **Acceptance:** every row RED for the right reason (a wrong file, or
+   a confident wrong type — not an empty answer). A row that is merely
+   empty is a different bug; move it out of this epic.
+
+### Phase B — the contract-level returns
+
+Fix the three shapes above before touching call sites; converting a
+caller of a single-provider function just moves the bug.
+
+1. `module_declaring_method_in_package` returns the **definer**, not a
+   name to re-look-up. Prefer returning what the caller actually needs
+   (the analysis, or a `(path, Arc<FileAnalysis>)`) over a name.
+2. `parents_cached` unions ancestry edges across providers. This runs
+   through `parents_of` — CLAUDE.md names it as the single
+   ancestor-enumeration seam, and that stays true; what changes is
+   what feeds it.
+3. Enrichment's import scan, same treatment.
+4. **Acceptance:** unit tests where the parent edge is declared only in
+   the losing file and ancestry still finds it.
+
+### Phase C — convert the user-visible consumers
+
+In dependency order, each a commit, each with a Phase-A row flipping
+green:
+
+1. Hover cross-file arms (`model/file_analysis/hover.rs`,
+   `lsp/symbols/hover.rs`).
+2. Class-query member types (`class_queries.rs`).
+3. Invocant / chain typing (`invocants.rs`, the registry's
+   `PackageSymbol` chases in `model/witnesses/`).
+4. Completion sources — through the CandidateSet's `complete()`, never
+   a handler-side append.
+5. `definitions()`' PackageRef and import lanes.
+
+The mechanical shape is the same each time: `get_cached(name)` →
+`visible_def_candidates(name, scope)` → ask each candidate the
+question → merge. **Merging is the design decision, not the lookup.**
+Record per family what "merge" means (first-answer-wins, union,
+ranked) and why, in the commit message; a silent `.next()` on an
+iterator of candidates is the single-winner bug with extra steps.
+
+### Phase D — the winner keeps its honest job
+
+`get_cached` is not deleted. Bookkeeping consumers — the
+`module_index` internal queries, registration, CLI paths that want *a*
+representative — keep it, and the epic ends with a comment at its
+definition naming exactly which kind of caller it is for. Anything
+user-visible that still calls it after this epic is a bug someone
+must justify in review.
+
+`prompt-scale-validation-hitlist.md` Tier 3 already lists "~10
+bookkeeping `get_cached` sites — **OPEN**, deliberate". That number
+should be roughly what survives; if it is much larger, Phase C is
+incomplete.
+
+### Phase E — the `@INC` / search-path axis
+
+Only if C lands clean. Key `all_defs` by `(name, root)` and let
+`VisibilityAxis::SearchPath` — which already ranks the asker's own
+`use lib` roots ahead of the process set, longest-prefix then root
+order — do the selection. This is the piece that makes `t/lib`
+shadowing work correctly, and it is separable: ship A–D without it.
+
+## Language-pack beat
+
+**This is the epic where the seam must be language-neutral, and it is
+the reason it goes first.** The single-provider assumption is not a
+Perl bug wearing a general name — every language the engine serves has
+its own spelling of it:
+
+- **Perl:** a `package` may be declared in any file and reopened in
+  several. Visibility is `VisibilityAxis::SearchPath` (`@INC`).
+- **C/C++:** the same name is provided by a header and its
+  implementation TU, by a prototype and a definition, and by every
+  translation unit that includes it. Visibility is
+  `VisibilityAxis::IncludeClosure` (flat linkage), and
+  `ScopedLookup.closure_scoped` is the narrowing that already keeps a
+  non-includer from seeing a header's names. The cpp arc already hit
+  this from the other side — see-through goto-def preferring the
+  **definition** over a prototype (`cpp-golive-map.md` item 6) is a
+  merge policy over a candidate set, decided once.
+
+The rule for every consumer converted here: **it must not ask what
+language it serves.** It asks `visible_def_candidates` for candidates
+and the scope's own `VisibilityAxis` for which of them are visible. If
+a conversion needs a language branch, the branch belongs in
+`VisibilityAxis::for_origin` — the ONE derivation — and nowhere else.
+
+The payoff is that a language whose identity model is *leaf-keyed with
+namespace claims layered on* (the shape a namespaced language wants)
+becomes a `VisibilityAxis` variant plus a merge policy, not a second
+resolution path. Write Phase C's merge policies so that is true.
+
+## Scaling beat
+
+**This epic touches the hottest relation in the system, and the FHEM
+shape is its worst case.** `scaling-limits.md` §1 (measured
+2026-08-17): FHEM declares `package main` in 534 of 614 files, so
+`main` is 27% of package lookups and **94% of provider fetches**, and
+the candidate set for it is 534 members wide. The relation is
+*semantically correct* — those files genuinely share one stash — so
+narrowing it would be wrong.
+
+Which means: **converting a consumer from the winner to the candidate
+set converts an O(1) read into an O(providers) one.** On well-behaved
+code that is 1–2. On FHEM it is 534, at 94% of fetches.
+
+Non-negotiable for every Phase C commit:
+
+1. **Measure before and after on a monoculture**, not on `crm`. FHEM is
+   in the corpus (`corpus/bootstrap.sh "" FHEM`), and it is the only
+   corpus where this regression is visible at all. Three runs minimum,
+   date the numbers, land them in `bench/` via `bench/measure.sh` —
+   per the house rules, a single run is not a baseline.
+2. **Ask for candidates lazily and stop early where the merge policy
+   allows it.** A first-answer-wins merge must not materialize 534
+   analyses to return the first. This is where the merge policy from
+   Phase C stops being bookkeeping and starts being the performance
+   design.
+3. **The prefilters already exist — use them, do not rebuild them.**
+   The relational row store (`adr/relational-ref-index.md`)
+   SOUND-pre-prunes provably-unreferenced names; the closedness
+   certificate (`index/closedness_store.rs`,
+   `model/witnesses/closedness.rs`) makes a bake's silence a trusted
+   `None` instead of a decode, and it *self-validates against the live
+   index* so a stale certificate costs a failed validation, never a
+   wrong answer. A candidate sweep that decodes providers the store
+   could have answered is the regression this epic is most likely to
+   ship.
+4. `scaling-limits.md` names the honest fix for the sweep level —
+   deduplicating provider decoding across a sweep (~13,456 rehydrates
+   for ~500 distinct providers is ~27× redundant). That fix is **Epic
+   15**, not this one. Do not build it here; do make sure this epic
+   does not make its arithmetic worse.
+
+Report in the PR: FHEM `--check` peak RSS and wall, cold and warm,
+before and after, with `RAYON_NUM_THREADS=4
+MALLOC_MMAP_THRESHOLD_=65536` as the documented workaround still
+applied — that is the configuration the doc tells users to run.
+
+## Invariants that MUST survive
+
+- `rebuild_name_registration` stays the ONE mutation seam for name
+  registration; sibling edges survive by construction, not by
+  diligence.
+- `parents_of` stays the single ancestor-enumeration seam.
+- The CandidateSet stays the one resolution entry point. A merge
+  policy is part of the set's construction, never a handler's loop.
+- `VisibilityAxis::for_origin` stays the ONE derivation of a scope's
+  visibility rule.
+- Derived-not-inserted: the winner is a projection of the relation. If
+  anything in this epic writes a winner into a map, the order
+  dependence `b32814a0` killed comes straight back.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS with the
+Phase-A rows promoted from xfail → gold, `lang-skip 0` in the summary ·
+`./e2e/run.sh` · substrate audit at parity-or-better with every moved
+count triaged · **the FHEM measurement above, in the PR body.**
+
+## Sizing & sequencing
+
+Medium, but wide. A → B → C strictly (A is the evidence, B is the
+prerequisite); C is a string of independent commits and is where the
+time goes; D is bookkeeping; E is separable and droppable.

--- a/docs/epics/02-dbic-out-of-core.md
+++ b/docs/epics/02-dbic-out-of-core.md
@@ -1,0 +1,285 @@
+# Epic 2 — DBIC out of core, phases 2–3 (meta-methods, parametric emission, projection)
+
+> **Status:** scheduled, second. Finishes the standing "core is
+> plugin-free except generic dispatch" commitment.
+> **Design owner-doc:** `docs/prompt-dbic-as-plugin.md` (read it whole —
+> the phase ladder, the projection table, the open questions).
+>
+> **Re-baselined:** phase 2 (`meta_methods()`) was drafted against the
+> pre-rework tree in an unmerged PR and does **not** exist on main —
+> `grep -rn 'meta_methods' src/ frameworks/` returns nothing. It is
+> re-absorbed here as Phase A rather than assumed landed.
+
+## Mission
+
+Move the last DBIC-specific machinery out of the builder and into the
+plugin layer, so `frameworks/dbic.rhai` (plus generic core seams) owns
+everything DBIC-shaped. Phase 1 landed: accessor/relationship
+synthesis, arg-name verbs, column-keyed verbs and fluent verbs live in
+the plugin (`frameworks/dbic.rhai` declares `column_keyed_verbs`,
+`fluent_verbs`, `column_actions`, `relationship_method`). What remains
+in core is the **meta-method suppression list**, the **parametric
+ResultSet minting**, and the **hardcoded semantics of
+`DBIx::Class::ResultSet`** — plus two pinned user-facing gaps that only
+make sense to fix on the plugin side of the move.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — rules #1 (tree traversal only in `build()`), #8
+   (plugin-synthesized content), #10 (never special-case shapes),
+   "Worklist invariants", "Type inference (witness bag)".
+2. `docs/prompt-dbic-as-plugin.md` — the design, including the
+   per-method projection table and the `parametric_semantics()` sketch.
+3. `docs/adr/parametric-types.md` — the sealed-flavor Parametric data
+   model and its per-axis policy.
+4. `docs/adr/cpp-templates.md` — **read this even though the epic is
+   about DBIC.** `ParametricType` is shared with C++ template
+   instantiation; see the Language-pack beat below.
+5. `docs/adr/return-expr.md` — the receiver-relative return machinery
+   (`Operator(RowOf)` is how `find` already projects to the row class).
+6. `docs/adr/plugin-system.md` — manifest families, emit vs query hooks.
+
+## Current state — exact anchors (verify with grep before editing)
+
+| What | Where | Find it |
+| --- | --- | --- |
+| Hardcoded meta-method / universal list | `src/lsp/symbols/diagnostics.rs` | `grep -n 'universal_methods' src/lsp/symbols/diagnostics.rs` — the true `UNIVERSAL::` surface plus a "DBIC meta-methods" comment block riding along with it |
+| Fold-time ResultSet minting | `src/build/builder/visit_method.rs` | `grep -rn 'extract_resultset_parametric' src/build/` |
+| Its re-emittable dedup set | `src/build/builder/` | `grep -rn 'parametric_emitted_refs' src/build/` (struct field + clear-and-emit doc + insert sites) |
+| Hardcoded DBIC class names in the model | `src/model/file_analysis/invocants.rs` | `grep -n 'DBIx::Class' src/model/file_analysis/invocants.rs` — the result-class predicate encodes `DBIx::Class::Core` / `::Row` / `::Schema` / `::ResultSet` |
+| Parametric semantics read side | `src/model/file_analysis/types.rs` | `grep -n 'fn hash_key_class\|fn dispatch_class\|fn element_type' src/model/file_analysis/` — these accessors ENCODE DBIC's semantics ("type_args[0] is the row class") in core |
+| Plugin as it stands | `frameworks/dbic.rhai` | `column_keyed_verbs`, `fluent_verbs`, `column_actions`, `relationship_method`, `on_match` |
+| Manifest plumbing template | `src/build/plugin/mod.rs` + `rhai_host.rs` | pick the freshest landed manifest family and copy its five touch points: trait default → registry iterator → rhai read → struct init → `FrameworkPlugin for RhaiPlugin` impl |
+| Where a baked table lands | `src/model/file_analysis/plugin_facts.rs` | the plugin lane — a new baked manifest union goes IN here, never beside it |
+
+Pinned gaps this epic closes:
+
+- **Custom resultset discovery** — `$schema->resultset('Users')` should
+  resolve to `<SchemaNS>::ResultSet::Users` when that package exists,
+  else default. Red-pinned by `goto_def_offers_custom_resultset_method`.
+- **Column-key completion at `->search({ | })`** — goto-def through a
+  typed key already works; `complete_keyval_args` has no
+  parametric-receiver branch. E2E pin: `e2e/dbic_parametric.lua`.
+
+## Non-goals — do NOT do these
+
+- Do NOT build the full type-system-encoding axis machinery
+  (`docs/prompt-type-system-encoding.md` stays parked). Phase 1 proved
+  the declarative-manifest route works; stay on it.
+- Do NOT port the plugin to Rhai-executed *fold* logic. Rhai hooks run
+  at parse time. Anything the worklist fold re-derives per iteration
+  must be DATA the plugin declares, consumed by a generic core pass. If
+  you want to call Rhai from `fold_to_fixed_point`, stop — declare
+  instead.
+- Do NOT leave a name-keyed lookup table for DBIC methods in core
+  (rule #10).
+- Do NOT touch `load_components` parent registration — generic mixin
+  machinery, stays core.
+
+## Phase breakdown
+
+### Phase A — `meta_methods()` manifest (re-absorbed phase 2)
+
+**Goal:** the "methods a framework gives every class of its family"
+list leaves `diagnostics.rs`.
+
+1. New manifest hook `meta_methods()` on the plugin trait (default
+   empty) + the rhai read + registry union, baked onto
+   `FileAnalysis.plugin` (`plugin_facts.rs`, serde-default).
+2. `frameworks/dbic.rhai` and `frameworks/moo.rhai` declare their own
+   entries. Core keeps ONLY the true `UNIVERSAL::` surface
+   (`new`/`AUTOLOAD`/`DESTROY`/`can`/`isa`/`DOES`).
+3. The unresolved-method diagnostic consults the baked union.
+4. **Acceptance:** existing diagnostics tests green unchanged;
+   `grep -n 'DBIx' src/lsp/symbols/diagnostics.rs` returns nothing;
+   substrate audit at exact parity (this is a pure move — any count
+   that moves means the lists were not equivalent, so reconcile before
+   merging).
+
+### Phase B — `parametric_bases()` manifest (semantics move out)
+
+**Goal:** the read-side policy "what does `Parametric{base, args}`
+mean" comes from the plugin, not from `ParametricType`'s accessors.
+
+1. Manifest shape (serde struct in `src/build/plugin/mod.rs`):
+   ```rust
+   pub struct ParametricBase {
+       pub base: String,                   // "DBIx::Class::ResultSet"
+       pub hash_key_arg_class: Projection, // where column-key args resolve
+       pub element_type: Projection,       // what ->find / element access yields
+       pub dispatch_class: Projection,     // where methods dispatch
+   }
+   pub enum Projection { TypeArg(usize), SelfBase } // closed, tiny
+   ```
+2. `hash_key_class` / `dispatch_class` / `element_type` become lookups
+   against the baked table. **Prefer mint-time resolution** — store the
+   resolved projections on the `ParametricType` when it is minted, so
+   the value carries its own answers and consumers stay zero-argument.
+   Check the call sites first: if any accessor is called from a place
+   without `FileAnalysis` access, mint-time is the only option.
+3. `frameworks/dbic.rhai` declares its entry (`hash_key_arg_class:
+   TypeArg(0)`, `element_type: TypeArg(0)`, `dispatch_class: SelfBase`).
+4. **Acceptance:** `parametric_resultset_tests.rs` passes unchanged;
+   `grep -rn 'DBIx' src/model/` returns only comments — plus the
+   Language-pack beat's C++ regression check below.
+
+### Phase C — minting moves to a declarative manifest
+
+**Goal:** delete `extract_resultset_parametric` from core.
+
+1. Manifest `parametric_mints()`:
+   ```rust
+   pub struct ParametricMint {
+       pub verb: String,                  // "resultset"
+       pub base_default: String,          // "DBIx::Class::ResultSet"
+       pub row_from_first_string_arg: bool,
+       pub discover_base: Option<String>, // "{schema_ns}::ResultSet::{row}"
+   }
+   ```
+   Core substitutes `{schema_ns}` (the invocant class's namespace root)
+   and `{row}` (the resolved row-class tail), then checks the index /
+   workspace symbols for existence — that is custom-resultset
+   discovery, done generically.
+2. The generic fold pass replaces `extract_resultset_parametric`: same
+   trigger conditions, same witness shape, same clear-and-emit
+   idempotency. **KEEP the dedup set and its invariant comment** —
+   rename it if you like, but the worklist invariant it enforces must
+   survive verbatim.
+3. Delete the DBIC name literals from the builder. The `+`-prefix /
+   `DBIx::Class::` bare-name expansion near `load_components` is
+   component loading and stays — *verify with grep* that it does not
+   also feed parametric minting; if it does, split it.
+4. **Acceptance:** `parametric_resultset_tests.rs` green; gold dbic
+   rows unmoved; **a new unit test proving a THIRD-PARTY rhai plugin
+   (a test fixture, not `dbic.rhai`) can mint a Parametric on its own
+   verb** — that is the proof the seam is generic, not a DBIC rename.
+
+### Phase D — per-method projection completes
+
+`search`/`search_rs` preserve via `fluent_verbs`; the `find` family
+projects via the `RowOf` `ReturnExpr` operator. Missing: `all`/`slice`
+(ArrayRef-of-row — plain `ArrayRef` is acceptable; note the honest
+loss), `count`/`exists`/`update`/`delete` (Numeric).
+
+Use the EXISTING seams — `overrides()` with a class-scoped method
+target, or the same `ReturnExpr` publication path `RowOf` rides. Do not
+invent a third mechanism if either fits. **Acceptance:** `$rs->count`
+types Numeric; `$rs->all` types ArrayRef; `$rs->find(1)->name` still
+resolves the column accessor; `$rs->search({...})->count` chains.
+
+### Phase E — the two pinned gaps
+
+1. Custom-resultset discovery lands with Phase C's `discover_base` —
+   flip `goto_def_offers_custom_resultset_method` from red pin to green.
+2. `complete_keyval_args` parametric branch: when the receiver types
+   `Parametric` and the verb is column-keyed, complete the row class's
+   column keys (ask the typed receiver via `hash_key_arg_class`, then
+   the row class's `HashKeyDef`s, cross-file via the lookup goto-def
+   already uses — **no parallel reverse index**, rule #8).
+3. **Acceptance:** a gold completion row for `->search({ | })` column
+   keys, authored with `gold-corpus/run.pl --emit completion`, status
+   `gold`; `e2e/dbic_parametric.lua` green.
+
+### Phase F — deletion sweep
+
+`grep -rn 'DBIx' src/` → only comments and generic examples. Bump
+`EXTRACT_VERSION` (FA shape and bag rules both changed). Update
+`docs/prompt-dbic-as-plugin.md` (phases 2–3 landed, honest residuals
+kept — prefetch `join =>` key extension stays out) and this README's
+coverage map.
+
+## Language-pack beat
+
+**`ParametricType` is not a DBIC type. It is the engine's parametric
+model, and C++ templates are its other tenant** — which makes Phase B
+the riskiest phase in this epic and the one most likely to break a
+language nobody working on it is thinking about.
+
+What rides the same shape (`docs/adr/cpp-templates.md`, slice c):
+`ParametricType::Instance` with exact-spelling dispatch; lazy
+`ParamOf` / `InstanceOf` receiver substitution *beside* `RowOf`;
+`substitute_type_params` for fields; the partial-pattern
+spec-selection ladder (exact > partial > primary) with
+`match_template_pattern` binding a spec's params from the concrete
+spelling.
+
+Concrete obligations:
+
+1. **`hash_key_class` / `dispatch_class` / `element_type` must keep
+   answering for a C++ instance**, which has no plugin manifest behind
+   it. A pack language's `Parametric` values are minted by the
+   extractor, not by a rhai plugin. So the baked table is a *lookup
+   with a default*, and the default must be exactly today's behavior —
+   not "empty means no answer".
+2. Prefer mint-time resolution (Phase B step 2) partly for this
+   reason: a value minted by the cpp extractor carries the projections
+   the extractor knows, and never consults a Perl plugin table at all.
+3. **Run the C++ suite on Phase B.** `cargo test --features cpp` and
+   the gold harness built `--features cpp` with `lang-skip 0` — a
+   plain release build lang-skips half the corpus and reports it as
+   skips, not failures, which is exactly how this regression would
+   escape.
+4. The generic-seam proof in Phase C (a third-party plugin minting a
+   Parametric on its own verb) is also the pack-language proof: if the
+   mint seam only works for a rhai plugin, a pack language that wants
+   framework-shaped parametric minting has to grow a second path.
+
+## Scaling beat
+
+This epic adds **two baked manifest unions to every `FileAnalysis`**
+(`meta_methods`, `parametric_bases`, plus `parametric_mints`). That is
+cheap per file and not cheap per corpus, so:
+
+1. **They go in `plugin_facts.rs`**, the plugin lane, which is
+   `#[serde(default)]` and default-empty. A Perl analysis with no
+   matching plugin carries an empty sub-struct, not three empty fields
+   in the top-level struct — this is the lane discipline CLAUDE.md
+   describes, and it is why `PackFacts`/`PluginFacts` exist.
+2. **`surface_feed` will not compile** until each new field's Surface
+   fate is decided (it destructures every field with no `..`). These
+   are *baked manifest data*, identical for every file a given plugin
+   set analyses — they are **not** cross-file-visible surface, and
+   including them would make every file's Surface differ on a plugin
+   edit rather than on a real change. Discard them with a reason, in
+   the code.
+3. **Each new field joins a `heap_estimate` bucket.** A per-file
+   manifest copy at 138k files is real: the CPAN-5k corpus is 138,822
+   files with a 1.73 GB `modules.db` at 13.9 KB/file (measured
+   2026-08-17). A few hundred bytes of duplicated manifest per file is
+   ~40 MB of database. If the union is large, intern it or key it by
+   plugin-set fingerprint rather than copying it per file — but
+   measure first; do not pre-optimize a 20-entry table.
+4. **`EXTRACT_VERSION` bump means a full cold re-index for every user.**
+   Bundle Phases A–F behind one bump if they land close together
+   rather than forcing three. The cold bulk index for CPAN-5k is
+   ~10.5 minutes (2026-08-17); that is what a bump costs someone with a
+   large workspace.
+5. Phase C's `discover_base` does an **existence check against the
+   index per mint**. On a fold that re-emits per iteration, that is a
+   per-iteration index consult. Cache the verdict on the dedup set that
+   already exists (`parametric_emitted_refs`) rather than adding a
+   second memo, and confirm with `--timings` on the substrate that the
+   slowest-modules tail does not move.
+
+## Invariants that MUST survive
+
+- Rule #1: only `build()` walks the tree. Manifest data is consumed by
+  existing walk/fold passes; no new tree consumers.
+- Re-emittable passes are clear-and-emit under a source tag; new tags
+  go in `witnesses::tags`, never inline.
+- Edges, not values: if the mint can point at an existing attachment,
+  push an `Edge`, not a materialized type.
+- Minted Parametrics keep their `TypeProvenance` trail so
+  `--dump-package` stays honest.
+
+## Verification gate
+
+`cargo test` **and** `cargo test --features cpp` · gold 0 FAIL /
+0 XPASS, built `--features cpp`, `lang-skip 0` confirmed in the summary ·
+`./e2e/run.sh` · substrate audit with always-on `undef-deref` at exact
+parity · `--timings` tail unmoved beyond noise.
+
+## Sizing & sequencing
+
+A → B → C → D → E → F. A is small and independently shippable; B and C
+are the bulk (~2/3). D is independent of B/C's ordering but precedes E.

--- a/docs/epics/03-openness.md
+++ b/docs/epics/03-openness.md
@@ -1,0 +1,302 @@
+# Epic 3 — Openness: one answer to "is this unresolved name real?"
+
+> **Status:** scheduled, third.
+> **Design owner-docs:** `docs/prompt-graph-walking.md` §"Deferred:
+> Scope nodes", `docs/open-problems.md` §"Qualified-name resolution
+> suppression is coarse", `docs/adr/graph-walking.md` (the landed walker
+> this builds on), `docs/adr/narrowing-diagnostics.md` (the promotion
+> ladder this epic monetizes).
+
+## Mission
+
+Every "couldn't resolve X" decision in the diagnostics uses a
+different, partial suppression rule: a `framework_imports` string set,
+a hardcoded `universal_methods` list, an AUTOLOAD-in-MRO skip, an
+unresolved-ancestor skip, a syntactic `SUPER::`/qualified-name skip,
+and — the audit's remaining noise class — nothing at all for open-world
+dispatch.
+
+Replace the pile with ONE structural question the graph answers: *walk
+outward from the reference site; if you reach an OPEN namespace before
+exhausting CLOSED ones, stay silent; if every namespace on the chain is
+closed and the name still does not resolve, warn.* Then use the trust
+gained to flip diagnostic flags default-on per the promotion path.
+
+## The vocabulary collision, up front
+
+**There is already a `closedness` concept in this codebase, and it is
+NOT this one.** Read both before naming anything:
+
+- `model/witnesses/closedness.rs` + `index/closedness_store.rs` — a
+  per-class **certificate** that a class's ancestry was fully
+  enumerable at mint time, used to turn a conclusion bake's *silence*
+  about a member into a trusted `None` instead of a full blob decode.
+  It is a performance instrument on the type-chase path, it
+  self-validates against the live index, and correctness never depends
+  on it (`docs/adr/conclusion-layer.md` §"World-level closedness").
+- This epic's **openness verdict** — a diagnostics-suppression
+  question: may a name legitimately exist that this analysis cannot
+  see?
+
+They ask overlapping questions of the same graph and they are not
+interchangeable: a class can be perfectly enumerable (certificate
+valid) and still be Open to arbitrary method names because it has an
+`AUTOLOAD`. Reuse the certificate as an *input* where it helps — a
+class whose ancestry failed to certify is a strong `UnresolvedAncestor`
+signal, and it is already computed — but do not fold the two verdicts
+into one type. Name yours distinctly and say why in the ADR.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — rule #10 (this epic exists because of it), the
+   resolution CandidateSet paragraph, "Inheritance & frameworks".
+2. `docs/adr/graph-walking.md` — `GraphView`, the closed `EdgeKind`,
+   exhaustive `edges_from`, why file roles are NOT graph nodes.
+3. `docs/adr/conclusion-layer.md` §"World-level closedness" — the
+   collision above.
+4. `docs/prompt-graph-walking.md` — the deferred Scope-node taxonomy;
+   note its warning that scope parent-climbing is a linked list, so
+   `Node::Scope` must be *earned* by Openness, not ported for its own
+   sake.
+5. `docs/adr/narrowing-diagnostics.md` — the flag ladder.
+6. `src/model/graph.rs` (read all of it) and the unresolved-method /
+   unresolved-function blocks in `src/lsp/symbols/diagnostics.rs`.
+
+## Current state — exact anchors
+
+| Suppression rule to subsume | Where | Find it |
+| --- | --- | --- |
+| `framework_imports` string set (unresolved-function) | `lsp/symbols/diagnostics.rs` | `grep -n 'framework_imports' src/lsp/symbols/diagnostics.rs` |
+| `universal_methods` hardcoded list | `lsp/symbols/diagnostics.rs` | `grep -n 'universal_methods' src/lsp/symbols/diagnostics.rs` — **Epic 2 Phase A splits this**: the true `UNIVERSAL::` half stays, the framework half becomes `meta_methods`. Both are genuine facts and become INPUTS to the one walk, not a parallel path |
+| AUTOLOAD-in-MRO skip | `lsp/symbols/diagnostics.rs` | `grep -n 'AUTOLOAD' src/lsp/symbols/diagnostics.rs` — this IS an openness fact; fold it in |
+| Unresolved-ancestor skip | `model/file_analysis/` | `grep -rn 'class_has_unresolved_ancestor' src/` |
+| `SUPER::`/qualified-name syntactic skip | `lsp/symbols/diagnostics.rs` | `grep -n 'SUPER::' src/lsp/symbols/` — replace with real resolution (Phase C) |
+| Open-world dispatch noise | `model/file_analysis/` | `grep -rn 'fn guard_redundancies' src/model/` |
+| Role-ness (already an openness fact) | `PackageFacts::is_role` | roles are Open by definition (`docs/adr/role-contracts.md`) |
+| Plugin namespaces / app surface | `plugin_facts.rs` | `for_each_entity_bridged_to`, `app_surface_consumers` |
+| Gated emissions (a class may gain content at query time) | `model/file_analysis/enrichment.rs` | `grep -n 'gated_emissions\|apply_gated_emissions' src/` — **landed**; a package with pending gated emissions is Open until its gate resolves |
+| Descendant fan-out | `children_index` via `GraphView` INHERITS_INV | reuse for "is this method overridden below me" |
+| The certificate (an input, not the verdict) | `index/closedness_store.rs` | `grep -n 'ClosednessCertificate' src/` |
+
+## Non-goals — do NOT do these
+
+- Do NOT build instance brands, `main::` program-boundary analysis, or
+  a `Symbol.home_namespace` field migration. This epic needs a QUERY
+  ("openness of package P in file F"), not a stored field. If you find
+  yourself running a serde migration on `Symbol`, you have overreached.
+- Do NOT delete `universal_methods` / `meta_methods` / `RoleMask` —
+  inputs, not competitors.
+- Do NOT make the walk recursive over arbitrary lexical scopes. Perl
+  lexical scopes do not affect method resolution; the chain is package
+  → ancestry (+ bridges + app surface), which `parents_of` already
+  enumerates. `Node::Scope` is justified ONLY if the implementation
+  genuinely needs lexical nodes — the expected outcome is that it does
+  not. **Record the decision either way in the ADR.**
+- Do NOT merge with the closedness certificate (see above).
+
+## Phase breakdown
+
+### Phase A — the openness verdict, as data
+
+1. New Model-layer API (`src/model/graph.rs` or a sibling — check
+   `src/layering_tests.rs`' layer map and assign the file if new; an
+   `.rs` outside a layer directory fails the walk):
+   ```rust
+   pub enum Openness { Open(OpenCause), Closed }
+   pub enum OpenCause { Autoload, Role, UnresolvedAncestor,
+                        PluginNamespace, AppSurface, DynamicParent,
+                        PendingGatedEmission }
+   ```
+   `openness_of(class, analysis, module_index) -> Openness` walks
+   ancestry via the existing `parents_of` seam — **never a second
+   parent enumeration** — and answers Open on the FIRST open fact.
+2. `OpenCause` exists for diagnostics text and tests: a verdict should
+   be able to say WHY it stayed silent.
+3. **Also verify the applicability matrix** in
+   `prompt-enrichment-inheritance-residual.md` here: `gated_emissions`
+   landed, so the doc's "two real gaps" header is stale. Confirm which
+   matrix rows are closed, update the doc, and add
+   `PendingGatedEmission` above only if a package can genuinely still
+   be awaiting a gate at diagnostic time. If it cannot, drop the
+   variant and say so — a cause nothing produces is dead weight.
+4. **Acceptance:** unit tests per cause, plus a Closed case (plain
+   class, full local MRO, no bridges) that stays Closed.
+
+### Phase B — unresolved-method/function rewired
+
+1. In the diagnostics block: after the universal/meta-method skips and
+   the local/workspace gates, replace the AUTOLOAD skip and the
+   unresolved-ancestor skip with one `openness_of(class) == Open →
+   continue`.
+2. unresolved-function: replace the `framework_imports.contains` skip
+   with openness of the ENCLOSING package. Keep `framework_imports` as
+   the implementation detail *behind* the verdict if that is the honest
+   mapping — but the diagnostic consults ONE function.
+3. **Behavior must not regress:** substrate audit before and after.
+   `unresolved-method` / `unresolved-function` counts may only go DOWN
+   or stay equal; always-on `undef-deref` at exact parity.
+4. **Acceptance:** existing diagnostics tests green unchanged; new
+   tests asserting AUTOLOAD suppression now reports through the same
+   path (message/absence identical to before).
+
+### Phase C — qualified names resolve instead of hiding
+
+1. `conventions::MethodToken` already parses the qualifier (FQ / SUPER
+   / main). For `Super`, resolve against the enclosing class's
+   PARENTS (`resolve_method_in_ancestors` starting from parents, not
+   self). For `Qualified(pkg)`, resolve against `pkg`'s MRO.
+2. Resolved → no diagnostic, and the ref gains a proper goto-def
+   target if it lacks one. Check whether `resolve.rs` already answers
+   these; if it does, **reuse its answer** — the CandidateSet is the one
+   resolution entry point, not a place to re-resolve beside.
+3. Unresolved AND the target package is Closed → the diagnostic fires
+   where it used to stay silent. Run the substrate audit and **triage
+   every new hit before merging**: each is either a real find (document
+   it) or an openness fact missed in Phase A.
+4. **Acceptance:** `$self->SUPER::real_parent_method()` silent;
+   `$self->SUPER::typo()` in a Closed chain fires; `Some::Pkg->method`
+   against a Closed resolvable package with no such method fires.
+
+### Phase D — the open-world-dispatch gate
+
+A base class's own method types `$self->m` (`sub meta_name { undef }`),
+but runtime receivers are subclasses that override it — so "this guard
+can never pass" is wrong.
+
+1. In `guard_redundancies`: when the belief deciding a verdict came
+   from a method call on a `$self`-like receiver, and `children_index`
+   shows ANY descendant of the enclosing class overriding that method,
+   downgrade the verdict to silence.
+2. If threading belief provenance is too invasive, the coarser sound
+   gate: suppress definitive verdicts on subjects assigned from a
+   `$self`-receiver method call when the enclosing class HAS
+   descendants. **Prefer the precise gate; document which you shipped.**
+3. **Acceptance:** a two-file regression test (base with `sub meta_name
+   { undef }` + subclass overriding it; a `defined $meta` guard in the
+   base must NOT flag) and a measured drop in the audit's
+   contradictory-guard count.
+
+### Phase E — promotion
+
+1. Rerun the full substrate audit; record the numbers.
+2. Flip `optionalDeref` default-on (INFO severity): the
+   `DiagnosticOptions` default, the serde/CLI tests, and the ladder
+   text in `adr/narrowing-diagnostics.md`.
+3. `redundantGuard` / `contradictory`: flip if Phase D put the noise
+   classes near zero; otherwise record precisely which class remains
+   and leave them opt-in. Do NOT flip `unresolvedMethodCrossFile` here
+   — its ladder promotes it last, and the named-helper first-param-self
+   gap in `gold-corpus/KNOWN-GAPS.md` is still open.
+4. Write `docs/adr/openness.md`: the verdict enum, the single
+   `parents_of`-seam walk, what subsumed what, the `Node::Scope`
+   decision, the deliberate separation from the closedness certificate,
+   and the promotion results.
+
+## Language-pack beat
+
+**This epic is Perl-flavored, and that is honest — but the flavor must
+live in the causes, not in the walk.**
+
+Pack languages have no diagnostics today, by deliberate policy:
+`prompt-multi-language.md` says diagnostics stay off for a pack
+language until a calibrated substrate exists, and the zero-false-
+positive sweep is the ship gate (Epic 13 Phase B owns that). The one
+exception is the C++ use-after-move channel, off by default
+(`lsp/symbols/diagnostics.rs`). So nothing here fires for C/C++ today.
+
+What that means for the design:
+
+1. **`openness_of` must not be reachable from a language-agnostic path
+   that assumes Perl's causes.** `Autoload` and `Role` are Perl facts;
+   `PluginNamespace` and `AppSurface` are plugin facts; `DynamicParent`
+   is a runtime-`@ISA` fact. A C++ class is Open for entirely different
+   reasons — virtual dispatch through a base pointer, a member injected
+   by a macro the extractor blanked, a symbol declared only in a
+   translation unit outside the include closure.
+2. So: put the verdict in the Model layer (it walks the graph), but let
+   the **cause set be produced per language**. The cheapest honest
+   shape is that `openness_of` consults facts already on the
+   `FileAnalysis` — which is language-tagged — and a pack language
+   simply produces none of the Perl causes and gets `Closed`. That is
+   correct only because nothing consults the verdict for pack
+   languages yet. **Write that dependency down in the ADR**, because
+   Epic 13 Phase B is exactly the moment it stops being true, and a
+   silent `Closed` default there is a false-positive flood.
+3. Concretely, leave Epic 13 a hook: the ADR should name what a pack
+   language must supply before its diagnostics consult this verdict.
+   The C++ analogue is already sitting in the tree —
+   `class_has_unresolved_ancestor`'s condition is "an ancestor we
+   cannot see", which for C++ means an unresolved `#include`. That is
+   one cause, cross-language, and it is the natural first one to
+   generalize.
+4. Phase C's qualified-name resolution is genuinely cross-language:
+   `MethodToken`'s qualifier parsing is Perl `&str` semantics
+   (`conventions.rs`, deliberately Perl-scoped), but "a written
+   qualifier names a scope, resolve against that scope's MRO" is the
+   same rule C++ needs for `Base::method()`. Do not generalize it here
+   — do name it in the ADR as a known shared rule so it is not
+   rediscovered.
+
+## Scaling beat
+
+**`openness_of` runs per unresolved reference site, and it walks
+ancestry.** That is the most dangerous shape in this epic: the current
+suppression pile is mostly string-set membership (O(1)) and this
+replaces it with a graph walk.
+
+Where that bites, measured:
+
+1. **`--check` is a batch verb over every workspace file**
+   (`scaling-limits.md` §1). FHEM does not complete `--check` on a
+   31 GB machine today — a diagnostics change that adds a per-site
+   ancestry walk lands directly on the verb that is already
+   pathological. FHEM has 534 files providing `main`; every `main`
+   lookup consults that candidate set.
+2. **Memoize per (class, file), not per site.** A file's diagnostics
+   pass hits the same enclosing class hundreds of times. The verdict is
+   pure over (class, analysis, index generation), so a per-pass memo is
+   sound and is the difference between "one walk" and "one walk per
+   reference".
+3. **Consult the closedness certificate before walking.** It already
+   exists, it is byte-bounded (`ClosednessStore`, 8 MiB default), and
+   its whole purpose is to answer "was this class's ancestry fully
+   enumerable" without a decode. A class that fails to certify is
+   `UnresolvedAncestor` — Open — with no walk at all. This turns the
+   expensive case into the *cheap* case, which is the right way round.
+4. **Measure on the right corpus.** Not `crm`. FHEM for the monoculture
+   shape and Koha (3,554 files, the only corpus hitting DBIC and Mojo
+   plugin paths together — minutes per round) for the normal shape.
+   Three runs, dated, into `bench/`.
+5. Phase C **adds** work: qualified names that were skipped by token
+   shape now resolve. That is a new MRO walk per qualified call site.
+   Budget it, and if the audit shows it dominating, cache the
+   per-`(pkg, method)` resolution for the pass — but only after
+   measuring, per the house rules.
+6. Phase E's flag promotions change what `--check` emits by default,
+   which changes what every CI running it pays. Note the new default
+   cost in the PR.
+
+## Invariants that MUST survive
+
+- `parents_of` stays the single ancestor-enumeration seam.
+- The CandidateSet stays the one resolution entry point — Phase C
+  reuses its answers, never a parallel resolve.
+- The closedness certificate stays a performance instrument whose
+  staleness costs a validation, never a wrong answer. If this epic
+  makes a diagnostic depend on it for *correctness*, the design is
+  wrong.
+- Always-on `undef-deref` at exact parity in every audit re-run.
+- Every count that goes UP in the audit gets a per-site triage note in
+  the PR.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS · `./e2e/run.sh` ·
+substrate audit before/after with per-code deltas and triage ·
+FHEM + Koha `--check` wall and peak RSS, three runs, dated.
+
+## Sizing & sequencing
+
+A → B, A → D independent after A; C after B (shares the diagnostic
+block); E last. Expect C to surface the surprises — budget triage time
+for the new `SUPER::` hits.

--- a/docs/epics/03-openness.md
+++ b/docs/epics/03-openness.md
@@ -59,6 +59,9 @@ into one type. Name yours distinctly and say why in the ADR.
    `Node::Scope` must be *earned* by Openness, not ported for its own
    sake.
 5. `docs/adr/narrowing-diagnostics.md` — the flag ladder.
+6. `docs/prompt-cfg-tier.md` §8.2 rung 1 — the path-sensitivity tier
+   (Epic 16) kills a noise class this epic will meet. See the note
+   under Phase D.
 6. `src/model/graph.rs` (read all of it) and the unresolved-method /
    unresolved-function blocks in `src/lsp/symbols/diagnostics.rs`.
 
@@ -175,6 +178,16 @@ can never pass" is wrong.
    { undef }` + subclass overriding it; a `defined $meta` guard in the
    base must NOT flag) and a measured drop in the audit's
    contradictory-guard count.
+4. **Know which noise class is yours and which is Epic 16's.** Open-world
+   dispatch is an *openness* problem and belongs here. **Correlated
+   branches** — `if ($ok) { $x = init() } … if ($ok) { $x->use }` — are
+   a *path-sensitivity* problem, named in `prompt-cfg-tier.md` §8.2 as
+   "the dominant real-world FP class", killed by that tier's rung 1
+   (SAT over atoms along the candidate trail) with no dependencies.
+   Do not build a correlated-branch heuristic here; it would be a
+   partial enumeration of a shape the CFG tier answers structurally
+   (rule #10). Triage them into the audit as a named, deferred class
+   instead.
 
 ### Phase E — promotion
 
@@ -184,7 +197,9 @@ can never pass" is wrong.
    text in `adr/narrowing-diagnostics.md`.
 3. `redundantGuard` / `contradictory`: flip if Phase D put the noise
    classes near zero; otherwise record precisely which class remains
-   and leave them opt-in. Do NOT flip `unresolvedMethodCrossFile` here
+   and leave them opt-in. If what remains is the correlated-branch
+   class, say so by name — that is Epic 16's rung 1, and naming it
+   turns "still noisy" into a scheduled fix. Do NOT flip `unresolvedMethodCrossFile` here
    — its ladder promotes it last, and the named-helper first-param-self
    gap in `gold-corpus/KNOWN-GAPS.md` is still open.
 4. Write `docs/adr/openness.md`: the verdict enum, the single
@@ -224,6 +239,10 @@ What that means for the design:
    silent `Closed` default there is a false-positive flood.
 3. Concretely, leave Epic 13 a hook: the ADR should name what a pack
    language must supply before its diagnostics consult this verdict.
+   Note that openness is not the only thing missing on that side —
+   `adr/narrowing-diagnostics.md` records that "D1/D2/D3/D4/D6 have no
+   cpp facts", which is Epic 16's job, not this one's. A pack code that
+   fails to promote may be waiting on either; say which.
    The C++ analogue is already sitting in the tree —
    `class_has_unresolved_ancestor`'s condition is "an ancestor we
    cannot see", which for C++ means an unresolved `#include`. That is

--- a/docs/epics/04-value-provenance.md
+++ b/docs/epics/04-value-provenance.md
@@ -1,0 +1,293 @@
+# Epic 4 — Value provenance, tier 1 (residual Parts 1, 2, 5a)
+
+> **Status:** scheduled, fourth. The largest of the type-intelligence
+> epics; run it after Epic 3 so the before/after substrate-diff habit
+> is already in muscle memory.
+> **Design owner-doc:** `docs/prompt-type-inference-residual.md`
+> (Parts 1, 2, 5a — read the whole doc; Parts 3, 4, 7 are NOT here).
+> **Strategic payoff:** this tier is the named gate for un-parking
+> instance brands (`prompt-graph-walking.md` §PARKED) and for the
+> untyped-receiver residual (`prompt-method-resolution-residuals.md`
+> §4). Do not build those here — build the tier they wait on.
+
+## Mission
+
+Three fact classes that trace VALUES (not declarations) through the
+program, each landing as **an emitter + reducer pair on the witness
+bag**, with no `InferredType` enum expansion:
+
+1. **Part 1 — invocant mutations, consumer wiring.** The facts exist;
+   nothing user-facing consumes them.
+2. **Part 2 — hash-key unions.** `{ %$defaults, %$overrides }` — keys
+   of a merged hash resolve to their source hashes.
+3. **Part 5a — value-indexed returns.** `get_config('host')` types from
+   a literal-keyed return table.
+
+## The decision Phase A actually makes
+
+CLAUDE.md is blunt about Part 1's starting state:
+
+> `mutated_keys_on_class(class)` — **no production caller** (tests + the
+> layering allowlist only), and every `HashKeyDef` minting site passes
+> `is_dynamic: false`. The dynamic-key lane is dormant, not wired…
+> **Delete it or revive it deliberately; do not cite it as a live
+> feature.**
+
+Phase A is that deliberate revival. If the completion payoff does not
+survive the noise guard, **the honest outcome of this epic is deleting
+the lane**, and that is a legitimate result to ship — record it and
+move on to Phases C/D. Do not leave it dormant for a third time.
+
+## Read first, in this order
+
+1. `CLAUDE.md` — "Type inference (witness bag)" and "Worklist
+   invariants" in full. This epic lives entirely inside those rules.
+2. `docs/adr/bag-canonical.md` — the bag is the only source of types.
+3. `docs/adr/structural-shapes.md` — `HashWithKeys`, `Projected`
+   drills, mutation extension, the whole-story trust gate. Part 2
+   composes with these; do not duplicate them. Note `SharedKeys`
+   (`b0fb6309`) — the clone product was deleted at the type, so a key
+   set is shared, not copied. Part 2's union must not reintroduce a
+   clone.
+4. `docs/adr/return-expr.md` — `ReturnExpr` variants; `UnionOnArgs`
+   dispatching on `arity_hint` is the pattern Part 5a copies.
+5. `docs/adr/conclusion-layer.md` — new witness shapes must be
+   representable (or honestly `Open`) in a conclusion bake, or every
+   cross-file consult of them falls back to a full decode.
+6. `docs/prompt-long-distance.md` — A4 v2 already landed cross-file
+   slot-read narrowing; Part 1 must NOT rebuild it.
+
+## Current state — exact anchors
+
+| Existing piece | Where | Find it |
+| --- | --- | --- |
+| Class-keyed mutated-key union (read API) | `model/file_analysis/queries.rs` | `grep -rn 'fn mutated_keys_on_class' src/` |
+| Mutation Facts + slot-type seeds | `build/builder/pipeline.rs` | `grep -rn 'FACT_MUTATION\|slot_writes' src/build/builder/` (in `populate_witness_bag`) |
+| `SlotTypeFold` | `model/witnesses/reducers.rs` | `grep -rn 'SlotTypeFold' src/model/witnesses/` |
+| Completion sources | `index/resolve/completion.rs` | completion SOURCES go through the CandidateSet's `complete()`; cursor-context slot detection stays put (`adr/resolution-candidate-set.md`'s honest boundary) |
+| Moo `is => 'ro'` knowledge | `frameworks/moo.rhai` | the plugin owns the vocabulary; core sees classified pairs |
+| Hash-literal shape builder | `build/builder/` | `grep -rn 'fn visit_anon_hash\|hash_literal' src/build/builder/` |
+| `HashKeyOwner` enum | `model/file_analysis/core_types.rs` | `grep -rn 'enum HashKeyOwner' src/`; index rebuild in `rebuild_enrichment_indices` |
+| Constant folding for string lists | `build/builder/` | `grep -rn 'declared_constants\|constant_strings' src/build/builder/` |
+| Arity-hint threading (the 5a pattern) | `model/witnesses/query.rs` | `grep -rn 'arity_hint' src/model/witnesses/ \| head` |
+
+## Non-goals
+
+- No instance brands, no birth-site chase, no `home` qualifiers.
+- No Parts 3 (method loops), 4 (map/grep), 5b (superseded by the landed
+  narrowing lattice — verify before touching), 7 (Rhai reducers).
+- **No new `InferredType` variants.** If a design wants one, the design
+  is wrong for this epic.
+- No parallel reverse indexes (rule #8).
+- `delete $self->{k}` drop-tracking: out.
+
+## Phase breakdown
+
+### Phase A — Part 1: dynamic-key completion (or the deletion)
+
+1. At the completion source where declared `HashKeyDef`s are offered
+   for the invocant class, also merge `mutated_keys_on_class(class)`,
+   deduped against the declared set and marked with a distinct
+   `CompletionItemKind`/detail ("observed write") so users can tell
+   contract from observation.
+2. Cross-file: `mutated_keys_on_class` reads the local bag. Mirror
+   however declared keys already cross files — **find that path first
+   and do it the same way**; if declared keys do NOT cross files here,
+   do not fix that in this epic, just note it.
+3. **Noise guard is mandatory, not optional.** Author a gold row
+   pinning the union with `exact_labels`, AND one proving an unrelated
+   class does not see these keys. See the Scaling beat — completion
+   payload is a measured, previously-regressed axis.
+4. **Acceptance:** a two-method class (one `has`, one
+   `$self->{observed} = 1`) completes both, the observed one flagged;
+   gold rows green. **Or:** the documented decision to delete the lane,
+   with the layering allowlist entry and the dead API removed.
+
+### Phase B — Part 1: ro-write hint
+
+1. New opt-in diagnostic `roWrite`. Grep `optional_deref` for every
+   site a flag touches — struct field, CLI flag, ADR ladder text,
+   tests — and hit exactly those.
+2. The fact: a `HashKeyAccess` Write on `$self->{attr}` where `attr` is
+   an attribute whose `is` is `ro`. **The `ro` knowledge lives in the
+   plugin**: extend the `has` synthesis to record read-only-ness on the
+   emitted symbol/HashKeyDef (an EmitAction field), NOT a core name
+   table. Direct slot writes only to start.
+3. Severity HINT; the message names the attribute and its declaring
+   `has`.
+4. **Acceptance:** tests both directions; substrate audit — expect
+   near-zero hits. If it shows >10, check whether `_build_*` / `BUILD`
+   / `BUILDARGS` contexts need exemption and document the choice.
+
+### Phase C — Part 2: hash-key unions
+
+**Goal:** `my $full = { %$defaults, key => 1 };` — `$full->{host}`
+resolves into `$defaults`'s key set.
+
+1. In the anon-hash visitor (rule #1 — the only tree consumer), detect
+   splice elements (`%$var` / `%hash` inside the literal). **Get the
+   node kinds from `perl-lsp --parse` on a snippet first; do not
+   guess.**
+2. Encode as a UNION witness, not an eager copy: the existing
+   `HashWithKeys` path for the literal keys, PLUS an Edge per splice
+   from the literal's shape attachment to the spliced variable's. A
+   splice makes the shape OPEN (unknown extra keys) even when the
+   source resolves — set that flag. `SharedKeys` means the key set is
+   shared at the type; do not clone it into the union.
+3. Reducer side: when a `Projected { base, HashKey(k) }` misses the
+   literal keys, chase the splice edges. The registry already chases
+   Edges — confirm the attachment shapes line up and add a cycle guard
+   via the existing `QueryState` visited set. `$a = { %$b }; $b = { %$a }`
+   is the test.
+4. Owner expansion for the linker (goto-def on a key): **prefer
+   index-time expansion** (one def per member) over a
+   `HashKeyOwner::Union` enum variant — no serde/rename/match ripple.
+   Expand in `rebuild_enrichment_indices`. Record the choice and why in
+   the commit message.
+5. Cross-file splices defer to enrichment: emit the edge and let the
+   registry chase it with a module index, exactly like slot types. **No
+   special enrichment pass.**
+6. **Acceptance:** merged-literal key goto-def lands on the source
+   hash's key def; completion on `$full->{` offers spliced and literal
+   keys; the cycle case terminates; `EXTRACT_VERSION` bump.
+
+### Phase D — Part 5a: value-indexed returns
+
+**Goal:** `sub get_config { my ($key) = @_; return $TABLE->{$key} }`
+types `get_config('host')` per key.
+
+1. Recognize the two shapes the owner doc names: `return { ... }->{$param}`
+   and `my %t = (...); return $t{$param}`. Anything else is an honest
+   miss.
+2. **Do NOT add `keyed_returns` to `SymbolDetail::Sub`** — the owner
+   doc predates bag-canonical, and CLAUDE.md's "the bag is the only
+   source of types" wins. Follow `UnionOnArgs`: a
+   `ReturnExpr::KeyedOnFirstArg(HashMap<String, InferredType>)` payload
+   on `Symbol(sid)`, mirrored to `PackageSymbol` by the existing
+   writeback. Verify the writeback mirrors `ReturnExpr` payloads; if
+   not, that is a writeback gap to fix **generically**, not to
+   special-case.
+3. Hint threading: `ReducerQuery` carries `arity_hint`; add
+   `first_arg_lit: Option<String>` beside it, populated at the SAME
+   call sites. `ReturnExprReducer` dispatches on it; no hint or unknown
+   key falls through to the agreement of the table's value types, else
+   `None`.
+4. Serde: `ReturnExpr` rides the cache blob — `EXTRACT_VERSION` bump.
+5. **Acceptance:** literal-arg call types per key; unknown key hits the
+   agreed-or-None fallback; no-arg call unchanged; a method-form test.
+   One gold row if the substrate exhibits the idiom (grep for it —
+   config tables are likely); if none, unit tests suffice, say so.
+
+### Phase E — verification + docs
+
+Full gate; update `prompt-type-inference-residual.md` (1, 2, 5a landed
+with pointers), this README's coverage map, and the instance-brands
+PARKED note in `prompt-graph-walking.md` — its prerequisite list
+shrinks to "constructor/field value flow".
+
+## Language-pack beat
+
+**The hash-key and structural-shape lanes are the engine's, not
+Perl's — and this epic is where that gets tested.**
+
+`HashWithKeys`, `Projected` drills, `HashKeyAccess`/`HashKeyDef`/
+`HashKeyOwner` and `SharedKeys` all live in the Model layer and are
+reached by any language whose extractor mints keyed-container
+witnesses. A pack language with string-keyed maps gets Part 2's union
+behavior for free *if* the union is expressed as edges between
+attachments — and gets nothing if it is expressed as a Perl-visitor
+special case.
+
+Obligations:
+
+1. **Phase C's emitter is Perl-side (rule #1, the anon-hash visitor) but
+   its ENCODING must be language-neutral.** The splice edge is
+   "attachment → attachment"; the openness flag is a property of the
+   shape. Neither should mention Perl. A pack language's extractor
+   mints the same shape from its own syntax and inherits the reducer.
+2. **Phase D is the opposite case, and should say so.** "A sub whose
+   return expression is a literal table subscripted by its first param"
+   is a *grammar* shape recognized in the Perl walk. Its ENCODING
+   (`ReturnExpr::KeyedOnFirstArg` + the `first_arg_lit` binder) is
+   neutral, so a pack language could publish it later from its own
+   recognizer. Add the binder to `ReducerQuery` in the neutral way —
+   beside `arity_hint`, not behind a Perl check.
+3. **`first_arg_lit` on `ReducerQuery` is a cross-language change.**
+   Every reducer sees it. Confirm `cargo test --features cpp` and the
+   cpp gold rows: a new binder that silently changes which conclusion
+   a bake can represent is the failure mode, and it is invisible to
+   Perl tests.
+4. Part 1's completion merge goes through the CandidateSet's
+   `complete()` — which pack languages already use for their symbol-
+   table completion. A merge added there is inherited; a merge added in
+   the Perl completion handler is not. Put it in the projection.
+
+## Scaling beat
+
+Three distinct costs, and they land in different places.
+
+**1. The bag grows, and the bag rides the cache blob.**
+Every witness added here is serialized per file into `modules.db`
+(bincode+zstd). CPAN-5k: 138,822 files, 1.73 GB, 13.9 KB/file
+(2026-08-17). Part 2 adds an edge per splice and Part 5a adds a table
+per recognized sub — both bounded by syntax, so the expected delta is
+small, but **measure it**: re-run a cold index on Koha and report the
+`modules.db` size and per-file cost delta in the PR. A blob-size
+regression is a warm-start regression for every user.
+
+**2. Part 2's chase is a graph walk with a cycle risk.**
+The `$a`/`$b` mutual-splice case is in the acceptance criteria for a
+reason. Use the existing `QueryState` visited set — do not add a second
+one. And note the interaction with the conclusion layer: a splice edge
+whose source is cross-file residualizes as a `Link`, which is the
+representable case; a splice that cannot be represented bakes as
+`Open`, which costs a full decode at every consult. `OpenReason`'s
+own tally exists to measure exactly this — check the bake's open-reason
+distribution before and after (`docs/adr/conclusion-layer.md`).
+
+**3. Completion payload is a measured, previously-regressed axis.**
+`prompt-scale-validation-hitlist.md` Tier 1 #4: completion at 138k
+files was **7.29 MB / 236 ms per keystroke**, fixed to 55.9 KB / 4 ms
+(`b6312ea2`). Phase A adds observed-write keys to a completion list.
+That is precisely the shape that regressed.
+
+- The gold `exact_labels` / `max_items` rows are the functional guard.
+- The **payload** guard is separate and also required: run
+  `bench/lsp_bench.py` with a completion scenario and report the
+  per-response byte size, three runs, dated
+  (`bench/editor-baseline.sh` is the wrapper; quiet box only). If the
+  merge inflates a response measurably, gate it — prefix-matched
+  candidates only, `is_incomplete: true`, or observed keys behind a
+  config flag.
+
+**4. Phase B adds a diagnostic**, which means `--check` pays for it on
+every workspace file. It is opt-in, so the default cost is zero; keep
+it that way until an audit justifies promotion (the ladder in
+`adr/narrowing-diagnostics.md`).
+
+## Invariants that MUST survive
+
+- Bag-canonical: production is `bag.push`, consumption is the registry.
+  No side table of types — this kills the owner doc's `keyed_returns`
+  field idea.
+- Monotone witnesses; clear-and-emit for anything a fold pass
+  re-derives; new source tags into `witnesses::tags`.
+- Edges, not values, for anything reachable through an attachment.
+- Rule #10: nothing keys on hash names, sub names, or "looks like a
+  config table". The two recognized shapes are grammar shapes, not name
+  shapes.
+- Completion additions always ship with a noise-guard gold row AND a
+  payload measurement.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS · `./e2e/run.sh` ·
+substrate audit at parity (completion changes do not show there — hence
+the gold rows) · cold-index blob-size delta on Koha · completion payload
+bytes, three runs, dated.
+
+## Sizing & sequencing
+
+A (small) → B (small) → C (large) → D (medium) → E. A/B are the warm-up
+and independently shippable; C and D are independent of each other. C
+may want two commits (emitter, then reducer + linker).

--- a/docs/epics/04-value-provenance.md
+++ b/docs/epics/04-value-provenance.md
@@ -56,6 +56,9 @@ move on to Phases C/D. Do not leave it dormant for a third time.
    cross-file consult of them falls back to a full decode.
 6. `docs/prompt-long-distance.md` — A4 v2 already landed cross-file
    slot-read narrowing; Part 1 must NOT rebuild it.
+7. `docs/prompt-cfg-tier.md` §3.6 — **before writing Phase C's cycle
+   guard.** It is three paragraphs and it names the one thing that
+   guard must not make harder.
 
 ## Current state — exact anchors
 
@@ -139,6 +142,17 @@ resolves into `$defaults`'s key set.
    Edges — confirm the attachment shapes line up and add a cycle guard
    via the existing `QueryState` visited set. `$a = { %$b }; $b = { %$a }`
    is the test.
+   **Do not entrench the silent drop.** `query_rec`'s visited guard
+   resolves an on-path revisit to *nothing*, so the cyclic arm vanishes
+   from the fold. That is harmless for types — a cyclic edge carries no
+   information, which is why it is correct here — but Epic 16 §3.6 has
+   to replace it with an explicit unknown-marker witness, because for
+   must/may facts a silently-dropped arm folds into a **stronger claim
+   than the paths justify**. Write this guard so the marker can be added
+   later without re-deriving where the cuts happen: cut in ONE place,
+   and leave a comment naming `docs/epics/16-cfg-tier.md` Phase C
+   step 3. A cycle guard spread across three call sites is the retrofit
+   that epic cannot afford.
 4. Owner expansion for the linker (goto-def on a key): **prefer
    index-time expansion** (one def per member) over a
    `HashKeyOwner::Union` enum variant — no serde/rename/match ripple.
@@ -181,9 +195,20 @@ types `get_config('host')` per key.
 ### Phase E — verification + docs
 
 Full gate; update `prompt-type-inference-residual.md` (1, 2, 5a landed
-with pointers), this README's coverage map, and the instance-brands
-PARKED note in `prompt-graph-walking.md` — its prerequisite list
-shrinks to "constructor/field value flow".
+with pointers), the epics README's coverage map, and the
+instance-brands PARKED note in `prompt-graph-walking.md`.
+
+**Be accurate about what that note still says.** Instance brands have
+TWO gates, not one: this value tier, *and* the CFG tier's P1 obligation
+— "brand = the birth-site of the instance, and the birth-site rule is
+this chase in provenance mode", with binding-keyed `Place`s seeing
+through the aliasing that killed the spike's spelling keys, and φ joins
+folding multi-arm receivers to an honest may-set of birth sites
+(`prompt-cfg-tier.md` §8.1; the xref is already in
+`prompt-graph-walking.md`). So this epic **shrinks** the prerequisite
+list, it does not empty it. Say what remains: constructor/field value
+flow, the CFG tier's P1 chase, the brand-key design round
+(`(birth-site, Option<home>)`), and the dispatch-gating consumer.
 
 ## Language-pack beat
 

--- a/docs/epics/05-one-seam-sweep.md
+++ b/docs/epics/05-one-seam-sweep.md
@@ -1,0 +1,196 @@
+# Epic 5 — One-seam sweep: magic tokens + the cst/conventions backlog
+
+> **Status:** scheduled (5th). Small, self-contained, zero unlanded
+> prerequisites — the best warm-up epic for a fresh implementer.
+> **Design owner-docs:** `docs/prompt-magic-tokens.md` (whole),
+> `docs/prompt-cst-migration.md` (ranked backlog items 1–5 and 7).
+
+## Mission
+
+Two flavors of one discipline — *encode the shape once, every consumer
+asks the value*:
+
+1. **Magic compile-time tokens** (`__PACKAGE__`, `__SUB__`, `__FILE__`,
+   `__LINE__`) resolve to typed values in the canonical expression
+   machinery, so dispatch / column-keyed args / goto-def / rename work
+   on them with **no per-consumer handling**.
+2. **The cst/conventions migration backlog, items 1–5 + 7** — the
+   remaining places that re-derive shapes `cst.rs` / `conventions.rs`
+   already own or should own.
+
+## Read first
+
+1. `CLAUDE.md` rule #1 (the `cst.rs` paragraph) and rule #10.
+2. `docs/prompt-magic-tokens.md` — the token/value table and the
+   single-seam fix shape. Note its verified non-gap: `__PACKAGE__->search`
+   on a Result class is an ERROR in DBIC, so NOT linking it is correct.
+3. `docs/prompt-cst-migration.md` — the ranked list. Items 1–5 and 7
+   are this epic; item 6 (the ~400-poke long tail) is a standing
+   strangler rule, NOT schedulable.
+
+## Phase breakdown
+
+### Phase A — `__PACKAGE__` uniform resolution
+
+1. Anchors: `grep -rn '__PACKAGE__' src/build/builder/ src/model/conventions.rs`
+   — the constructor / bless / classdata paths already mint
+   `ClassName(current_package)`; the gap is uniformity.
+2. Emit an `Expr(span)` witness with
+   `InferredType::ClassName(current_package)` for the token in
+   `expr_payload`. **Verify the node kind with `perl-lsp --parse` on a
+   snippet first** (it parses as a `func0op_call_expression` with text
+   `__PACKAGE__`). `invocant_type_at_node` gets the same answer through
+   its existing func0op arm or a sibling — ONE resolution rule, both
+   entry points.
+3. Consumers must NOT grow token checks. The test of success:
+   `__PACKAGE__->new({ name => 1 })` in a DBIC Result class links the
+   `name` arg key to the column (the column-keyed seam reads the
+   invocant type and never sees the token), and `__PACKAGE__->my_method`
+   resolves goto-def / references / rename.
+4. **Acceptance:** unit tests for both, plus hover type on the token;
+   grep proof that no consumer outside the two typing entry points
+   mentions `__PACKAGE__` (except `conventions.rs`, which owns
+   recognition).
+
+### Phase B — `__SUB__`, `__FILE__`, `__LINE__`
+
+1. `__SUB__` → `InferredType::CodeRef { return_edge }` pointing at the
+   enclosing sub's symbol (the same shape `coderef_return_edge_for`
+   builds — grep it). Test: `__SUB__->(@args)` inside a sub types its
+   return as the sub's own; goto-def on the token lands on the sub.
+2. `__FILE__` → `String`, `__LINE__` → `Numeric` — hover/type only.
+3. **Acceptance:** one unit test each.
+
+### Phase C — backlog item 1: the `$self` short-circuit
+
+`invocant_type_at_node`'s literal `"$self"` check is the last
+invocant-name site not routed through `is_conventional_invocant_name`,
+so `$class` / `$proto` invocants miss it. One-line fix + a
+`$proto->method` regression test.
+
+### Phase D — backlog item 2: positional-receiver node predicate
+
+`is_shift_call` / `is_positional_receiver` answer the node-level version
+of `InvocantText::PositionalReceiver`. Move the node-shape predicate into
+`cst.rs` (`is_positional_receiver_node(node, src)`); the builder keeps
+only `shift_is_invocant_here`'s context sensitivity. Pure move — all
+existing tests green.
+
+### Phase E — backlog item 3: one text→class resolver
+
+`invocant_text_to_class`, `resolve_invocant_class`, and cursor_context's
+`resolve_text_invocant` are three near-duplicates with different
+fallbacks. Collapse to one `FileAnalysis` seam; `cursor_context`
+composes it (rules #3/#5). **Before collapsing, table the three fallback
+behaviors** (`package_at` vs scope-chain vs analysis-optional) and
+preserve each caller's semantics — write the table into the commit
+message. If the fallbacks genuinely conflict, the seam takes a small
+options enum; do NOT silently pick one.
+
+### Phase F — backlog item 4: one string-value extractor
+
+`extract_node_string`, `extract_string_content`, `extract_key_text` (+
+`arg_info_for`'s inline copy) overlap. `cst.rs` gains
+`string_value(node, src) -> Option<(String, Span)>` encoding the
+quote-flavor trap (the `string_content` child; empty literals have
+none). Migrate the callers. `extract_key_text` also returns an
+`is_dynamic` flag — keep that at its call site, composed on top.
+
+### Phase G — backlog items 5 + 7
+
+- Route `for_each_has_option_pair` and the export-pair detectors through
+  `pair_nodes` (they pre-date it). **Remember the fat-comma rule**:
+  pair walking is positional and separator-agnostic; gating on `=>`
+  silently drops the plain-comma spelling, which is the exact bug that
+  hid `use constant { 'GAMMA', 3 }`.
+- Add `typed_node!` wrappers as far as the visitors touched in C–F
+  warrant: `SubDecl`, `VariableDecl`, `Assignment`, `AnonHash`,
+  `UseStatement`. **Only wrap what a migrated call site actually
+  uses** — wrappers without consumers are dead weight.
+
+## Non-goals
+
+- Item 6's ~400-poke long tail (strangler rule only).
+- Anything DBIC-shaped (Epic 2 owns it).
+- `__DATA__` / `__END__` (section markers, not values).
+- **The forward-compat `parenthesized_expression` arms.** ~27 Perl-side
+  arms are inert today because the kind is absent from ts-parser-perl
+  1.1.4's `node-types.json`, and they become correct the day the parser
+  lands it. Do not "clean them up" — CLAUDE.md says so explicitly.
+
+## Language-pack beat
+
+**`cst.rs` is Perl's typed CST view, and it must stay that way.**
+
+The engine has two tree-consuming worlds and they are deliberately
+separate: Perl walks the tree through `cst.rs` inside `build()`, and
+pack languages extract through queries (`build/query_extract/`) with a
+`.scm` skeleton plus predicates — no per-language Rust types. This epic
+is entirely in the first world, and the correct answer to "does this
+generalize?" is **no, and here is the boundary**:
+
+- `cst.rs`'s `typed_node!` wrappers, `NodeExt`, `pair_nodes` and
+  `call_args` encode *tree-sitter-perl* grammar traps. A pack language's
+  equivalent trap is encoded in its `.scm` skeleton and predicates.
+  Adding a wrapper here does not help C++ and is not supposed to.
+- `model/conventions.rs` is likewise Perl name semantics, pure `&str`,
+  importable by tree-free layers. It is not a cross-language name
+  vocabulary.
+- The one genuinely shared piece is the **`Slot` taxonomy**
+  (`lsp/cursor_slot.rs`) — one vocabulary over both `cursor_context`
+  (Perl) and `cursor_sentinel` (pack). Phase E touches
+  `cursor_context`'s `resolve_text_invocant`. **Do not let the collapsed
+  seam grow a language branch**; if the unified resolver needs to know
+  what it is resolving for, it takes a `Slot`, not a language id.
+- Magic tokens (Phases A–B) are the same story from the other side:
+  `__PACKAGE__` is a Perl token, but "a compile-time token whose value
+  is the enclosing class" is a shape several languages have. The
+  ENCODING — an `Expr(span)` witness carrying `ClassName` — is already
+  neutral, and that is the whole point: consumers ask the value, and
+  the value's language is irrelevant to them. Nothing further to
+  generalize.
+
+**One real check:** `src/layering_tests.rs` enforces the model's
+Point-only tree-sitter surface and single-point grammar access. Phases D
+and F move code *into* `cst.rs`. Run the layering tests — a predicate
+moved to the wrong side fails `cargo test`, which is the design working.
+
+## Scaling beat
+
+**This epic is behavior-neutral by construction, which makes its
+scaling obligation unusually simple: prove nothing moved.**
+
+- Phases C–G are refactors. Their scaling beat is the **substrate audit
+  at exact parity, per code** — not merely "no failures". A pure move
+  that changes a count changed semantics.
+- Phases A–B *do* emit new witnesses (one per magic token occurrence).
+  That is bounded by source syntax and tiny, but it is an
+  `EXTRACT_VERSION` bump, which costs every user a cold re-index —
+  ~10.5 minutes at CPAN-5k scale (2026-08-17). Land A and B under one
+  bump.
+- The one place a "pure move" can genuinely cost: Phase F's
+  `string_value` gets called from hot walk paths that previously had
+  inlined, specialized extraction. If the unified version does more
+  work (an extra child lookup, an allocation the inline version avoided),
+  it pays that on every string literal in every file. Check
+  `--timings` on the substrate for the slowest-modules tail, and use
+  `bphase!` if you need per-file attribution — **never a hand-rolled
+  `eprintln!` timer**; a per-file region printed per entry cost one
+  138k run 3.2M lines and 43 minutes and measured a run that no longer
+  resembled the one being measured (`adr/instrument-blindness.md`).
+- Phase G's `typed_node!` wrappers are zero-copy by design. If a
+  wrapper allocates, it is written wrong.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS · `./e2e/run.sh` ·
+substrate audit at **exact parity per code** for C–G; A–B may move
+`unresolved-*` counts DOWNWARD only · `--timings` tail unmoved beyond
+noise · `EXTRACT_VERSION` bump for A–B.
+
+## Sizing
+
+Small. A–B one commit each; C is a one-liner; D–G one commit each.
+Parallel-safe with the other epics except Phase D touches
+`shift_denotes_invocant`'s neighborhood — coordinate if Epic 4 is in
+flight.

--- a/docs/epics/06-rename-provenance.md
+++ b/docs/epics/06-rename-provenance.md
@@ -1,0 +1,169 @@
+# Epic 6 — Rename provenance: the residual
+
+> **Status:** scheduled (6th). Smaller than it was — the headline phase
+> landed.
+> **Design owner-doc:** `docs/prompt-ref-provenance.md` §"What's still
+> missing" (three items; the doc has already been trimmed to them).
+
+## What landed, so nobody rebuilds it
+
+**`Ref.folded_from` is done.** Constant-fold rename provenance works:
+`my $m = 'process'; $self->$m()` — renaming the sub rewrites the source
+string literal, not just the call site. The field is on `Ref`
+(`model/file_analysis/core_types.rs`), the edit site is added during
+CandidateSet construction (`index/resolve/collect.rs`), and it is pinned
+by a rename-group test (`index/resolve/tests/groups_tests.rs`).
+
+The framework-attribute unified rename group also landed via the
+attr-projection machinery. **Verify before assuming otherwise** — this
+epic's first job is to confirm what is already green rather than to
+write it again.
+
+## Mission
+
+Three residuals, each independently shippable:
+
+1. **Import-list rename** — verify and pin.
+2. **Package rename → file rename** — the LSP `RenameFile` operation.
+3. **Inheritance override scoping** — rename `Animal::speak`, offer
+   `Dog::speak`, never touch `Unrelated::speak`.
+
+## Read first
+
+1. `docs/prompt-ref-provenance.md` — whole doc (it is short now).
+2. `docs/adr/resolution-candidate-set.md` — rename is a projection
+   (`rename_edits()` / `renameable()`). **ALL new grouping goes into
+   CandidateSet construction, NEVER into the rename handler.** This is
+   the epic's one architectural landmine.
+3. `CLAUDE.md` rule #9 + the CandidateSet paragraph; `src/index/resolve/`
+   module docs. Per-feature policy on a target is a method on
+   `TargetRef` (e.g. `supports_cross_file_rename`) — never a
+   `RenameKind`→`TargetRef` map inlined in a handler.
+
+## Phase breakdown
+
+### Phase A — import-list rename (verify, pin)
+
+Write the owner doc's `test_import_list_renamed_with_sub`: renaming
+`sub bar` in `Foo` updates `use Foo qw(bar)` plus call sites. If green,
+commit the pin and move on. If not, the import-spec ref already exists
+— the gap will be in CandidateSet **membership**, so fix it there.
+
+### Phase B — package rename → file rename
+
+LSP `WorkspaceEdit.documentChanges` supports `RenameFile`. When the
+rename target is a package/class symbol whose defining file's path
+agrees with the package name, append a `RenameFile` operation for the
+computed new path.
+
+**Guards, all mandatory:**
+
+- Only when the file exists and the new path does not.
+- Never move a file whose path did NOT agree with the old name —
+  out-of-convention layouts stay untouched.
+- **Only when the package has exactly one provider.** Epic 1 makes this
+  question answerable: a reopened package declared in several files has
+  no single "defining file" to rename, and moving one of them is a
+  confident wrong action on a user's disk. Ask
+  `visible_def_candidates`; if it returns more than one, refuse the
+  file operation and rename the symbol only. This is the interlock that
+  makes Epic 1 a soft prerequisite.
+
+**Acceptance:** an e2e test if the nvim harness supports
+`documentChanges`; if it does not, assert the `WorkspaceEdit` JSON shape
+in a unit test and note the e2e gap explicitly.
+
+### Phase C — inheritance override scoping
+
+Renaming `Animal::speak` should offer `Dog::speak` (the override family)
+and must NOT touch `Unrelated::speak`.
+
+The pieces exist: `children_index` (descendants via `GraphView`
+INHERITS_INV) and the override-family machinery the heatmap already
+counts through. **Verify current behavior first** — an `OverrideScope`
+knob may already exist (`grep -rn 'OverrideScope' src/`); this phase may
+be "wire the knob into LSP rename and default it sanely" rather than new
+analysis.
+
+The name-collision NEGATIVE test is the acceptance bar:
+`Unrelated::speak` untouched.
+
+## Non-goals
+
+- Cross-file rename of DEPENDENCY files (`RoleMask::EDITABLE` stands).
+- Renaming through dynamic dispatch that constant folding could NOT
+  resolve — an honest miss, never a guess.
+
+## Language-pack beat
+
+**Rename is the verb where a Perl-only assumption becomes a corrupted
+source file, so the pack side is not optional here.**
+
+- Rename already serves pack languages through the same projection.
+  C++ rename went through a "full-or-refuse" hardening
+  (`cpp-golive-map.md` wave 1, finding C2): a rename that cannot rewrite
+  every site **refuses** rather than rewriting some. Phase B must obey
+  the same rule — a `RenameFile` that lands while some reference to the
+  old path does not get rewritten is exactly that failure with a worse
+  blast radius.
+- **Phase B is the phase to think hardest about.** "Package name agrees
+  with file path" is a Perl convention (`Foo::Bar` → `Foo/Bar.pm`). The
+  equivalent exists in other languages with entirely different rules,
+  and some have none at all. So: **derive the agreement from the
+  language, not from a hardcoded `::`→`/` transform.** The natural home
+  is beside the existing per-language path knowledge — the driver
+  already knows a language's file extensions and its visibility axis.
+  If a language declares no path convention, Phase B does nothing for
+  it, which is the correct answer.
+- Phase C is genuinely cross-language: `children_index` /
+  `GraphView` INHERITS_INV is the shared descendant walk, and C++ has
+  the same override-family question for virtual methods. Do not build a
+  Perl-side override walk — use the graph, and the pack languages
+  inherit it. `EdgeKind` is closed and `edges_from` is exhaustive, so
+  this is enforced rather than hoped for.
+- Known pack residual, do not re-report it: **pack rename through
+  aliases** is listed in `gold-corpus/KNOWN-GAPS.md` under "Refs
+  symmetry" as non-rewritable and deliberately not renamed.
+
+## Scaling beat
+
+**Rename's cost is references' cost, and references is the one Tier-1
+scaling row still open.**
+
+`prompt-scale-validation-hitlist.md` Tier 1 #3, measured 2026-08-17 and
+re-confirmed on the server path at 138k files: `references` **RETURNS**
+(it used to never return, at 7+ GB) but takes **265–368 s at 2.8 GB
+peak**, and marks the answer incomplete. Rename is that walk plus edit
+construction.
+
+Obligations:
+
+1. **Do not widen the reference walk.** Phase C's override family is a
+   fan-out over descendants; on a deep hierarchy that multiplies the
+   candidate set. Bound it — the graph walk is lazy (`GraphView::walk`),
+   so consume it lazily rather than collecting descendants first.
+2. **Phase B is cheap and must stay cheap.** The single-provider check
+   is one `visible_def_candidates` call; do not turn it into a workspace
+   scan for "who references this path".
+3. **Measure rename, not just references.** `bench/lsp_bench.py`
+   scenarios drive the editor surface; if no rename scenario exists,
+   add one and land the baseline in `bench/baselines.jsonl` via
+   `seed-baselines.py`. Three runs, dated, quiet box.
+4. The honest framing to preserve in any doc this epic touches: rename
+   at 138k scale is *bounded and slow*, not fast. Epic 15 owns making it
+   fast. This epic must not make it slower.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold, including a rename row authored
+with `--emit rename` · `./e2e/run.sh` · substrate audit at parity.
+
+**Rename is the highest-blast-radius verb: every phase lands with its
+negative tests** — what must NOT be edited. Phase B: disagreeing paths
+not moved, multi-provider packages not moved. Phase C: unrelated
+same-name subs untouched.
+
+## Sizing
+
+Small-to-medium. A is verification-only if it passes. B and C are
+independent and individually droppable if QA pull shifts.

--- a/docs/epics/07-diagnostic-framework.md
+++ b/docs/epics/07-diagnostic-framework.md
@@ -29,6 +29,39 @@ because per-code objects are their named forcing function.
    pattern every config surface here must keep.
 5. `docs/adr/config-superposition-declarations.md` — the landed
    declaration model; do not contradict it.
+6. `docs/prompt-cfg-tier.md` §7 ("Consumers this is built for") — the
+   automation tier this framework is the delivery vehicle for. Three of
+   its four items are packaging decisions **this epic makes**, and two
+   of them are cheap now and expensive later. See the ordering
+   constraint below.
+
+## Two forward constraints from the CFG tier
+
+`prompt-cfg-tier.md` §7 names the automation tier these seams deliver,
+and it calls SARIF "the highest leverage-to-effort item on the list".
+Two of its requirements are representation decisions that cost nothing
+to honor now and are painful retrofits:
+
+1. **Finding fingerprints key on `(rule, function symbol, Place path)`
+   — never line numbers.** Baselines and inline suppressions ride the
+   fingerprint, so a code edit that shifts a line must not orphan a
+   suppression. `Place` does not exist yet (Epic 16 Phase B), so this
+   epic cannot use it — but Phase C's suppression key and Phase D's
+   SARIF `ruleId`/location shape must be designed so a fingerprint can
+   become the key **without a format break**. Concretely: do not make
+   the line number part of the suppression's identity, and leave the
+   SARIF result shape room for a `partialFingerprints` entry.
+2. **must/may is a structured confidence field, not a severity.** The
+   brief's framing: "must gates CI, may informs review — the zero-FP
+   discipline and a Klocwork-style recall mode become one engine at two
+   thresholds, and **the finding says which it is**." Severity and
+   confidence are different axes; collapsing them into one enum in
+   Phase B's config is the retrofit. Reserve the axis even though
+   nothing populates it yet.
+
+The fourth item, differential CI, is already built — Surface equality +
+`dirty_consumers` + the persisted `modules.db` artifact — so this epic
+inherits it rather than owing it anything.
 
 ## Ordering constraint
 

--- a/docs/epics/07-diagnostic-framework.md
+++ b/docs/epics/07-diagnostic-framework.md
@@ -1,0 +1,250 @@
+# Epic 7 — The diagnostic framework: PL-codes, config, suppressions, SARIF
+
+> **Status:** scheduled (7th). The CI-readiness gate.
+> **Design owner-docs:** `docs/prompt-cli-tools.md` §"Diagnostic
+> framework" (codes table, config JSON, suppression comments, SARIF) and
+> `docs/prompt-config-schema.md` (whose "forcing function" section says
+> THIS epic is the moment its deferred pieces land).
+
+## Mission
+
+`--check` and the LSP diagnostics grow a real framework: stable
+diagnostic codes, per-code severity config from `.perl-lsp.json` + LSP
+`initializationOptions`, in-source comment suppressions, and SARIF
+output for CI annotation. The config-schema doc's deferred pieces — the
+owning `Config` struct and the generated editor schema — land here
+because per-code objects are their named forcing function.
+
+## Read first
+
+1. `docs/prompt-cli-tools.md` — the PL-code table, config JSON shape,
+   suppression grammar, SARIF.
+2. `docs/prompt-config-schema.md` — WHOLE doc; it prescribes the
+   `Config` shape (own at top, pass slices) and the schemars plan, and
+   warns off the `define_options!` macro.
+3. `docs/adr/narrowing-diagnostics.md` — the existing flag ladder. The
+   framework must EXPRESS it, not replace its semantics.
+4. `grep -n 'struct DiagnosticOptions' -A 20 src/lsp/symbols/diagnostics.rs`
+   and the `cli_flags_match_diagnostic_option_fields` drift test — the
+   pattern every config surface here must keep.
+5. `docs/adr/config-superposition-declarations.md` — the landed
+   declaration model; do not contradict it.
+
+## Ordering constraint
+
+**Do NOT renumber or re-key existing diagnostics' string codes**
+(`unresolved-function`, `undef-deref`, `optional-deref`, …) — editors
+and gold rows key on them. PL-codes are an ADDITIONAL stable alias
+(SARIF `ruleId` + suppression key). The LSP `code` field may carry
+`PLxxx` with the descriptive name in `codeDescription`/message — decide
+ONE presentation and write it in the ADR.
+
+Extend the table with a row for **every diagnostic that exists today**
+(the narrowing family: `undef-deref`, `optional-deref`,
+`redundant-guard`, `contradictory`, `deref-shape`; `helper-not-loaded`;
+`composer-mismatch`; the C++ `use-after-move` channel) **before adding
+any new lint.** Registering the existing surface is Phase A; new lints
+are LAST.
+
+## Phase breakdown
+
+### Phase A — the registry + codes for existing diagnostics
+
+1. New `src/lsp/diagnostics.rs` (add it to `src/layering_tests.rs`'
+   layer map — an `.rs` outside a layer directory fails the walk, so
+   placing the file places it in the architecture). A static registry:
+   ```rust
+   struct DiagnosticCode {
+       pl: &'static str, name: &'static str,
+       default_severity: Severity, default_enabled: bool,
+       languages: LanguageApplicability,   // see the Language-pack beat
+   }
+   ```
+   Every `Diagnostic { code: … }` construction site routes through it
+   (`grep -n 'NumberOrString::String' src/lsp/symbols/`).
+2. A drift test in the spirit of
+   `cli_flags_match_diagnostic_option_fields`: every emitted code string
+   appears in the registry, and PL numbers are unique.
+3. **Acceptance:** `--check` output unchanged by default, except each
+   diagnostic now also carries its PL code.
+
+### Phase B — `Config` + `.perl-lsp.json` + per-code severity
+
+1. Per `prompt-config-schema.md` piece 1: one owning
+   `struct Config { diagnostics: DiagnosticsConfig, exclude: Vec<String> }`,
+   parsed ONCE (workspace-root file + `initializationOptions` +
+   `didChangeConfiguration`, later sources overriding earlier
+   field-wise). Backend holds `Arc<RwLock<Config>>`.
+   **Call sites keep taking the narrow slice** — the doc is explicit and
+   gives the reasons; keep `collect_diagnostics(&cfg.diagnostics, …)`.
+2. `DiagnosticsConfig`: per-code `"error"|"warning"|"info"|"hint"|"off"`,
+   keyed by either the PL code or the descriptive name (accept both,
+   normalize through the registry). The existing `DiagnosticOptions`
+   bools become the LEGACY spelling — keep deserializing them so current
+   configs keep working; document the mapping.
+3. `exclude` globs honored by `--check` and the workspace diagnostic
+   pass — **NOT by indexing itself**: resolution still needs excluded
+   files' symbols, only reporting is filtered.
+4. **Acceptance:** precedence tests (file < init options < didChange),
+   per-code override, `"off"`, legacy-bool compatibility; the drift test
+   extended to assert every registry row is configurable.
+
+### Phase C — comment suppressions
+
+1. Grammar: `# perl-lsp: ignore(PL001)`, `ignore-next-line(PL001)`,
+   `ignore-file(PL004)` (file-form only in the first 10 lines). Accept
+   descriptive names in the parens too.
+2. Rule #1: comments are scanned during build — collect
+   `FileAnalysis` suppressions in the builder's comment handling
+   (serde; `EXTRACT_VERSION` bump; the field goes in its lane, and
+   `surface_feed` will not compile until its Surface fate is decided —
+   suppressions are file-local, not cross-file-visible, so discard with
+   a reason). The builder stores the raw code string; registry
+   lookup/validation happens at DIAGNOSTIC time, and an unknown code
+   gets its own `unknown-suppression` hint from the framework
+   (self-hosting).
+3. `collect_diagnostics` filters through suppressions before emitting.
+4. **Acceptance:** unit tests per form + the unknown-code hint; a gold
+   diagnostics row exercising `ignore-next-line`.
+
+### Phase D — SARIF 2.1.0 (`--check --format sarif`)
+
+1. `runs[0].tool.driver` from the registry (rules = registry rows, help
+   text from their doc strings); `results` with `ruleId` = PL code;
+   locations with 1-based line/col matching `--check`'s existing
+   coordinate contract; level from severity.
+2. Validate the shape in a test against a golden file — hand-assert
+   required fields and enum values; **do not pull a validator
+   dependency**.
+3. Wire a CI smoke if in scope; if not, note it in the PR.
+4. **Acceptance:** golden-file test; `jq` sanity commands in the doc.
+5. This discharges the heatmap doc's deferred SARIF note — record that
+   in `docs/adr/heatmap.md` (heatmap SARIF stays deferred; only
+   `--check` gains it here).
+
+### Phase E — schemars + new lints (only now)
+
+1. `#[derive(schemars::JsonSchema)]` on the config structs +
+   `--dump-options-schema`. Field `///` docs become descriptions —
+   write them as user-facing.
+2. New lints, **EACH its own commit with a before/after substrate
+   audit**: PL003 unused-import, PL004 unused-variable, PL007
+   shadow-variable, PL010 deprecated-pattern (`use base` → `use
+   parent`). PL005 unused-export / PL006 dead-sub **REUSE the heatmap's
+   guards verbatim** (`grep -rn 'reachable_guard' src/lsp/cli/heatmap.rs`)
+   — a lint that flags what the heatmap shields is a bug. PL008
+   missing-import and PL009 circular-dependency: only if the audit shows
+   clean signal, else registered-but-default-off with a note.
+3. **Acceptance per lint:** unit tests + the substrate hit count in the
+   PR + zero hits on the repo's own fixtures unless genuinely justified.
+
+## Non-goals
+
+- The `define_options!` macro (the config-schema doc says the drift test
+  is cheaper; it stays).
+- `--migrate` and the analysis subcommands (Epic 10).
+- Changing any diagnostic's SEMANTICS — this epic is packaging.
+
+## Language-pack beat
+
+**This is the epic that decides whether pack-language diagnostics are
+possible, and it is the single most consequential language decision on
+the slate.** Get it wrong and Epic 13 has to rebuild the framework.
+
+The state today: pack languages have **no diagnostics by deliberate
+policy** — `prompt-multi-language.md` says none exist until a calibrated
+substrate does, with the zero-false-positive sweep as the ship gate. The
+one exception is the C++ `use-after-move` channel, off by default
+(`lsp/symbols/diagnostics.rs`). So the framework is being designed while
+its second tenant is still hypothetical, which is exactly when a
+Perl-shaped assumption gets baked in.
+
+Non-negotiables:
+
+1. **The registry row carries language applicability from Phase A.**
+   The `languages` field above is not speculative — `use-after-move`
+   already exists and is C++-only. A registry that cannot express "this
+   code applies to these languages" will be rewritten by Epic 13.
+   Model it as an explicit set or "all", never as an implicit default.
+2. **The PL namespace is the engine's, not Perl's.** `use-after-move`
+   gets a PL number in Phase A alongside the Perl codes, from the same
+   sequence. Do NOT create a parallel `CPPxxx` space — one namespace,
+   because a user's config and a CI's SARIF should not care which
+   language produced a finding.
+3. **`.perl-lsp.json` is now a misnomer and this epic should say so.**
+   Do not rename it in this epic (it is a shipped, user-visible
+   filename), but pick the config KEY names to be language-neutral, and
+   record in the ADR that a neutral filename is a future migration with
+   the old name kept as an alias. `perl-lsp` "becomes the
+   Perl-configured distribution of that binary, name and install base
+   intact" — the doc's own framing.
+4. **Per-language severity defaults must be expressible.** A lint that
+   is `warning` for Perl and `off` for a pack language until its
+   substrate calibrates is the exact ladder Epic 13 needs. If Phase B's
+   config can only set one default per code, Epic 13 cannot promote a
+   pack language incrementally.
+5. **Suppressions (Phase C) are comment-syntax-dependent.** `#` is not
+   every language's comment. The builder scans comments; the pack side
+   extracts through queries. Put the suppression *grammar* in the
+   registry-adjacent code and let each language supply its comment
+   token, or explicitly scope Phase C to Perl and say so — either is
+   fine, silence is not.
+6. SARIF (Phase D) is the payoff for all of the above: one SARIF run
+   over a mixed-language workspace, one tool driver, one rule set. That
+   only works if 1–4 held.
+
+## Scaling beat
+
+**`--check` is a batch verb, and it is already the pathological one.**
+
+`scaling-limits.md` §1, measured: FHEM (991k LOC, 973 files, 87% of them
+providing `package main`) **does not complete `--check` on a 31 GB
+machine**. The documented workaround is
+`RAYON_NUM_THREADS=4 MALLOC_MMAP_THRESHOLD_=65536`, which cuts peak 67%
+for 4.9% wall. `prompt-scale-validation-hitlist.md`: the CLI one-shot at
+138k files was DNF, killed at 42:32 / 7.11 GB; PR #125 made it finite at
+350 s.
+
+So every phase here lands on a verb whose scaling is already the
+constraint:
+
+1. **Phase A is free** — a static registry lookup per diagnostic
+   construction. Keep it that way: a registry that does a hash lookup by
+   `String` per emission on a workspace-wide sweep is a real cost. Key
+   by a `&'static str` or an index, and let the drift test prove the
+   mapping.
+2. **Phase B's `exclude` globs are the one place this epic can make
+   `--check` *faster*** — and users with vendored trees will reach for
+   it first. Compile the glob set ONCE into the `Config`, not per file.
+   Note the interaction with `scaling-limits.md` §2 (vendored dependency
+   piles are MISLEADING, not slow) — excluding them changes what is
+   *reported*, not what is *indexed*, and the doc's honest framing must
+   survive this epic.
+3. **Phase C's suppressions ride the FA and the cache blob.** A file
+   with no suppressions must carry an empty vec that costs nothing —
+   default-empty, in its lane, joined to a `heap_estimate` bucket.
+   `EXTRACT_VERSION` bump: bundle it with any other bump landing nearby;
+   a cold re-index is ~10.5 min at CPAN-5k (2026-08-17).
+4. **Phase D's SARIF materializes every finding into a JSON document.**
+   On a corpus where `--check` produces tens of thousands of
+   diagnostics, that is a large in-memory value. Stream it if the shape
+   allows, and at minimum **measure the peak RSS delta of
+   `--format sarif` versus `--format json`** on Koha and report it.
+5. **Phase E's new lints each add a per-file pass.** Report per lint:
+   the substrate hit count AND the `--check` wall delta on Koha, three
+   runs, dated. A lint that costs 15% of `--check` for six findings is
+   a bad trade and the number is how you know.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS · `./e2e/run.sh` ·
+substrate audit at **exact parity** for Phases A–D (pure packaging),
+per-lint audited deltas in Phase E · Koha `--check` wall + peak RSS,
+three runs, dated, for D and E · the promotion states from
+`adr/narrowing-diagnostics.md` must survive the config migration
+exactly.
+
+## Sizing
+
+Large-ish but mechanical; A→B→C→D→E strictly ordered. E is droppable to
+a follow-up without hurting A–D's value.

--- a/docs/epics/08-heatmap-residuals.md
+++ b/docs/epics/08-heatmap-residuals.md
@@ -7,7 +7,14 @@
 
 ## Mission
 
-Two gaps, both plugin-knowledge-shaped (rule #10 — never a
+One measured cost and two gaps. The cost first, because the gaps make
+it worse:
+
+0. **`--heatmap` runs on one core** while `--check` uses all of them —
+   up to a 17× ratio on a fan-in-heavy corpus. `scaling-limits.md` §5
+   records the fix as "the obvious next step" and nobody has taken it.
+
+Then two gaps, both plugin-knowledge-shaped (rule #10 — never a
 per-verb/per-name list in core):
 
 1. **Handlers become heatmap-eligible** with a plugin-stamped
@@ -50,7 +57,59 @@ per-verb/per-name list in core):
 
 ## Phase breakdown
 
-### Phase A — plugin-stamped Handler definition site
+### Phase A — parallelize the gather (do this first)
+
+**`--heatmap` runs on one core.** `scaling-limits.md` §5, measured:
+104–105% CPU throughout, where `--check`'s diagnostics sweep
+parallelises across all of them. The ratios there are two effects
+compounding — more work per declaration, done serially:
+
+| corpus | `--check` | `--heatmap` | ratio | max fan-in |
+|---|---:|---:|---:|---:|
+| WeBWorK (225 files) | 3.80 s | 5.00 s | 1.3x | 81 |
+| Webmin (1,333) | 4.76 s | 31.07 s | 6.5x | 199 |
+| BMO (739) | 5.39 s | 91.69 s | **17x** | 340 |
+
+Cost tracks **fan-in, not file count** — BMO is smaller than Webmin and
+costs 3× more, which follows from what the verb does. The doc's own
+closing line: *"the serial half looks addressable with the same
+`par_iter` + channel shape the diagnostics sweep already uses. Not
+attempted; recorded as the obvious next step."*
+
+**It goes first because the rest of this epic adds symbols to the
+listing.** Handlers (Phases B–C) mean more declarations, each with a
+fan-in walk. Parallelising first lands those additions on a faster
+baseline and makes their measured cost legible instead of buried.
+
+1. The shape is already map-then-collect. `cli_heatmap`'s two gather
+   loops (`entries`, then `pack_entries`) call one `gather` closure per
+   file, which pushes into four accumulators (`symbol_rows`,
+   `dead_rows`, `dead_export_rows`) plus a `SourceCache`. Convert to
+   `par_iter` producing per-file row batches, then concatenate — copy
+   the diagnostics sweep's `par_iter` + channel shape rather than
+   inventing one.
+2. **`SourceCache` is the only shared mutable, and it partitions
+   cleanly** — it is keyed by path and `gather` is per-file. Give each
+   worker its own (`map_init` or fold/reduce) rather than putting a
+   mutex on the hot path.
+3. **Determinism is already safe, and must stay that way.** Both output
+   sorts are TOTAL — `symbol_rows` on `(fan_in desc, file, line)` and
+   `dead_export_rows` on `(name, file, line)` — so gather order cannot
+   reach the output. Verify that rather than trusting it: this codebase
+   has already paid for three fold-nondeterminism bugs (PR #123, where
+   witnesses landed in `HashMap` order and the same file built twice
+   differed). **Acceptance includes two runs byte-identical**, on a
+   corpus with ties.
+4. **Do not parallelise the pack loop and the Perl loop into one pass**
+   without checking their routing: they pass different `CrossFileLookup`
+   implementations, different visibility masks, and the pack loop has no
+   pre-prune (its refs are not in the hub's row store). Two parallel
+   loops is fine; one loop with a branch inside is the rule-#10 shape.
+5. **Acceptance:** BMO and Webmin wall, three runs, dated, before and
+   after; byte-identical output across two runs; **peak RSS reported
+   alongside** — see the Scaling beat, this trades wall for memory.
+
+### Phase B — plugin-stamped Handler definition site
 
 1. **CHECK FIRST:** if Handlers already carry a declaration span that
    the fan-in subtraction simply does not use, this phase is wiring, not
@@ -70,7 +129,7 @@ per-verb/per-name list in core):
    dead-candidate), and the same pair for a route and an event.
    `EXTRACT_VERSION` bump if the Handler shape changed.
 
-### Phase B — Handlers in the report
+### Phase C — Handlers in the report
 
 1. `heatmap_symbol_eligible` admits stamped Handlers; the fan-in
    subtraction uses the stamped site.
@@ -82,7 +141,7 @@ per-verb/per-name list in core):
    updated. **Decide and document** in `adr/heatmap.md`'s schema
    section — a silent shape change breaks every downstream consumer.
 
-### Phase C — framework-consumed reachability
+### Phase D — framework-consumed reachability
 
 1. New plugin manifest `framework_consumed()` → the method names a
    framework invokes through its own machinery: Mojo (`startup`),
@@ -125,12 +184,12 @@ the entry-point guard reads the analysis language's declared
 `entrypoint_symbols`, and `Namespace::Language` distinguishes native
 symbols. A C++ heatmap run exists and works. That means:
 
-1. **Phase B's eligibility change is cross-language by default.** A
+1. **Phase C's eligibility change is cross-language by default.** A
    pack language that mints Handler-shaped symbols gets them listed;
    one that does not is unaffected. Verify the C++ heatmap output is
-   byte-identical before/after Phase B — if it is not, the eligibility
+   byte-identical before/after Phase C — if it is not, the eligibility
    predicate grew a Perl assumption.
-2. **Phase C's `framework_consumed` manifest is a `.rhai` plugin
+2. **Phase D's `framework_consumed` manifest is a `.rhai` plugin
    hook, and pack languages have no rhai plugin tier.** Their framework
    knowledge, when it exists, arrives as query overlays and driver
    capabilities. So `framework_consumed` needs a second producer to be
@@ -142,7 +201,7 @@ symbols. A C++ heatmap run exists and works. That means:
 3. Do NOT let the guard become a name list in `heatmap.rs`. That is the
    rule-#10 failure this epic exists to prevent, and it is the exact
    shape a "just add `main` for C++" fix would take.
-4. The `--heatmap` schema decision in Phase B is user-visible for every
+4. The `--heatmap` schema decision in Phase C is user-visible for every
    language. Whatever version story you pick applies to all of them.
 
 ## Scaling beat
@@ -152,21 +211,35 @@ explicitly. This epic must not blur that.**
 
 Facts to respect:
 
-1. **The heatmap runs `cli_full_startup` with `LanguageScope::All`**
+1. **Phase A is this epic's own scaling work, and it trades wall for
+   memory.** Heatmap memory is currently mild *because* it is serial
+   (Webmin 0.47 → 0.95 GB, BMO 0.49 → 0.70 GB — a wall cost, not a
+   memory one). Parallelising multiplies the in-flight working set by
+   worker count, and `scaling-limits.md` §1 already established that
+   **per-worker in-flight sets own the crest** on the `--check` sweep:
+   `RAYON_NUM_THREADS=4` cuts its peak 67% for 4.9% wall. Expect the
+   same knob to matter here, report peak RSS at the default and at 4,
+   and say in the docs which the user should reach for.
+2. **The deeper heatmap cost is not addressable here.** Fan-in is the
+   `references()` projection, and references at scale is Epic 15
+   Phase A (265–368 s at 138k files, still OPEN). Phase A of this epic
+   makes the serial half parallel; Epic 15 makes each walk cheaper.
+   They compose and neither substitutes for the other.
+3. **The heatmap runs `cli_full_startup` with `LanguageScope::All`**
    (`grep -n 'LanguageScope::All' src/lsp/cli/heatmap.rs`) — correct,
    because it sweeps the workspace, and CLAUDE.md's rule is that
    under-indexing a sweeping verb is a quiet wrong answer. It is also
    why it is expensive: the CLI's one-shot semantics are O(corpus) in
    time and RAM, and `--heatmap` is named in the hitlist among the verbs
    that bounds as workspace-scale tools.
-2. **Fan-in must stay the `references()` projection.** It is also the
+4. **Fan-in must stay the `references()` projection.** It is also the
    most expensive thing the heatmap does — references at 138k files
-   takes 265–368 s (2026-08-17, Tier 1 #3, still OPEN). Phase A/B add
+   takes 265–368 s (2026-08-17, Tier 1 #3, still OPEN). Phase B/C add
    Handlers to the listing, which adds symbols whose fan-in must be
    computed. **Report the delta in listed-symbol count and in wall
    time** on Koha, three runs, dated. If Handlers add 20% more symbols,
    the heatmap got 20% slower and users deserve to know.
-3. **Do not defeat the sound pre-prune.** The relational row store
+5. **Do not defeat the sound pre-prune.** The relational row store
    pre-prunes the fan-in walk for provably-unreferenced names,
    degrading to the full projection when rows are absent
    (`adr/relational-ref-index.md`). A Handler whose refs are minted by
@@ -174,10 +247,10 @@ Facts to respect:
    Handler that is pre-pruned because the row store never saw it is a
    silently-wrong "dead" verdict, which is the one thing the heatmap
    promises never to do.
-4. **Phase C's guard is a set membership check per symbol** — cheap, as
+6. **Phase D's guard is a set membership check per symbol** — cheap, as
    long as the set is baked once per file and not recomputed. Keep it in
    the plugin lane, default-empty.
-5. The honest framing in `adr/heatmap.md` — over-approximation, named
+7. The honest framing in `adr/heatmap.md` — over-approximation, named
    failure modes, batch-not-interactive — is load-bearing. Any number
    this epic changes gets its date stamped in the doc.
 
@@ -187,9 +260,11 @@ Facts to respect:
 `./e2e/run.sh` · a `--heatmap` run over the substrate committed as a
 before/after summary in the PR: **dead candidates by kind** — Handlers
 should ADD candidates (orphans found) while framework-consumed REMOVES
-false ones; both deltas listed · C++ heatmap output unchanged by Phase B ·
-Koha `--heatmap` wall, three runs, dated.
+false ones; both deltas listed · C++ heatmap output unchanged by Phase C ·
+Koha `--heatmap` wall, three runs, dated · for Phase A: BMO/Webmin wall
+**and peak RSS** before and after, plus two runs byte-identical.
 
 ## Sizing
 
-Medium-small. A+B one PR arc, C a second.
+Medium. A is small, self-contained and independently valuable — ship it
+alone if the rest stalls. B+C are one PR arc, D a second.

--- a/docs/epics/08-heatmap-residuals.md
+++ b/docs/epics/08-heatmap-residuals.md
@@ -1,0 +1,195 @@
+# Epic 8 — Heatmap residuals: Handlers + plugin-owned reachability
+
+> **Status:** scheduled (8th).
+> **Design owner-doc:** `docs/adr/heatmap.md` — the honest
+> over-approximation, the guard table, the failure modes, and the two
+> residuals this epic closes.
+
+## Mission
+
+Two gaps, both plugin-knowledge-shaped (rule #10 — never a
+per-verb/per-name list in core):
+
+1. **Handlers become heatmap-eligible** with a plugin-stamped
+   definition site, so orphan routes / never-enqueued tasks /
+   never-emitted events surface in the dead-code queue. The reference
+   graph already computes their fan-in correctly — only the listing
+   elides them.
+2. **Plugin-declared "framework-consumed" reachability** replaces the
+   blanket dynamic-dispatch shield for lifecycle hooks — fixing the
+   verified false positive where a Mojolicious `sub startup` is flagged
+   dead, which violates the heatmap's "never falsely flag a live
+   symbol" promise.
+
+## Read first
+
+1. `docs/adr/heatmap.md` — WHOLE doc, especially the guard table and
+   the failure modes.
+2. `docs/adr/resolution-candidate-set.md` — heatmap fan-in **is** the
+   `references()` projection, minted at each declaration. Nothing here
+   may add a parallel count; that equality is what makes the heatmap's
+   numbers match the references verb by construction.
+3. `docs/adr/relational-ref-index.md` — the dead-export queue is the
+   relational `unused_exported_syms` view, and the same row store
+   SOUND-pre-prunes the fan-in walk. A new guard must not defeat the
+   pre-prune's soundness.
+4. `docs/adr/plugin-system.md` — EmitAction shapes; how Handlers are
+   minted.
+
+## Current state — anchors
+
+| What | Where | Find it |
+| --- | --- | --- |
+| Listing policy | `lsp/cli/heatmap.rs` | `grep -n 'heatmap_symbol_eligible' src/lsp/cli/heatmap.rs` — admits `Sub\|Method\|Package\|Class\|Module`, elides `Handler` |
+| Declaration subtraction | `lsp/cli/heatmap.rs` | the fan-in logic subtracts `AccessKind::Declaration` + the decl name-token span — insufficient for Handlers, whose registration IS one of their refs |
+| Guards | `lsp/cli/heatmap.rs` | `grep -n 'reachable_guard' src/lsp/cli/heatmap.rs` |
+| The language capability already consulted | `lsp/cli/heatmap.rs` | `grep -n 'entrypoint_symbols\|LanguageRegistry::caps\|Namespace::Language' src/lsp/cli/heatmap.rs` — the entry-point guard already reads the analysis language's declared symbols. **This is the pattern to extend, not to invent.** |
+| Handler minting | `src/build/plugin/mod.rs` | `grep -n 'Handler' src/build/plugin/mod.rs \| head` |
+| Handlers in the bundled plugins | `frameworks/*.rhai` | `grep -ln 'Handler' frameworks/*.rhai` |
+| The HTML viewer | `src/heatmap.html` | embedded via `include_str!` |
+
+## Phase breakdown
+
+### Phase A — plugin-stamped Handler definition site
+
+1. **CHECK FIRST:** if Handlers already carry a declaration span that
+   the fan-in subtraction simply does not use, this phase is wiring, not
+   schema.
+2. Otherwise, extend the Handler-minting EmitAction with a
+   definition-site marker — the Handler-shaped equivalent of
+   `AccessKind::Declaration`. The plugin knows the span at mint time
+   (the string key in `add_task(cleanup => …)`, the `Controller#action`
+   in `->to(…)`, the event name in `->on(…)`). Mirror how plugin
+   Methods record theirs.
+3. Update every bundled plugin that mints Handlers to stamp it. A
+   plugin that does not stamp gets a decided fallback: **elide-unless-
+   stamped is the safe default** (no `fan_in ≥ 1` noise). Write the
+   decision down.
+4. **Acceptance:** on a fixture — a wired+dispatched task (`fan_in ≥ 1`,
+   not dead), a wired-never-dispatched task (`fan_in = 0`,
+   dead-candidate), and the same pair for a route and an event.
+   `EXTRACT_VERSION` bump if the Handler shape changed.
+
+### Phase B — Handlers in the report
+
+1. `heatmap_symbol_eligible` admits stamped Handlers; the fan-in
+   subtraction uses the stamped site.
+2. The HTML viewer gives Handlers their outline word (route/task/event —
+   `HandlerDisplay` already knows) in the treemap tooltip and the
+   dead-code table.
+3. **Acceptance:** the `--heatmap` JSON schema stays `v1`-compatible
+   (additive fields only) or bumps to `v2` with the schema string
+   updated. **Decide and document** in `adr/heatmap.md`'s schema
+   section — a silent shape change breaks every downstream consumer.
+
+### Phase C — framework-consumed reachability
+
+1. New plugin manifest `framework_consumed()` → the method names a
+   framework invokes through its own machinery: Mojo (`startup`),
+   Moo/Moose lifecycle (`BUILD`, `BUILDARGS`, `DEMOLISH`), DBIC
+   (`sqlt_deploy_hook`, `register`…).
+   **`_build_*` is a pattern, and patterns are the wrong shape here** —
+   prefer emit-time enumeration: the moo plugin SEES the
+   `builder => '_build_x'` option and can mark that symbol precisely.
+   No prefix matching, no name table.
+2. Carrier: for plugin-minted symbols, an EmitAction field. For
+   USER-WRITTEN symbols like `sub startup` the plugin cannot mint — it
+   must MARK. Add a small `MarkFrameworkConsumed { name }` EmitAction
+   applied per-package when the trigger fires; bake as a set on the FA's
+   plugin lane, serde-default.
+3. Heatmap: `reachable_guard = "framework-consumed"` checked BEFORE the
+   blanket dynamic-dispatch shield (most-specific-first, per the guard
+   table), and such symbols skip fan-OUT hotspot dilution.
+4. **Epic 7 interlock:** PL006 dead-sub must consult the same guard. If
+   Epic 7 landed first, extend its guard reuse; if not, leave the
+   pointer.
+5. **Acceptance:** the verified FP as a regression test — `sub startup`
+   in a Mojolicious fixture is NOT a dead candidate and carries the new
+   guard; a genuinely-uncalled non-lifecycle method in the SAME fixture
+   still flags (the shield must not over-widen).
+
+## Non-goals
+
+- SARIF for heatmap (deferred; `--check` SARIF is Epic 7).
+- Transitive fan-out depth (deferred).
+- Fan-in precision split by `RefKind` (deferred until `RefLocation`
+  carries kind).
+
+## Language-pack beat
+
+**The heatmap already serves pack languages, so this epic is a
+maintenance obligation, not an opportunity.**
+
+`lsp/cli/heatmap.rs` already asks the language for its capabilities:
+the entry-point guard reads the analysis language's declared
+`entrypoint_symbols`, and `Namespace::Language` distinguishes native
+symbols. A C++ heatmap run exists and works. That means:
+
+1. **Phase B's eligibility change is cross-language by default.** A
+   pack language that mints Handler-shaped symbols gets them listed;
+   one that does not is unaffected. Verify the C++ heatmap output is
+   byte-identical before/after Phase B — if it is not, the eligibility
+   predicate grew a Perl assumption.
+2. **Phase C's `framework_consumed` manifest is a `.rhai` plugin
+   hook, and pack languages have no rhai plugin tier.** Their framework
+   knowledge, when it exists, arrives as query overlays and driver
+   capabilities. So `framework_consumed` needs a second producer to be
+   honest cross-language: **the language capability**. `entrypoint_symbols`
+   is the precedent sitting right there — a C++ language declaring
+   `main` as an entry point is the same idea. Design the guard to
+   consume a UNION of (plugin manifest ∪ language capability), so the
+   pack side has a door even before anyone walks through it.
+3. Do NOT let the guard become a name list in `heatmap.rs`. That is the
+   rule-#10 failure this epic exists to prevent, and it is the exact
+   shape a "just add `main` for C++" fix would take.
+4. The `--heatmap` schema decision in Phase B is user-visible for every
+   language. Whatever version story you pick applies to all of them.
+
+## Scaling beat
+
+**`--heatmap` is a batch verb, and `scaling-limits.md` §5 says so
+explicitly. This epic must not blur that.**
+
+Facts to respect:
+
+1. **The heatmap runs `cli_full_startup` with `LanguageScope::All`**
+   (`grep -n 'LanguageScope::All' src/lsp/cli/heatmap.rs`) — correct,
+   because it sweeps the workspace, and CLAUDE.md's rule is that
+   under-indexing a sweeping verb is a quiet wrong answer. It is also
+   why it is expensive: the CLI's one-shot semantics are O(corpus) in
+   time and RAM, and `--heatmap` is named in the hitlist among the verbs
+   that bounds as workspace-scale tools.
+2. **Fan-in must stay the `references()` projection.** It is also the
+   most expensive thing the heatmap does — references at 138k files
+   takes 265–368 s (2026-08-17, Tier 1 #3, still OPEN). Phase A/B add
+   Handlers to the listing, which adds symbols whose fan-in must be
+   computed. **Report the delta in listed-symbol count and in wall
+   time** on Koha, three runs, dated. If Handlers add 20% more symbols,
+   the heatmap got 20% slower and users deserve to know.
+3. **Do not defeat the sound pre-prune.** The relational row store
+   pre-prunes the fan-in walk for provably-unreferenced names,
+   degrading to the full projection when rows are absent
+   (`adr/relational-ref-index.md`). A Handler whose refs are minted by
+   a plugin must either be in the rows or must degrade correctly — a
+   Handler that is pre-pruned because the row store never saw it is a
+   silently-wrong "dead" verdict, which is the one thing the heatmap
+   promises never to do.
+4. **Phase C's guard is a set membership check per symbol** — cheap, as
+   long as the set is baked once per file and not recomputed. Keep it in
+   the plugin lane, default-empty.
+5. The honest framing in `adr/heatmap.md` — over-approximation, named
+   failure modes, batch-not-interactive — is load-bearing. Any number
+   this epic changes gets its date stamped in the doc.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS ·
+`./e2e/run.sh` · a `--heatmap` run over the substrate committed as a
+before/after summary in the PR: **dead candidates by kind** — Handlers
+should ADD candidates (orphans found) while framework-consumed REMOVES
+false ones; both deltas listed · C++ heatmap output unchanged by Phase B ·
+Koha `--heatmap` wall, three runs, dated.
+
+## Sizing
+
+Medium-small. A+B one PR arc, C a second.

--- a/docs/epics/09-mojo-polish.md
+++ b/docs/epics/09-mojo-polish.md
@@ -1,0 +1,200 @@
+# Epic 9 — Mojo polish: route names, stash intelligence, hooks, transitive plugins
+
+> **Status:** scheduled (9th). The user-facing feature epic.
+> **Design owner-doc:** `docs/prompt-mojo-todo.md` — read WHOLE; its
+> stash section contains a fully-made design decision (per-action
+> ownership via the brand) that this epic implements as written.
+
+## Mission
+
+Four missing Mojo features, all landing as plugin patches
+(`frameworks/mojo-*.rhai`) on existing core seams: route naming +
+`url_for`, stash-key intelligence, hook completion + signatures, and
+transitive plugin-chain helper discovery. Plus a `.conf` config
+completion stretch, explicitly droppable.
+
+## Read first
+
+1. `docs/prompt-mojo-todo.md` — the spec. Its "Ready vs missing"
+   paragraph for stash is the checklist.
+2. `docs/adr/route-branding.md` — `BrandedRoute` accumulates route
+   defaults; the stash key set per action IS the brand's stash at the
+   terminal `->to`.
+3. `docs/adr/plugin-system.md` + `docs/PLUGIN_AUTHORING.md` — emit vs
+   query hooks; `Handler` + bridges; `classified_pairs`.
+4. `frameworks/mojo-routes.rhai`, `frameworks/mojo-helpers.rhai`.
+
+## Phase breakdown
+
+### Phase A — route naming + `url_for`
+
+1. At `->name('show_user')` chain links, `mojo-routes.rhai` emits a
+   Handler keyed by the route NAME (display `Route`), bridged the way
+   routes already are. Lite auto-naming emits the same Handler when no
+   explicit `->name` exists — **implement only the documented default
+   rule**, and mark synthesized-name Handlers `hide_in_outline` to avoid
+   outline noise.
+2. `url_for('…')` / `redirect_to('…')` first-string-arg becomes a
+   dispatch ref to that Handler, via the existing dispatch-verb
+   machinery (register the verbs through the manifest).
+3. Completion inside the string arg offers known route names — an
+   `on_completion` query hook enumerating the route-name namespace.
+4. **Acceptance:** goto-def from `url_for('show_user')` to the `->name`
+   call; references on the name lists both; completion offers it; a gold
+   row for each; the heatmap treats a never-`url_for`ed named route
+   honestly (fan-in 0 → orphan). This composes with Epic 8 — note it
+   either way.
+
+### Phase B — stash intelligence (the big one)
+
+Implement the owner doc's decision EXACTLY — keys are per-ACTION,
+sourced from the brand. Do not relitigate per-controller ownership; the
+doc explains why it over-broadens.
+
+1. **Emission, route side:** at each terminal `->to` naming an action,
+   emit `HashKeyDef`s for the in-force `BrandedRoute.stash` keys
+   (inherited overlay + local), owned per-action. Ownership shape: the
+   doc's options (a)+(b) BOTH — an action-scoped `HashKeyOwner` variant
+   for deref reads AND namespace registration for string-arg
+   enumeration. **The owner enum lives in core and is generic
+   ("action-scoped key"); the MINTING is the plugin's.**
+2. **Emission, body side:** `render(k => v)` / `stash(k => v)` inside
+   `sub action` add body-local keys to the same per-action set — plugin
+   `on_method_call` with `classified_pairs`, skipping the known render
+   options (`template`/`format`/`status`/`handler`/…), a vocabulary the
+   plugin owns.
+3. **Identity bridge:** the body-side `<current_package>#<sub>` must
+   meet the decl-side `users#list` through the SAME decamelize +
+   namespace rule goto-def already uses. **Grep the controller
+   resolution in `mojo-routes.rhai` and REUSE it** — a second spelling
+   of decamelize is the bug the doc warns about.
+4. **Read side:** `$c->stash('|')` string-arg completion (query hook);
+   `$c->stash->{|}` hash-key completion + goto-def via the owner path;
+   hover on a key shows the defining `->to`/`render` site.
+5. **Honest boundary (from the doc):** an action whose chain roots at an
+   unbranded hashref param has an empty inherited stash — body-local
+   keys still work. Do not attempt to fix that boundary here
+   (`open-problems.md` owns it).
+6. **Acceptance:** the doc's worked example as a fixture; completion at
+   both read forms lists exactly the expected labels for `list` and NOT
+   for `show`; gold completion rows with `exact_labels`; cross-file (app
+   file + controller file) versions of the same.
+
+### Phase C — hook completion + signatures
+
+1. A new small `mojo-hooks.rhai` (hooks are their own concept):
+   `on_completion` inside `->hook('|')` returns the hook-name table;
+   `on_signature_help` returns the per-hook param shape. The owner
+   doc's table is complete — encode it as plugin DATA.
+2. The handler sub's params get typed via the existing
+   `NamedSubParamType`/`VarType` emission the helpers plugin already
+   uses.
+3. **Acceptance:** completion + sig-help rows for two hooks with
+   different shapes (`before_dispatch` vs `around_dispatch`).
+
+### Phase D — transitive plugin chains
+
+Plugin A's `register` calls `$app->plugin('B')` — B's helpers should
+reach the host. Short-name resolution and one hop landed; this adds the
+transitive walk **at RESOLVE time, not parse time**: where helper
+resolution consults loaded plugins, follow `plugin_loads` found in an
+already-loaded plugin's module one more level, with a seen-set and a
+small depth cap. **Termination goes on the dispatcher, never the
+worker** (rule #10's note).
+
+**Acceptance:** a three-file fixture (app loads A; A's register loads B;
+B registers helper `h`) — `$c->h` resolves in the app's controllers; a
+cycle fixture terminates.
+
+### Phase E — `.conf` config completion (STRETCH — droppable)
+
+Only if A–D land with room. Mojo config is a Perl hashref, so it can be
+parsed with the existing parser as an expression file; emit its key
+shape and complete `$app->config->{…}` off it via the existing hash-key
+machinery. **If the parse story gets ugly, drop the phase and record
+why in the owner doc.**
+
+## Non-goals
+
+- Multi-app workspaces (parked with instance brands).
+- The unbranded-root boundary (`open-problems.md`).
+
+## Language-pack beat
+
+**This epic is Perl-only, and that is correct — but it is also the
+best available reference implementation of a framework tier, and Epic
+13 will read it.**
+
+Pack languages have no framework plugin tier today; giving them one is
+the open design round (`prompt-multi-language.md`), and it is Epic 13
+Phase C. The honest statement for this epic is: *nothing here
+generalizes, and nothing here should try.* But two things it produces
+are worth writing down deliberately, because they are the requirements
+document for that future tier:
+
+1. **What this epic needs that a query overlay could NOT express.**
+   Phase B is the interesting case: the stash key set is accumulated
+   along a route chain (`BrandedRoute` inheritance) and then attributed
+   to an action identified by a decamelize rule. That is *name surgery
+   and accumulation across nodes*, not pattern matching. When Epic 13
+   asks "does a declarative query overlay suffice, or does the tier need
+   an imperative hook?", Phase B is the exhibit. **Record, in the PR or
+   the owner doc, which of these four phases could have been a pure
+   pattern match and which could not.** That list is worth more to Epic
+   13 than any speculation.
+2. **The core seams this epic extends must not gain Mojo names.** The
+   action-scoped `HashKeyOwner` variant (Phase B step 1) lives in core
+   and is generic; `HandlerDisplay`, dispatch verbs, and
+   `classified_pairs` are all already generic. If any phase needs a
+   `if framework == Mojo` branch in core, that is a rule-#10 violation
+   AND a signal that the seam is under-specified for the pack tier —
+   fix the seam, do not add the branch.
+
+## Scaling beat
+
+**Two of these phases add completion candidates, and completion payload
+is a measured, previously-regressed axis.**
+
+`prompt-scale-validation-hitlist.md` Tier 1 #4 (2026-08-17): completion
+at 138k files was **7.29 MB and 236 ms per keystroke**; fixed to 55.9 KB
+/ 4 ms (`b6312ea2`). Phases A, B and C each add a completion source.
+
+Obligations:
+
+1. **Every completion phase ships an `exact_labels` gold row AND a
+   payload measurement.** The gold row proves correctness; the payload
+   number proves you did not undo `b6312ea2`. Use
+   `bench/lsp_bench.py` with a completion scenario, three runs, dated,
+   into `bench/`.
+2. **Phase A's route-name namespace and Phase C's hook table are
+   bounded and small** — a workspace has tens of routes, and the hook
+   table is fixed. These are safe. Say so with a number rather than
+   assuming.
+3. **Phase B is the one to watch.** Per-action stash key sets are
+   emitted as `HashKeyDef`s per terminal `->to`. A large Mojo app has
+   many routes × many inherited stash keys, and the emission is
+   per-route, not per-key-once. Report the FA symbol-count delta on the
+   corpus's Mojo project. Koha is the right corpus — it is the only one
+   hitting DBIC **and** Mojo plugin paths together, and it runs in
+   minutes per round.
+4. **Phase D walks plugin chains at resolve time**, which means it
+   happens on the query path, not the index path. A depth cap and a
+   seen-set are correctness requirements (cycles) *and* latency
+   requirements. Cap it low — the doc says one more level; do not make
+   it unbounded because a fixture wanted three.
+5. `EXTRACT_VERSION` bump for the emission changes; bundle A–D under
+   one.
+
+## Verification gate
+
+`cargo test` · gold, with each phase authoring its rows (`exact_labels`
+for every completion addition) · **e2e additions in `e2e/mojo_*.lua`
+where cursor-position behavior is the deliverable** — completion inside
+a string literal is exactly what e2e catches and unit tests fake ·
+substrate audit at parity (emission changes can move unresolved counts;
+triage any) · completion payload bytes, three runs, dated.
+
+## Sizing
+
+Large overall but cleanly phased; A/C/D are each small, B is the bulk.
+Ship phases as separate PRs.

--- a/docs/epics/10-cli-analysis-and-migrate.md
+++ b/docs/epics/10-cli-analysis-and-migrate.md
@@ -1,0 +1,206 @@
+# Epic 10 — CLI analysis subcommands + `--migrate`
+
+> **Status:** scheduled (10th).
+> **Design owner-doc:** `docs/prompt-cli-tools.md` §"Analysis
+> subcommands still missing" and §"`--migrate`" (targets table,
+> implementation shape, phase order).
+
+## Mission
+
+Round out the CLI: the thin-wrapper analysis subcommands over existing
+`FileAnalysis` queries, then the marquee `--migrate` (framework
+translation via span-based edits), in the owner doc's easy→ambitious
+order.
+
+## Read first
+
+1. `docs/prompt-cli-tools.md` — the two sections.
+2. `src/lsp/cli/mod.rs` (dispatch), `positions.rs` (the coordinate
+   contract), `query.rs` (the verb bodies), `heatmap.rs` (the best
+   template for a full report verb).
+3. `CLAUDE.md` §"A verb indexes only the language families its answer
+   can consult" and §"Startup is not one thing" — both are directly
+   about writing a new CLI verb, and both are easy to get quietly wrong.
+4. For `--migrate`: how `--rename` builds span-based `WorkspaceEdit`s
+   (`grep -rn 'fn cli_rename' src/lsp/cli/`) — migrate reuses that
+   edit-application shape.
+
+## The two contracts every new verb must honor
+
+**1. Coordinates.** 0-based input, 1-based output, per `--help`. Copy an
+existing position-taking subcommand EXACTLY; `positions.rs` owns the
+conversion and has its own tests.
+
+**2. `LanguageScope`, declared by the verb.** `cli_full_startup` takes
+it. `of_file(path)` for a verb with a target; `All` for one that sweeps
+the workspace. Over-indexing is wasted work; **UNDER-indexing is a
+quiet wrong answer**, because an unattached pack sub-index does not
+answer empty — `lookup_for` routes that language to the Perl hub.
+Adding a verb means choosing its scope, deliberately, and saying why in
+the code.
+
+**3. Streams.** Chatter to stderr, data to stdout — the heatmap's
+pattern.
+
+## Phase breakdown
+
+### Phase A — thin analysis subcommands
+
+Each a small `cli_*` fn + a `--help` entry + tests; separate commits, in
+this order:
+
+1. `--completions <root> <file> <line> <col>` — the completion engine at
+   a position. Mirror `--signature-help`'s plumbing.
+   `LanguageScope::of_file`.
+2. `--dependency-graph <root> [--format dot|json|list]` — module import
+   edges from each FA's `imports`, plus parent edges as a distinct edge
+   kind; cycles via DFS, reported in all formats. `LanguageScope::All`.
+3. `--export-api <root> <module> [--format json|markdown]` — exports,
+   params, return types, parents, framework, from the cached FA.
+   `--dump-package` is the debugging sibling; this is the user-facing
+   one — share extraction where trivial.
+4. `--impact <root> <file-or-module>` — reverse deps: who imports /
+   inherits from this. The reverse index and `children_index` already
+   answer both; this is formatting.
+5. `--framework-report <root>` — classes by framework, counts + list.
+6. `--unused-exports` / `--dead-code`: implement as **ALIASES** over the
+   Epic 7/8 machinery if those landed (PL005/PL006 + the heatmap
+   guards). If this epic runs first, SKIP them and leave the pointer —
+   **do not build a third dead-code path.**
+7. `--repl-complete` — stdin-accumulated source, complete at EOF.
+   Lowest priority; drop if time-boxed out.
+
+**Acceptance per subcommand:** a golden-output test on a fixture
+workspace; `--help` updated; stream discipline preserved; the
+`LanguageScope` choice justified in a comment.
+
+### Phase B — `--migrate` step 1: `use base` → `use parent`
+
+The deliberately-trivial first target, to build the harness.
+
+1. `cli_migrate(root, target, from, to, dry_run)` — index, select files
+   by `--from` detection (the FA knows its frameworks), produce span
+   edits; `--dry-run` prints a unified diff, else write files.
+2. **The edit goes through the semantic model** — the statement's span
+   from the FA/refs, NOT a regex — preserving everything else
+   byte-for-byte.
+3. **Acceptance:** golden diff test; idempotence (re-run produces no
+   edits); `--dry-run` writes nothing (assert content and mtimes).
+
+### Phase C — Moose → Moo, Moo → Moose
+
+Mostly removals and small additions per the owner table. **Every
+construct the writer cannot translate emits
+`# TODO: manual migration needed — <reason>` at the site** rather than
+guessing. **Acceptance:** golden diffs both directions on a fixture
+exercising `has` flavors, `extends`, `with`, method modifiers;
+untranslatable constructs produce TODOs, not edits.
+
+### Phase D — Moo/Moose → core `class` (the headline)
+
+The owner doc's table row by row: `class` / `:isa` / `:does`, `has` →
+`field` with `:param :reader (:writer)`, defaults, lazy via `ADJUST`,
+`sub` → `method` with the invocant dropped. Untranslatable
+(BUILD/BUILDARGS, DEMOLISH, complex isa constraints, coercions,
+triggers, delegation) → TODO comments. Span-based, never whole-file
+regeneration; comments and non-framework code byte-identical.
+**Acceptance:** golden diffs per table row, plus a `perl -c` compile
+check of migrated output in the test (emit the
+`use v5.38; use experimental 'class';` preamble and assert it compiles).
+
+### Phase E — bless → Moo (heuristic; LAST, gated)
+
+Only when the FA's evidence is strong: a conventional constructor
+blessing a hash literal plus accessor-shaped subs. Anything below full
+confidence → TODO comment, no edit. **If the false-edit rate on the
+substrate is nonzero, ship it behind `--allow-heuristic` or drop the
+phase — and record the measurement either way.**
+
+## Non-goals
+
+- Diagnostic codes / config / SARIF (Epic 7).
+- **Editing files the semantic model did not fully parse.** Any ERROR
+  node in a target file → skip the file with a warning. Never edit
+  around broken syntax.
+
+## Language-pack beat
+
+**Phase A is where a language decision gets made per verb, and Phases
+B–E are Perl-only by their nature. Both need saying out loud.**
+
+1. **Every Phase-A verb picks a `LanguageScope`, and three of them are
+   genuinely multi-language.** `--dependency-graph`, `--impact` and
+   `--framework-report` sweep the workspace and will encounter pack
+   files. Decide per verb whether the answer spans languages:
+   - `--dependency-graph`: a C++ `#include` edge and a Perl `use` edge
+     are both dependency edges. Emitting them in one graph is the
+     RIGHT answer for a mixed workspace, and it needs the edge kind
+     labeled. `LanguageScope::All`.
+   - `--impact`: same. The reverse index is per-language, so the verb
+     must ask each.
+   - `--export-api`: `of_file`-ish — it names one module. But "module"
+     is a Perl noun; for a pack language the addressable unit is a
+     file/header. Either accept a path for pack languages or scope the
+     verb to Perl and say so in `--help`.
+   - `--framework-report`: Perl's `package_framework` has no pack
+     analogue today. Scope it, and note that Epic 13's framework tier
+     is what would widen it.
+2. **`--migrate` is Perl-only, permanently, and should say so in
+   `--help`.** It translates between Perl object systems. There is no
+   general "framework migration" abstraction hiding here and building
+   one would be inventing a requirement. The *harness* (index → select →
+   span edits → dry-run diff → write) is generic and worth keeping
+   clean, but the writers are Perl.
+3. The one shared risk: **`--migrate` writes to disk in a workspace that
+   may contain pack files.** The file-selection step must never pick up
+   a non-Perl file, even one whose extension is ambiguous. Select by the
+   analysis's `language` tag, not by extension.
+
+## Scaling beat
+
+**Every verb here calls `cli_full_startup`, and that is O(corpus) in
+time and RAM. This epic multiplies the surface that inherits that
+cost.**
+
+The measurements (2026-08-17): the CLI one-shot at 138k files was DNF,
+killed at 42:32 / 7.11 GB; PR #125 made it finite — **exit 0 in 350 s**
+with a real answer. `prompt-scale-validation-hitlist.md`'s verdict is
+that the CLI's "act like the LSP just started" semantics bound
+`--check` / `--heatmap` / `--workspace-symbol` / batch **as
+workspace-scale tools**. Warm LSP ready, by contrast, is scale-free
+(1.06 s at 138k).
+
+Obligations:
+
+1. **Pick the narrowest honest `LanguageScope`.** This is not a
+   micro-optimization — the pack-indexing row (Tier 1 #6) measured a
+   synthetic Perl query at **−52% CPU** and the pack phase at
+   **936 ms → 0.11 ms** once the verb declared its scope. A new verb
+   defaulting to `All` when `of_file` would do is that cost, re-added.
+2. **Position-taking verbs (`--completions`) must use `of_file`** and
+   should be *fast* — they are the ones a user might script in a loop.
+3. **Sweeping verbs inherit the batch-verb caveat, and their `--help`
+   should not pretend otherwise.** Match the honest framing already in
+   `scaling-limits.md` §5 for `--heatmap`.
+4. **`--migrate --dry-run` over the gold substrate is both the honesty
+   check and the scaling check.** Run it for each target and attach the
+   summary (files matched, edits, TODO counts, wall) to the PR — the
+   substrate is where the writers prove they do not touch what they
+   should not, and where a pathological cost would show.
+5. Report, for each new sweeping verb, its wall and peak RSS on Koha,
+   three runs, dated. If a verb cannot finish on Koha, it cannot finish
+   on a customer monorepo, and that belongs in `--help` before it
+   belongs in a bug report.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold untouched (these are additive
+CLI surfaces) · for migrate phases the golden-diff suite IS the gate,
+plus `perl -c` compile checks of outputs · `--migrate --dry-run`
+substrate summary in the PR · Koha wall + peak RSS for each sweeping
+verb, three runs, dated.
+
+## Sizing
+
+Phase A is a string of small wins (good for ramping a new implementer).
+B small; C medium; D large; E small-but-risky. Separate PRs per phase.

--- a/docs/epics/11-program-boundaries.md
+++ b/docs/epics/11-program-boundaries.md
@@ -1,0 +1,229 @@
+# Epic 11 — Program boundaries: file→program assignment + `main::` unification
+
+> **Status:** scheduled (11th). Half-gated: the file→program assignment
+> and MAIN-1 are unblocked NOW; the instance-brand consumer additionally
+> waits on Epic 4 plus constructor/field flow.
+> **Design owner-docs:** `docs/prompt-entrypoint-analysis.md` (the
+> program-boundary concept and the landed conservative fallback) and
+> `docs/open-problems.md` §"`main::` aggregation across `require` of
+> package-less scripts" (the require-edge design and its recommendation,
+> which this epic implements as option 1).
+
+## Mission
+
+Give the analyzer the notion of a **program**: which entrypoint(s) a
+file belongs to, via each entrypoint's statically-resolvable
+`use`/`require`/`do` closure. Two consumers land with it:
+
+1. **MAIN-1** — package-less files `require`d into a script share its
+   `main::`; unqualified calls resolve along require edges (the AWStats
+   shape, ~270 false positives each direction) **without** unifying
+   unrelated scripts' `main::` — every `t/*.t` keeps its own.
+2. **`main::` rename fan-out lift** — the deliberately-file-local `main`
+   fallback in resolve widens to program-scoped.
+
+## Read first
+
+1. Both owner docs, whole.
+2. `CLAUDE.md` §"Workspace indexing" — `scan_entrypoint_scripts` and its
+   `extra: &[String]` seam (reserved for a workspace-config
+   `entrypoint_dirs`; if Epic 7's config landed, this epic wires that
+   key). Note the standing warning: **do not broaden the entrypoint scan
+   to a recursive walk** — it would enumerate non-Perl source trees.
+3. `src/index/resolve/` — the `package == "main"` file-local arm
+   (`grep -rn '"main"' src/index/resolve/`).
+4. `docs/adr/heatmap.md` §failure modes — entrypoint-script free-subs
+   are deliberately listed as dead candidates *pending this tier*; this
+   epic upgrades that floor.
+
+## Phase breakdown
+
+### Phase A — the require/do edge, as data
+
+1. During the walk (rule #1), record load edges the builder can see:
+   `require "literal/path.pl"`, `require Bare::Module`, `do
+   "literal/path"`, and constant-folded variable forms (`require $file`
+   where `$file` folds — the same folding `Ref.folded_from` rides). A
+   dynamic path that does not fold is an honest miss; degrade silently.
+   **`require Foo::Bar` has NO `module:` field** unlike `use_statement`
+   — match structurally, and note `require 5.010` / `require v5.36` are
+   a different kind entirely (`require_version_expression`).
+2. Store on the FA in its lane: `load_edges: Vec<LoadEdge { target,
+   span }>`, serde-default, `EXTRACT_VERSION` bump. **`use` already
+   populates `imports` — do NOT duplicate it**; `LoadEdge` is for the
+   require/do path forms `imports` does not carry.
+3. `surface_feed` will not compile until the field's Surface fate is
+   decided: load edges ARE cross-file-visible (they change what a
+   program contains), so they belong in the projection — which means a
+   Surface equality-net arm too.
+4. **Acceptance:** unit tests per form, including the folded-variable
+   case and a non-folding dynamic path producing nothing.
+
+### Phase B — program assignment
+
+1. At workspace-index completion (the resolver's post-index hook),
+   compute programs: for each entrypoint from `scan_entrypoint_scripts`
+   (+ configured `entrypoint_dirs` if available), BFS its closure over
+   `imports` ∪ `load_edges`. Resolve paths conservatively — try the
+   entrypoint's own dir first, then the workspace root; unresolvable →
+   skip. A file reachable from N entrypoints belongs to all N; a file
+   reachable from none belongs to a synthetic "unassigned" program.
+2. Store where resolve-time code can read it (`path → SmallVec<ProgramId>`
+   on the index or a sibling), rebuilt on watcher changes with the
+   hooks indexing already uses. **This is derived state — never
+   serialized into per-file FAs.** It is workspace-shaped, not
+   file-shaped, and recompute is cheap.
+3. **Acceptance:** a fixture workspace with two scripts requiring
+   disjoint plugin files plus one shared library — assignments come out
+   `{A: script1}`, `{B: script2}`, `{lib: both}`.
+
+### Phase C — MAIN-1 consumption
+
+1. Unqualified-call resolution for `main`-package files consults the
+   program's other `main` files: extend the resolve `main` arm —
+   same-file first (current behavior), then same-program `main::`
+   symbols. Bounded by the program set; **NO workspace-wide `main`
+   union, ever** (the owner doc: modeling it wrong is worse than the
+   false positive).
+2. The unresolved-function diagnostic gains the same visibility, so the
+   AWStats-shaped FPs drop.
+3. Rename fan-out for `main` globals/subs widens file-local →
+   program-scoped, still never cross-program. **The negative test is
+   mandatory:** two scripts each with `our $x` / `sub helper` — rename
+   in one MUST NOT touch the other.
+4. **Acceptance:** an AWStats-shaped fixture (host script + `require`d
+   package-less plugin, calls both directions) — goto-def, references
+   and diagnostics all resolve across the pair; the negative pair above;
+   substrate audit at parity-or-better.
+
+### Phase D — heatmap upgrade + docs
+
+1. Entrypoint-reachable `main` free-subs: a sub whose program's
+   entrypoint calls it is reachable — fan-in flows through the normal
+   reference graph now that same-program `main` calls resolve. **No new
+   guard needed**; update `adr/heatmap.md`'s deliberate-listing note to
+   reflect the improved floor.
+2. Update `prompt-entrypoint-analysis.md` (fallback lift landed;
+   instance brands remain parked on their own gate) and
+   `open-problems.md` (MAIN-1 → landed; keep the duplicate-package
+   section's own state accurate — Epic 1 owns it).
+3. ADR `docs/adr/program-boundaries.md`: the closure rules, the
+   relative-path resolution order, multi-membership, the "unassigned"
+   program, and the non-goals below.
+
+## Non-goals
+
+- Instance brands / per-app helper surfaces — parked on Epic 4 plus
+  constructor/field flow. This epic only supplies the file→program key
+  they will eventually use.
+- No runtime `@INC` emulation; no execution of config to resolve dynamic
+  require paths.
+- **No cross-program anything.** The entire point is isolation by
+  default, sharing only along proven edges.
+
+## Language-pack beat
+
+**A program boundary is not a Perl concept, and the C++ analogue is
+already in the tree — under a different name, with a different owner.
+Read it before designing Phase B.**
+
+The C++ equivalent of "which entrypoint's closure is this file in" is
+**the include closure**, and it is landed:
+
+- `VisibilityAxis::IncludeClosure` is the visibility rule that already
+  models C's flat linkage, sitting beside Perl's `SearchPath` in the one
+  derivation (`VisibilityAxis::for_origin`).
+- `PackFacts` carries include directives **and the closure**.
+- `index/pack_invalidator.rs` is the ONE owner of pack-file
+  invalidation, and it holds "the single `is_consumer` include-closure
+  rule" — which is exactly Phase B's question ("which files does a
+  change here affect") answered for the pack side.
+
+So the honest framing for this epic:
+
+1. **Perl's program closure and C++'s include closure are the same
+   abstraction with different edge sources.** Both are: a derived,
+   workspace-shaped, watcher-rebuilt reachability relation over
+   per-file load edges, consulted at resolve time and never serialized
+   per file. Phase B is building the second instance.
+2. **Do not unify them in this epic** — the pack side is landed, in
+   production, and owns invalidation semantics this epic has no reason
+   to touch. But **do write Phase B so a unification is possible**: keep
+   the closure computation separate from the *Perl* edge extraction,
+   and give the ADR a section naming the pack sibling and what a
+   future merge would need. `prompt-scale-validation-hitlist.md` Tier 3
+   already lists "merge the two index families" as OPEN; this is the
+   same shape of debt, and adding a third unmergeable closure is how it
+   gets worse.
+3. **Concretely reusable now:** the incremental-rebuild discipline.
+   `PackInvalidator` already solved "recompute a closure on a watcher
+   event without a storm" — serialization lock, bulk-index defer/
+   reconcile, source-generation guard. Phase B's watcher rebuild should
+   study it rather than re-derive it, and the ADR should say which parts
+   it adopted.
+4. `scan_entrypoint_scripts` is Perl-specific (a shebang scan over root
+   + `bin/` + `script/`). A pack language's entry points come from its
+   language capability — the heatmap already reads
+   `entrypoint_symbols` from `LanguageRegistry::caps`. Keep the Perl
+   scanner where it is; if Phase B needs "the entry points for this
+   workspace", route through the capability so a pack language answers
+   for itself.
+
+## Scaling beat
+
+**Phase B computes a BFS closure over the whole workspace and rebuilds
+it on file changes. That is a new workspace-scale derived structure,
+and the corpus that will break it is FHEM.**
+
+The measurement (`scaling-limits.md` §1, 2026-08-17): FHEM is 973 Perl
+files, 991k LOC, with **`fhem.pl` `do`-loading all of them into a single
+interpreter** and 361 of them calling into `fhem.pl`'s `main`. That is
+not a pathological input to this epic — **it is this epic's canonical
+input**, and it is a single program with ~600 members.
+
+Obligations:
+
+1. **Measure Phase B on FHEM first, not last.** A closure with a
+   600-member program is the design point, not the edge case. Report the
+   closure computation's wall and the resulting map's size.
+2. **Phase C's `main` resolution consults the program's other `main`
+   files.** On FHEM that is ~534 files providing `main`, and `main` is
+   27% of package lookups and **94% of provider fetches**. This is the
+   same relation Epic 1 is converting consumers onto, and this epic adds
+   a consumer. Two consequences:
+   - **Coordinate with Epic 1.** If Epic 1 has landed, Phase C uses
+     `visible_def_candidates` narrowed by program membership — which is
+     strictly *better* than today, because the program set is smaller
+     than the workspace set. If Epic 1 has not landed, Phase C must not
+     introduce a second candidate-enumeration path.
+   - The program boundary is, for FHEM, a **narrowing**: it replaces
+     "any `main` in the workspace" with "any `main` in this program".
+     For most workspaces that is a big win. For FHEM it is a no-op,
+     because there is one program. Say that plainly in the ADR — this
+     epic does not fix FHEM.
+3. **The rebuild must be incremental, not a full recompute per watcher
+   event.** A `did-change` on one file in a 973-file program that
+   recomputes the whole closure is an editor stall. Study
+   `PackInvalidator`'s defer/reconcile coordination (Language-pack beat,
+   point 3).
+4. **The map is derived and must be bounded like every other derived
+   store.** CLAUDE.md's residency discipline: bounded caches only, byte
+   accounted. `path → SmallVec<ProgramId>` for 138k files is small, but
+   state the number rather than assuming it.
+5. Phase C changes what the unresolved-function diagnostic emits, which
+   changes `--check`'s output on every workspace with entrypoint
+   scripts. Substrate audit, per-code deltas, triage anything up.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS ·
+`./e2e/run.sh` · substrate audit at parity-or-better · the fixture
+suite above, **including the cross-program negative rename test** ·
+watcher incrementality: touch a require line in the fixture and assert
+reassignment without a full restart · FHEM closure wall + map size,
+three runs, dated.
+
+## Sizing
+
+Medium. A small; B is the design core; C is the payoff; D is cleanup.
+One PR per phase, or A+B together.

--- a/docs/epics/12-type-tiny-completeness.md
+++ b/docs/epics/12-type-tiny-completeness.md
@@ -55,6 +55,10 @@
    `is_`/`assert_` companion generation) and `base_constant_type`.
 5. `grep -rn 'type_constraint_names' src/build/plugin/mod.rs` — the
    global gate and its "first cut" caveat.
+6. `docs/prompt-cfg-tier.md` §3.3 and §8.1 — **this epic mints new
+   `GuardFact`s over `NarrowSubject`s, which is exactly the
+   representation that tier promotes.** Two obligations land on the
+   arms written here; see below.
 
 ## Phase breakdown
 
@@ -90,7 +94,20 @@
    asks the invocant's TYPE — **no name matching on `$type`** (rule
    #10). This is the payoff of the ADR's "a constraint is a value"
    decision.
-6. **Acceptance:** unit tests per form (`is_ArrayRef` if/unless/postfix;
+6. **Two forward obligations from the CFG tier, both free here and
+   unrecoverable later** (`prompt-cfg-tier.md` §3.3, §8.1):
+   - **`NarrowSubject` becomes `Place`** — spelling→binding, flat key→
+     path steps. The new arms should take the subject from
+     `narrow_subject_of` and never re-spell it as a string; a `String`
+     subject minted here is one more of the three spellings Epic 16
+     Phase B has to converge.
+   - **P2: keep the condition's symbolic form.** A check-guard's
+     condition is `is_X($subject)` — a shape that fits the decidable
+     fragment trivially (equality over a symbolic value). Record it
+     under the atom as the dormant `SymExpr` payload rather than
+     flattening straight to the resolved `NarrowOp`. Nothing reads it
+     yet; that is the point.
+7. **Acceptance:** unit tests per form (`is_ArrayRef` if/unless/postfix;
    `assert_Str` fall-through; the `->check` object form; a NON-imported
    `is_Foo` user sub narrows nothing — see Phase B); **the deref-shape
    diagnostic composes** (an `is_ArrayRef`-guarded `$x->{k}` hash deref

--- a/docs/epics/12-type-tiny-completeness.md
+++ b/docs/epics/12-type-tiny-completeness.md
@@ -1,0 +1,235 @@
+# Epic 12 — Type::Tiny completeness: check-guards, import-scoped vocabulary
+
+> **Status:** scheduled (12th; independent — can run any time, pairs
+> naturally with Epic 5's small-seam character).
+> **Design owner-docs:** `docs/adr/type-constraints.md` (the landed
+> `TypeConstraintOf` design — the foundation everything here projects
+> through), `frameworks/type-tiny.rhai` (the vocabulary plugin),
+> `docs/adr/flow-narrowing.md` + `docs/adr/narrowing-diagnostics.md`
+> (the lattice the guards feed).
+
+## What is ALREADY landed (do not rebuild)
+
+- `InferredType::TypeConstraintOf(inner)` — a constraint is a VALUE over
+  the type it constrains, never conflated with it; consumers project via
+  `constrained_inner()`.
+- The vocabulary plugin: `InstanceOf` / `ConsumerOf`, `Maybe[T]` →
+  `Optional<T>`, the 0-arity base constants (`Str`/`Int`/`Num`/
+  `ArrayRef`/…) folding to their reps — both `isa` spellings (quoted
+  string and bareword constructor) type accessors identically.
+- Import vocabulary: `Types::Standard` / `Types::Common::{String,
+  Numeric}` / `Types::Common` export lists including the
+  `is_X`/`assert_X`/`to_X` companions, `-all`/`:all` expansion, and the
+  BYO story for house type libraries (their plugin emits a
+  `SyntheticUse`).
+
+## Mission — what is NOT yet designed
+
+1. **Check-function guards feed the narrowing lattice.**
+   `if (is_ArrayRef($x)) { $x->[0] }` and `assert_Str($name); …` are
+   type guards exactly like `ref $x eq 'ARRAY'` / `defined $x` — today
+   they narrow nothing. The vocabulary already enumerates every
+   `is_X`/`assert_X` name; the lattice already has the ops. Connect
+   them, plugin-declared.
+2. **The constraint-constructor gate becomes import-scoped.** The
+   `type_constraint_names()` gate is global — ANY call named `Str`/`Int`
+   anywhere types as a constraint, colliding with user subs. Scope it to
+   packages that actually imported the name.
+3. **Close the `completion-typetiny-imported-blessed` xfail** — a
+   generic gap (imported names missing from bareword completion) that
+   happens to be pinned on a Type::Tiny fixture.
+4. **Doc hygiene:** `frameworks/type-tiny.rhai` cites a design doc that
+   does not exist (`docs/prompt-type-constraint-types.md`). The design
+   lives in `adr/type-constraints.md`; fix the pointer.
+
+## Read first
+
+1. `CLAUDE.md` — rules #1, #10; the narrowing and witness sections.
+2. `docs/adr/type-constraints.md`, `docs/adr/flow-narrowing.md`.
+3. `src/build/builder/narrowing.rs` — `recognize_guards` and the
+   `GuardFact`/`NarrowOp` shapes. The truthiness recognizer
+   (`NarrowOp::StripOptionalTruthy`) is the freshest example of
+   extending it; `src/build/builder/narrowing_tests.rs` is its test
+   pattern.
+4. `frameworks/type-tiny.rhai` — `types_standard_exports()` (the
+   `is_`/`assert_` companion generation) and `base_constant_type`.
+5. `grep -rn 'type_constraint_names' src/build/plugin/mod.rs` — the
+   global gate and its "first cut" caveat.
+
+## Phase breakdown
+
+### Phase A — `type_check_guards()` manifest + narrowing recognizer
+
+1. New plugin manifest `type_check_guards()` returning
+   `{ fn_name, constraint_name, asserts }` entries. **The plugin DERIVES
+   them from the same base list that generates the exports** — one
+   vocabulary, three projections (`is_X` → check-guard, `assert_X` →
+   asserting guard, the export list) — never a second hand-kept table.
+   Only names whose constraint folds to an expressible type contribute
+   (ask `base_constant_type`; `is_Object` folds to nothing → omit).
+2. Core resolves each entry's `constraint_name` → `InferredType` through
+   the EXISTING `type_constraint_inner` fold (empty params) at
+   registry-bake time — **no second name→type mapping in core.** Bake
+   the resolved map onto the FA's plugin lane, serde-default,
+   `EXTRACT_VERSION` bump.
+3. `recognize_guards` gains a function-call arm: a condition
+   `is_X($subject)` whose name is in the baked map and whose argument is
+   a narrowable subject yields
+   `GuardFact { subject, op: To(resolved), asserts_when_true: true }`.
+   `HashRef`/`ArrayRef`/`CodeRef` reps → `To(rep)` (same as `ref…eq`);
+   `Str`/`Num` → `To(String/Numeric)`. **Negation, polarity and
+   elsif-chains come free from the existing machinery** — do not
+   re-implement them.
+4. `assert_X($subject);` at statement level: the fall-through narrows
+   (assert dies otherwise). Reuse the early-exit statement machinery —
+   the assert IS the guard and the region is the rest of the block.
+   Postfix and bare-statement forms.
+5. **Object form:** `$type->check($x)` where the invocant types
+   `TypeConstraintOf(T)` narrows `$x` to `T` in the guarded region;
+   `$type->assert_valid($x)` narrows the fall-through. The recognizer
+   asks the invocant's TYPE — **no name matching on `$type`** (rule
+   #10). This is the payoff of the ADR's "a constraint is a value"
+   decision.
+6. **Acceptance:** unit tests per form (`is_ArrayRef` if/unless/postfix;
+   `assert_Str` fall-through; the `->check` object form; a NON-imported
+   `is_Foo` user sub narrows nothing — see Phase B); **the deref-shape
+   diagnostic composes** (an `is_ArrayRef`-guarded `$x->{k}` hash deref
+   flags) — one test proving the LATTICE, not just the type, sees the
+   guard. Substrate audit: guard-lint counts move only DOWN; triage
+   anything up.
+
+### Phase B — import-scoped constraint gate
+
+1. The builder's `type_constraint_names` gate and the Phase-A guard map
+   both consult per-package import state: the name must be imported in
+   the enclosing package (literal qw-list, meta-import expansion, or
+   `SyntheticUse` — all already recorded on `imports` or handled by the
+   plugin's `on_use`).
+2. Keep a compatibility carve-out ONLY if the substrate shows real code
+   using the constructors without importable evidence. **Measure first;
+   the expected answer is no carve-out** — Type::Tiny constants must be
+   imported to compile.
+3. **Acceptance:** a user package with its own `sub Str` — calls type as
+   the sub's return, not a constraint; existing bareword-isa tests still
+   green; substrate audit at parity-or-better.
+
+### Phase C — imported names in bareword completion
+
+Bareword/function completion candidates fold in
+`analysis.imports[].imported_symbols` (goto-def and diagnostics already
+consult them; completion does not). **Route through the CandidateSet's
+completion sources (`complete()`), not a handler-side append.** Flip the
+`completion-typetiny-imported-blessed` xfail row to gold, and add an
+`exact_labels`/`max_items` noise-guard row alongside — see the Scaling
+beat.
+
+### Phase D — doc hygiene
+
+Fix the stale pointer in `frameworks/type-tiny.rhai` →
+`docs/adr/type-constraints.md` (+ this epic). Note: touching the rhai
+changes the plugin fingerprint, so caches self-invalidate — expected and
+harmless, but say it in the PR so nobody debugs it.
+
+## Non-goals
+
+- `ArrayRef[T]` / `HashRef[T]` ELEMENT typing — parked with
+  sequence-types (`prompt-sequence-types.md`, QA pulls).
+- House Type::Library generators (runtime `setup_import_methods`) — the
+  runtime-export-generator open problem. The BYO `SyntheticUse` plugin
+  story is the supported answer. **Do not attempt static execution.**
+- Coercions (`to_X`, `coerce => …`) — recognized as exports for
+  suppression only; no semantic modeling.
+- `Enum[…]`/`Dict[…]`/`Tuple[…]` beyond what already folds — each is its
+  own design conversation; decline cleanly (the fold already returns
+  unit for unhandled shapes).
+
+## Language-pack beat
+
+**Perl-only in its vocabulary; cross-language in the seam it extends —
+and the second half is the part to protect.**
+
+`recognize_guards` / `GuardFact` / `NarrowOp` are the narrowing lattice,
+and the lattice is explicitly cross-language. From the cpp arc's own
+record (`cpp-golive-map.md`, ARC 2 E): *"a narrowing is a SCOPED
+ASSERTION over a region, not a temporal value — must be explicitly
+region-bounded… cutoff is the shared `earliest_rebind_in`, edge-driven,
+consumed by Perl AND the query engine (cross-language)."* C++ narrowing
+rides the same machinery; `instanceof`-shaped narrowing in any pack
+language would too.
+
+Obligations:
+
+1. **The new recognizer arm is a Perl-syntax arm producing a
+   language-neutral `GuardFact`.** That split must stay clean: the
+   function-call shape recognition is Perl's; the `GuardFact` it
+   produces is the lattice's. If the arm needs to add a field to
+   `GuardFact` or `NarrowOp`, that field is now cross-language — check
+   `cargo test --features cpp` and the cpp gold rows, because a
+   lattice change that breaks C++ narrowing is invisible to every Perl
+   test.
+2. **Region-boundedness is not optional.** Phase A step 4 narrows "the
+   rest of the block" after an `assert_X`. That must go through the
+   existing region machinery and the shared `earliest_rebind_in`
+   cutoff — a hand-rolled "until the end of the block" is exactly the
+   temporal-value mistake the cpp arc already made and fixed.
+3. **A future pack language gets check-guards for free if the manifest
+   is the only Perl-specific part.** `type_check_guards()` is a `.rhai`
+   plugin hook, and pack languages have no rhai tier — so the baked map
+   on the FA should be populated by *whoever knows*, with the manifest
+   as one producer. Do not gate the recognizer on "a plugin declared
+   this"; gate it on "the baked map contains this name". That one word
+   is the difference between a reusable seam and a Perl seam.
+4. Type::Tiny's vocabulary itself does not generalize, and should not
+   try to. `is_ArrayRef` is a Perl library's function name.
+
+## Scaling beat
+
+**Two costs: a per-condition map lookup in the walk, and a completion
+list that grows.**
+
+1. **Phase A adds a lookup to every function-call condition the walk
+   sees.** That is a hot path — `recognize_guards` runs per condition
+   per file. The baked map must be a fast lookup (interned or
+   hash-by-`&str`), baked once per file, not rebuilt per condition.
+   Check `--timings` on the substrate: the slowest-modules tail must not
+   move beyond noise. Use `bphase!` if you need per-file attribution —
+   it routes to `ghost_stats::timed` and accumulates, which is the right
+   shape for a per-file region; **a printed line per entry is not**
+   (`adr/instrument-blindness.md`).
+2. **Phase A's payoff is a scaling win, not just a correctness one.**
+   More narrowing means fewer `Optional`/unknown beliefs, which means
+   fewer speculative chases downstream. Report the guard-lint deltas and
+   note any change in the conclusion bake's open-reason distribution —
+   better narrowing should move keys out of `NoAnswerOpaque`.
+3. **Phase C is the risky one.** It folds every imported symbol into
+   bareword completion. `Types::Standard -all` alone is a large export
+   list, and a file importing several libraries has hundreds. Completion
+   payload is a measured, previously-regressed axis: 7.29 MB / 236 ms
+   per keystroke at 138k files, fixed to 55.9 KB / 4 ms (`b6312ea2`,
+   2026-08-17).
+   - Ship the `exact_labels`/`max_items` noise-guard row.
+   - **If the candidate flood is bad, complete only on ≥1 typed
+     character with a prefix match, and record the policy** — this is
+     exactly what the C++ side does for macros and cross-file
+     identifiers (prefix-gated server-side, `is_incomplete: true` so
+     clients re-request per keystroke). Reuse that pattern rather than
+     inventing one.
+   - Measure the payload bytes with `bench/lsp_bench.py`, three runs,
+     dated.
+4. **Phase B should make things cheaper**, not more expensive: an
+   import-scoped gate rejects more names earlier. Confirm it does, and
+   report the substrate delta.
+
+## Verification gate
+
+`cargo test` (both feature sets — the lattice is shared) · gold 0 FAIL /
+0 XPASS with the Phase-C promotion · `./e2e/run.sh` · substrate audit
+with Phase A/B deltas individually triaged and always-on parity ·
+`--timings` tail unmoved · completion payload bytes for Phase C, three
+runs, dated.
+
+## Sizing
+
+Small-to-medium. A is the core (recognizer + manifest); B is a contained
+gate change with a measurement step; C/D are small. One PR for A+B, one
+for C+D works.

--- a/docs/epics/13-pack-language-ceiling.md
+++ b/docs/epics/13-pack-language-ceiling.md
@@ -101,11 +101,22 @@ Gated on Phase A. The rule is the one already in force:
    swept over the substrate → per-site triage → default-on at a stated
    severity. The C++ `use-after-move` channel is already registered and
    off by default; it is the template and the first candidate.
+3. **Calibration is one gate; the facts are another.** Several pack
+   codes are not blocked on a substrate at all — they are blocked on
+   analysis that does not exist. `adr/narrowing-diagnostics.md` records
+   that **"D1/D2/D3/D4/D6 have no cpp facts"** and that nothing records
+   cpp guard sites for redundancy; `adr/use-after-move.md` ships a
+   decidable subset explicitly *because* there is no CFG. That tier is
+   **Epic 16**, and its motivating consumer is C++. So when a code fails
+   to promote, say which gate it is waiting on — a substrate, an
+   openness fact (Epic 3), or the path-sensitivity facts (Epic 16).
+   Three different answers with three different owners.
 3. The sweep is over the Phase-A substrate, and the number goes in the
    PR. A code with unexplained hits does not promote — it gets its
    noise class written into `gold-corpus/KNOWN-GAPS.md`.
 4. **Acceptance per code:** the sweep count, the triage, the ladder
-   position recorded in the language's status doc.
+   position recorded in the language's status doc, and — for anything
+   still off — the named gate it waits on.
 
 ### Phase C — the framework tier (the open design round)
 

--- a/docs/epics/13-pack-language-ceiling.md
+++ b/docs/epics/13-pack-language-ceiling.md
@@ -1,0 +1,257 @@
+# Epic 13 — The pack-language ceiling: calibration, diagnostics, framework tier
+
+> **Status:** scheduled (13th) but **pullable to first at any time** —
+> it is the epic that turns a pack language from "parses and answers"
+> into a product.
+> **Design owner-doc:** `docs/prompt-multi-language.md` §"What pack
+> languages still don't get" and §"Calibration is the ship gate".
+> **Reference implementation:** `docs/cpp-golive-map.md` is the record
+> of doing this once, for C/C++. Read its arc structure before planning
+> phases; it is the only evidence anyone has about how long this takes.
+
+## Mission
+
+Pack languages (C/C++, Python, R, CMake) ship behind opt-in Cargo
+features with a `PackDriver` constructor, a `.scm` skeleton and
+predicates — no new Rust types per language. That machinery is landed
+and works. What they do **not** get is the ceiling:
+
+1. **A calibration substrate** — the gold-corpus sibling. This is the
+   ship gate, not a nice-to-have, and `prompt-multi-language.md`
+   budgets it as **half the work**.
+2. **Diagnostics** — deliberately NONE for pack languages until (1)
+   exists, because a diagnostic without a zero-false-positive sweep is
+   a product liability.
+3. **A framework tier** — keying plugin hooks on capture events the way
+   rhai hooks key on `CallContext` today. This is the named open design
+   round.
+
+Maturity is the scoreboard: `Maturity::{Stable, Beta, Alpha}` in
+`build/language_driver.rs`, reported by `--languages`. Beta means
+*"broad gold coverage, known gaps documented"* — which is precisely
+(1). **This epic is how a language earns its next tier.**
+
+## Read first
+
+1. `docs/prompt-multi-language.md` — whole.
+2. `docs/cpp-golive-map.md` — the arc record: what was done, in what
+   order, and what the review waves caught. Note especially the
+   dogfood → hitlist → fix → promote cycle; it is the method, not an
+   anecdote.
+3. `gold-corpus/README.md` — the harness. **`run.pl` is
+   language-agnostic; it shells the binary.** The fixture format is
+   reused verbatim. This is the single biggest reason calibration is
+   tractable.
+4. `docs/cpp-status.md` — what an honest per-language status page looks
+   like, including the scaling caveat it refuses to hide.
+5. `src/build/language_driver.rs` — `Maturity`, `LanguageDriver`,
+   `PackDriver`, `LanguageRegistry`, `dependency_roots`, the capability
+   surface, and `PackDriver::analyze_with_path`'s eight named phases.
+6. `docs/adr/cursor-context-completion.md` — **the completion half is
+   further along than `prompt-multi-language.md` says.** The two-half
+   pack completion (in-scope symbols + sentinel-reparse member access +
+   the trigger-char gate) is landed, and `lsp/cursor_slot.rs` gives one
+   `Slot` vocabulary over both `cursor_context` (Perl) and
+   `cursor_sentinel` (pack). Update the stale doc as part of Phase A.
+
+## Phase breakdown
+
+### Phase A — the calibration substrate (the ship gate)
+
+This is the phase. Everything else is gated on it.
+
+1. **A pinned substrate**, per language, snapshot-pinned the way
+   `gold-corpus/local/` is for Perl — a package-manager-materialized
+   tree at a recorded snapshot (CRAN via `renv` for R, top-N by
+   downloads for each language's registry). Pinned, because a moving
+   substrate turns every regression into an archaeology exercise.
+   The recipe goes in the `dev-setup` skill, not in the repo.
+2. **Fixture rows in the existing format.** `run.pl` already shells the
+   binary and is language-agnostic; C/C++ proved it with 255 rows. The
+   statuses are unchanged: `gold` (must hold), `xfail` (known gap →
+   XPASS when fixed, promote the row), `provisional` (reported, never
+   fails). A crash is always a hard fail.
+3. **`lang-skip 0` is the acceptance criterion, and it is easy to
+   miss.** A build without the language's feature lang-skips its rows
+   and reports them as *skips, not failures* — CLAUDE.md warns that a
+   plain release build silently leaves half the corpus unexercised.
+   Every gate in this epic checks the `lang-skip` line.
+4. **The dogfood loop is how rows get authored.** The `dogfood-loop`
+   skill owns the protocol: task-driven probe agents against real
+   projects, findings become RED xfail rows *before* the fix, promote
+   on green. `docs/hitlist-*.md` files are its working product.
+5. **Corpus entries for the real-project axis too.** Gold asserts
+   answers; `corpus/` measures behaviour at scale. Add the language's
+   projects to `corpus/bootstrap.sh` so `edit-bench` can measure them.
+6. **Acceptance:** the language's row count and pass/xfail split
+   reported in its status doc; `lang-skip 0`; the substrate recipe
+   reproducible on a fresh box per `dev-setup`.
+
+### Phase B — diagnostics, promoted one code at a time
+
+Gated on Phase A. The rule is the one already in force:
+**zero-false-positive sweep before a diagnostic exists.**
+
+1. The registry from Epic 7 carries per-language applicability and
+   per-language severity defaults — **this epic is the reason those
+   fields exist.** If Epic 7 has not landed, either land its Phase A
+   first or accept that this phase rebuilds it.
+2. Each code promotes on its own evidence, exactly like the Perl
+   ladder in `adr/narrowing-diagnostics.md`: registered → default-off →
+   swept over the substrate → per-site triage → default-on at a stated
+   severity. The C++ `use-after-move` channel is already registered and
+   off by default; it is the template and the first candidate.
+3. The sweep is over the Phase-A substrate, and the number goes in the
+   PR. A code with unexplained hits does not promote — it gets its
+   noise class written into `gold-corpus/KNOWN-GAPS.md`.
+4. **Acceptance per code:** the sweep count, the triage, the ladder
+   position recorded in the language's status doc.
+
+### Phase C — the framework tier (the open design round)
+
+**Read `prompt-multi-language.md`'s framing before designing:** the
+question is keying plugin hooks on CAPTURE EVENTS the way rhai hooks
+key on `CallContext`. The tenants are real (tidyverse for R, CMake
+module conventions) and they are what makes a pack language feel
+*known* rather than merely parsed.
+
+Design constraints, from the existing system:
+
+- **Every pack predicate already written is trivially rhai**
+  (`ctor_class`, `module_paths`, `cmd_effects`, `annot_type`,
+  `shape_ctor`, `import_call`), and the rhai host with fingerprinted
+  cache invalidation already ships. The distance is smaller than it
+  looks.
+- **`EmitAction` is the shared vocabulary** and must stay shared. A
+  framework tier that mints a second action vocabulary for pack
+  languages is the fork this whole architecture exists to avoid.
+- **Walk-phase patterns run as ONE query.** Perl's plugin patterns are
+  concatenated into a single tree-sitter `Query` with `pattern_index`
+  routing matches back to owners, because a `QueryCursor::matches` call
+  is a full tree traversal. A pack framework tier must inherit that
+  discipline from day one — one query per overlay walked every file
+  once per overlay is the regression. `PERL_LSP_PD_NO_COMBINE=1` and
+  `PERL_LSP_PD_EQUIV=1` are the existing escape hatch and A/B control;
+  the pack tier should have the equivalents.
+- **A malformed overlay must not take the tier down.** Perl's rule: a
+  spec whose query fails to compile is dropped *before* the
+  concatenation. Same here.
+
+**Sequencing advice:** a declarative overlay (patterns in the standard
+capture vocabulary, no callbacks) covers more tenants than it looks
+like it will, and it needs no engine at query time. Build that first,
+find the tenant it genuinely cannot serve, and let that tenant justify
+the imperative hook. Epic 9's PR is asked to record which of its Mojo
+phases could have been a pure pattern match — that list is this phase's
+requirements document.
+
+**Acceptance:** one real framework served end-to-end for one pack
+language, with gold rows, and the engine carrying none of that
+framework's names.
+
+### Phase D — status pages and the maturity bump
+
+Each language gets a `docs/<lang>-status.md` in the shape of
+`cpp-status.md`: the tier and why it meets the bar, what works, the
+measured limits with dates, what would lift each caveat. **Then bump
+`Maturity` in the driver** — the tier is a promise about whether to
+trust the answers, and it is not allowed to run ahead of the evidence.
+
+## Non-goals
+
+- **The `lsp-engine` crate cut.** Parked by `prompt-multi-language.md`'s
+  own text: it does not start before a second pack language's ceiling
+  work forces the split's cost to pay for itself. That is *this epic* —
+  so the crate cut is the epic AFTER this one, and only if this one
+  shows the seam hurting. The `workspace-split` branch is the
+  mechanical playbook; a crate split was already executed once and
+  REJECTED, with layering tests enforcing the DAG instead.
+- Runtime-loadable packs (`{grammar, skeleton.scm, predicates.rhai,
+  pack.toml}` installable like `.perl-lsp/` plugins). Compiled-in
+  first; dynamic loading is the step after.
+- Rewriting `symbols.rs`' verb/intelligence split. That disentanglement
+  is named as the biggest single line item of the crate cut, and it
+  belongs with it.
+
+## Language-pack beat
+
+This epic **is** the language-pack beat, so the section inverts: what
+does it owe **Perl**?
+
+1. **Nothing may regress for Perl, and Perl is the harder constraint.**
+   Perl is `Stable`; it has the largest gold corpus and the only
+   substrate audit. Every seam this epic generalizes must leave the
+   Perl path byte-identical. The substrate audit at exact parity is the
+   proof.
+2. **Generalizing a seam is allowed to make Perl's spelling of it
+   simpler, and that is the win to look for.** Every pack seam that
+   generalizes shrinks `prompt-unify-language-paths.md`'s parked
+   cleanup — it is parked precisely because it has no user-visible
+   product, and it gets cheaper each time this epic touches something.
+   Re-read that doc at the end of this epic and record how much is
+   left.
+3. **Do not "generalize" by moving a Perl rule into a shared layer.**
+   `model/builtins.rs` is Perl-driver-scoped on purpose; pack languages
+   never consult it. `model/conventions.rs` likewise. The layering
+   tests catch a file in the wrong *layer*; nothing catches a Perl
+   *semantic* in a shared function. That is a review obligation.
+
+## Scaling beat
+
+**Calibration and scale are the same gate wearing two hats, and
+`cpp-status.md` is the cautionary tale: C/C++ meets the correctness bar
+for beta and explicitly does not promise scaling.**
+
+1. **A language does not reach Beta on gold rows alone.** The maturity
+   enum's bar is about answers, so gold coverage is what it asks for —
+   but the status doc must carry the measured scaling envelope beside
+   it, dated, the way `cpp-status.md` does. A tier claim with no
+   measurement behind it is the thing that gets discovered by a user.
+2. **Phase A's corpus entries are the instrument.** `corpus/` is a
+   SEPARATE axis from gold: gold asserts answers, corpora measure wall,
+   RSS, and the pathologies no fixture reproduces. **Every scaling limit
+   in `docs/scaling-limits.md` came from them, and none reproduced on
+   synthetic input.** A pack language with gold rows and no corpus entry
+   has a correctness story and no idea what it costs.
+3. **Measure with the protocol, not with a stopwatch.** `edit-bench`
+   owns it. Three runs minimum; stamp the date. Land rows in the JSONL
+   store via `bench/measure.sh` and the editor surface via
+   `bench/lsp_bench.py` / `bench/editor-baseline.sh` (quiet box only —
+   run lines record loadavg).
+4. **Watch the two known pack-side residency hazards specifically:**
+   - `PackBagCache` — the 13.9 GB P0 came from a denormalized byte
+     counter plus a lock-free map collapsing the LRU to one entry.
+     Re-soak it; `prompt-scale-validation-hitlist.md` lists that re-soak
+     as **OWED**.
+   - Warm stubs — the pack warm scan registers from the `stubs` table
+     rather than decoding full blobs, with declared fallback lanes. A
+     new pack lane that is not in the stub is a silent full-decode per
+     file on warm start.
+5. **The residency tripwire is not optional for a new pack language.**
+   A post-bulk-index count of fully-resident pack copies against the
+   deliberate whole-copy sites errors on unexplained pins — functional
+   tests cannot see a RAM regression, and this can.
+6. **Phase B's diagnostics run on `--check`**, the batch verb that is
+   already the constrained one. A new language's diagnostics multiply
+   the sweep. Report `--check` wall and peak RSS on that language's
+   corpus entry, three runs, dated.
+7. **Phase C's framework tier adds query work per file.** The
+   one-combined-query discipline above is the scaling requirement, not
+   a style preference: it is the difference between one traversal per
+   file and one per overlay.
+
+## Verification gate
+
+`cargo test` for every feature combination the change touches · gold
+built with the language's feature, **`lang-skip 0` confirmed in the
+summary**, 0 FAIL / 0 XPASS · the pack e2e lane · Perl substrate audit
+at **exact parity** (this epic must be invisible to Perl) · the corpus
+measurements above, three runs, dated · `docs/<lang>-status.md` current,
+with the `Maturity` value it justifies.
+
+## Sizing
+
+Large, and honestly so — `prompt-multi-language.md` budgets calibration
+alone as half the work, and the C/C++ arc is the evidence for that
+estimate. A is the gate and the bulk; B is incremental and shippable per
+code; C is a design round followed by a build; D is a day.

--- a/docs/epics/14-per-file-stall.md
+++ b/docs/epics/14-per-file-stall.md
@@ -1,0 +1,282 @@
+# Epic 14 — The per-file stall: C/C++ beta → GA
+
+> **Status:** scheduled (14th) but **high priority by impact** — this is
+> the one place the product is measurably unusable rather than merely
+> incomplete.
+> **Design owner-docs:** `docs/cpp-status.md` §"The scaling limit:
+> measured" and §"What would lift the scaling caveat",
+> `docs/prompt-macro-salvage-scaling.md` (the ranked fixes),
+> `docs/prompt-vendored-dirs.md` (the role-remap lever).
+
+## Mission
+
+`cpp-status.md` states the gate plainly:
+
+> **What beta does not promise is scaling.** … yes for small-to-medium
+> projects, not yet at Godot's size. A performance limit, not a
+> correctness one.
+
+And it names the next step, unambiguously:
+
+> The per-file stall, specifically — an aggregate number will not settle
+> it. The gate is a large generated header (`d3d12.h`,
+> `vulkan_handles.hpp`) analysed in interactive time, **and no
+> measurement of total wall across a corpus substitutes for that. Nobody
+> has profiled where those 30–66 seconds go; that is the next step and
+> it has not been taken.**
+
+This epic takes that step, then fixes what it finds.
+
+## The measurement, as it stands (dated — re-take before trusting)
+
+From `cpp-status.md`:
+
+| project | C++ files | result |
+|---|---:|---|
+| fmt | 80 indexed | 4.2 s, 0.50 GB — fine |
+| Godot | 7,041 | **did not complete in 4 minutes**; killed |
+
+Godot's **memory behaviour is good** — RSS plateaus flat at ~2 GB across
+7,041 files, better per-file than the Perl side manages. The problem is
+wall time, concentrated in individual files:
+
+```
+[stall] 66s  thirdparty/vulkan/include/vulkan/vulkan_handles.hpp
+[stall] 34s  thirdparty/vulkan/include/vulkan/vulkan_raii.hpp
+[stall] 32s  thirdparty/directx_headers/include/directx/d3d12.h
+[stall] 31s  thirdparty/ufbx/ufbx.c
+```
+
+**Every stall is a large generated or vendored header.** `d3d12.h` alone
+is 1.5 MB. A per-file cost of 30–66 seconds is unusable interactively no
+matter what the aggregate looks like.
+
+Note the failure mode is the **opposite** of the Perl side's: C++ is
+memory-healthy and wall-pathological; Perl's FHEM shape is
+memory-pathological. They share no mechanism.
+
+## Read first
+
+1. `docs/cpp-status.md` — whole; it is short and it is the charter.
+2. `docs/prompt-macro-salvage-scaling.md` — the machinery, the two
+   sibling defects, and the **ranked** fixes with a recommended order.
+   The ranking is not advisory; it was reasoned about and endorsed.
+3. `docs/prompt-vendored-dirs.md` — the role-remap design, its two
+   levers, and the survey evidence behind them.
+4. `docs/adr/macro-handling.md`, `docs/adr/reparse-stratification.md`,
+   `docs/adr/cpp-templates.md` — the landed machinery this profiles.
+5. `docs/adr/instrument-blindness.md` — **before you add a single
+   timer.** The instrument distorting the measurement is a mistake this
+   project has already made and paid for.
+
+## Phase breakdown
+
+### Phase A — profile the stall (no fixes)
+
+**Ship nothing but a number.** The owner doc is explicit that nobody has
+attributed these seconds, and every fix below is a guess until someone
+does.
+
+1. Reduce to a repro: one file, one open, wall-clocked. `d3d12.h` and
+   `vulkan_handles.hpp` are the named specimens; put them in the C++
+   corpus tree (`~/personal/cpp-bench` is where the C/C++ scale work
+   lives) so the repro is reproducible on another box.
+2. Attribute with the existing instrumentation, not new `eprintln!`s:
+   - `PERL_LSP_PHASE_TIMING` + `timings::phase` / `tphase!` for the
+     named phases. `PackDriver::analyze_with_path`'s pipeline is **eight
+     named phases** (gather context → transform+parse → extract → remap
+     spans → enrich skeleton → `into_file_analysis` → `emit_return_fuel`
+     → register post-build hooks) — the attribution should land on one
+     of them before it lands anywhere finer.
+   - `bphase!` → `ghost_stats::timed` for per-file regions, and
+     `ghost_stats::count_by` for per-file quantities. **A printed line
+     per entry only suits a region entered once per run**; a per-file
+     region printed per entry cost one run 3.2M lines and 43 minutes and
+     measured a run that no longer resembled the one being measured.
+   - `PERL_LSP_GHOST_JSON[_DIR]`, `PERL_LSP_TIMINGS_JSON[_DIR]`,
+     `PERL_LSP_HEAP_JSON[_DIR]` for the machine-readable sinks; the
+     `_DIR` variants write one file per process.
+3. **Hypotheses to discriminate between**, in the order the docs make
+   likely — but let the profile decide, not this list:
+   - **Macro-expansion salvage bisection.** The prime suspect. Per
+     `prompt-macro-salvage-scaling.md`, the salvage machinery does
+     *blind* bisection over macro names, each probe a fresh full parse
+     of a 16k-line file. On a 1.5 MB generated header the arithmetic is
+     brutal and the doc already documents the shape on `op.c`.
+   - **Reparse stratification / splice mapping** over a file with tens
+     of thousands of expansion sites.
+   - **Template extraction** — `vulkan_raii.hpp` and
+     `vulkan_handles.hpp` are template-dense; the spec-selection ladder
+     and `substitute_type_params` run per instantiation.
+   - **Query extraction itself** — one combined query over a 1.5 MB
+     tree, or a pathological pattern.
+4. **Acceptance:** a written attribution — "N of the 66 seconds are in
+   phase X" — in the PR and in `cpp-status.md`. Three runs, dated. **No
+   code fix in this phase.** If the profile contradicts the ranked fixes
+   below, the ranking loses and the profile wins.
+
+### Phase B — macro-salvage fixes, in the doc's recommended order
+
+Only the ones the profile justifies.
+
+1. **#2 — per-name expansion-verdict cache** (the doc's recommended
+   first move: smallest diff, biggest payoff, user-endorsed). A macro
+   name's expansion safety is *stable*: classify each name once as
+   `{clean-expand | blank | drop}` and persist the verdict keyed by
+   header-set/toolchain — **it rides the SQLite blob machinery
+   already.** `pTHX_` gets classified blankable on first open and is
+   never bisected again, so the probe budget goes only to genuinely
+   ambiguous names.
+2. **#1 — damage localization instead of blind bisection** (the
+   principled follow-up, and the one that also covers
+   position-dependent names). The first full-expansion parse already
+   surfaces the ERROR node's byte range; map it back through the splice
+   map to the covering macro-name group → the culprit is known in O(1),
+   no search. Turns O(names) blind probes into O(bad-groups) targeted
+   ones.
+3. **#3 — incremental reparse per probe** (the general lever, most
+   invasive). tree-sitter can reparse just the edited subtree given the
+   prior tree; this attacks cost-per-probe rather than probe-count, and
+   the doc estimates the budget could rise 10–100× nearly free. Levers
+   #3/#4 are for "if #1 and #2 prove insufficient" — #4
+   (`is_context_free_safe`) has already landed.
+4. **Acceptance per fix:** the specimen file's wall, three runs, dated,
+   before and after; plus the C/C++ gold suite unmoved. A salvage
+   change that speeds up the file and loses symbols is a regression —
+   assert the symbol count too.
+
+### Phase C — the interactive escape hatch
+
+Even a fixed salvage path will meet a file that is genuinely too big.
+The server must degrade, not stall.
+
+1. A per-file analysis budget with a declared degradation: past the
+   budget, fall back to the cheapest honest analysis (skeleton
+   extraction with macros blanked rather than salvaged) and **mark the
+   analysis degraded** — the `degraded` flag already exists on
+   `FileAnalysis` (it is `serde(skip)`, which is why the enrichment
+   overlay clones rather than round-trips: a round-trip silently reset
+   it and an enriched copy of a degraded analysis claimed to be whole).
+2. Degradation must be **visible**: the status/`--languages` surface or
+   a diagnostic should be able to say "this file was analysed in
+   degraded mode", so a user with a mysteriously incomplete answer can
+   find out why. A silent budget is worse than a slow file.
+3. The existing precedents to follow rather than reinvent: the 1 MB cap
+   (`scaling-limits.md` §6 — note "why the same file measures 0.39 s or
+   29 s"), the depth gate and queued descent from the P0 stack-overflow
+   fix, and `util/watchdog.rs`.
+4. **Acceptance:** the specimen file opens in interactive time
+   (single-digit seconds) or degrades visibly; a test pinning that a
+   degraded analysis is never cached as whole.
+
+### Phase D — the vendored-dirs lever
+
+The workaround `cpp-status.md` documents today is *"excluding
+`thirdparty/` from the workspace avoids most of it, since that is where
+the giant headers live in every project we measured."* Make that a
+supported, discoverable feature rather than folklore.
+
+Implement `prompt-vendored-dirs.md`'s design as written — it is
+survey-backed and the decisions are made:
+
+1. **Vendored = the DEPENDENCY role, in-tree.** A remap to the existing
+   `RoleMask` DEPENDENCY tier, **not a new flag consumers check.**
+   Everything follows from the role: no sweep/`--check` diagnostics, no
+   dead-export queue entries, demoted workspace-symbol ranking — while
+   goto-def INTO the vendor keeps working. This is rust-analyzer's shape
+   exactly.
+2. **Two levers, not one:** `vendor` (analysed, navigable, silent) and
+   `exclude` (not indexed at all — for build OUTPUT like `blib/`, which
+   is a copy of `lib/` and mints duplicate definitions if indexed).
+3. **Rename across the role boundary REFUSES, loudly.** A partial edit
+   set breaks builds invisibly; a vendored fork can call workspace code.
+4. **Dead-export asymmetry:** vendor stops PRODUCING dead-code entries
+   but keeps COUNTING as a referencer.
+5. **Detection is layered and PRINTABLE.** Convention defaults on by
+   default, enumerable via a dump verb, overridable; precedence user >
+   inner project > outer. golangci-lint deleted its invisible built-in
+   list as a support burden — that is the lesson.
+6. **Acceptance:** Godot indexes with `thirdparty/` auto-detected as
+   vendor; goto-def into it still works; `--check` is silent on it;
+   the dump verb prints why each directory was classified.
+
+### Phase E — re-measure and re-tier
+
+Re-run the Godot measurement. Update `cpp-status.md` — the table, the
+stall list, the "what would lift the caveat" section, **all with
+dates.** If the gate is met, bump `Maturity` and say what the new tier
+promises.
+
+## Non-goals
+
+- Rewriting the macro model. `adr/macro-handling.md` and the
+  config-variant model are landed and correct; this is a cost problem.
+- Chasing aggregate corpus wall. The owner doc explicitly rejects it as
+  a substitute for the per-file number.
+- The parked template residue (deduction/dependent-type rungs,
+  template-template params, `extern template` ERROR parse) — correctness
+  work on its own brief.
+
+## Language-pack beat
+
+C/C++-specific by subject; **cross-language in three of its four
+mechanisms**, and each should be built to be inherited:
+
+1. **The per-file budget + degraded fallback (Phase C) is engine-level.**
+   Any language can meet a pathological file — Perl already has the 1 MB
+   cap and the depth gate. Build one budget mechanism with a
+   per-language policy, not a C++ one.
+2. **Vendored-dirs (Phase D) is explicitly cross-language.** The
+   convention defaults `prompt-vendored-dirs.md` lists are Perl's
+   (`cpan-lib`, `local/lib/perl5`, `extlib/`, `inc/`) plus linguist's
+   generic regexes — the design was written from the Perl side and C++'s
+   `thirdparty/` is the same shape. `scaling-limits.md` §2 ("Vendored
+   dependency piles — MISLEADING, not slow") is the Perl-side evidence.
+   **One implementation, per-language default lists**, and the dump verb
+   prints all of them.
+3. **The profiling method (Phase A) is the reusable product.** If
+   attributing a pack language's per-file cost requires ad-hoc work,
+   the next language pays it again. Whatever phase instrumentation
+   Phase A needs, land it in `util/timings.rs` and
+   `PackDriver::analyze_with_path`'s named phases so every pack language
+   inherits the attribution.
+4. Only the macro-salvage fixes (Phase B) are genuinely C-family. Keep
+   them there.
+
+## Scaling beat
+
+This epic **is** a scaling beat, so the section states the discipline
+instead:
+
+1. **Per-file, not aggregate.** The gate is one large generated header
+   analysed in interactive time. Report the specimen's wall, not the
+   corpus's.
+2. **Three runs, dated, every number.** `cpp-status.md`'s existing
+   numbers are dated; keep it that way. A number without a date rots
+   silently — abseil's warm RSS sat recorded at 34 MB and 47 MB in two
+   ADRs, both ~2× low seven weeks later.
+3. **Watch RSS while fixing wall.** Godot's memory behaviour is
+   currently *good* (~2 GB flat across 7,041 files, better per-file than
+   Perl manages). A verdict cache (Phase B #1) and an incremental-reparse
+   lane (#3) both hold state. Report peak RSS beside every wall number
+   so a wall win that costs 4 GB is visible immediately.
+4. **The C++ scale tree is its own** — `~/personal/cpp-bench`, with
+   abseil at `~/personal/cpp-bench/abseil-cpp`. Godot goes there too.
+   `$PERL_CORPORA` is the Perl root and stays separate.
+5. **Do not let a long measurement run inside an agent worktree** —
+   unchanged agent worktrees get swept mid-run. Detach long measurement
+   work outside them.
+
+## Verification gate
+
+`cargo test --features cpp` · gold built `--features cpp` with
+**`lang-skip 0`**, 0 FAIL / 0 XPASS · the pack e2e lane · Perl substrate
+audit at exact parity (Phases C and D touch shared machinery) ·
+**the specimen-file wall + peak RSS, three runs, dated, in the PR and in
+`cpp-status.md`** · the Godot run, or an explicit statement of what
+still blocks it.
+
+## Sizing
+
+Medium — but front-loaded with genuine unknowns. Phase A may take as
+long as B and is the only phase that cannot be skipped or reordered.

--- a/docs/epics/15-query-paths-at-scale.md
+++ b/docs/epics/15-query-paths-at-scale.md
@@ -1,0 +1,283 @@
+# Epic 15 — Query paths at scale: the Tier 1 residual
+
+> **Status:** scheduled (15th) but **high priority by impact** — with
+> Epic 14 it is one of the two places the product is unusable rather
+> than incomplete, and it is the one that bounds the stated target
+> market.
+> **Design owner-docs:** `docs/prompt-scale-validation-hitlist.md`
+> (the status board is the worklist; every row has a detail section),
+> `docs/scaling-limits.md` (the two measured pathologies),
+> `docs/adr/skipping-cross-file-work.md` (**read before proposing to do
+> less cross-file work — seven proposals were measured and rejected**).
+
+## Mission
+
+The 122× validation pass reached a clear verdict, and it is two
+sentences:
+
+> **Storage and startup hold.** Warm ready is scale-free, post-ready RSS
+> is flat, the bulk walk is near-linear, and per-file db cost *fell* at
+> 39× the corpus. …
+> **Query paths break**, each for its own reason, and the CLI's one-shot
+> "act like the LSP just started" semantics are O(corpus) in time and
+> RAM.
+
+Storage is done. This epic is the other half.
+
+## The board, as of the last measurement (2026-08-17)
+
+| metric | crm (1,136) | Koha (3,554) | CPAN-5k (138,822) |
+|---|---|---|---|
+| LSP warm ready | 0.81 s | 1.58 s | **1.06 s** |
+| post-ready RSS (warm) | ~297 MB | 170 MB | **255 MB** |
+| open (warm) | — | 1.6 ms | 0.9 ms |
+| hover/def (warm) | — | 0.2 ms | 402 ms |
+| completion (warm) | — | 7 ms / 24 KB | 188 ms / 55.9 KB *(after `b6312ea2`)* |
+| references, hot name | ~15 ms | 5.6 s | **265–368 s**, 2.8 GB peak, marked incomplete |
+| diagnostics after edit | — | 330 ms | **never (60 s)** |
+| CLI one-shot (warm) | 1.33 s | 1.90 s | **350 s** *(after PR #125; was DNF at 42:32 / 7.11 GB)* |
+
+**Re-take every one of these before acting on it.** They are dated, the
+tree has moved, and a number without a fresh date is a hypothesis.
+
+## Read first
+
+1. `docs/prompt-scale-validation-hitlist.md` — the status board, then
+   the detail section for whichever row you are taking.
+2. `docs/scaling-limits.md` — §1 (FHEM `package main` monoculture) and
+   §4 (memory and fan-out are independent axes) in particular.
+3. `docs/adr/skipping-cross-file-work.md` — **seven proposals to do less
+   cross-file work were each measured and rejected.** Do not re-open
+   without reading it. The one that worked (the resident-copy export
+   gate) took the cross-file provider chase from 1,541 ms to 241 ms.
+4. `docs/adr/relational-ref-index.md` — the row store that made
+   `references` return at all.
+5. `docs/adr/conclusion-layer.md` and `model/witnesses/closedness.rs` —
+   the persisted bake and the closedness certificate; both exist to
+   avoid decodes, and both are levers here.
+6. `docs/prompt-storage-residuals.md` — the known unbounded residuals,
+   deliberately listed.
+7. `bench/MEASURE.md` and the `edit-bench` skill — the protocol.
+
+## Phase breakdown
+
+### Phase A — `references` at scale (Tier 1 #3, the headline)
+
+**Status: RETURNS, honestly, and slowly.** It used to never return, at
+7+ GB; `32a3bf4e` and `b6312ea2` made it finite. At 138k files it is
+265–368 s at 2.8 GB peak and marks the answer incomplete. Slow, honest,
+and bounded — not yet fast.
+
+1. **Profile first.** The hitlist lists "profile the 150 s of refs CPU"
+   as IN PROGRESS; finish it and publish the attribution before
+   optimizing. The candidate costs are known in shape:
+   - the backward-walk matcher rehydrating per candidate file,
+   - the `matcher_view` upgrade to a whole copy when a name-matching
+     ref's verdict is not baked (`Ref::match_verdict_baked` — unstamped
+     MethodCall, unowned hash key),
+   - the candidate set itself (`ref_candidate_files` = refs UNION syms).
+2. **The row store is the pre-prune and it is already sound.** `refs`
+   rows are `(name_id, file_id)` pairs, `WITHOUT ROWID` so the table IS
+   the name index, with **deliberately no occurrence `count` column** —
+   a row count is a CANDIDATE count, and that over-approximation is what
+   makes `unused_exported_syms` sound. Any speedup that adds a count
+   column breaks that. Use `PERL_LSP_REF_ROWS=0` and
+   `--refs-parity <root> [--sample=N]` as the A/B nets.
+3. **Reduce the whole-copy upgrades.** Every upgrade is a full decode.
+   The honest lever is making more verdicts bakeable — which is the
+   conclusion layer's job, and `OpenReason`'s tally exists to measure
+   exactly which population would convert.
+4. **Acceptance:** the 138k hot-name reference query in **interactive
+   time or with a declared, visible incompleteness** — and if it stays
+   slow, an honest bound stated in the docs rather than a silent
+   timeout. Three runs, dated. `--refs-parity` clean.
+
+### Phase B — the sweep-level provider decode dedup
+
+`scaling-limits.md` §1 names this as the remaining honest fix for the
+FHEM shape, with the arithmetic:
+
+> deduplicating provider decoding across a sweep (~13,456 rehydrates for
+> ~500 distinct providers is ~27× redundant)
+
+1. The relation is **semantically correct** — 534 files genuinely
+   providing `package main` is what FHEM is — so narrowing it would be
+   wrong. The fix is at the sweep level, not the relation level.
+2. **This interlocks hard with Epic 1**, which converts ~75 consumers
+   from the single winner to the candidate set. If Epic 1 lands first,
+   this phase's arithmetic gets worse before it gets better and its
+   value goes up correspondingly. Coordinate: Epic 1's PR reports the
+   FHEM numbers this phase then has to fix.
+3. **Bounded, byte-accounted, and shared.** CLAUDE.md's residency
+   discipline is not negotiable: a per-sweep dedup cache is a derived
+   copy store and must be byte-accounted like `PackBagCache` and the
+   enrichment overlay (128 MiB + 64 entries). Note the measured trap:
+   the per-file memo byte cap **engaged correctly (19,929 evictions) and
+   made peak worse (+15%) and wall worse (+51%)** — it was reverted.
+   Whatever you build, measure it against that outcome.
+4. Note also what is already known not to work, so it is not re-tried:
+   the sweep path memo is **load-bearing** (disabling it moves peak 0.7%
+   and costs 55% wall); walk residency, overlay clones, allocator arena
+   count, the diagnostics channel and the source-byte admission gate
+   were each ruled out **by a control, not an argument**.
+5. **Acceptance:** FHEM `--check` completes on a normal machine, or the
+   remaining gap is attributed. Report peak RSS and wall with and
+   without the documented workaround
+   (`RAYON_NUM_THREADS=4 MALLOC_MMAP_THRESHOLD_=65536`, which today cuts
+   peak 67% for 4.9% wall).
+
+### Phase C — the CLI one-shot, and diagnostics-after-edit
+
+1. **CLI one-shot** (Tier 1 #5 residual + #6). PR #125 made it finite —
+   350 s at 138k with a real answer. The root cause of the remaining
+   pack share is understood: `LanguageScope` lets a verb declare the
+   families its answer can consult, measured at **−52% CPU** on a
+   synthetic Perl query with the pack phase falling 936 ms → 0.11 ms.
+   **That is ROOT-CAUSED but unconfirmed at 138k** — confirm it, then
+   audit every verb's scope choice (Epic 10 adds more).
+2. **Diagnostics after edit: never, at 60 s** on CPAN-5k. This is the
+   most user-visible row on the board — it is the thing an editor does
+   after every keystroke pause. Attribute it: it is the enriched
+   diagnostic path over an open document, and
+   `adr/enrichment-build-cost.md` already measured the composition
+   (copy 3.8%, cross-file provider chase 61.6% — **that share predates
+   the resident-copy export gate**, which took the chase from 1,541 ms
+   to 241 ms, so re-measure rather than citing it).
+   `prompt-incremental-build.md` is the parked design space, and this
+   row is its forcing function: read its Tier 0 ("stop blocking, reuse
+   the existing lane") first — it ships alone and may be most of the
+   answer.
+3. **Acceptance:** diagnostics-after-edit returns at 138k with a stated
+   latency; the CLI scope audit complete with per-verb justification.
+
+### Phase D — the owed validations
+
+`prompt-scale-validation-hitlist.md` §Validation lists four rows as
+**OWED** or **IN PROGRESS**, and they are owed because a fix is not
+verified until the corpus that found the bug runs clean:
+
+1. **Cold cpan5k with every fix in** — OWED.
+2. **The differential sweep (main vs branch)** — OWED. This is the one
+   track the whole validation pass still owes; `--refs-parity` is the
+   template for what a differential net looks like.
+3. **Re-soak `PackBagCache` on current tip** — OWED. The pack-language
+   soak that ran was clean at 3h20m but **pre-rows-lane**, and the 4.65 h
+   Perl soak was Perl-only, so `PackBagCache` was compiled in and never
+   exercised. This is the cache whose denormalized byte counter once
+   collapsed the LRU to one entry and cost 13.9 GB.
+4. **Profile the 150 s of refs CPU** — IN PROGRESS; it is Phase A's
+   step 1.
+
+Land the results in `bench/` and update the status board. A row that
+cannot be closed gets its residual named.
+
+### Phase E — the Tier 2/3 stragglers, or an explicit decline
+
+Each of these is OPEN and small; take them or decline them with a
+reason, but do not leave them unlabelled:
+
+- `query_rec` 512-depth cap — seen again during the Phase-A probe.
+- `cursor_slot.rs` deferred reducible case.
+- Merge the two index families (Tier 3, structural — likely its own
+  arc, and Epic 11's ADR is asked to note the same debt from the
+  closure side).
+- The grammar-kind tripwire — IN FLIGHT, and it **must accept DECLARED
+  future kinds or it eats the forward-compat arms**
+  (`parenthesized_expression` is the live example: ~27 deliberate
+  arms, inert until the parser lands the kind).
+- "A stale cache hides a fix as readily as it hid the crash" — OPEN,
+  and it cost one false gold FAIL during integration. This is a
+  developer-experience bug with a real cost; `perl-lsp --clear-cache`
+  is the tool, and **never "fix" a flaky gold run by clearing the real
+  cache** — that deletes the evidence a warm gap exists, and a PARTIAL
+  clear is worse than none.
+
+## Non-goals
+
+- **Re-opening the rejected cross-file-work reductions.**
+  `adr/skipping-cross-file-work.md` measured and rejected seven. Read it
+  first; if you have an eighth, the doc's format is the bar.
+- Narrowing a semantically-correct relation to make it cheaper. FHEM's
+  534 providers of `main` are real.
+- Level-indexed enrichment as stated — its named prerequisite (shrink
+  the copy) is not the bottleneck; the copy is 3.8%.
+
+## Language-pack beat
+
+**The two axes point opposite ways, and conflating them has already
+cost time.**
+
+`cpp-status.md` says it plainly: C++ is **memory-healthy and
+wall-pathological** (Godot: RSS flat at ~2 GB across 7,041 files, but
+30–66 s on individual generated headers); Perl's FHEM shape is
+**memory-pathological** (does not complete `--check` on 31 GB). *"They
+share no mechanism, and the Perl scaling work neither caused nor fixed
+the C++ one."*
+
+So:
+
+1. **This epic is the Perl/engine axis. Epic 14 is the C/C++ per-file
+   axis.** Do not merge them, and do not cite one's numbers as evidence
+   about the other.
+2. **But the shared machinery is shared, and every fix here must be
+   proven not to hurt the pack side.** The row store, the conclusion
+   layer, the closedness certificate, the eviction/residency discipline,
+   `LanguageScope` and the warm-stub path all serve both. Every phase
+   runs `cargo test --features cpp` and the gold suite with
+   `lang-skip 0`.
+3. **Phase C's `LanguageScope` work is explicitly cross-language** —
+   the whole row exists because pack indexing dominated startup on a
+   *Perl* corpus. Every verb's scope choice is a language decision, and
+   Epic 10 adds more verbs that need auditing.
+4. **Phase D's `PackBagCache` re-soak is the pack side's row on this
+   board**, and it is owed. Do not close the validation section without
+   it.
+5. `prompt-unify-language-paths.md` is parked and stays parked — a
+   cleanup with no user-visible product does not belong in the epic
+   whose entire subject is user-visible cost.
+
+## Scaling beat
+
+The whole epic is the beat; what follows is the method, which is
+non-negotiable here more than anywhere:
+
+1. **A single run is not a baseline.** Three minimum. A phantom +400 ms
+   "regression" survived a day on one.
+2. **A number without a date rots silently.** Stamp every measurement.
+3. **Quiet box only** for the editor surface; `bench/editor-baseline.sh`
+   records loadavg on its run lines for exactly this reason.
+4. **Raw at collection, aggregated at query.** `bench/measure.sh` emits
+   tall JSONL (`{kind,name,value,unit}`); `bench/load.sql` /
+   `report.sql` slice it. `bench/baselines.jsonl` is the checked-in KPI
+   record, curated by `seed-baselines.py` after a *trusted* sweep — every
+   row carries sha/dirty/host/n/spread, and `baseline-check.sql` flags
+   only moves clearing both sides' measured noise. **Counters are
+   diagnostics and are never baselined.**
+5. **`bench/RESULTS.md` is append-only.** Findings go in; nothing is
+   quietly revised.
+6. **The instrument must not distort the measurement.** Route everything
+   through `util/timings.rs`; `bphase!` for per-file regions,
+   `ghost_stats::count_by` for per-file quantities, never a hand-rolled
+   env-gated `eprintln!`. `adr/instrument-blindness.md` is the record of
+   getting this wrong.
+7. **Detach long measurement runs from agent worktrees** — unchanged
+   worktrees get swept mid-run.
+
+## Verification gate
+
+`cargo test` (both feature sets) · gold 0 FAIL / 0 XPASS with
+`lang-skip 0` · `./e2e/run.sh` · substrate audit at exact parity
+(**this epic must not change a single answer** — it changes what they
+cost) · `--refs-parity` clean for Phase A · the status board in
+`prompt-scale-validation-hitlist.md` updated, with every row this epic
+touched moved to CLOSED or given a named residual · `bench/RESULTS.md`
+appended · `bench/baselines.jsonl` re-seeded from a trusted sweep for
+any KPI that moved.
+
+## Sizing
+
+Large, and the least predictable on the slate — it is profiling work,
+and profiling work sizes itself. Phase A is the headline and should go
+first; B interlocks with Epic 1; C is the most user-visible; D is owed
+regardless of whether anything else here happens, and could be done by
+itself in a day of machine time.

--- a/docs/epics/16-cfg-tier.md
+++ b/docs/epics/16-cfg-tier.md
@@ -1,0 +1,354 @@
+# Epic 16 — The CFG tier: path sensitivity on the witness bag
+
+> **Status:** scheduled (16th on the slate, but see the ordering note —
+> **two of its representation decisions bind on epics scheduled
+> before it**).
+> **Design owner-doc:** `docs/prompt-cfg-tier.md` — read it WHOLE
+> before planning anything. It is a completed design brief with the
+> options weighed and the pick made; this epic is its ladder, its
+> anchors and its gates, not a second design round.
+
+## Mission
+
+Three shipped things are parked on a tier that does not exist:
+
+- `docs/adr/use-after-move.md` ships a **decidable subset** explicitly
+  *because* "we don't have a CFG";
+- the cpp D-codes (`adr/narrowing-diagnostics.md` §C/C++ applicability)
+  are blocked on a nullability layer **along cpp control flow** —
+  "D1/D2/D3/D4/D6 have no cpp facts";
+- **D9 reachability** needs a pass nobody has written.
+
+The brief's answer is deliberately *not* a control-flow graph in the
+textbook sense. It is **sparse guarded value-flow on the existing
+`FlowEdge` spine**: `FlowEdge` is already the def-site record and
+`earliest_rebind_in` is already a poor-man's dominance query, so the
+tier adds only what SSA adds to a def list — **join points and guard
+labels on their arms**.
+
+## The two constraints, and why they are non-negotiable
+
+Both are quoted from the brief because a phase that violates either
+produces a second engine, which is the failure this design exists to
+avoid:
+
+1. **Spans are the program-point currency.** "A CFG design that makes
+   consumers key on block IDs introduces a second program-point
+   currency beside spans — the parallel-store disease." **No `BlockId`
+   is ever a consumer key.**
+2. **The bag is monotone; textbook dataflow is not.** Per-point IN/OUT
+   tables with kill/gen transfer functions violate the bag's
+   invariants. The escape is SSA: "a kill stops being *delete the
+   nullness fact* and becomes *a newer def is the one that reaches
+   you* — superseded by structure, not destroyed." The whole design is
+   chosen backward from that fact.
+
+The pick, already made: **region algebra as the persisted substrate,
+sparse guarded value-flow as the analysis.** Dense basic blocks never
+persist and never exist as a resident structure; the worklist is the
+already-landed `fold_to_fixed_point` driver. Do not relitigate this —
+the brief weighs all three options and says why.
+
+## Read first
+
+1. `docs/prompt-cfg-tier.md` — whole. §§1–2 are the constraints and the
+   pick; §3 is the entity list; §4 is "the solver is not a component";
+   §6 is this epic's ladder.
+2. `docs/adr/flow-narrowing.md`, `docs/adr/use-after-move.md`,
+   `docs/adr/narrowing-diagnostics.md`, `docs/adr/bag-canonical.md`.
+3. `src/model/witnesses/registry.rs` — `query_rec` and its visited
+   guard (§3.6 is the one place this tier changes shared semantics).
+4. `src/build/builder/narrowing.rs` — `NarrowSubject`, `GuardFact`,
+   `NarrowOp`, `recognize_guards`.
+5. `src/model/file_analysis/core_types.rs` — `FlowEdge`,
+   `earliest_rebind_in`.
+6. CLAUDE.md worklist invariants, in full.
+
+## Current state — exact anchors
+
+| Entity | Where it is today | Find it |
+| --- | --- | --- |
+| `control_regions` (untyped `Vec<Span>`) | **`PackFacts`** — pack-only | `grep -rn 'control_regions' src/` — note `surface_feed` discards it as "own-file straight-line gate spans"; the typed upgrade is also its promotion to a lane Perl populates |
+| `NarrowSubject` (builder-transient) | `build/builder/narrowing.rs` | `grep -rn 'NarrowSubject' src/` |
+| The three spellings `Place` converges | across layers | `GuardSite.subject: String`, `moved_from`'s `(String, Span, ScopeId)`, `ArrowDerefSite.receiver` |
+| `FlowEdge` + the dominance stand-in | `model/file_analysis/core_types.rs` | `grep -n 'struct FlowEdge' -A 12 src/model/file_analysis/core_types.rs`; `grep -n 'fn earliest_rebind_in'` |
+| `BranchArmFold` — what grows into `JoinFold` | `model/witnesses/reducers.rs` | `grep -rn 'BranchArmFold' src/model/witnesses/` |
+| The cycle-cut site | `model/witnesses/registry.rs` | `grep -n 'fn query_rec' src/model/witnesses/registry.rs` |
+| Does NOT exist yet | — | `place_state_at`, `PredicateAtom`, `GuardRef`, `ExitFact`, `unreachable_regions` — all return zero hits; that is expected |
+
+## Phase breakdown (the brief's §6 ladder, verbatim in order)
+
+### Phase A — typed `ControlRegion` + `ExitFact`
+
+**No φ, no solver.** Buys D9 reachability, UAM class-3 arm-scoping, and
+`unless`/`until` correctness.
+
+1. `ControlRegion { span, kind, condition: Option<Span>, arms:
+   Vec<Span>, guard: Option<GuardRef> }` with `kind` a **closed** enum:
+   `If | Ternary | Loop { has_back_edge } | Switch | PreprocIf |
+   Catchy`. Per-language recognition, rule #1: Perl beside
+   `build/builder/narrowing.rs`; packs via new capture vocabulary
+   (`@ctl.region` / `@ctl.cond` / `@ctl.arm`, following the `@flow`
+   pattern).
+2. `ExitFact` per §3.2, including the `Unwind` / `NoReturn` split — a
+   `croak` is catchable by an enclosing `Catchy`; an `exit` wrapper is
+   not, and reachability dies regardless. **Jump destinations are edges,
+   not baked spans** (the brief's own late correction — do not bake a
+   resolved span).
+3. UAM's Gate C keeps reading regions **kind-blind** (containment still
+   works) and gets arm-scoping for free. Verify that rather than
+   assuming it.
+4. Persisted, `#[serde(default)]`, `EXTRACT_VERSION` bump, in its lane,
+   with its `surface_feed` fate decided (see the Scaling beat).
+5. **Acceptance:** D9 unreachable-arm detection on a fixture per region
+   kind; UAM class-3 arm-scoping; `unless`/`until` polarity tests; the
+   pack capture vocabulary exercised by at least one pack language.
+
+### Phase B — the `Place` promotion
+
+**Mechanical and wide.** Buys UAM class-2 (subobject moves) and unified
+subjects.
+
+`NarrowSubject` is promoted three ways at once (§3.3): **spelling → binding**
+(so aliases stop breaking it), **flat key → path steps** (so
+`other.msg_type` and `self.msg_type` are disjoint paths rather than a
+lossy string — a flat string faking prefix queries is rule #10's
+lossy-string projection), and **builder-transient → Model-layer serde
+entity**. `NarrowSubject` becomes its recognition-side constructor.
+
+This converges `GuardSite.subject`, `moved_from`'s tuple, and
+`ArrowDerefSite.receiver` into one entity. **Acceptance:** all three
+call sites read `Place`; a subobject-move test that the flat spelling
+could not express; an aliasing test that the spelling key got wrong.
+
+### Phase C — assembler + `JoinFold` + cycle-cut markers + atoms
+
+The core. Buys cpp D1/D2/D6 along real control flow and must/may UAM.
+**v1 needs no fixpoint at all**; loop precision is v2 via the existing
+driver.
+
+1. The φ as a `Join { place, at }` attachment plus a `JoinFold`
+   reducer — **`BranchArmFold` grown up** to handle bypass arms and
+   back edges. Not a new parallel reducer beside it.
+2. `PredicateAtom`, the **closed** guard algebra, including
+   `Config(macro)` so a superposition-qualified verdict is
+   expressible.
+3. **The one shared-machinery change (§3.6), and the most dangerous
+   item in this epic.** `query_rec`'s visited guard currently resolves
+   an on-path revisit to *nothing* — the cyclic arm vanishes from the
+   fold. Harmless for types; **wrong in the dangerous polarity for
+   must/may facts**: a loop-head φ whose back-edge arm is silently
+   dropped folds over the remaining arm and answers "must be the init
+   value" — a stronger claim than the paths justify, which is the
+   mechanism for a manufactured false positive. And because the chase
+   resolves edges into synthetic witnesses before reducers see the
+   list, a reducer **cannot distinguish** "arm resolved to nothing"
+   from "arm was cycle-cut".
+   **Fix:** a cycle-cut leaves an **explicit unknown-marker witness**.
+   `JoinFold` folds it as ⊤ ("a path exists whose value I cannot name"
+   → silence). Type reducers ignore the marker and behave exactly as
+   today — assert that with a test, because it is the compatibility
+   claim the whole change rests on.
+4. **P1 binds here.** `place_state_at` must have a provenance mode
+   returning the path skeleton it traversed —
+   `Vec<(join_at, arm_taken, guard_atom)>` — alongside the verdict.
+   This is free today and an unrecoverable retrofit later. It pays
+   rent immediately as **hover provenance** ("possibly-null because the
+   else-arm never assigned"), before any referee exists.
+5. **P2 binds here.** `PredicateAtom` flattens `if (n > 0)` to `Opaque`
+   by design; the **extraction-time** lowering (query time is
+   tree-free) must ALSO record the condition in a small symbolic IR
+   when it fits the fragment — comparisons, linear integer arithmetic,
+   equality over symbolic values, boolean structure — and `Opaque`
+   otherwise. It rides `GuardRef` as a **dormant payload**; no
+   always-on consumer reads it. Do not build a consumer here.
+6. **Verdict outputs (§3.7) are the design's strongest property:**
+   region-bounded `Variable`/`Place` witnesses under a
+   `Builder("cfg_flow")` clear-and-emit tag, which the existing D1–D6
+   seams and `inferred_type_via_bag` consume with **zero consumer
+   changes**. Plus `unreachable_regions: Vec<Span>` as a plain
+   `FileAnalysis` row for D9. If a phase here needs a consumer change,
+   something has gone wrong upstream of it.
+7. **Acceptance:** cpp D1/D2/D6 fire along real control flow with a
+   substrate sweep showing zero new false positives; must/may UAM; the
+   correlated-branch case (`if ($ok) { $x = init() } … if ($ok) {
+   $x->use }`) behaves; a loop fixture proving the cycle-cut marker
+   prevents the over-strong claim; type reducers byte-identical.
+
+### Phase D — consumer wiring and the promotion it unblocks
+
+Wire the verdicts to the diagnostics that were waiting: D9's
+unreachable arms, the cpp D-codes, UAM's must/may. Each promotes on its
+own substrate evidence per `adr/narrowing-diagnostics.md`'s ladder —
+this epic supplies facts, it does not get to skip the promotion bar.
+
+Write `docs/adr/cfg-tier.md`: what landed, the cycle-cut semantics
+change and its compatibility argument, the P1/P2 payloads and their
+dormancy, and the honest boundary (no interprocedural effects).
+
+## Non-goals — each has a named owner
+
+- **Interprocedural effects** (ladder step 4: `Moves(param)`,
+  `Derefs(param)`, the `CallBinding` upgrade, Surface membership for
+  summaries). **Its own arc, and it is not epic-ready:** §5.2 is a
+  deliberately open hole — parameter identity for dependent effects,
+  where positional vs invocant vs Perl `@_` flattening/aliasing vs
+  kwargs vs unpacking projections all disagree about what a parameter
+  *is*. The brief enumerates the axes and the requirements any answer
+  must satisfy; that design round gates the arc. Do not start it inside
+  this epic.
+- **Path-symbolic refinement** (§8 — the demand-driven referee, the
+  checker ladder, SMT). Forward-looking and additive; **only P1 and P2
+  bind now**, and they are Phase C items above. Do not build a
+  refuter, a confirmer, or a solver here.
+- **Dense basic blocks, per-block bitvectors, a second worklist.** The
+  brief rejects option B explicitly.
+- **A `BlockId` consumer key.** Ever.
+- Loop fixpoint precision — v2, via the existing
+  `fold_to_fixed_point` driver, once v1 is honest.
+
+## Ordering note — the obligations bind before the epic runs
+
+`P1`/`P2` and the cycle-cut change are **representation decisions that
+are free today and unrecoverable retrofits.** Three epics scheduled
+ahead of this one touch exactly those representations, and each carries
+a pointer back here:
+
+- **Epic 4** adds a cycle guard on the registry's visited set (its
+  Phase C) and touches `BranchArmFold`'s neighborhood. It must not
+  entrench the silent drop.
+- **Epic 12** adds narrowing recognizer arms that mint `GuardFact`s over
+  `NarrowSubject`s — P2's lowering and Phase B's `Place` both land on
+  what those arms record.
+- **Epic 7** designs suppression keys and SARIF output, and §7 of the
+  brief says finding fingerprints key on `(rule, function symbol,
+  Place path)` — **never line numbers**.
+
+If this epic runs late, those three still owe it their seams.
+
+## Language-pack beat
+
+**This is the most cross-language epic on the slate, and unusually it
+is cross-language by birth rather than by retrofit — the pack languages
+are the *motivating* consumers, not the inherited ones.**
+
+Evidence, all from the tree and the ADRs:
+
+- **The cpp D-codes are the headline consumer.**
+  `adr/narrowing-diagnostics.md` states "D1/D2/D3/D4/D6 have no cpp
+  facts. The whole narrowing tier is a child of the Perl side", and
+  "nothing records cpp guard sites for redundancy". Phase C is what
+  changes that.
+- **`use-after-move` is a C++ diagnostic**, already registered and
+  off by default, and it ships a decidable subset *because* this tier
+  is missing. UAM class-2 and class-3 are Phases B and A.
+- **`control_regions` is currently a `PackFacts` lane** — the pack side
+  got here first. Phase A's typed upgrade promotes it to a lane Perl
+  also populates, which is the opposite of the usual direction.
+- **Recognition is per-language by construction** (rule #1): Perl in
+  the builder beside `narrowing.rs`; packs through **new capture
+  vocabulary** (`@ctl.region` / `@ctl.cond` / `@ctl.arm`) following the
+  landed `@flow` pattern. That split is already the right shape — one
+  entity, two recognizers.
+- **The narrowing lattice is already shared and already region-bounded.**
+  The cpp arc's own lesson (`cpp-golive-map.md` ARC 2 E): "a narrowing
+  is a SCOPED ASSERTION over a region, not a temporal value — must be
+  explicitly region-bounded… cutoff is the shared
+  `earliest_rebind_in`, edge-driven, consumed by Perl AND the query
+  engine (cross-language)." Phase A is that lesson's next rung.
+
+Obligations:
+
+1. **Every phase runs `cargo test --features cpp` and the gold suite
+   built with it, `lang-skip 0` confirmed.** A tier whose motivating
+   consumer is C++ cannot be validated on Perl tests.
+2. **Phase A's capture vocabulary is an interface, not an
+   implementation detail.** It is how every future pack language gets
+   control regions. Design it with more than one language in mind and
+   land at least one pack language's recognition in Phase A, so the
+   vocabulary is exercised rather than hypothesised.
+3. **`PredicateAtom::Config(macro)`** is there so a
+   superposition-qualified verdict is expressible — a C-family concern
+   (`#ifdef` arms) with no Perl analogue. It must be in the closed enum
+   from Phase C, not bolted on.
+4. **When the effects arc eventually runs, `CallBinding` is where each
+   language's calling convention is encoded once** — "cpp by-ref params
+   make every callee write a caller-place effect; Perl's `@_` aliasing
+   is the same trap in older clothes." That is a note for the arc, not
+   work for this epic, but it is why §5.2's hole is language-shaped.
+5. **Epic 13 interlock:** pack-language diagnostics beyond
+   `use-after-move` are gated on a calibrated substrate (Epic 13
+   Phase A) *and* on these facts existing. Neither alone is enough;
+   say which one is missing when a code fails to promote.
+
+## Scaling beat
+
+**The brief's §4 title is the whole discipline: "the solver is not a
+component."** This tier can be built so that it costs nothing until a
+diagnostic asks, or so that it taxes every keystroke. The difference is
+placement.
+
+1. **Placement is the first decision, and the brief already made it:**
+   diagnostic finalization or CI-only — the `--use-after-move` opt-in
+   is the named precedent — **never the interactive fold.** Memoize by
+   finding fingerprint × file generation.
+2. **v1 has no fixpoint at all.** That is a cost decision as much as a
+   precision one; do not add the loop iteration in Phase C because a
+   fixture wanted it. v2 reuses `fold_to_fixed_point`, which already
+   has a bounded driver and a debug-only `MAX_FOLD_ITERATIONS` net.
+3. **Phase A and B both grow the persisted `FileAnalysis`.** Typed
+   `ControlRegion`s replace bare spans (bigger per region);
+   `Place` promotes a builder-transient into a serde entity with path
+   steps. Both ride the bincode+zstd blob into `modules.db` — 1.73 GB at
+   138,822 files, 13.9 KB/file (2026-08-17). **Report the per-file blob
+   delta on Koha for each phase.** A blob regression is a warm-start
+   regression for every user, and `EXTRACT_VERSION` bumps cost a cold
+   re-index (~10.5 min at CPAN-5k).
+4. **Both new lanes need a `surface_feed` decision and it is not
+   obvious.** `surface_feed` destructures every field with no `..`, so
+   this will not compile until decided. Control regions and places are
+   *file-local* — discard with a reason. **Effects would be the
+   opposite** (§5's "summaries join the Surface — load-bearing"), which
+   is exactly why that arc is deferred: it is the phase that changes
+   the invalidation story, and `FreshnessIndex::dirty_consumers` is
+   what makes differential CI cost proportional to blast radius.
+5. **P1's trail is allocated per chase.** A `Vec<(join_at, arm_taken,
+   guard_atom)>` built on every `place_state_at` call, when almost no
+   caller reads it, is a per-query allocation on a hot path. Make the
+   provenance mode **opt-in at the call** — the brief says "a
+   provenance mode", not "always on" — and assert the non-provenance
+   path allocates nothing.
+6. **P2's `SymExpr` is a dormant payload with no always-on consumer**,
+   and it rides the blob. Keep the fragment small and bail to `Opaque`
+   early; an unbounded symbolic IR recorded for every guard in every
+   file is a blob regression bought for a feature that does not exist
+   yet.
+7. **The cycle-cut marker adds witnesses to the bag** on every cut.
+   Monotone and bounded by the chase, but measure: the bag rides the
+   blob too, and `query_rec` cuts are not rare on real code (the
+   512-depth cap is an open Tier-2 row and was seen again during the
+   references probe).
+8. **`--check` is the batch verb that will pay for Phase D**, and it is
+   already the constrained one — FHEM does not complete it on 31 GB.
+   Report `--check` wall and peak RSS on Koha and FHEM, three runs,
+   dated, for each promoted code.
+
+## Verification gate
+
+`cargo test` **and** `cargo test --features cpp` · gold 0 FAIL /
+0 XPASS built `--features cpp` with **`lang-skip 0`** in the summary ·
+`./e2e/run.sh` · **substrate audit at exact parity for Phases A–C** —
+this tier adds facts, and no diagnostic changes behavior until Phase D
+promotes it; a count that moves earlier means a fact leaked into a
+consumer · per-code audited deltas in Phase D · **a test proving type
+reducers are byte-identical across the cycle-cut change** · per-file
+blob-size delta on Koha for A and B · `--check` wall + peak RSS, three
+runs, dated.
+
+## Sizing
+
+Large. A is self-contained and independently valuable (D9 alone
+justifies it). B is mechanical but wide — expect it to touch more call
+sites than it looks like. C is the bulk and holds the only shared-
+semantics change in the epic. D is promotion work whose length depends
+on what the audits say.

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -38,6 +38,15 @@ Epics 13–15 exist because the two axes have mass with no home in a
 feature epic: the pack-language ceiling, the C++ per-file stall, and
 the Tier-1 query-path residual are each an arc, not a paragraph.
 
+**Epic 16 is a third kind of entry: a tier three shipped features are
+already parked on.** `use-after-move` ships a decidable subset because
+there is no CFG; the cpp D-codes have no facts to read; D9 reachability
+has no pass. It is scheduled late, but **two of its representation
+decisions bind on epics scheduled before it** — they are free today and
+unrecoverable retrofits — so Epics 4, 7 and 12 each carry a pointer
+back to it. Read the ordering note in `16-cfg-tier.md` before starting
+any of those three.
+
 ## The slate
 
 | # | Epic | Size | Depends on |
@@ -57,6 +66,7 @@ the Tier-1 query-path residual are each an arc, not a paragraph.
 | 13 | [Pack-language ceiling: diagnostics, framework tier, calibration](13-pack-language-ceiling.md) | L | — |
 | 14 | [The per-file stall — C++ beta → GA](14-per-file-stall.md) | M | — |
 | 15 | [Query paths at scale — Tier 1 residual](15-query-paths-at-scale.md) | L | 1 interlocks (candidate sets) |
+| 16 | [The CFG tier — path sensitivity on the bag](16-cfg-tier.md) | L | **4, 7 and 12 owe it seams** — see below |
 
 **Suggested order.** 1 first (it is a class of confidently-wrong
 answers, and Veesh named it next); then 14 and 15, because they are the
@@ -106,6 +116,10 @@ residuals, or (d) explicitly out of scope. Nothing is unaccounted for.
 | `open-problems.md` — untyped param/hash-element boundary | Hard boundary; Epic 4 + constructor/field flow are the approach vector |
 | `open-problems.md` — runtime export generators | Hard boundary; MooseX::Role::Parameterized and Sub::Exporter ride it |
 | `prompt-optional-types.md` / `prompt-relational-iteration.md` | Landed (see `adr/relational-ref-index.md`) |
+| `prompt-cfg-tier.md` | **Epic 16** — ladder steps 1–3 (typed regions/exits, the `Place` promotion, the assembler + `JoinFold` + cycle-cut markers + atoms), plus the two binding obligations P1/P2 |
+| `prompt-cfg-tier.md` §5 — interprocedural effects (ladder step 4) | **Blocked on a design round, not on an epic.** §5.2 is a deliberately open hole: parameter identity for dependent effects, where positional vs invocant vs Perl `@_` flattening/aliasing vs kwargs vs unpacking projections disagree about what a parameter *is*. The brief enumerates the axes and the requirements any answer must satisfy. Its own arc once that round closes; note it is also the phase where summaries join the Surface |
+| `prompt-cfg-tier.md` §8 — path-symbolic refinement | **Forward-looking and additive.** Only P1 (the chase reports its arm trail) and P2 (guards keep a decidable-fragment `SymExpr`) bind now, as Epic 16 Phase C items. The checker ladder (atom-SAT → intervals → optional SMT) and its placement are all later |
+| `adr/use-after-move.md` residual classes | **Epic 16** — class-3 arm-scoping is Phase A, class-2 subobject moves are Phase B, must/may is Phase C. The ADR's decidable subset is the honest floor until then |
 | `prompt-lsp-surface-parity.md` | Landed — the type-hierarchy / call-hierarchy / typeDefinition cluster plus a re-scoped documentLink, each with gold rows. The brief's own non-goals stand; `linkedEditingRange` stays OFF |
 | `prompt-wasm-web-extension.md` | **Backburner** (ROADMAP). The crate split it assumes was executed and REJECTED; `workspace-split` is the playbook if wasm ever forces it |
 | `parser-shortcomings.md` | Upstream tree-sitter-perl bugs, handed off to the parser team. Not schedulable here; `adr/error-recovery.md` is what we do about them meanwhile |

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -58,7 +58,7 @@ any of those three.
 | 5 | [One-seam sweep: magic tokens + cst backlog](05-one-seam-sweep.md) | S | — |
 | 6 | [Rename provenance (residual)](06-rename-provenance.md) | S–M | 1 gates Phase B |
 | 7 | [Diagnostic framework: codes, config, SARIF](07-diagnostic-framework.md) | L | after 3's promotions |
-| 8 | [Heatmap residuals: Handlers + framework-consumed](08-heatmap-residuals.md) | S–M | interlocks with 7 |
+| 8 | [Heatmap: parallelize, then the residuals](08-heatmap-residuals.md) | M | interlocks with 7 |
 | 9 | [Mojo polish: routes, stash, hooks, chains](09-mojo-polish.md) | L | — |
 | 10 | [CLI analysis subcommands + `--migrate`](10-cli-analysis-and-migrate.md) | L | 7/8 for two lint aliases |
 | 11 | [Program boundaries + MAIN-1](11-program-boundaries.md) | M | brands-half waits on 4 |
@@ -153,7 +153,7 @@ residuals, or (d) explicitly out of scope. Nothing is unaccounted for.
 | `prompt-scale-validation-hitlist.md` §Validation ("OWED" rows) | **Epic 15** Phase D — cold cpan5k with every fix in, the differential sweep, the `PackBagCache` re-soak |
 | `prompt-scale-validation-hitlist.md` Tier 2/3 open rows (`query_rec` 512-depth, `cursor_slot.rs:205`, index-family merge) | **Epic 15** Phase C, or explicitly declined there |
 | `scaling-limits.md` §1 (FHEM `package main` monoculture) | **Epic 1** owns the mechanism (the 534-member candidate set IS the package-identity relation) and **Epic 15** owns the sweep-level dedup |
-| `scaling-limits.md` §5 (`--heatmap` is a batch verb) | **Epic 8** must not make it worse; the honest framing stays |
+| `scaling-limits.md` §5 (`--heatmap` is a batch verb, and single-threaded) | **Epic 8 Phase A** — the doc's own closing line schedules it ("the obvious next step"): 104–105% CPU where `--check` uses every core, up to a 17x ratio. The batch-verb framing stays honest either way; the deeper fan-in cost is Epic 15 Phase A |
 | `prompt-incremental-build.md` | **Parked** with a named bar in-doc; Epic 15 Phase D's measurements are its forcing function |
 | `prompt-storage-residuals.md` | Known unbounded residuals, deliberately listed; not an epic until one is measured to hurt |
 | `prompt-enrichment-delta.md` (enrichment as a delta artifact) | **Design, not started.** Its three named pressures — level-indexed enrichment's rejection, the FHEM crest, the overlay retention story — are all Epic 15 territory; it is the candidate design if Phase B's dedup proves insufficient. Do not start it before Epic 15 Phase C measures the enrichment path fresh |

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -1,0 +1,207 @@
+# Epics — the scheduled work, and where every design doc stands
+
+Each numbered file here is a **self-contained implementation prompt**:
+mission, reading list, grep-able code anchors, phased ladder with
+per-phase acceptance criteria, hard non-goals, invariants, and the
+verification gate. An implementing session starts with `CLAUDE.md`,
+then its epic file, then the epic's listed design docs.
+
+Ordering is a schedule, not a dependency graph — dependencies are
+stated inside each epic. `docs/ROADMAP.md` links here and carries what
+is deliberately *not* scheduled.
+
+## Every epic carries three axes, not one
+
+The slate was first drawn when this was a Perl analyzer with a
+performance appendix. It is now a multi-language engine with a measured
+scaling envelope, and those two facts are not a separate workstream —
+they are properties of every seam anyone touches. So each epic file
+carries two standing sections beside its ladder:
+
+- **`## Language-pack beat`** — what this epic owes the pack languages
+  (C/C++, Python, R, CMake). There are three legitimate answers and the
+  epic must give one explicitly: *the seam is neutral and packs inherit
+  it*, *the seam is Perl-flavored and here is where the pack sibling
+  lives*, or *this is Perl-only and here is why that is honest*.
+  Leaving it unanswered is how a Perl-shaped rule ends up in a shared
+  layer — `src/layering_tests.rs` catches a file in the wrong layer,
+  but nothing catches a Perl *semantic* in a shared function.
+- **`## Scaling beat`** — the measured cost this epic must respect, and
+  the scaling row it advances or endangers. Numbers come from
+  `docs/scaling-limits.md`, `docs/prompt-scale-validation-hitlist.md`,
+  `docs/cpp-status.md` and `bench/RESULTS.md` — always with the date
+  they were taken, because a number without one rots silently
+  (CLAUDE.md's own warning; abseil's warm RSS was recorded ~2× low in
+  two ADRs seven weeks apart).
+
+Epics 13–15 exist because the two axes have mass with no home in a
+feature epic: the pack-language ceiling, the C++ per-file stall, and
+the Tier-1 query-path residual are each an arc, not a paragraph.
+
+## The slate
+
+| # | Epic | Size | Depends on |
+|---|---|---|---|
+| 1 | [Provider identity — retire the single-winner assumption](01-provider-identity.md) | M | — |
+| 2 | [DBIC out of core, phases 2–3](02-dbic-out-of-core.md) | M | — |
+| 3 | [Openness — one answer to "is this name real?"](03-openness.md) | M | — |
+| 4 | [Value provenance, tier 1](04-value-provenance.md) | L | — |
+| 5 | [One-seam sweep: magic tokens + cst backlog](05-one-seam-sweep.md) | S | — |
+| 6 | [Rename provenance (residual)](06-rename-provenance.md) | S–M | 1 gates Phase B |
+| 7 | [Diagnostic framework: codes, config, SARIF](07-diagnostic-framework.md) | L | after 3's promotions |
+| 8 | [Heatmap residuals: Handlers + framework-consumed](08-heatmap-residuals.md) | S–M | interlocks with 7 |
+| 9 | [Mojo polish: routes, stash, hooks, chains](09-mojo-polish.md) | L | — |
+| 10 | [CLI analysis subcommands + `--migrate`](10-cli-analysis-and-migrate.md) | L | 7/8 for two lint aliases |
+| 11 | [Program boundaries + MAIN-1](11-program-boundaries.md) | M | brands-half waits on 4 |
+| 12 | [Type::Tiny completeness](12-type-tiny-completeness.md) | S–M | — |
+| 13 | [Pack-language ceiling: diagnostics, framework tier, calibration](13-pack-language-ceiling.md) | L | — |
+| 14 | [The per-file stall — C++ beta → GA](14-per-file-stall.md) | M | — |
+| 15 | [Query paths at scale — Tier 1 residual](15-query-paths-at-scale.md) | L | 1 interlocks (candidate sets) |
+
+**Suggested order.** 1 first (it is a class of confidently-wrong
+answers, and Veesh named it next); then 14 and 15, because they are the
+two places the product is currently *unusable* rather than merely
+incomplete; then 2–4, which finish the standing type-intelligence
+commitments; then the rest pull-driven.
+
+## Coverage map — every open design doc and item
+
+The rule: every forward-design doc is either (a) scheduled in an epic,
+(b) parked with a named unblock condition, (c) landed with only parked
+residuals, or (d) explicitly out of scope. Nothing is unaccounted for.
+
+### Perl / type-intelligence
+
+| Doc / item | Disposition |
+|---|---|
+| `open-problems.md` §"Duplicate-package resolution" | **Epic 1** — the relation landed (`b32814a0`); the consumer conversion is the epic |
+| `prompt-dbic-as-plugin.md` | **Epic 2** (phase 1 landed; phase 2's `meta_methods` manifest was drafted in the unmerged #109 and is re-absorbed here) |
+| `prompt-graph-walking.md` — Scope nodes / Openness | **Epic 3** |
+| `prompt-graph-walking.md` — instance brands | **Parked**: unblocks after Epic 4 + constructor/field flow; rebuild ONLY per its birth-site rule, never the syntactic spike |
+| `prompt-type-inference-residual.md` Parts 1, 2, 5a | **Epic 4** |
+| `prompt-type-inference-residual.md` Parts 3, 4 | Queued after Epic 4 (same engine, QA pulls decide) |
+| `prompt-type-inference-residual.md` Part 5c residuals (prefetch, `join =>` keys) | Queued; natural follow-on to Epic 2 |
+| `prompt-type-inference-residual.md` Part 7 (Rhai reducers) | **Parked**: wants a second concrete consumer beyond route aggregation |
+| `prompt-magic-tokens.md` | **Epic 5** (phases A–B) |
+| `prompt-cst-migration.md` items 1–5, 7 | **Epic 5** (phases C–G); item 6 is a standing strangler rule, not schedulable |
+| `prompt-ref-provenance.md` | **Epic 6** — `Ref.folded_from` LANDED; phases B–E remain |
+| `prompt-cli-tools.md` — diagnostic framework | **Epic 7** |
+| `prompt-config-schema.md` | **Epic 7** (its named forcing function) |
+| `adr/heatmap.md` §residuals | **Epic 8** (SARIF piece rides Epic 7) |
+| `prompt-mojo-todo.md` | **Epic 9** |
+| `prompt-cli-tools.md` — analysis subcommands + `--migrate` | **Epic 10** |
+| `prompt-entrypoint-analysis.md` | **Epic 11** (brands-half stays parked) |
+| `open-problems.md` §"`main::` aggregation across `require`" | **Epic 11** (phase C) |
+| Type::Tiny check-guards, import-scoped vocabulary | **Epic 12**; `ArrayRef[T]` elements parked with sequence-types |
+| `open-problems.md` §"Cross-file `ClassIsa`-trigger emissions" | **LANDED** — `plugin.gated_emissions` + `class_isa_prefix` + `enrichment::apply_gated_emissions`; the doc section is stale and Epic 3 Phase A retires it |
+| `prompt-enrichment-inheritance-residual.md` | Landed with the above; only the `ClassIsa`/`param_types` applicability matrix rows remain, verified in **Epic 3** |
+| `prompt-helper-consumption.md` | Phases 1–2 landed; phase 3 (per-app surfaces) **parked** with instance brands |
+| `prompt-long-distance.md` | Landed; open-world caller gather **parked** on Epic 3's enumerability witness |
+| `prompt-method-resolution-residuals.md` | §§1–3 landed; probe-based plugin generation **parked** (needs a runtime-probe design); §4 rides Epic 4 |
+| `prompt-flow-narrowing.md` / `prompt-optional-types.md` | Landed; residuals parked in-doc |
+| `prompt-sequence-types.md` | **Parked — QA pulls** |
+| `prompt-type-is-the-gate.md` | **Parked**: waits for the next motivating strict-eq gate; Epic 2's emission work is the likeliest place it surfaces |
+| `prompt-type-system-encoding.md` | **Parked**: Epic 2 decides the manifest-vs-axis question at the boundary |
+| `prompt-type-system-futures.md` | Pillar 1 (narrowing) LANDED; pillar 2 (effects/throws) aspirational, out of the QA loop by its own charter |
+| `open-problems.md` — untyped param/hash-element boundary | Hard boundary; Epic 4 + constructor/field flow are the approach vector |
+| `open-problems.md` — runtime export generators | Hard boundary; MooseX::Role::Parameterized and Sub::Exporter ride it |
+| `prompt-optional-types.md` / `prompt-relational-iteration.md` | Landed (see `adr/relational-ref-index.md`) |
+| `prompt-lsp-surface-parity.md` | Landed — the type-hierarchy / call-hierarchy / typeDefinition cluster plus a re-scoped documentLink, each with gold rows. The brief's own non-goals stand; `linkedEditingRange` stays OFF |
+| `prompt-wasm-web-extension.md` | **Backburner** (ROADMAP). The crate split it assumes was executed and REJECTED; `workspace-split` is the playbook if wasm ever forces it |
+| `parser-shortcomings.md` | Upstream tree-sitter-perl bugs, handed off to the parser team. Not schedulable here; `adr/error-recovery.md` is what we do about them meanwhile |
+
+### Language packs
+
+| Doc / item | Disposition |
+|---|---|
+| `prompt-multi-language.md` §"What pack languages still don't get" | **Epic 13** — diagnostics, framework tier (capture-event hooks), completion context, the calibration substrate |
+| `prompt-multi-language.md` §"Shipping shape" (the `lsp-engine` crate cut) | **Parked** by its own text: does not start before a second pack language's ceiling work forces the split to pay for itself — i.e. after Epic 13 |
+| The next serve-in-anger pack language | Scheduled, brief not yet on main. It rides **Epic 1** (its identity model is the same single-winner residual) and its calibration substrate is **Epic 13** Phase A. Add its rows here when the branch lands |
+| `cpp-status.md` §"The scaling limit: measured" | **Epic 14** — the per-file stall is the beta→GA gate |
+| `prompt-macro-salvage-scaling.md` | **Epic 14** (its ranked fixes are the epic's Phase B) |
+| `prompt-vendored-dirs.md` | **Epic 14** (Phase D — the role-remap lever; `scaling-limits.md` §2 is the Perl-side evidence) |
+| `prompt-cpp-member-refs.md` §residuals | Queued behind Epic 14; each is a separate careful change |
+| `prompt-unify-language-paths.md` (serving tier) | **Parked** with a stated condition in-doc: a cleanup with no user-visible product, and it gets cheaper every time a pack seam generalizes. Epics 3/7/13 each shrink it; re-read after 13 |
+| `prompt-unify-semantic-tiers.md` (the emission twin) | **Parked** with its sibling above. Perl and the packs already share ONE witness engine, registry, chase and storage stack; what differs is emission. Its phase 4 just points at the serving-tier brief, so the two land together or not at all |
+| `prompt-parallel-realities.md` (config-lifted `#ifdef`) | **PARKED — needs deep thought before any build**, by its own header. The spike PoC modules it cites were removed in the 2026-07-13 GC; re-land from the brief if the arc starts. Sibling to `adr/reparse-stratification.md` |
+| `cpp-system-headers.md`, `cpp-stdlib-autoconfig-research.md`, `cpp-lsp-experience-research.md`, `clangd-comparison.md`, `clangd-benchmark-procedure.md` | Research and procedure records, not schedulable work. Epic 14 reads them |
+| `cpp-golive-map.md` §Deferred | Recorded, not queued — each line names its own prerequisite |
+| `docs/adr/cpp-templates.md` parked residue (deduction, template-template params, `extern template`) | **Parked** on their own brief |
+| Pack framework plugins (tidyverse, CMake conventions) | **Epic 13** Phase C — keying plugin hooks on capture events is the open design round |
+| PHP target scouting (`780065a5`) | Not scheduled; a market question, not an engineering one |
+
+### Scaling
+
+| Doc / item | Disposition |
+|---|---|
+| `prompt-scale-validation-hitlist.md` Tier 1 #3 (`references` at scale) | **Epic 15** Phase A — RETURNS at 138k but 265–368 s; slow, honest, bounded, not yet fast |
+| `prompt-scale-validation-hitlist.md` Tier 1 #5 residual + #6 | **Epic 15** Phase B — CLI one-shot is O(corpus); `LanguageScope` root-caused but unconfirmed at 138k |
+| `prompt-scale-validation-hitlist.md` §Validation ("OWED" rows) | **Epic 15** Phase D — cold cpan5k with every fix in, the differential sweep, the `PackBagCache` re-soak |
+| `prompt-scale-validation-hitlist.md` Tier 2/3 open rows (`query_rec` 512-depth, `cursor_slot.rs:205`, index-family merge) | **Epic 15** Phase C, or explicitly declined there |
+| `scaling-limits.md` §1 (FHEM `package main` monoculture) | **Epic 1** owns the mechanism (the 534-member candidate set IS the package-identity relation) and **Epic 15** owns the sweep-level dedup |
+| `scaling-limits.md` §5 (`--heatmap` is a batch verb) | **Epic 8** must not make it worse; the honest framing stays |
+| `prompt-incremental-build.md` | **Parked** with a named bar in-doc; Epic 15 Phase D's measurements are its forcing function |
+| `prompt-storage-residuals.md` | Known unbounded residuals, deliberately listed; not an epic until one is measured to hurt |
+| `prompt-enrichment-delta.md` (enrichment as a delta artifact) | **Design, not started.** Its three named pressures — level-indexed enrichment's rejection, the FHEM crest, the overlay retention story — are all Epic 15 territory; it is the candidate design if Phase B's dedup proves insufficient. Do not start it before Epic 15 Phase C measures the enrichment path fresh |
+| `bench/RESULTS.md` + `bench/baselines.jsonl` | The standing record. Every epic that moves a KPI updates it — see the house rules |
+
+### Ledgers, not design docs
+
+These are records with their own lifecycles. They are **not** covered by
+the rule above, and the epics do not supersede them:
+
+- **`docs/PARKED.md`** is THE deferred-work ledger and stays the source
+  of truth for what is deliberately not done — design-debt, feature and
+  residual-bug tiers. The relationship: **PARKED is the pool, an epic is
+  a commitment.** Work moves PARKED → epic when it gets scheduled, and
+  an epic's dropped phase moves back. Its design-debt tier is drained by
+  the `tighten-loop` skill between feature arcs, not by an epic.
+- `docs/open-forks.md` — architectural forks picked mid-flight and
+  logged for later ratification, per the loosely-coupled-option
+  convention. Read it before relitigating a fork.
+- `docs/forks-resolved.md`, `docs/review-narrow-seams.md`,
+  `docs/rework-hitlist.md`, `docs/gold-roadmap.md`,
+  `docs/cpp-golive-map.md`, `docs/hitlist-*.md` — completed audits, arc
+  records and working docs. The `docs-gc` skill converts them to their
+  durable form when their arc closes; do not treat a closed hitlist as
+  a worklist.
+- `docs/PLUGIN_AUTHORING.md` — user-facing reference.
+- `gold-corpus/KNOWN-GAPS.md` — the live per-row gap tracker. Always
+  current, always readable, never an epic.
+
+## House rules for implementers (apply to every epic)
+
+- Read `CLAUDE.md` first; its numbered rules override anything an epic
+  doc accidentally contradicts. When in doubt, the rule wins and the
+  epic doc gets a PR comment.
+- **Verify every anchor before editing it.** These files name grep
+  targets, not line numbers, and the tree moves. An anchor that does
+  not resolve is a signal that the epic's premise changed — go read
+  what replaced it before writing code against a memory.
+- Every epic ends at the same gate: `cargo test` (and `--features cpp`
+  when the change is not Perl-only), gold harness 0 FAIL / 0 XPASS
+  (XPASS → promote the row) built `--features cpp` with `lang-skip 0`
+  in the summary, `./e2e/run.sh`, and — for anything touching inference
+  or diagnostics — the substrate audit diffed against a pre-epic
+  binary with always-on `undef-deref` at exact parity:
+
+  ```
+  perl-lsp --clear-cache gold-corpus/local/lib/perl5
+  perl-lsp --check gold-corpus/local/lib/perl5 --format json --severity hint \
+    --optional-deref --redundant-guard --deref-shape --unresolved-method-cross-file
+  ```
+
+- **A measurement claim needs three runs and a date.** A single run is
+  not a baseline (a phantom +400 ms "regression" survived a day on
+  one). The protocol is the `edit-bench` skill; the store is
+  `bench/measure.sh` → JSONL, and `bench/baselines.jsonl` is the
+  checked-in KPI record. Never hand-roll an env-gated `eprintln!`
+  timer — route through `util/timings.rs`.
+- Bump `EXTRACT_VERSION` whenever FA shape or bag rules change; new
+  Fact families / source tags go into `witnesses::tags`, never inline.
+  A new `FileAnalysis` lane goes INTO its owner sub-struct, and
+  `surface_feed` will not compile until its Surface fate is decided.
+- One phase = one reviewable commit (or PR); each lands with its
+  negative tests, not just its happy path.
+- Update the owner design doc + this README's coverage map in the same
+  PR that changes a disposition.

--- a/docs/prompt-cfg-tier.md
+++ b/docs/prompt-cfg-tier.md
@@ -1,0 +1,488 @@
+# The CFG tier — sparse guarded value-flow on the witness bag
+
+**Status: design brief, not landed.** The path-sensitivity tier the
+diagnostics arc is parked on: `docs/adr/use-after-move.md` ships a
+decidable subset *because* "we don't have a CFG"; the cpp D-codes
+(`docs/adr/narrowing-diagnostics.md` §C/C++ applicability) are blocked
+on a nullability layer "along cpp control flow"; D9 needs a
+reachability pass that doesn't exist. This doc is the design for that
+tier: what it is, what new entities it needs, and — load-bearing —
+what it does NOT add (a second engine).
+
+Prereq reading: `docs/adr/flow-narrowing.md`, `docs/adr/use-after-move.md`,
+`docs/adr/narrowing-diagnostics.md`, `docs/adr/bag-canonical.md`,
+`src/model/witnesses/` (attachments; `query_rec` in `registry.rs`),
+`src/build/builder/narrowing.rs` (`NarrowSubject`),
+`src/model/file_analysis/core_types.rs` (`FlowEdge`, `earliest_rebind_in`),
+CLAUDE.md worklist invariants. Scheduled as
+`docs/epics/16-cfg-tier.md` — read that for the phased ladder, the
+anchors and the gates; this brief is the design it implements.
+
+## 1. The two constraints that shape everything
+
+**Spans are the program-point currency.** A narrowing is a scoped
+assertion over a region; witnesses carry spans for temporal ordering;
+the rebind cutoff is span arithmetic over `flow_edges`. A CFG design
+that makes consumers key on block IDs introduces a second program-point
+currency beside spans — the parallel-store disease. Everything below
+stays span/point-keyed at the seams; no `BlockId` is ever a consumer
+key.
+
+**The bag is monotone; textbook dataflow is not.** Per-point IN/OUT
+state tables with kill/gen transfer functions violate the bag's
+invariants (witnesses append, nothing rewrites them). The escape is the
+same one compilers found: **SSA form converts mutation into immutable
+names plus structural joins.** A kill stops being "delete the nullness
+fact" and becomes "a newer def is the one that reaches you" —
+superseded by structure, not destroyed. SSA-shaped dataflow is monotone
+and append-only, i.e. bag-native. The design below is chosen backward
+from that fact.
+
+## 2. Options considered, and the pick
+
+- **A — region algebra++** (typed control regions, no graph): buys arm
+  membership, inverted conditions, better cutoffs. Cannot buy joins,
+  loops, or reachability — span algebra is a tree, control flow is a
+  DAG with cycles; the second doesn't embed in the first.
+- **B — dense classic CFG** (basic blocks + per-block bitvector
+  dataflow): the textbook menu, but a whole second spine with per-block
+  mutable state — fights both the bag invariants and the residency
+  discipline. Wrong prominence.
+- **C — sparse guarded value-flow** (φ nodes on the `FlowEdge` spine):
+  `FlowEdge` is already the def-site record; `earliest_rebind_in` is
+  already a poor-man's dominance query. Add the two things SSA adds to
+  a def list — join points and guard labels on their arms — and
+  dataflow runs sparse, per place, through the existing edge-chase.
+
+**Pick: A as the persisted substrate, C as the analysis.** B's worklist
+exists only as the already-landed `fold_to_fixed_point` driver; dense
+blocks never persist, never exist as a resident structure.
+
+## 3. New entities
+
+### 3.1 `ControlRegion` (typed) — upgrades `control_regions: Vec<Span>`
+
+> Today that field is `PackFacts.control_regions` — a pack-only lane,
+> discarded by `surface_feed` as own-file straight-line gate spans. The
+> typed upgrade is also its promotion to a lane Perl populates.
+
+`{ span, kind, condition: Option<Span>, arms: Vec<Span>, guard: Option<GuardRef> }`
+with `kind` a closed enum: `If | Ternary | Loop { has_back_edge } |
+Switch | PreprocIf | Catchy` (eval/try — the arm that catches unwind).
+Per-language recognition (rule #1: Perl in the builder next to
+`build/builder/narrowing.rs`; packs via new capture vocabulary `@ctl.region` /
+`@ctl.cond` / `@ctl.arm`, the `@flow` pattern). UAM's Gate C keeps
+reading it kind-blind (containment still works), then gets arm-scoping
+for free. Persisted, `#[serde(default)]`, `EXTRACT_VERSION` bump.
+
+### 3.2 `ExitFact`
+
+`{ span, kind }` per scope. Return *types* already ride
+`SymbolReturnArm`; the *exit* is a separate control fact. Feeds
+reachability (D9) and "does this arm fall through". Kinds:
+
+- `Return`.
+- `Unwind` — **catchable** frame exit (Perl `die`, cpp `throw`).
+  Pairs with the `Catchy` region kind: reachability after one depends
+  on enclosing catch arms (and, cross-frame, on callers via the §5
+  `MayThrow`/`MustThrow` effects).
+- `NoReturn` — **uncatchable** process/frame-fatal exit (`exit`,
+  `abort`): kills reachability unconditionally, no region rescues it.
+  Two kinds, not one `Throw`: D9 treats them differently, and only
+  `Unwind` feeds `Catchy` joins. NoReturn-ness of a *callee* (a
+  helper wrapping `exit`) arrives as a `NeverReturns` effect (§5) —
+  never a name allowlist in core; only the builtins/syntax forms mint
+  the ExitFact directly.
+- `Break | Continue | Goto` — **no target field at all.** A label
+  string is a spelling every consumer re-resolves; a baked resolved
+  span is just a label someone resolved early and stopped watching —
+  a materialized value that drifts (the edges-not-values smell), and
+  forward jumps (`goto done` before `done:`) can't even bake in one
+  pass. The destination is an **edge**: unlabeled break/continue
+  resolve structurally to the enclosing `ControlRegion` (the
+  assembler's job, no token names a destination); labeled forms and
+  `goto` resolve through the label REF at assembly time
+  (`ref_at(exit.span)` → `resolves_to` — the ref system already
+  handles def-after-use). One resolution owner: the CFG destination
+  and goto-def nav are the same fact and can't drift. The C pack
+  already mints label refs (`@def.label`/`@ref.label`); Perl loop
+  labels (`OUTER: while … last OUTER`) mint NO ref today — purely a
+  rule-#7 ref-emission gap (a free nav feature when filled). An
+  unresolved label ref degrades the enclosing function's reachability
+  to Opaque via ordinary unresolved-ref semantics — no bespoke
+  `Option`.
+
+### 3.3 `Place` — the promotion of `NarrowSubject`
+
+Narrowing already found the right semantics
+(`builder/narrowing.rs::NarrowSubject`): a stable place path, with
+`key_vars` as an honest aliasing story (a place reached through a
+dynamic key stops being trustworthy when the key rebinds). Three
+promotions, all representational:
+
+- **Spelling → binding identity.** `Variable(String)` becomes
+  (name, declaring `ScopeId`) — what `resolve_variable_refs` /
+  `FlowEdge.target_scope` already compute. Joins merge defs across
+  sibling arm scopes; same-spelled variables in sibling scopes must
+  not merge.
+- **Flat key → structured path.** Root binding + `Vec<PathStep>`
+  (`Field(name) | Index | Deref`), bounded depth, spelling retained for
+  display. Equality was all narrowing asked; control flow also asks
+  *disjointness* (the UAM subobject-move FP: moved `other`'s `Base`
+  subobject, read `other.msg_type` — disjoint paths, safe). A flat
+  string faking prefix queries is the lossy-string projection (rule
+  #10).
+- **Builder-transient → Model-layer serde entity.** Lives in
+  `model/file_analysis/`; `NarrowSubject` becomes its recognition-side
+  constructor. Converges the three current spellings of the same
+  concept: `GuardSite.subject: String`, `moved_from`'s
+  `(String, Span, ScopeId)`, `ArrowDerefSite.receiver`.
+
+Kill vocabulary generalizes from `key_vars`: a place's governing def is
+invalidated by a write to the place, a write to any base of its path,
+or a write to any key-var. Narrowing already enforces the third.
+
+### 3.4 `PredicateAtom` — the closed guard algebra
+
+`IsDefined | IsNull | IsClass(C) | HasRep(RepKind) | Engaged | Moved |
+Config(macro) | Opaque`, plus polarity, on a `Place`. Normalizes what
+`GuardSite` half-stores so a predicate can label a φ arm and be met at
+a join without re-parsing what the guard meant. Closed and tiny (rule
+#10: consumers ask the atom, never the syntax). `Opaque` is the honest
+arm for unrecognized guards. `Config(macro)` is the superposition
+bridge: cpp `preproc_if` arms are control regions whose guard is a
+config atom the 3-valued reachability machinery already evaluates —
+dataflow verdicts become config-qualified ("null deref when
+`PERL_DEBUG` is off"), a checker class no built-config-only incumbent
+has.
+
+The atom is deliberately lossy (`if (n > 0)` → `Opaque`); when the
+condition is in a decidable symbolic fragment the guard ALSO keeps its
+`SymExpr` — the dormant payload §8's referee wakes (obligation P2).
+Atoms stay the always-on label; nothing reads the `SymExpr` until the
+refinement tier engages.
+
+### 3.5 The φ — `Join { place, at }` attachment + `JoinFold` reducer
+
+**The bag already contains one φ:** `BranchArm(Span)` is a hand-built
+join for the one control join Perl spells as an expression (ternary
+arms → per-arm collector → `BranchArmFold` agrees them). The general φ
+is `BranchArmFold` grown up: arms are statement regions, **bypass
+edges**, and **back edges** — joins with no owning expression node —
+so an assembler pass mints them from `ControlRegion` × `FlowEdge`,
+keyed on (place, join point), each arm an edge to a def-or-previous-φ
+labeled with the arm's `PredicateAtom`.
+
+Why the existing machinery can't fake it:
+
+- **The bypass path.** `my $x = "s"; if ($c) { $x = 5; } f($x);` — the
+  bag holds Str@decl and Int@assign; latest-wins answers Int; on the
+  ¬c path `$x` is Str. The missing fact — the old value flows *around*
+  the if — has no token to hang a witness on. Region-bounding can't
+  express "executions that took the then-arm".
+- **The back edge.** A loop-head read sees the previous iteration's
+  textually-later write; "skip witnesses past the query point" is an
+  approximation of dominance that is false across a back edge.
+- **Why not plain `Edge` witnesses:** an Edge asserts identity,
+  unconditionally, and multiple edges on one attachment merge by
+  *reducer policy* (latest/narrowest/priority) — control-flow-blind. A
+  φ asserts "exactly one of these, selected by which path executed";
+  the arm-set and selection structure ARE the payload. Flatten it to
+  plain edges and the path information is destroyed.
+
+`JoinFold` claims the attachment shape (the `BranchArmFold` /
+`SymbolReturnArmFold` pattern), folds arms by lattice join, refines
+each arm by its guard atom — single-subject path sensitivity, no path
+enumeration. Diagnostics ask a thin entry point
+(`place_state_at(place, point)`, the `inferred_type_via_bag` shape)
+that resolves the governing def-or-φ and queries the registry — with a
+provenance mode returning the arm trail it traversed (§8's obligation
+P1; the chase walks those arms anyway).
+
+Representation choice: v1 keeps φs **build-transient** (minted in the
+assembler, folded during the same build; only conclusions persist as
+region-bounded witnesses under a `cfg_flow` source tag). Promote to a
+persisted `FileAnalysis` row only when a query-time consumer (hover
+provenance: "possibly-null because the else-arm never assigned")
+demands the chain — residency discipline says don't persist a graph
+nobody rehydrates.
+
+### 3.6 The one shared-machinery change: explicit cycle-cuts
+
+`query_rec`'s visited guard resolves an on-path revisit to nothing —
+the cyclic arm **vanishes from the fold**. Harmless for types (a cyclic
+edge carries no info). Wrong in the dangerous polarity for must/may
+facts: a loop-head φ whose back-edge arm is silently dropped folds over
+the remaining arm and answers "must be the init value" / "must not
+moved" — a *stronger* claim than the paths justify, i.e. the mechanism
+for a manufactured false positive. And since the edge chase resolves
+edges into synthetic witnesses before reducers see the list, a reducer
+cannot distinguish "arm resolved to nothing" from "arm was cycle-cut".
+
+Fix: a cycle-cut leaves an **explicit unknown-marker witness** in the
+materialized list instead of dropping silently. `JoinFold` folds the
+marker as ⊤ ("a path exists whose value I cannot name" → silence).
+Type reducers ignore the marker and behave exactly as today. This is
+the single point where the tier touches shared engine semantics rather
+than adding beside it.
+
+### 3.7 Verdict outputs
+
+Solver conclusions that persist: region-bounded `Variable`/`Place`
+witnesses (`Builder("cfg_flow")`, clear-and-emit) — the existing D1–D6
+seams and `inferred_type_via_bag` consume them with **zero** consumer
+changes, which is the strongest property of the design. Plus
+`unreachable_regions: Vec<Span>` (D9, dead-arm diagnostics) as a plain
+`FileAnalysis` row.
+
+## 4. "The solver" is not a component
+
+The word names a phase boundary, not a thing. The tier decomposes onto
+existing patterns, all under the existing driver:
+
+1. **Assembler** — build pass minting φ arms + guard labels from
+   `ControlRegion` × `FlowEdge` (`populate_witness_bag`'s sibling;
+   re-derives per fold iteration under a `cfg_join` clear-and-emit
+   tag, since guards reference types that converge).
+2. **`JoinFold`** — a reducer, registered like any other.
+3. **Effect application** — build pass in the fold orbit
+   (`propagate_call_bindings_to_constraints` is the precedent: it
+   already pushes call-site-derived facts per iteration).
+4. **Iteration** — `fold_to_fixed_point`, unchanged. The loop-φ
+   recurrence reaches fixpoint the way every lattice fact does.
+
+Precision ladder that falls out: **v1 needs no fixpoint at all** — a
+single reducer chase with cycle-cut-as-unknown reproduces today's
+honesty on loops (loop-carried → unknown → silence; what UAM Gate C
+does by blunter means) while gaining correct branch joins and the
+bypass path. v2 lets fold iterations refine back-edge arms toward the
+real fixpoint — riding the existing driver. Never a new engine.
+
+Backward-direction questions (liveness, dead stores) don't chase
+naturally (edges point value←source); `resolves_to`'s def→uses index
+answers them as index scans, not reducer work.
+
+## 5. Call flow: effects
+
+**Effects, not summary-values.** A callee fact splits in two: *return-
+value facts* (Optional-ness of the return — already the type lattice's
+job) and *effects proper* — what the call does to caller state
+(`Moves(param)`, `Derefs(param)`, `Sets(place-from-param, atom)`,
+`Kills(place-from-param)`, `MayThrow`/`MustThrow`). An effect is a
+transfer-function fragment consumed by the flow passes at a **call
+site**, not a value folded by a reducer at a query. The codebase
+already has one effect in disguise: `WitnessPayload::ReturnExpr(Receiver)`
+— a payload that is a function of the call site, applied by
+substitution (`UnionOnArgs`/arity likewise). Parameter-directed effects
+extend that family.
+
+Decisions:
+
+- **Transport**: effect witnesses on `Symbol(sid)` — same serde rails,
+  same cross-file transport (`MethodOnClass` edges, enrichment
+  overlay). No new store. Their only reader is the effect-application
+  pass; no existing reducer ever folds them.
+- **Closed, unconditional vocabulary, v1.** Conditional effects
+  ("derefs param 0 iff param 1 nonzero") are where effect systems
+  explode. `Opaque` is the escape hatch.
+- **`Opaque` = havoc on everything reachable from the arguments.**
+  Note the polarity: havoc *suppresses* diagnostics (all bets off →
+  silence). The zero-FP discipline is preserved by the default, not by
+  vigilance. Perl's `AUTOLOAD` / string `eval` / `goto &sub`, cpp fn
+  pointers → `Opaque`, honestly silent.
+- **Dispatch is a join over the CandidateSet.** The effect of a method
+  call is the lattice join of the candidates' effects; an open set
+  (unresolvable receiver, `$obj->$m` unfolded) joins `Opaque`. Policy
+  on the application step, keyed by what resolution answers — never a
+  per-call-shape branch.
+- **SCC ordering.** Summaries compute bottom-up over call-graph SCCs,
+  cycles iterated to fixpoint (finite vocabulary; MRO's depth-cap
+  precedent as backstop). Intra-file: one more pass in
+  `fold_to_fixed_point`'s orbit. Cross-file: the resolver thread.
+- **Summaries join the Surface — load-bearing.** An effect summary is
+  a cross-file-visible fact: if `Callee::f` gains `Moves(param)`,
+  every caller's flow verdicts are stale. That invalidation machinery
+  is `Surface` equality + `FreshnessIndex::dirty_consumers`; effects
+  become a Surface field **with an equality-net arm** (R1 applies). A
+  body edit that doesn't change effects fans out to nobody. Bypassing
+  Surface means rebuild-the-world or serve-stale — both disqualifying.
+- **Unwind flow.** `MayThrow`/`MustThrow`/`NeverReturns` effects + the
+  `Catchy` region kind: the join after a guarded region gains an
+  incoming arm from every may-throw call inside it. `MustThrow` is
+  catchable (`croak` — an enclosing `Catchy` rescues reachability);
+  `NeverReturns` is not (an `exit` wrapper — reachability dies
+  regardless), mirroring the `Unwind`/`NoReturn` split on `ExitFact`
+  (§3.2). Payoffs: D9 after a must-throw call (`croak` then code),
+  and honest suppression of undef-deref inside `eval { }` where the
+  deref IS the check.
+- **No context sensitivity v1.** The two cheap forms that matter
+  already exist: arity-keyed returns (`UnionOnArgs`) and
+  receiver-keyed dispatch (`MethodOnClass`).
+
+### 5.1 `CallBinding` upgrade
+
+Applying `Moves(param)` at a site needs "which caller expression — and
+which caller *place* — feeds that parameter": the existing
+`call_bindings` upgraded to carry, per argument, its span and
+`Option<Place>` (`f($x)` binds a place; `f($x + 1)` binds only a
+value — effects on the latter are vacuous). This is where each
+language's calling convention is encoded once. cpp by-ref params make
+every callee write a caller-place effect; Perl's `@_` aliasing is the
+same trap in older clothes.
+
+### 5.2 ⚠ OPEN HOLE: parameter identity for dependent effects
+
+**Deliberately not designed here.** `Moves(param)` needs a way to NAME
+a parameter that survives every language's calling convention, and the
+conventions disagree about what a parameter even is:
+
+- **Positional index** — cpp's natural key; but overloads mean the
+  index is per-signature (per-`SymbolId`? per arity-family?), and
+  default arguments make trailing indices optional at the site.
+- **The invocant** — Perl's `my ($self) = @_` / shift, Python's
+  explicit `self`, cpp's implicit `this`. Is the receiver "param 0" or
+  its own axis? (`emit_return_fuel`'s `implicit_this_members`
+  capability and `conventions.rs::is_conventional_invocant_scalar`
+  already model invocant-ness — the effect key must agree with them,
+  not re-derive.)
+- **Perl `@_` flattening + aliasing** — there are no declared
+  positions; the builder infers params from unpacking idioms, and `@_`
+  elements alias caller storage, so an effect on `$_[0]` IS an effect
+  on the caller's argument place.
+- **Named/kwargs** — Python kwargs and Perl fat-comma pair-lists are
+  *key*-identified, not position-identified (and the fat-comma rule
+  applies: the pair walk is separator-agnostic). R adds partial name
+  matching.
+- **Unpacking at the boundary** — destructuring binds (`my ($a, @rest)
+  = @_`, Python tuple params) mean one caller argument can feed a
+  projected slice of a formal (the `Extraction` vocabulary —
+  `Positional`/`Slurpy`/`KeyOf` — already models this direction for
+  flow edges; the effect key likely wants the same steps).
+
+The open question: is the effect's parameter key an ordinal, a name,
+an invocant-tag, or a per-language `ParamKey` the pack defines with a
+core-generic binding step (the `cursor_slot` shape: one vocabulary,
+per-language recognition)? Requirements any answer must satisfy:
+authored once per callee, applied at call sites of any spelling; stable
+enough to ride Surface equality without spurious dirtying; degrades to
+`Opaque` when the binding can't be proven. Whoever picks this up:
+survey how the four packs' `CallBinding`s actually bind before choosing
+— the key must be derivable on BOTH ends (decl side for the summary,
+call side for application) in every language served.
+
+## 6. Sequencing
+
+1. **Typed `ControlRegion` + `ExitFact`** — D9 reachability, UAM
+   class-3 arm-scoping, `unless`/`until` correctness. No φ, no solver.
+2. **`Place` promotion** — UAM class-2 (subobject moves), unified
+   subjects. Mechanical, wide.
+3. **Assembler + `JoinFold` + cycle-cut markers + nullability atoms** —
+   cpp D1/D2/D6 along real control flow, must/may UAM. v1: no
+   fixpoint; v2: loop precision via the existing driver.
+4. **Effects + `CallBinding` upgrade + Surface membership** —
+   interprocedural. Own arc; the §5.2 hole gates its design round.
+
+## 7. Consumers this is built for (the automation tier)
+
+Kept here so the entities serve them; none of this is engine work.
+**Finding fingerprints** keyed on (rule, function symbol, `Place`
+path) — never line numbers; baselines + inline suppression with
+reasons ride them (the gold harness's gold/xfail/provisional taxonomy
+is the same lifecycle idea). **must/may from the solver** surfaces as
+a structured confidence field: must gates CI, may informs review —
+the zero-FP discipline and a Klocwork-style recall mode become one
+engine at two thresholds, and the finding says which it is. **SARIF**
+output over the existing diagnostics seams (highest leverage-to-effort
+item on the list). **Differential CI** is already built: Surface
+equality + `dirty_consumers` + a persisted `modules.db` cache artifact
+make PR analysis cost proportional to blast radius by construction —
+once summaries are Surface fields (§5). **Determinism** graduates to
+contractual (two runs → byte-identical output; the RandomState hunt
+already paid for it). Cyclomatic complexity is `ControlRegion`
+arithmetic; dead code/exports already ship in `--heatmap`.
+
+## 8. Forward: path-symbolic refinement — the demand-driven referee
+
+**Status: forward-looking; only the two provenance obligations below
+bind the base tier now.** The Coverity/Klocwork family runs symbolic
+execution as a *scout*: fork a symbolic state at every branch, carry a
+path condition, report when a bad state is satisfiably reachable.
+Exponential in branches, solver in the hot loop, cost paid globally
+whether or not anything is wrong — the second-engine mistake, and a
+non-starter for the interactive budget.
+
+The bolt-on shape inverts it: symbolic execution as a **referee over
+candidates the sparse tier already surfaced**. Precedents: Pinpoint
+(PLDI 2018 — sparse value-flow finds chains, SMT checks feasibility
+per candidate), Thresher (PLDI 2013 — an on-demand refuter that can
+only KILL findings, never mint them), Infer Pulse / incorrectness
+logic (POPL 2020 — under-approximate execution that PROVES a bug
+reachable, minting a concrete witness path). Cost flips from
+exponential-in-program to bounded-per-candidate; the tier engages the
+way the parametric ladder does (`ParametricType::Instance` carries the
+concrete spelling so substitution can run per-query, off the hot
+path): cheap representation preserves structure eagerly, heavy
+calculus runs on demand.
+
+Two honest directions, both composing with the FP discipline instead
+of fighting it:
+
+- **Refute**: every realizing path of a may-finding has an
+  unsatisfiable condition → the finding dies. This is what makes a
+  recall mode shippable — the noisy tier gets a referee before
+  anything reaches a user.
+- **Confirm**: one satisfiable path forces the bad state → the finding
+  upgrades to **must**, carrying its concrete path witness ("when `$c`
+  is false and `n <= 0` …"). The house-native direction: it
+  manufactures certainty, never findings.
+
+Budget overflows (paths per candidate, atoms per condition) degrade to
+*unknown → the finding stays may* — the budget can never invent or
+destroy soundness, only leave precision unharvested.
+
+### 8.1 The obligations that bind NOW
+
+Everything else in this section is additive later; these two are
+representation decisions that are free today and unrecoverable
+retrofits:
+
+- **P1 — the chase reports its arm trail.** `place_state_at` (§3.5)
+  must have a provenance mode returning the path skeleton it
+  traversed — `Vec<(join_at, arm_taken, guard_atom)>` — alongside the
+  verdict. The referee's entire input is this trail; a value-only
+  chase discards it at the moment it exists for free. (The same trail
+  is the hover-provenance story — "possibly-null because the else-arm
+  never assigned" — so it pays rent before the referee ever lands.)
+  **Instance brands are a second named consumer**
+  (`prompt-graph-walking.md` PARKED): brand = the birth-site of the
+  instance, and the birth-site rule is this chase in provenance mode —
+  the trail's terminal def identity, chased through aliases (the
+  binding-keyed `Place` kills the spike's spelling-key failure) and
+  the accessor's return edge, with φ joins folding multi-arm receivers
+  to an honest may-set of birth sites.
+- **P2 — guards keep their `SymExpr` under the atom.** `PredicateAtom`
+  flattens `if (n > 0)` to `Opaque` by design; the extraction-time
+  lowering (query-time is tree-free) must ALSO record the condition in
+  a small symbolic IR — comparisons, linear integer arithmetic,
+  equality over symbolic values, boolean structure — when it fits the
+  fragment, `Opaque` otherwise. It rides `GuardRef` as a dormant
+  payload; no always-on consumer reads it.
+
+### 8.2 The checker ladder (all later, all additive)
+
+- **Rung 1 — SAT over atoms.** No arithmetic: collect atoms along the
+  candidate trail; same place + contradictory polarity → infeasible.
+  Kills the dominant real-world FP class — correlated branches
+  (`if ($ok) { $x = init() } … if ($ok) { $x->use }`) — with no
+  dependencies.
+- **Rung 2 — intervals / difference logic.** Hand-rolled decision
+  procedure; catches `n > 0` … `n <= 0` contradictions.
+- **Rung 3 — a real SMT solver behind a feature flag**, only if a
+  corpus audit shows rung 2 leaves value on the table. Treat like
+  perltidy: optional, external, absent → unknown.
+
+Placement: diagnostic finalization or CI-only (the `--use-after-move`
+opt-in precedent), never the interactive fold; memoized by finding
+fingerprint × file generation. Interprocedurally, path conditions
+crossing calls are *conditional effects* — the §5.2 hole's neighbor,
+one more reason that hole gates the effects design round.

--- a/docs/prompt-graph-walking.md
+++ b/docs/prompt-graph-walking.md
@@ -1,6 +1,6 @@
 # Graph walking — forward work
 
-The walker landed: `src/model/graph.rs` (`GraphView` + `walk`), the closed
+The walker landed: `src/graph.rs` (`GraphView` + `walk`), the closed
 `EdgeKind` enum with exhaustive `edges_from`, and the INHERITS /
 INHERITS_INV / BRIDGES edge kinds. The whole inheritance axis routes
 through it; `children_index`'s descendant fan-out and plugin bridges
@@ -92,6 +92,15 @@ Prerequisite to un-park: the value-provenance layer of
 `prompt-type-inference-residual.md` (esp. Part 2 hash-key unions,
 Part 5a value-indexed returns, and constructor/field value flow). When
 that lands, build the birth-site rule as one of its consumers.
+
+The CFG tier (`prompt-cfg-tier.md`) supplies the chase chassis for
+this: its P1 obligation (the `place_state_at` chase reports its trail)
+IS the birth-site trace — binding-keyed `Place`s see through the
+aliasing that killed the spike's spelling keys, and φ joins fold
+multi-arm receivers to an honest may-set of birth sites. Brands are
+named there as P1's second consumer; what this feature still waits on
+beyond it: Parts 2/5a above, the brand-key design round
+(`(birth-site, Option<home>)`), and the dispatch-gating consumer.
 
 ## Deferred: Scope nodes (the future taxonomy)
 


### PR DESCRIPTION
Docs only. Reorganizes open work into `docs/epics/` — sixteen self-contained implementation prompts with grep-able anchors, phased ladders, per-phase acceptance criteria, hard non-goals, invariants and a verification gate — plus a coverage map that accounts for **every** open design doc as scheduled, parked with a named unblock condition, landed with parked residuals, or out of scope.

Supersedes the docs half of #109 (whose code half predates the rework and needs its own re-baselining) and all of #118 (docs-only; its brief lands here, scheduled).

## Why it isn't just a reorganization

The slate was first drawn when this was a Perl analyzer with a performance appendix. It is now a multi-language engine with a measured scaling envelope, and neither of those is a separate workstream — they are properties of every seam. So **every epic carries two standing sections** beside its ladder:

- **`## Language-pack beat`** — three legitimate answers, and the epic must give one explicitly: the seam is neutral and packs inherit it, the seam is Perl-flavored and here is where the pack sibling lives, or this is Perl-only and here is why that is honest. Leaving it unanswered is how a Perl-shaped rule lands in a shared layer — `layering_tests.rs` catches a file in the wrong *layer*, but nothing catches a Perl *semantic* in a shared function.
- **`## Scaling beat`** — the measured cost the epic must respect and the row it advances or endangers, always with the date the number was taken.

Both sections verified present in all sixteen.

## Re-baselined against the post-rework tree

Every anchor was re-grepped; the tables name paths that exist. Three findings moved epics:

- **Gated cross-file emission is LANDED** — `plugin.gated_emissions` + `class_isa_prefix` + `enrichment::apply_gated_emissions`. Its epic is gone; `open-problems.md` still carries a stale section on it.
- **`Ref.folded_from` is LANDED.** Rename provenance shrank to three residuals.
- **Package identity**: the relation landed in `b32814a0`, its ~75 single-winner consumers did not. That epic is now the consumer conversion and goes **first** — confidently-wrong answers, not misses.
- DBIC's `meta_methods` manifest was drafted against the old tree and never merged, so it is re-absorbed rather than assumed. (The one grep anchor in the whole set that returns nothing — deliberately, and the epic says so.)

Openness gets a section on its collision with the landed **closedness certificate**, which asks an overlapping question of the same graph for an unrelated purpose (a performance instrument on the type-chase path that self-validates, vs. a diagnostics-suppression verdict). A class can be perfectly enumerable and still Open because it has an `AUTOLOAD`.

## Three epics for axis mass with no feature home

- **13 — pack-language ceiling.** Calibration is the ship gate, budgeted by its own brief as half the work.
- **14 — the per-file stall.** C/C++ is beta and explicitly does not promise scaling: Godot DNF at 4 minutes, 30–66 s on individual vendored headers. Phase A ships **only a profile** — nobody has attributed those seconds, and every fix below it is a guess until someone does.
- **15 — query paths at scale.** Storage and startup hold at 122×; query paths break.

## The CFG tier (#118) is scheduled, and it binds early

Epic 16 is the brief's §6 ladder — typed regions/exits, the `Place` promotion, then the assembler + `JoinFold` + cycle-cut markers + atoms. Interprocedural effects stay out: §5.2's parameter-identity hole is deliberately open and gates that arc's design round.

The part that matters for review order: **P1, P2 and the cycle-cut change are free today and unrecoverable retrofits**, and three epics scheduled ahead of it touch exactly those representations. Each now carries a pointer back:

- Epic 4's Phase C adds a cycle guard on the registry's visited set — correct for types, and the exact mechanism §3.6 must replace, since a silently-dropped back-edge arm folds into a stronger claim than the paths justify. It is now told to cut in **one** place.
- Epic 7 designs suppression keys and SARIF while §7 requires fingerprints on `(rule, symbol, Place path)` and must/may as a confidence axis distinct from severity.
- Epic 12 mints `GuardFact`s over `NarrowSubject`s — the entity Phase B promotes.

## Ledgers, reconciled rather than duplicated

`docs/PARKED.md` stays the deferred-work source of truth. **PARKED is the pool, an epic is a commitment**; its design-debt tier is still drained by `tighten-loop`, not by an epic. `ROADMAP.md` delegates the schedule and keeps what is deliberately not scheduled.

## Checks

All internal links resolve · every `docs/*.md` has a coverage row · every cited grep anchor hits the tree except the one documented absence · the four referenced-but-missing docs are three ADRs the epics are tasked with *writing* plus the stale pointer Epic 12 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)