### PR TITLE
Bare blocks scope; @_ is an argument window and shift consumes its head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to perl-lsp are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are the published
 crate / VS Code extension versions.
 
+## Unreleased
+
+### Type inference
+
+- **`shift` consumes `@_`; only the first read is the invocant.** A second
+  `shift`, a `$_[0]` after shifts, a `shift` inside a callback, and
+  `my $x = shift` in a plain helper all used to type as the enclosing
+  class, and subs returning them followed. They answer correctly now.
+- **Method-ness comes from class evidence** (parents, a framework, a
+  `bless` in the package), so the `use Mojo::Base -strict` opt-out is no
+  longer needed and the two-flag form `-base, -strict` now records its
+  parent, which it previously dropped.
+- Signature help no longer shows a slurpy hash (`my ($self, %attrs) = @_`)
+  typed as a sequence of the class.
+
+### Scoping
+
+- **A bare block is a lexical scope.** A `my` inside `{ ... }` used to
+  shadow the outer declaration past the closing brace, so goto-def,
+  rename, and references on the outer variable followed the wrong one.
+
 ## v0.7.0 — 2026-08-31
 
 A large accumulation: a full second language (C/C++ in beta, plus alpha-tier

--- a/docs/epics/16-cfg-tier.md
+++ b/docs/epics/16-cfg-tier.md
@@ -72,7 +72,7 @@ the brief weighs all three options and says why.
 | `NarrowSubject` (builder-transient) | `build/builder/narrowing.rs` | `grep -rn 'NarrowSubject' src/` |
 | The three spellings `Place` converges | across layers | `GuardSite.subject: String`, `moved_from`'s `(String, Span, ScopeId)`, `ArrowDerefSite.receiver` |
 | `FlowEdge` + the dominance stand-in | `model/file_analysis/core_types.rs` | `grep -n 'struct FlowEdge' -A 12 src/model/file_analysis/core_types.rs`; `grep -n 'fn earliest_rebind_in'` |
-| `shift_certainly_runs` — syntactic dominance for the `@_` window (a `shift` under a postfix modifier / loop condition / nested block opens the window) | `build/builder/infra.rs` | `grep -n 'fn shift_certainly_runs' src/build/builder/infra.rs` — reachability replaces the "straight-line or open" rule with the real must-run verdict |
+| `cst::is_conditionally_executed` — the syntactic must-run stand-in, shared by key-write flow edges and the `@_` window (`consume_arg_head`: a conditional `shift` opens the window) | `cst.rs` | `grep -rn 'is_conditionally_executed' src/` — reachability replaces the "unconditional syntax or open" rule with the real must-run verdict |
 | `BranchArmFold` — what grows into `JoinFold` | `model/witnesses/reducers.rs` | `grep -rn 'BranchArmFold' src/model/witnesses/` |
 | The cycle-cut site | `model/witnesses/registry.rs` | `grep -n 'fn query_rec' src/model/witnesses/registry.rs` |
 | Does NOT exist yet | — | `place_state_at`, `PredicateAtom`, `GuardRef`, `ExitFact`, `unreachable_regions` — all return zero hits; that is expected |

--- a/docs/epics/16-cfg-tier.md
+++ b/docs/epics/16-cfg-tier.md
@@ -72,6 +72,7 @@ the brief weighs all three options and says why.
 | `NarrowSubject` (builder-transient) | `build/builder/narrowing.rs` | `grep -rn 'NarrowSubject' src/` |
 | The three spellings `Place` converges | across layers | `GuardSite.subject: String`, `moved_from`'s `(String, Span, ScopeId)`, `ArrowDerefSite.receiver` |
 | `FlowEdge` + the dominance stand-in | `model/file_analysis/core_types.rs` | `grep -n 'struct FlowEdge' -A 12 src/model/file_analysis/core_types.rs`; `grep -n 'fn earliest_rebind_in'` |
+| `shift_certainly_runs` — syntactic dominance for the `@_` window (a `shift` under a postfix modifier / loop condition / nested block opens the window) | `build/builder/infra.rs` | `grep -n 'fn shift_certainly_runs' src/build/builder/infra.rs` — reachability replaces the "straight-line or open" rule with the real must-run verdict |
 | `BranchArmFold` — what grows into `JoinFold` | `model/witnesses/reducers.rs` | `grep -rn 'BranchArmFold' src/model/witnesses/` |
 | The cycle-cut site | `model/witnesses/registry.rs` | `grep -n 'fn query_rec' src/model/witnesses/registry.rs` |
 | Does NOT exist yet | — | `place_state_at`, `PredicateAtom`, `GuardRef`, `ExitFact`, `unreachable_regions` — all return zero hits; that is expected |

--- a/gold-corpus/fixtures/diagnostics.json
+++ b/gold-corpus/fixtures/diagnostics.json
@@ -140,8 +140,8 @@
           "\"file\":\"Daemon.pm\",\"line\":\"92\""
         ]
       },
-      "status": "xfail",
-      "note": "GAP: `on(request => sub { my $tx = shift; $tx->req })` — $tx is a transaction, but first-param-self leaks into the anonymous callback and types it as the Daemon. Unfixed. XPASSes only on a cache whose ref-rows migration silently failed (bag-evicted sweep copies drop the invocant type, hiding the FP) — a healthy store still shows the diagnostic."
+      "status": "gold",
+      "note": "`on(request => sub { my $tx = shift; $tx->req })` — an anonymous sub has its own @_ window with no invocant head, so $tx stays untyped and the Daemon-typed unresolved-method FP is gone."
     }
   ]
 }

--- a/src/build/builder/chain.rs
+++ b/src/build/builder/chain.rs
@@ -260,7 +260,9 @@ impl<'a> Builder<'a> {
                 }
                 Some(InferredType::ClassName(text.to_string()))
             }
-            // A bare `shift` reads the head of `@_`'s window at its point.
+            // A bare `shift` READS the head of `@_`'s window at its point;
+            // the consume is the walk's `consume_arg_head`, once per node.
+            // This arm re-runs every fold iteration, so it must stay a read.
             "func1op_call_expression" if self.is_shift_call(node) => {
                 self.arg_window_at(node)?.element_at(0).cloned()
             }

--- a/src/build/builder/chain.rs
+++ b/src/build/builder/chain.rs
@@ -260,15 +260,9 @@ impl<'a> Builder<'a> {
                 }
                 Some(InferredType::ClassName(text.to_string()))
             }
-            // `shift` / `shift()` / `$_[0]` in method-body invocant
-            // position all mean `$self`. Use `package_at_pos` for
-            // post-walk correctness; same reason as the `$self`
-            // case above.
+            // A bare `shift` reads the head of `@_`'s window at its point.
             "func1op_call_expression" if self.is_shift_call(node) => {
-                if !self.shift_is_invocant_here(node) {
-                    return None;
-                }
-                self.package_for_node(node).map(InferredType::ClassName)
+                self.arg_window_at(node)?.element_at(0).cloned()
             }
             "array_element_expression" => {
                 // Arrow deref on an expression (`$x->[0]`,
@@ -282,16 +276,8 @@ impl<'a> Builder<'a> {
                 };
                 let varname = array.named_child(0)?;
                 let index = node.child_by_field_name("index")?;
-                // `$_[0]` is the positional-receiver pseudo-invocant
-                // (`sub m { $_[0]->... }`) — enclosing-class identity,
-                // not a real array read.
-                if self.is_positional_receiver(node) {
-                    if !self.shift_is_invocant_here(node) {
-                        return None;
-                    }
-                    return self.package_for_node(node).map(InferredType::ClassName);
-                }
-                // General `$arr[N]`: read `@arr`'s Sequence shape from
+                // General `$arr[N]` — `$_[N]` included, `@_` being the
+                // argument window: read the Sequence shape from
                 // the bag and project the index. Mirror of
                 // `FileAnalysis::resolve_expression_type`'s array arm.
                 let name = varname.utf8_text(self.source).ok()?;
@@ -330,7 +316,7 @@ impl<'a> Builder<'a> {
             }
             "function_call_expression" | "ambiguous_function_call_expression" => {
                 if self.is_shift_call(node) {
-                    return self.package_for_node(node).map(InferredType::ClassName);
+                    return self.arg_window_at(node)?.element_at(0).cloned();
                 }
                 let func = node.child_by_field_name("function")?;
                 let name = func.utf8_text(self.source).ok()?;

--- a/src/build/builder/frameworks.rs
+++ b/src/build/builder/frameworks.rs
@@ -822,9 +822,13 @@ impl<'a> Builder<'a> {
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i) {
                 if child.start_byte() <= module_end { continue; }
-                if let Some(text) = self.extract_node_string(child) {
-                    args.push(text);
-                }
+                // `-base, -strict` arrives as one `list_expression`.
+                let leaves = if child.kind() == "list_expression" {
+                    (0..child.named_child_count()).filter_map(|j| child.named_child(j)).collect()
+                } else {
+                    vec![child]
+                };
+                args.extend(leaves.into_iter().filter_map(|n| self.extract_node_string(n)));
             }
         }
         if args.is_empty() {

--- a/src/build/builder/frameworks.rs
+++ b/src/build/builder/frameworks.rs
@@ -814,23 +814,13 @@ impl<'a> Builder<'a> {
         self.package_parents.entry(pkg).or_default().extend(parents);
     }
 
+    /// The `use Mojo::Base ...` args as strings: `-base`/`-strict` flags
+    /// (autoquoted barewords) and parent names, through the DSL-arg list
+    /// walk so `-base, -strict` (one `list_expression`) and folded
+    /// constants read the same as a lone flag. The module itself is a
+    /// `package` node, which the walk never strings.
     pub(super) fn extract_mojo_base_args(&self, node: Node<'a>) -> Vec<String> {
-        let mut args = Vec::new();
-        let module_end = node.child_by_field_name("module")
-            .map(|m| m.end_byte())
-            .unwrap_or(0);
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i) {
-                if child.start_byte() <= module_end { continue; }
-                // `-base, -strict` arrives as one `list_expression`.
-                let leaves = if child.kind() == "list_expression" {
-                    (0..child.named_child_count()).filter_map(|j| child.named_child(j)).collect()
-                } else {
-                    vec![child]
-                };
-                args.extend(leaves.into_iter().filter_map(|n| self.extract_node_string(n)));
-            }
-        }
+        let args: Vec<String> = self.extract_arg_name_list(node).into_iter().map(|(s, _)| s).collect();
         if args.is_empty() {
             // Fallback to standard extraction
             let (standard, _) = self.extract_use_import_list(node);

--- a/src/build/builder/infra.rs
+++ b/src/build/builder/infra.rs
@@ -58,12 +58,13 @@ impl<'a> Builder<'a> {
 
     /// A bare `shift` consumes `@_`'s head: from the call's end the window
     /// is the tail, latest-wins like any rebind. Only a shift that certainly
-    /// ran (straight-line in the sub body, no postfix modifier) keeps the
-    /// window known; any other opens it, so later reads answer unknown.
+    /// ran keeps the window known (`cst::is_conditionally_executed` is the
+    /// syntactic stand-in for that until the CFG tier, `docs/epics/16-cfg-
+    /// tier.md`); any other opens it, so later reads answer unknown.
     pub(super) fn consume_arg_head(&mut self, node: Node<'a>) {
         let Some(scope) = self.enclosing_sub_scope() else { return };
         let tail = match self.arg_window_at(node) {
-            Some(InferredType::Sequence(v)) if self.shift_certainly_runs(node) => {
+            Some(InferredType::Sequence(v)) if !crate::cst::is_conditionally_executed(node) => {
                 v.into_iter().skip(1).collect()
             }
             _ => Vec::new(),
@@ -74,27 +75,6 @@ impl<'a> Builder<'a> {
             constraint_span: Span { start: node.end_position(), end: node.end_position() },
             inferred_type: InferredType::Sequence(tail),
         });
-    }
-
-    /// Syntactic dominance, the pre-CFG stand-in for "this shift's statement
-    /// runs on every path to the read": straight-line in the sub body, no
-    /// postfix modifier. Under-approximates (any doubt opens the window).
-    /// Subsumed by the CFG tier's reachability (`docs/epics/16-cfg-tier.md`,
-    /// the `FlowEdge` dominance stand-in row) when it lands.
-    fn shift_certainly_runs(&self, node: Node<'a>) -> bool {
-        if Some(self.current_scope()) != self.enclosing_sub_scope() {
-            return false;
-        }
-        let mut cur = node.parent();
-        while let Some(n) = cur {
-            match n.kind() {
-                "expression_statement" => return true,
-                "postfix_conditional_expression" | "postfix_loop_expression"
-                | "postfix_for_expression" => return false,
-                _ => cur = n.parent(),
-            }
-        }
-        false
     }
 
     /// `@_`'s argument window at `node`'s own point: the sub-entry shape

--- a/src/build/builder/infra.rs
+++ b/src/build/builder/infra.rs
@@ -76,6 +76,11 @@ impl<'a> Builder<'a> {
         });
     }
 
+    /// Syntactic dominance, the pre-CFG stand-in for "this shift's statement
+    /// runs on every path to the read": straight-line in the sub body, no
+    /// postfix modifier. Under-approximates (any doubt opens the window).
+    /// Subsumed by the CFG tier's reachability (`docs/epics/16-cfg-tier.md`,
+    /// the `FlowEdge` dominance stand-in row) when it lands.
     fn shift_certainly_runs(&self, node: Node<'a>) -> bool {
         if Some(self.current_scope()) != self.enclosing_sub_scope() {
             return false;

--- a/src/build/builder/infra.rs
+++ b/src/build/builder/infra.rs
@@ -56,20 +56,50 @@ impl<'a> Builder<'a> {
         None
     }
 
-    /// Is a bare `shift` / `$_[0]` here the method invocant (→ enclosing class),
-    /// or just `arg[0]`? OO-by-convention is the default (a base class like
-    /// `DateTime` types `bless {...}, ref $_[0]` even without declared parents),
-    /// EXCEPT in a package that explicitly opted out of class machinery via
-    /// `use Mojo::Base -strict`. There the first `@_` element is an ordinary
-    /// argument, so typing it as the class produced bogus `unresolved-method`
-    /// diagnostics (`$tx = shift; $tx->res` in `Mojo::WebSocket`). (rule #10:
-    /// the opt-out is recorded as a package property at the `use` site, not
-    /// re-derived from the `shift` shape here.)
-    pub(super) fn shift_is_invocant_here(&self, node: Node<'a>) -> bool {
-        match self.package_for_node(node) {
-            Some(pkg) => !self.non_oo_packages.contains(&pkg),
-            None => true,
+    /// A bare `shift` consumes `@_`'s head: from the call's end the window
+    /// is the tail, latest-wins like any rebind. Only a shift that certainly
+    /// ran — its statement a direct child of the sub body, no postfix
+    /// modifier — keeps the window known; any other opens it, so later
+    /// reads answer unknown instead of guessing.
+    pub(super) fn consume_arg_head(&mut self, node: Node<'a>) {
+        let Some(scope) = self.enclosing_sub_scope() else { return };
+        let tail = match self.arg_window_at(node) {
+            Some(InferredType::Sequence(v)) if self.shift_certainly_runs(node) => {
+                v.into_iter().skip(1).collect()
+            }
+            _ => Vec::new(),
+        };
+        let end = node.end_position();
+        self.push_type_constraint(TypeConstraint {
+            variable: "@_".into(),
+            scope,
+            constraint_span: Span { start: end, end },
+            inferred_type: InferredType::Sequence(tail),
+        });
+    }
+
+    fn shift_certainly_runs(&self, node: Node<'a>) -> bool {
+        if Some(self.current_scope()) != self.enclosing_sub_scope() {
+            return false;
         }
+        let mut cur = node.parent();
+        while let Some(n) = cur {
+            match n.kind() {
+                "expression_statement" => return true,
+                "postfix_conditional_expression" | "postfix_loop_expression"
+                | "postfix_for_expression" => return false,
+                _ => cur = n.parent(),
+            }
+        }
+        false
+    }
+
+    /// `@_`'s argument window at `node`'s own point: the sub-entry shape
+    /// with every earlier straight-line `shift` consumed. `None` outside a
+    /// sub, or after a shift that may not have run.
+    pub(super) fn arg_window_at(&self, node: Node<'a>) -> Option<InferredType> {
+        let p = node.start_position();
+        self.bag_query_variable("@_", self.scope_at_point(p), p)
     }
 
     /// Innermost scope containing `point`. Mirrors

--- a/src/build/builder/infra.rs
+++ b/src/build/builder/infra.rs
@@ -58,9 +58,8 @@ impl<'a> Builder<'a> {
 
     /// A bare `shift` consumes `@_`'s head: from the call's end the window
     /// is the tail, latest-wins like any rebind. Only a shift that certainly
-    /// ran — its statement a direct child of the sub body, no postfix
-    /// modifier — keeps the window known; any other opens it, so later
-    /// reads answer unknown instead of guessing.
+    /// ran (straight-line in the sub body, no postfix modifier) keeps the
+    /// window known; any other opens it, so later reads answer unknown.
     pub(super) fn consume_arg_head(&mut self, node: Node<'a>) {
         let Some(scope) = self.enclosing_sub_scope() else { return };
         let tail = match self.arg_window_at(node) {
@@ -69,11 +68,10 @@ impl<'a> Builder<'a> {
             }
             _ => Vec::new(),
         };
-        let end = node.end_position();
         self.push_type_constraint(TypeConstraint {
             variable: "@_".into(),
             scope,
-            constraint_span: Span { start: end, end },
+            constraint_span: Span { start: node.end_position(), end: node.end_position() },
             inferred_type: InferredType::Sequence(tail),
         });
     }
@@ -98,8 +96,7 @@ impl<'a> Builder<'a> {
     /// with every earlier straight-line `shift` consumed. `None` outside a
     /// sub, or after a shift that may not have run.
     pub(super) fn arg_window_at(&self, node: Node<'a>) -> Option<InferredType> {
-        let p = node.start_position();
-        self.bag_query_variable("@_", self.scope_at_point(p), p)
+        self.bag_query_variable("@_", self.scope_at_point(node.start_position()), node.start_position())
     }
 
     /// Innermost scope containing `point`. Mirrors

--- a/src/build/builder/mod.rs
+++ b/src/build/builder/mod.rs
@@ -408,10 +408,6 @@ struct Builder<'a> {
     /// reducer with the right context.
     package_framework: std::collections::HashMap<String, crate::model::witnesses::FrameworkFact>,
 
-    /// Packages that explicitly opted out of class machinery (`use Mojo::Base
-    /// -strict`). In these, a bare `shift` / `$_[0]` is an ordinary argument,
-    /// not the method invocant — see `shift_is_invocant_here`.
-    non_oo_packages: std::collections::HashSet<String>,
 
     // Walk state
     scope_stack: Vec<ScopeId>,

--- a/src/build/builder/mod.rs
+++ b/src/build/builder/mod.rs
@@ -408,8 +408,7 @@ struct Builder<'a> {
     /// reducer with the right context.
     package_framework: std::collections::HashMap<String, crate::model::witnesses::FrameworkFact>,
 
-    /// Packages with a `bless` in this file: the class evidence a
-    /// parent-less base class (DateTime, Path::Tiny) offers.
+    /// Packages with a `bless` in this file (`PackageFacts::blesses`).
     blessing_packages: std::collections::HashSet<String>,
 
 

--- a/src/build/builder/mod.rs
+++ b/src/build/builder/mod.rs
@@ -408,6 +408,10 @@ struct Builder<'a> {
     /// reducer with the right context.
     package_framework: std::collections::HashMap<String, crate::model::witnesses::FrameworkFact>,
 
+    /// Packages with a `bless` in this file: the class evidence a
+    /// parent-less base class (DateTime, Path::Tiny) offers.
+    blessing_packages: std::collections::HashSet<String>,
+
 
     // Walk state
     scope_stack: Vec<ScopeId>,

--- a/src/build/builder/pipeline.rs
+++ b/src/build/builder/pipeline.rs
@@ -630,6 +630,7 @@ fn build_once(
     // Post-pass 5: fill in tail POD docs for subs that didn't get preceding doc
     bphase!("resolve_tail_pod_docs", b.resolve_tail_pod_docs());
 
+    let packages = b.package_facts();
     let mut fa = FileAnalysis::new(crate::model::file_analysis::FileAnalysisParts {
         scopes: b.scopes,
         symbols: b.symbols,
@@ -637,14 +638,7 @@ fn build_once(
         fold_ranges: b.fold_ranges,
         imports: b.imports,
         call_bindings: b.call_bindings,
-        packages: crate::model::file_analysis::PackageFacts::fold(
-            b.package_parents,
-            b.package_uses,
-            b.package_framework,
-            b.role_requires,
-            b.role_packages,
-            b.dynamic_parent_packages,
-        ),
+        packages,
         method_call_bindings: b.method_call_bindings,
         framework_imports: b.framework_imports,
         export: b.export,
@@ -765,12 +759,27 @@ impl<'a> Builder<'a> {
     /// inside the worklist, once `invocant_class` is filled.
     /// `@_` at every sub entry the walk did not seed: the argument window,
     /// headed by the invocant when the sub is a `method` or a named sub of
-    /// a class package (parents, a framework, or a `bless` anywhere in it —
-    /// a verdict complete only after the walk). `consume_arg_head` advanced
+    /// a class package (`PackageFacts::is_class`, complete only after the
+    /// walk). `consume_arg_head` advanced
     /// the window during the walk; a one-element window's tail is empty
     /// either way, so the head can land here.
+    /// The per-package table as the walk has it so far — the one fold of
+    /// the builder's lanes, read by the window seed and the final assembly.
+    fn package_facts(&self) -> std::collections::HashMap<String, PackageFacts> {
+        PackageFacts::fold(
+            self.package_parents.clone(),
+            self.package_uses.clone(),
+            self.package_framework.clone(),
+            self.role_requires.clone(),
+            self.role_packages.clone(),
+            self.dynamic_parent_packages.clone(),
+            self.blessing_packages.clone(),
+        )
+    }
+
     fn seed_arg_windows(&mut self) {
         use crate::model::witnesses::WitnessAttachment;
+        let facts = self.package_facts();
         let seeded: std::collections::HashSet<ScopeId> = self.bag.all().iter().filter_map(|w| match &w.attachment {
             WitnessAttachment::Variable { name, scope } if name == "@_"
                 && w.span.start == self.scopes[scope.0 as usize].span.start => Some(*scope),
@@ -785,9 +794,7 @@ impl<'a> Builder<'a> {
             };
             let (Some(pkg), false) = (scope.package.clone(), seeded.contains(&scope.id)) else { continue };
             let (id, span) = (scope.id, scope.span);
-            let class_pkg = self.package_parents.contains_key(&pkg)
-                || self.framework_modes.contains_key(&pkg)
-                || self.blessing_packages.contains(&pkg);
+            let class_pkg = facts.get(&pkg).is_some_and(PackageFacts::is_class);
             let head = (is_method || (class_pkg && !anon)).then(|| InferredType::FirstParam { package: pkg });
             self.push_type_constraint(TypeConstraint {
                 variable: "@_".into(),

--- a/src/build/builder/pipeline.rs
+++ b/src/build/builder/pipeline.rs
@@ -310,6 +310,7 @@ fn build_once(
         bag: crate::model::witnesses::WitnessBag::new(),
         unresolved_expr_nodes: Vec::new(),
         package_framework: std::collections::HashMap::new(),
+        blessing_packages: std::collections::HashSet::new(),
         scope_stack: Vec::new(),
         // Perl's implicit top-level package. Without this seed,
         // top-level scripts (`Mojolicious::Lite` apps, one-off
@@ -762,10 +763,46 @@ impl<'a> Builder<'a> {
     /// Method-call return edges (`Expression(refidx) → Edge(PackageSymbol{package, method})`)
     /// are emitted later — by `emit_method_call_return_edges` from
     /// inside the worklist, once `invocant_class` is filled.
+    /// `@_` at every sub entry the walk did not seed: the argument window,
+    /// headed by the invocant when the sub is a `method` or a named sub of
+    /// a class package (parents, a framework, or a `bless` anywhere in it —
+    /// a verdict complete only after the walk). `consume_arg_head` advanced
+    /// the window during the walk; a one-element window's tail is empty
+    /// either way, so the head can land here.
+    fn seed_arg_windows(&mut self) {
+        use crate::model::witnesses::WitnessAttachment;
+        let seeded: std::collections::HashSet<ScopeId> = self.bag.all().iter().filter_map(|w| match &w.attachment {
+            WitnessAttachment::Variable { name, scope } if name == "@_"
+                && w.span.start == self.scopes[scope.0 as usize].span.start => Some(*scope),
+            _ => None,
+        }).collect();
+        for i in 0..self.scopes.len() {
+            let scope = &self.scopes[i];
+            let (is_method, anon) = match &scope.kind {
+                ScopeKind::Method { .. } => (true, false),
+                ScopeKind::Sub { name } => (false, name == "(anon)"),
+                _ => continue,
+            };
+            let (Some(pkg), false) = (scope.package.clone(), seeded.contains(&scope.id)) else { continue };
+            let (id, span) = (scope.id, scope.span);
+            let class_pkg = self.package_parents.contains_key(&pkg)
+                || self.framework_modes.contains_key(&pkg)
+                || self.blessing_packages.contains(&pkg);
+            let head = (is_method || (class_pkg && !anon)).then(|| InferredType::FirstParam { package: pkg });
+            self.push_type_constraint(TypeConstraint {
+                variable: "@_".into(),
+                scope: id,
+                constraint_span: span,
+                inferred_type: InferredType::Sequence(head.into_iter().collect()),
+            });
+        }
+    }
+
     pub(super) fn populate_witness_bag(&mut self) {
         use crate::model::witnesses::{
             TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,
         };
+        self.seed_arg_windows();
 
         // Rep observations from `$v->{k}` access. Method-call return
         // edges on `Expression(refidx)` are emitted later — by the

--- a/src/build/builder/pipeline.rs
+++ b/src/build/builder/pipeline.rs
@@ -746,23 +746,6 @@ impl<'a> Builder<'a> {
     }
 
 
-    /// Post-walk pass: ref-derived facts that don't need walk-time
-    /// visibility — `HashRefAccess` observations from `$v->{k}` refs
-    /// and invocant-mutation facts on hash-key writes. Variable
-    /// witnesses for TCs and walk-time idiom witnesses (branch arms,
-    /// arity gating) are already in the bag — pushed live during the
-    /// walk via `push_type_constraint` and `bag.push` from the emit
-    /// sites.
-    ///
-    /// Method-call return edges (`Expression(refidx) → Edge(PackageSymbol{package, method})`)
-    /// are emitted later — by `emit_method_call_return_edges` from
-    /// inside the worklist, once `invocant_class` is filled.
-    /// `@_` at every sub entry the walk did not seed: the argument window,
-    /// headed by the invocant when the sub is a `method` or a named sub of
-    /// a class package (`PackageFacts::is_class`, complete only after the
-    /// walk). `consume_arg_head` advanced
-    /// the window during the walk; a one-element window's tail is empty
-    /// either way, so the head can land here.
     /// The per-package table as the walk has it so far — the one fold of
     /// the builder's lanes, read by the window seed and the final assembly.
     fn package_facts(&self) -> std::collections::HashMap<String, PackageFacts> {
@@ -777,6 +760,12 @@ impl<'a> Builder<'a> {
         )
     }
 
+    /// `@_` at every sub entry the walk did not seed: the argument window,
+    /// headed by the invocant when the sub is a `method` or a named sub of
+    /// a class package (`PackageFacts::is_class`, complete only after the
+    /// walk). `consume_arg_head`
+    /// advanced the window during the walk; a one-element window's tail is
+    /// empty either way, so the head can land here.
     fn seed_arg_windows(&mut self) {
         use crate::model::witnesses::WitnessAttachment;
         let facts = self.package_facts();
@@ -805,6 +794,17 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Post-walk pass: ref-derived facts that don't need walk-time
+    /// visibility — `HashRefAccess` observations from `$v->{k}` refs
+    /// and invocant-mutation facts on hash-key writes. Variable
+    /// witnesses for TCs and walk-time idiom witnesses (branch arms,
+    /// arity gating) are already in the bag — pushed live during the
+    /// walk via `push_type_constraint` and `bag.push` from the emit
+    /// sites.
+    ///
+    /// Method-call return edges (`Expression(refidx) → Edge(PackageSymbol{package, method})`)
+    /// are emitted later — by `emit_method_call_return_edges` from
+    /// inside the worklist, once `invocant_class` is filled.
     pub(super) fn populate_witness_bag(&mut self) {
         use crate::model::witnesses::{
             TypeObservation, Witness, WitnessAttachment, WitnessPayload, WitnessSource,

--- a/src/build/builder/pipeline.rs
+++ b/src/build/builder/pipeline.rs
@@ -310,7 +310,6 @@ fn build_once(
         bag: crate::model::witnesses::WitnessBag::new(),
         unresolved_expr_nodes: Vec::new(),
         package_framework: std::collections::HashMap::new(),
-        non_oo_packages: std::collections::HashSet::new(),
         scope_stack: Vec::new(),
         // Perl's implicit top-level package. Without this seed,
         // top-level scripts (`Mojolicious::Lite` apps, one-off

--- a/src/build/builder/tests/core_tests.rs
+++ b/src/build/builder/tests/core_tests.rs
@@ -1165,3 +1165,19 @@ fn bare_block_is_a_lexical_scope() {
     assert_eq!(bound(3, 10), Some(inner), "use inside the block binds to the block's decl");
     assert_eq!(bound(5, 6), Some(outer), "use after the block binds to the outer decl again");
 }
+
+#[test]
+fn shift_consumes_the_argument_window() {
+    let src = "package Foo;\nuse parent 'Bar';\nsub greet {\n    my $self = shift;\n    my $name = shift;\n    my $other = $_[0];\n    shift if $name;\n    my $late = $_[0];\n    return $name;\n}\nsub anon { my $s = shift; my $cb = sub { my $x = shift; $x }; $s }\n1;\n";
+    let fa = build_fa(src);
+    let class = |var: &str, row: usize| {
+        fa.inferred_type_via_bag(var, Point::new(row, 60)).and_then(|t| t.class_name().map(str::to_string))
+    };
+    assert_eq!(class("$self", 3).as_deref(), Some("Foo"));
+    assert_eq!(class("$name", 4), None, "the second shift is arg 1, not the invocant");
+    assert_eq!(class("$other", 5), None, "$_[0] after two shifts is arg 2");
+    assert_eq!(class("$late", 7), None, "a conditional shift opens the window");
+    assert_eq!(class("$s", 10).as_deref(), Some("Foo"));
+    assert_eq!(class("$x", 10), None, "an anon sub has its own @_");
+    assert!(fa.sub_return_type_at_arity("greet", None).is_none(), "greet returns arg 1, not Foo");
+}

--- a/src/build/builder/tests/core_tests.rs
+++ b/src/build/builder/tests/core_tests.rs
@@ -1147,3 +1147,21 @@ fn builtin_call_keyword_gets_a_core_bound_ref() {
         "a CORE-bound builtin call must not mint a rename kind",
     );
 }
+
+#[test]
+fn bare_block_is_a_lexical_scope() {
+    let src = "my $x = 1;\n{\n    my $x = 2;\n    print $x;\n}\nprint $x;\n";
+    let fa = build_fa(src);
+    let outer = fa.resolve_variable("$x", Point::new(0, 3)).expect("outer decl").id;
+    let inner = fa.resolve_variable("$x", Point::new(3, 10)).expect("inner decl").id;
+    assert_ne!(outer, inner);
+    assert_ne!(fa.symbol(outer).scope, fa.symbol(inner).scope, "block must mint its own scope");
+    let bound = |row: usize, col: usize| {
+        fa.refs()
+            .iter()
+            .find(|r| r.target_name == "$x" && matches!(r.kind, RefKind::Variable) && r.span.start == Point::new(row, col))
+            .and_then(|r| r.resolved_symbol())
+    };
+    assert_eq!(bound(3, 10), Some(inner), "use inside the block binds to the block's decl");
+    assert_eq!(bound(5, 6), Some(outer), "use after the block binds to the outer decl again");
+}

--- a/src/build/builder/tests/frameworks_tests.rs
+++ b/src/build/builder/tests/frameworks_tests.rs
@@ -1622,8 +1622,8 @@ fn test_mojo_base_base_and_strict_still_oo() {
     ] {
         let fa = build_fa(src);
         assert_eq!(
-            fa.inferred_type_via_bag("$x", Point::new(4, 9)),
-            Some(InferredType::ClassName("C".into())),
+            fa.inferred_type_via_bag("$x", Point::new(4, 9)).and_then(|t| t.class_name().map(String::from)),
+            Some("C".into()),
             "-base makes the package OO regardless of a redundant -strict: {src}"
         );
     }

--- a/src/build/builder/visit_bless.rs
+++ b/src/build/builder/visit_bless.rs
@@ -29,6 +29,9 @@ impl<'a> Builder<'a> {
     /// 2nd arg (`bless {}`) → current package (Perl's one-arg bless blesses
     /// into the caller's package).
     pub(super) fn visit_bless_call(&mut self, node: Node<'a>) {
+        if let Some(p) = self.current_package.clone() {
+            self.blessing_packages.insert(p);
+        }
         let args = self.extract_call_args(node);
         let obj = match args.first() {
             Some(n) => *n,

--- a/src/build/builder/visit_decl.rs
+++ b/src/build/builder/visit_decl.rs
@@ -85,6 +85,9 @@ impl<'a> Builder<'a> {
             }
             // Built-in calls: abs($x), length($s), time(), etc.
             "func1op_call_expression" | "func0op_call_expression" => {
+                if self.is_shift_call(node) {
+                    self.consume_arg_head(node);
+                }
                 self.visit_func1op(node);
             }
             "method_call_expression" => self.visit_method_call(node),
@@ -732,15 +735,14 @@ impl<'a> Builder<'a> {
         //     user can call it `$c`/`$ctx`/whatever.
         // Framework-specific invocant markers (`as_invocant_params` from
         // a plugin) stack on top via EmittedParam → ParamInfo.
-        if let Some(first) = params.first_mut() {
-            let name_says_invocant =
-                crate::model::conventions::is_conventional_invocant_name(&first.name);
-            let pkg_is_subclass = self.current_package
-                .as_ref()
-                .map_or(false, |p| self.package_parents.contains_key(p));
-            if is_method || name_says_invocant || pkg_is_subclass {
-                first.is_invocant = true;
-            }
+        let pkg_is_subclass = self.current_package
+            .as_ref()
+            .map_or(false, |p| self.package_parents.contains_key(p));
+        let has_invocant = is_method || pkg_is_subclass || params.first().is_some_and(|p| {
+            crate::model::conventions::is_conventional_invocant_name(&p.name)
+        });
+        if let Some(first) = params.first_mut().filter(|_| has_invocant) {
+            first.is_invocant = true;
         }
 
         // Extract preceding POD/comment documentation
@@ -807,7 +809,7 @@ impl<'a> Builder<'a> {
         }
 
         // Detect first-param-is-self pattern
-        self.detect_first_param_type(&params, node);
+        self.detect_first_param_type(&params, node, has_invocant);
 
         // Role-contract param typing: a plugin `param_types()` rule may type
         // a named param (e.g. `$app` in a `Clove::Upgrade::OneTime` doer's
@@ -863,7 +865,7 @@ impl<'a> Builder<'a> {
             None,
         );
         self.record_signature_params(node, &params);
-        self.detect_first_param_type(&params, node);
+        self.detect_first_param_type(&params, node, false);
         self.queue_children_then(node, |b| { b.pop_scope(); });
     }
 
@@ -1093,10 +1095,8 @@ impl<'a> Builder<'a> {
         match node.kind() {
             "bareword" => node.utf8_text(self.source).ok() == Some("shift"),
             "func1op_call_expression" => {
-                // shift without explicit args: func1op_call_expression with child "shift"
-                node.child(0)
-                    .and_then(|c| c.utf8_text(self.source).ok())
-                    == Some("shift")
+                node.named_child_count() == 0
+                    && node.child(0).and_then(|c| c.utf8_text(self.source).ok()) == Some("shift")
             }
             "ambiguous_function_call_expression" | "function_call_expression" => {
                 use crate::cst::NodeExt;
@@ -1277,28 +1277,31 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub(super) fn detect_first_param_type(&mut self, params: &[ParamInfo], node: Node<'a>) {
-        // Find the first param with `is_invocant = true` — normally params[0] for
-        // regular methods, but params[1] for `around` modifiers (params[0] is $orig).
-        // The caller that sets up the param list (visit_sub for named subs,
-        // visit_anonymous_sub for modifier bodies) is responsible for marking the
-        // correct param as the invocant.
-        let invocant = params
-            .iter()
-            .find(|p| p.is_invocant && p.name.starts_with('$'));
-        let invocant = match invocant {
-            Some(p) => p,
-            None => return,
-        };
-
-        if let Some(ref pkg) = self.current_package {
+    /// Types the marked invocant param (params[0] normally, params[1] under
+    /// `around`) and seeds `@_`'s argument window for this sub scope: element
+    /// 0 is the invocant when the sub is a method, the rest unknown. Every
+    /// bare `shift` / `$_[N]` projects the window at its own point, and
+    /// `consume_arg_head` advances it — so "is this read the invocant" is
+    /// answered by position, never by the read's shape or the package's look.
+    pub(super) fn detect_first_param_type(&mut self, params: &[ParamInfo], node: Node<'a>, has_invocant: bool) {
+        let invocant = params.iter().find(|p| p.is_invocant && p.name.starts_with('$'));
+        let Some(pkg) = self.current_package.clone() else { return };
+        let (scope, span) = (self.current_scope(), node_to_span(node));
+        if let Some(p) = invocant {
             self.push_type_constraint(TypeConstraint {
-                variable: invocant.name.clone(),
-                scope: self.current_scope(),
-                constraint_span: node_to_span(node),
+                variable: p.name.clone(),
+                scope,
+                constraint_span: span,
                 inferred_type: InferredType::FirstParam { package: pkg.clone() },
             });
         }
+        let head = (has_invocant || invocant.is_some()).then(|| InferredType::FirstParam { package: pkg });
+        self.push_type_constraint(TypeConstraint {
+            variable: "@_".into(),
+            scope,
+            constraint_span: span,
+            inferred_type: InferredType::Sequence(head.into_iter().collect()),
+        });
     }
 
     pub(super) fn visit_variable_decl(&mut self, node: Node<'a>) {

--- a/src/build/builder/visit_decl.rs
+++ b/src/build/builder/visit_decl.rs
@@ -735,14 +735,15 @@ impl<'a> Builder<'a> {
         //     user can call it `$c`/`$ctx`/whatever.
         // Framework-specific invocant markers (`as_invocant_params` from
         // a plugin) stack on top via EmittedParam → ParamInfo.
-        let pkg_is_subclass = self.current_package
-            .as_ref()
-            .map_or(false, |p| self.package_parents.contains_key(p));
-        let has_invocant = is_method || pkg_is_subclass || params.first().is_some_and(|p| {
-            crate::model::conventions::is_conventional_invocant_name(&p.name)
-        });
-        if let Some(first) = params.first_mut().filter(|_| has_invocant) {
-            first.is_invocant = true;
+        if let Some(first) = params.first_mut() {
+            let name_says_invocant =
+                crate::model::conventions::is_conventional_invocant_name(&first.name);
+            let pkg_is_subclass = self.current_package
+                .as_ref()
+                .map_or(false, |p| self.package_parents.contains_key(p));
+            if is_method || name_says_invocant || pkg_is_subclass {
+                first.is_invocant = true;
+            }
         }
 
         // Extract preceding POD/comment documentation
@@ -809,7 +810,7 @@ impl<'a> Builder<'a> {
         }
 
         // Detect first-param-is-self pattern
-        self.detect_first_param_type(&params, node, has_invocant);
+        self.detect_first_param_type(&params, node);
 
         // Role-contract param typing: a plugin `param_types()` rule may type
         // a named param (e.g. `$app` in a `Clove::Upgrade::OneTime` doer's
@@ -865,7 +866,7 @@ impl<'a> Builder<'a> {
             None,
         );
         self.record_signature_params(node, &params);
-        self.detect_first_param_type(&params, node, false);
+        self.detect_first_param_type(&params, node);
         self.queue_children_then(node, |b| { b.pop_scope(); });
     }
 
@@ -1277,31 +1278,38 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Types the marked invocant param (params[0] normally, params[1] under
-    /// `around`) and seeds `@_`'s argument window for this sub scope: element
-    /// 0 is the invocant when the sub is a method, the rest unknown. Every
-    /// bare `shift` / `$_[N]` projects the window at its own point, and
-    /// `consume_arg_head` advances it — so "is this read the invocant" is
-    /// answered by position, never by the read's shape or the package's look.
-    pub(super) fn detect_first_param_type(&mut self, params: &[ParamInfo], node: Node<'a>, has_invocant: bool) {
-        let invocant = params.iter().find(|p| p.is_invocant && p.name.starts_with('$'));
-        let Some(pkg) = self.current_package.clone() else { return };
-        let (scope, span) = (self.current_scope(), node_to_span(node));
-        if let Some(p) = invocant {
+    pub(super) fn detect_first_param_type(&mut self, params: &[ParamInfo], node: Node<'a>) {
+        // Find the first param with `is_invocant = true` — normally params[0] for
+        // regular methods, but params[1] for `around` modifiers (params[0] is $orig).
+        // The caller that sets up the param list (visit_sub for named subs,
+        // visit_anonymous_sub for modifier bodies) is responsible for marking the
+        // correct param as the invocant.
+        let invocant = params
+            .iter()
+            .find(|p| p.is_invocant && p.name.starts_with('$'));
+        let invocant = match invocant {
+            Some(p) => p,
+            None => return,
+        };
+
+        if let Some(pkg) = self.current_package.clone() {
+            let (scope, span) = (self.current_scope(), node_to_span(node));
+            let head = InferredType::FirstParam { package: pkg };
             self.push_type_constraint(TypeConstraint {
-                variable: p.name.clone(),
+                variable: invocant.name.clone(),
                 scope,
                 constraint_span: span,
-                inferred_type: InferredType::FirstParam { package: pkg.clone() },
+                inferred_type: head.clone(),
+            });
+            // `@_`'s argument window for this scope, headed by the same
+            // invocant (`seed_arg_windows` covers the scopes without one).
+            self.push_type_constraint(TypeConstraint {
+                variable: "@_".into(),
+                scope,
+                constraint_span: span,
+                inferred_type: InferredType::Sequence(vec![head]),
             });
         }
-        let head = (has_invocant || invocant.is_some()).then(|| InferredType::FirstParam { package: pkg });
-        self.push_type_constraint(TypeConstraint {
-            variable: "@_".into(),
-            scope,
-            constraint_span: span,
-            inferred_type: InferredType::Sequence(head.into_iter().collect()),
-        });
     }
 
     pub(super) fn visit_variable_decl(&mut self, node: Node<'a>) {

--- a/src/build/builder/visit_decl.rs
+++ b/src/build/builder/visit_decl.rs
@@ -21,12 +21,14 @@ impl<'a> Builder<'a> {
             "assignment_expression" => self.visit_assignment(node),
 
             // A bare `{ ... }` statement is its own block node in this
-            // grammar (no separate `block` child). It's a hard package
-            // boundary like any other block — `{ package Inner; }` must not
-            // leak Inner to following statements.
+            // grammar (no separate `block` child), so the `block` arm below
+            // never sees it. It is both a package boundary (`{ package
+            // Inner; }` must not leak Inner past the close) and a lexical
+            // scope (a `my` inside must not shadow past the close).
             "block_statement" => {
                 self.add_fold_range(node);
-                self.walk_block_package_scoped(node);
+                self.push_scope(ScopeKind::Block, node_to_span(node), None);
+                self.walk_block_package_scoped_then(node, |b| { b.pop_scope(); });
             }
 
             // Blocks create scopes (but only standalone blocks, not sub/class/for bodies)

--- a/src/build/builder/visit_use.rs
+++ b/src/build/builder/visit_use.rs
@@ -327,13 +327,6 @@ impl<'a> Builder<'a> {
                 }
                 if !parents.is_empty() {
                     self.apply_mojo_base_mode(pkg, parents, node);
-                } else if raw_args.iter().any(|a| a == "-strict") {
-                    // Pure `-strict` (no `-base`, no parent): strict-mode only,
-                    // no class machinery. A bare `shift` here is arg[0], not the
-                    // invocant (see `shift_is_invocant_here`).
-                    if let Some(p) = self.current_package.clone() {
-                        self.non_oo_packages.insert(p);
-                    }
                 }
             } else if raw_args.iter().any(|a| a == "-base") {
                 // `use Mojo::EventEmitter -base` / any `use X -base`: X becomes a

--- a/src/index/module_cache/schema.rs
+++ b/src/index/module_cache/schema.rs
@@ -10,7 +10,7 @@ const SCHEMA_VERSION: &str = "10";
 /// Bumped when the builder's analysis output changes shape in a way that
 /// invalidates cached blobs. Unlike `SCHEMA_VERSION`, this does not drop
 /// the table — stale entries are re-resolved lazily with priority.
-pub const EXTRACT_VERSION: i64 = 185;
+pub const EXTRACT_VERSION: i64 = 186;
 
 /// Bumped when the ROW format of the relational ref index changes shape.
 /// Unlike `EXTRACT_VERSION` (which governs the blobs), a mismatch only wipes

--- a/src/model/file_analysis/core_types.rs
+++ b/src/model/file_analysis/core_types.rs
@@ -500,9 +500,12 @@ impl FlowEdge {
                 base: WitnessAttachment::Expr(self.source),
                 step: ProjectionStep::ArrayIndex(*n as i32),
             },
-            // A slurpy tail (`@rest`) carries the source's element type — the
-            // whole-source edge approximates it (same element lattice).
-            Extraction::Slurpy(_) => WitnessPayload::Edge(WitnessAttachment::Expr(self.source)),
+            // `my (@all) = …` IS the source; a hash is not the list, and a tail
+            // from a later position has no projection step yet.
+            Extraction::Slurpy(0) if self.target_name.starts_with('@') => {
+                WitnessPayload::Edge(WitnessAttachment::Expr(self.source))
+            }
+            Extraction::Slurpy(_) => return None,
             // KeyOf awaits its HashKey-projection lowering (a later stage).
             Extraction::KeyOf(_) => return None,
             // A bare bind clears to undef — a value the bind uniquely knows

--- a/src/model/file_analysis/mod.rs
+++ b/src/model/file_analysis/mod.rs
@@ -372,6 +372,11 @@ pub struct PackageFacts {
     /// diagnostics stay honest-silent.
     #[serde(default)]
     pub dynamic_parents: bool,
+
+    /// A `bless` in this file targets `pkg` — the class evidence a
+    /// parent-less base class (DateTime, Path::Tiny) offers.
+    #[serde(default)]
+    pub blesses: bool,
 }
 
 impl PackageFacts {
@@ -386,6 +391,7 @@ impl PackageFacts {
         requires: HashMap<String, Vec<String>>,
         roles: HashSet<String>,
         dynamic_parents: HashSet<String>,
+        blessing: HashSet<String>,
     ) -> HashMap<String, PackageFacts> {
         let mut out: HashMap<String, PackageFacts> = HashMap::new();
         for (pkg, v) in parents {
@@ -406,7 +412,17 @@ impl PackageFacts {
         for pkg in dynamic_parents {
             out.entry(pkg).or_default().dynamic_parents = true;
         }
+        for pkg in blessing {
+            out.entry(pkg).or_default().blesses = true;
+        }
         out
+    }
+
+    /// Is this package a class: does it inherit, run a framework, or bless?
+    /// The one spelling of the verdict that makes a named sub's `@_` head
+    /// the invocant.
+    pub fn is_class(&self) -> bool {
+        !self.parents.is_empty() || self.framework.is_some() || self.blesses
     }
 }
 

--- a/src/model/surface.rs
+++ b/src/model/surface.rs
@@ -187,6 +187,7 @@ impl Surface {
                 framework: _framework, // framework return folds → `ret`; synthesized accessors are already `symbols`
                 requires: _requires, // required names synthesize contract-marker Method symbols that already project
                 dynamic_parents: _dynamic_parents, // honest-silence gate for this file's own diagnostics; resolvable edges ride `parents`
+                blesses: _blesses, // class evidence for this file's own `@_` windows; what that does to returns rides `ret`
             } = facts;
             let entry = by_pkg.entry(pkg.clone()).or_insert_with(|| PackageSurface {
                 name: pkg.clone(),


### PR DESCRIPTION
## Bare block statements are lexical scopes

A statement-level `{ ... }` parses as `block_statement` with its statements as direct children, so the `block` arm that pushes a Block scope never saw it. A `my` inside a bare block landed in the enclosing scope and kept shadowing the outer declaration past the close, so goto-def, rename and references on the outer variable followed the wrong declaration. Bare blocks now push and pop a Block scope like `if`/`while` bodies already did.

## `@_` is a place; `shift` is an effect on it

Every bare `shift` and `$_[0]` in an OO-looking package answered the enclosing class, whatever had been consumed before it. In a method, the second `shift`, a `$_[0]` after two shifts, and `my $x = shift` in a plain helper all typed as the class, and the subs returning them followed. The invocant was a shape, gated by a package opt-out set (`non_oo_packages`, fed by `use Mojo::Base -strict`).

Now:

- Each sub scope seeds `@_` with an argument window at entry. Element 0 is `FirstParam` when the sub is a method; the rest is unknown.
- A straight-line `shift` pushes the window's tail as a zero-width witness at its own end, latest-wins like any rebind. A shift under a postfix modifier, in a loop condition, or in a nested block opens the window, so later reads answer unknown rather than guess.
- Bare `shift` and `$_[N]` read the window at their own point through the ordinary variable query. "Is this read the invocant" is a position, never a shape.
- Method-ness is minted once per scope: a marked invocant param seeds the head during the walk; the remaining scopes are seeded after the walk from class evidence (parents, a framework mode, or a `bless` anywhere in the package). Anonymous subs never take the head from their package.

`shift_is_invocant_here`, `non_oo_packages` and the `-strict` branch are gone.

## Two bugs this surfaced

- `use Mojo::Base -base, -strict` parses its flags as one `list_expression`, and the args extractor never descended into it, so the two-flag form recorded no parent and no framework mode. Its test passed only because every `shift` used to be the invocant.
- The destructuring lowering gave a slurpy hash in `my ($self, %attrs) = @_` an edge to the whole RHS; with `@_` typed, signature help rendered `%attrs: Sequence<Class>`. A hash target now gets no type witness, and only `my (@all) = ...` takes the whole source.

## Gold

`diag-mojo-daemon-callback-fp` promoted from xfail to gold: `on(request => sub { my $tx = shift; $tx->req })` no longer types `$tx` as the Daemon, because the callback owns its own `@_`.

`EXTRACT_VERSION` bumped (185 → 186).

## Verification

| Suite | Result |
|---|---|
| `cargo test` | 1628 passed, 0 failed |
| `./e2e/run.sh` (nvim 0.11) | 121 passed across 11 suites |
| `gold-corpus/run.pl` (`--features cpp`) | 504 pass, 16 xfail, 0 fail, 0 XPASS, lang-skip 0, warm clean |

Gold moved from 497 pass to 504 with one promotion, so six rows fixed and none lost.

## Known residual

`sub helper { my $x = shift }` in a package with class evidence still types `$x` as the class, because the class-package rule applies to every named sub. A helper in a package with no such evidence now answers unknown where it used to claim the class. `blessing_packages` is builder-local state for now; it is a package fact and belongs in `PackageFacts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T93pSDBqF6TfCcUX55tEyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T93pSDBqF6TfCcUX55tEyw)_